### PR TITLE
Improve viewer framing controls and MCP toggle access

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pywebview>=5.0
 Pillow>=10.0
+mcp>=1.0

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -7,7 +7,7 @@ belongs in mod_loader instead.
 
 import webview
 
-from . import edit_session, mod_loader, toggle_api
+from . import edit_session, mesh_metadata, mod_loader, toggle_api
 
 
 class ModViewerAPI:
@@ -27,8 +27,14 @@ class ModViewerAPI:
         # Preview any pending, not-yet-exported edits over the real files.
         overrides = edit_session.overrides_for(folder_path)
         pending_new_sections = edit_session.new_sections_for(folder_path)
-        return mod_loader.load_mod(folder_path, overrides=overrides,
-                                    pending_new_sections=pending_new_sections)
+        result = mod_loader.load_mod(folder_path, overrides=overrides,
+                                     pending_new_sections=pending_new_sections)
+        if isinstance(result, dict) and not result.get("error"):
+            result["__mesh_names__"] = mesh_metadata.load(folder_path)
+        return result
+
+    def save_mesh_names(self, folder_path, names):
+        return mesh_metadata.save(folder_path, names)
 
     # -- toggle authoring -----------------------------------------------------
     #

--- a/src/app/mesh_metadata.py
+++ b/src/app/mesh_metadata.py
@@ -1,0 +1,20 @@
+"""Persistent viewer-only mesh labels stored beside a mod."""
+import json
+import os
+
+METADATA_NAME = ".mod_viewer.json"
+
+def load(folder_path):
+    try:
+        with open(os.path.join(folder_path, METADATA_NAME), encoding="utf-8") as fh:
+            names = json.load(fh).get("mesh_names", {})
+        return names if isinstance(names, dict) else {}
+    except (OSError, ValueError, TypeError):
+        return {}
+
+def save(folder_path, names):
+    path = os.path.join(folder_path, METADATA_NAME)
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        json.dump({"mesh_names": names}, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+    return {"saved": True, "path": path}

--- a/src/app/mod_loader.py
+++ b/src/app/mod_loader.py
@@ -18,7 +18,7 @@ from core.ini_parser import (build_draw_groups, extract_menu_toggles,
                         extract_variable_defaults, find_inis, merge_sections)
 from core.mesh_builder import build_mesh_payload
 
-RESERVED_KEYS = ("__textures__", "__toggles__", "__menu__")
+RESERVED_KEYS = ("__textures__", "__toggles__", "__menu__", "__mesh_names__")
 
 
 def _ini_scope(ini_path, folder_path, multi):

--- a/src/build.py
+++ b/src/build.py
@@ -71,6 +71,8 @@ ASSET_FILES = {
         f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/build/three.module.js",
     os.path.join("addons", "controls", "OrbitControls.js"):
         f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/examples/jsm/controls/OrbitControls.js",
+    os.path.join("addons", "controls", "ArcballControls.js"):
+        f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/examples/jsm/controls/ArcballControls.js",
 }
 
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,0 +1,74 @@
+"""Optional MCP companion for 3DMigoto Mod Viewer.
+
+Run with ``python src/mcp_server.py`` from an MCP client.  The server reuses
+the same staged edit session as the desktop UI; INI files are not changed
+until ``export_mod_changes`` is explicitly called.
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+from app import edit_session, mod_loader, toggle_api
+
+mcp = FastMCP("3DMigoto Mod Viewer")
+
+
+@mcp.tool()
+def inspect_mod(folder_path: str) -> dict:
+    """Load a mod and return its meshes, toggles, menus, and textures."""
+    return mod_loader.load_mod(
+        folder_path,
+        overrides=edit_session.overrides_for(folder_path),
+        pending_new_sections=edit_session.new_sections_for(folder_path),
+    )
+
+
+@mcp.tool()
+def list_toggle_source_inis(folder_path: str) -> list:
+    """List INI files that can receive staged toggle edits."""
+    return toggle_api.list_source_inis(folder_path)
+
+
+@mcp.tool()
+def get_toggle_details(folder_path: str, ini_rel: str, section_name: str) -> dict:
+    """Inspect one toggle before editing it."""
+    return toggle_api.get_toggle_details(folder_path, ini_rel, section_name)
+
+
+@mcp.tool()
+def add_mod_toggle(folder_path: str, ini_rel: str, name: str, key_combo: str,
+                   var: str, values: list[str], default: str | None = None,
+                   back_combo: str | None = None) -> dict:
+    """Stage a new toggle; use export_mod_changes to write it."""
+    return toggle_api.add_toggle(
+        folder_path, ini_rel, name, key_combo, var, values,
+        {"default": default, "back_combo": back_combo},
+    )
+
+
+@mcp.tool()
+def edit_mod_toggle(folder_path: str, ini_rel: str, section_name: str,
+                    changes: dict) -> dict:
+    """Stage edits to a toggle, including its display name."""
+    return toggle_api.edit_toggle(folder_path, ini_rel, section_name, changes)
+
+
+@mcp.tool()
+def delete_mod_toggle(folder_path: str, ini_rel: str, section_name: str) -> dict:
+    """Stage deletion of a toggle."""
+    return toggle_api.delete_toggle(folder_path, ini_rel, section_name)
+
+
+@mcp.tool()
+def export_mod_changes(folder_path: str) -> dict:
+    """Write staged changes and create the viewer's timestamped backups."""
+    return toggle_api.export_changes(folder_path)
+
+
+@mcp.tool()
+def discard_mod_changes(folder_path: str) -> dict:
+    """Discard staged changes without writing them."""
+    return toggle_api.discard_changes(folder_path)
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -96,6 +96,10 @@ body {
   font-size: 20px; line-height: 1;
   display: flex; align-items: center; justify-content: center;
 }
+.view-gizmo { display: grid; grid-template-columns: repeat(3, 22px); gap: 2px; margin-top: 4px; }
+.view-gizmo button { width: 22px; height: 20px; padding: 0; font-size: 10px; color: #cdd9e5; background: #21262d; border: 1px solid #30363d; border-radius: 3px; cursor: pointer; }
+.view-gizmo button:hover { background: #1f6feb; }
+.mesh-state { width: 14px; text-align: center; font-size: 11px; flex-shrink: 0; }
 #wire-btn.active { background: #1f6feb; }
 #grid-btn { background: #1f6feb; }
 #grid-btn.off { background: #21262d; }

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -38,11 +38,11 @@ body {
 #export-btn:disabled { opacity: .35; cursor: default; background: #21262d; color: #8b949e; }
 
 /* ── canvas ──────────────────────────────────────────────────────────────── */
-#canvas-container { position: fixed; top: 46px; left: 0; right: 0; bottom: 28px; }
+#canvas-container { position: fixed; top: 46px; left: 0; right: 0; bottom: 52px; }
 
 /* ── footer ──────────────────────────────────────────────────────────────── */
 #footer {
-  position: fixed; bottom: 0; left: 0; right: 0; height: 28px;
+  position: fixed; bottom: 0; left: 0; right: 0; height: 52px;
   background: #161b22; border-top: 1px solid #30363d;
   display: flex; align-items: center; justify-content: space-between;
   padding: 0 14px; z-index: 100;
@@ -56,7 +56,7 @@ body {
 
 /* ── left dock (meshes panel + toolbox) ──────────────────────────────────── */
 #left-dock {
-  position: fixed; top: 58px; left: 12px; z-index: 10;
+  position: fixed; top: 58px; left: 12px; z-index: 110;
   display: flex; align-items: flex-start; gap: 10px;
 }
 
@@ -86,8 +86,8 @@ body {
 }
 
 /* ── toolbox (wireframe / grid) ───────────────────────────────────────────── */
-#tool-panel { display: flex; flex-direction: column; gap: 6px; }
-#tool-buttons { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+#tool-panel { position: fixed; left: 50%; bottom: 6px; transform: translateX(-50%); z-index: 200; display: flex !important; align-items: center; gap: 8px; background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 4px 8px; }
+#tool-buttons { display: flex; align-items: center; gap: 6px; }
 #tool-buttons.collapsed { display: none; }
 .tool-btn {
   width: 40px; height: 40px; padding: 0;
@@ -96,10 +96,8 @@ body {
   font-size: 20px; line-height: 1;
   display: flex; align-items: center; justify-content: center;
 }
-.view-gizmo { display: grid; grid-template-columns: repeat(3, 22px); gap: 2px; margin-top: 4px; }
-.view-gizmo button { width: 22px; height: 20px; padding: 0; font-size: 10px; color: #cdd9e5; background: #21262d; border: 1px solid #30363d; border-radius: 3px; cursor: pointer; }
-.view-gizmo button:hover { background: #1f6feb; }
-.mesh-state { width: 14px; text-align: center; font-size: 11px; flex-shrink: 0; }
+.mesh-state-btn { width: 18px; height: 18px; padding: 0; border: 0; background: transparent; font-size: 13px; line-height: 18px; cursor: pointer; flex-shrink: 0; }
+.mesh-state-btn:hover { filter: brightness(1.25); transform: scale(1.08); }
 #wire-btn.active { background: #1f6feb; }
 #grid-btn { background: #1f6feb; }
 #grid-btn.off { background: #21262d; }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -40,6 +40,14 @@
       <button id="grid-btn" class="tool-btn" title="Grid visibility">⊞</button>
       <button id="shading-btn" class="tool-btn" title="Smooth/flat shading">◐</button>
       <button id="texture-btn" class="tool-btn" title="Textures visibility">▩</button>
+      <button id="frame-btn" class="tool-btn" title="Frame model">⌖</button>
+      <button id="reset-view-btn" class="tool-btn" title="Reset view">↺</button>
+      <button id="reset-state-btn" class="tool-btn" title="Return meshes to default state">⌂</button>
+      <div class="view-gizmo" title="View orientation">
+        <button id="front-view-btn">F</button><button id="back-view-btn">B</button>
+        <button id="left-view-btn">L</button><button id="right-view-btn">R</button>
+        <button id="top-view-btn">T</button><button id="bottom-view-btn">D</button>
+      </div>
     </div>
   </div>
 </div>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -43,11 +43,7 @@
       <button id="frame-btn" class="tool-btn" title="Frame model">⌖</button>
       <button id="reset-view-btn" class="tool-btn" title="Reset view">↺</button>
       <button id="reset-state-btn" class="tool-btn" title="Return meshes to default state">⌂</button>
-      <div class="view-gizmo" title="View orientation">
-        <button id="front-view-btn">F</button><button id="back-view-btn">B</button>
-        <button id="left-view-btn">L</button><button id="right-view-btn">R</button>
-        <button id="top-view-btn">T</button><button id="bottom-view-btn">D</button>
-      </div>
+      <button id="trackball-btn" class="tool-btn" title="Toggle trackball gizmo">◉</button>
     </div>
   </div>
 </div>
@@ -138,6 +134,9 @@
 <div id="info">Drag to rotate &nbsp;·&nbsp; Scroll to zoom &nbsp;·&nbsp; Right-drag to pan</div>
 
 <div id="footer">
+  <div id="tool-panel-footer">
+    <div id="tool-buttons-footer"></div>
+  </div>
   <span id="app-version">v__APP_VERSION__</span>
   <a id="github-link" href="__REPO_URL__" title="GitHub Repository" target="_blank" rel="noopener noreferrer">
     <svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true">

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -1,8 +1,8 @@
 // Entry point: wires the toolbar and orchestrates loading a mod.
 
-import { fitTo, toggleGrid } from './scene.js';
+import { fitTo, frameView, toggleGrid } from './scene.js';
 import { setTextures } from './mesh-factory.js';
-import { activeMeshes, reset, toggleWireframe, toggleSmoothShading, toggleTextures } from './visibility.js';
+import { activeMeshes, reset, resetToDefaultState, toggleWireframe, toggleSmoothShading, toggleTextures } from './visibility.js';
 import { initSelection, clearSelection } from './selection.js';
 import { buildMeshPanel } from './mesh-panel.js';
 import { buildTogglePanel } from './toggle-panel.js';
@@ -179,6 +179,12 @@ $('wire-btn').addEventListener('click', toggleWireframe);
 $('grid-btn').addEventListener('click', toggleGrid);
 $('shading-btn').addEventListener('click', toggleSmoothShading);
 $('texture-btn').addEventListener('click', toggleTextures);
+$('frame-btn').addEventListener('click', () => frameView('perspective', activeMeshes));
+for (const view of ['front', 'back', 'left', 'right', 'top', 'bottom']) {
+  $(`${view}-view-btn`).addEventListener('click', () => frameView(view, activeMeshes));
+}
+$('reset-view-btn').addEventListener('click', () => frameView('perspective', activeMeshes));
+$('reset-state-btn').addEventListener('click', resetToDefaultState);
 initSelection();
 
 // Collapses a panel's body when its header is clicked.

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -1,6 +1,6 @@
 // Entry point: wires the toolbar and orchestrates loading a mod.
 
-import { fitTo, frameView, toggleGrid } from './scene.js';
+import { fitTo, frameView, toggleGrid, toggleTrackballGizmo } from './scene.js';
 import { setTextures } from './mesh-factory.js';
 import { activeMeshes, reset, resetToDefaultState, toggleWireframe, toggleSmoothShading, toggleTextures } from './visibility.js';
 import { initSelection, clearSelection } from './selection.js';
@@ -72,7 +72,7 @@ function displayMeshPayload(payload) {
 
   lastToggles = payload.__toggles__ || {};
   setTextures(payload.__textures__);
-  buildMeshPanel(payload);
+  buildMeshPanel(payload, payload.__mesh_names__ || {}, currentModPath);
   buildTogglePanel(payload.__toggles__, { modPath: currentModPath, onChange: reloadCurrentMod });
   buildMenuPanel(payload.__menu__);
   fitTo(activeMeshes);
@@ -179,11 +179,9 @@ $('wire-btn').addEventListener('click', toggleWireframe);
 $('grid-btn').addEventListener('click', toggleGrid);
 $('shading-btn').addEventListener('click', toggleSmoothShading);
 $('texture-btn').addEventListener('click', toggleTextures);
-$('frame-btn').addEventListener('click', () => frameView('perspective', activeMeshes));
-for (const view of ['front', 'back', 'left', 'right', 'top', 'bottom']) {
-  $(`${view}-view-btn`).addEventListener('click', () => frameView(view, activeMeshes));
-}
-$('reset-view-btn').addEventListener('click', () => frameView('perspective', activeMeshes));
+$('frame-btn').addEventListener('click', () => frameView(activeMeshes));
+$('reset-view-btn').addEventListener('click', () => frameView(activeMeshes));
+$('trackball-btn').addEventListener('click', toggleTrackballGizmo);
 $('reset-state-btn').addEventListener('click', resetToDefaultState);
 initSelection();
 

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -109,7 +109,9 @@ function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
   cb.checked = true;
   cb.addEventListener('change', () => {
     mesh.userData.manualVisible = cb.checked;
+    mesh.userData.manuallyToggled = true;
     applyMeshVisibility(mesh);
+    updateStateIndicator(mesh, state);
     const any = itemCbs.some(c => c.checked);
     const all = itemCbs.every(c => c.checked);
     masterCb.indeterminate = any && !all;
@@ -120,7 +122,27 @@ function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
   const label = entry.drawindexed
     ? entry.drawindexed.join(', ')
     : '#' + name.slice(groupName.length + 1);
-  row.append(cb, document.createTextNode(label));
+  const state = document.createElement('span');
+  state.className = 'mesh-state';
+  mesh.userData.stateIndicator = state;
+  const labelSpan = document.createElement('span');
+  labelSpan.className = 'mesh-label';
+  labelSpan.textContent = mesh.userData.displayName || label;
+  row.append(state, cb, labelSpan);
+  const updateStateIndicator = (m, indicator) => {
+    indicator.textContent = m.userData.manuallyToggled ? (m.visible ? '✅' : '🟨') : (m.visible ? '✅' : '🟥');
+    indicator.title = m.userData.manuallyToggled ? 'Manually toggled in the viewer' : (m.visible ? 'Visible by default' : 'Hidden by the mod default state');
+  };
+  updateStateIndicator(mesh, state);
+  labelSpan.title = 'Double-click to rename this mesh in the viewer';
+  labelSpan.addEventListener('dblclick', (e) => {
+    e.stopPropagation();
+    const next = window.prompt('Mesh name:', labelSpan.textContent);
+    if (next && next.trim()) {
+      mesh.userData.displayName = next.trim();
+      labelSpan.textContent = mesh.userData.displayName;
+    }
+  });
 
   mesh.userData.row = row;
   row.addEventListener('click', (e) => {

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -104,14 +104,17 @@ function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
   const row = document.createElement('div');
   row.className = 'draw-item';
 
-  const cb = document.createElement('input');
-  cb.type = 'checkbox';
+  const cb = document.createElement('button');
+  cb.type = 'button';
+  cb.className = 'mesh-state-btn';
   cb.checked = true;
-  cb.addEventListener('change', () => {
+  cb.addEventListener('click', (e) => {
+    e.stopPropagation();
+    cb.checked = !mesh.visible;
     mesh.userData.manualVisible = cb.checked;
     mesh.userData.manuallyToggled = true;
     applyMeshVisibility(mesh);
-    updateStateIndicator(mesh, state);
+    updateStateIndicator(mesh);
     const any = itemCbs.some(c => c.checked);
     const all = itemCbs.every(c => c.checked);
     masterCb.indeterminate = any && !all;
@@ -122,18 +125,16 @@ function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
   const label = entry.drawindexed
     ? entry.drawindexed.join(', ')
     : '#' + name.slice(groupName.length + 1);
-  const state = document.createElement('span');
-  state.className = 'mesh-state';
-  mesh.userData.stateIndicator = state;
   const labelSpan = document.createElement('span');
   labelSpan.className = 'mesh-label';
   labelSpan.textContent = mesh.userData.displayName || label;
-  row.append(state, cb, labelSpan);
-  const updateStateIndicator = (m, indicator) => {
-    indicator.textContent = m.userData.manuallyToggled ? (m.visible ? '✅' : '🟨') : (m.visible ? '✅' : '🟥');
-    indicator.title = m.userData.manuallyToggled ? 'Manually toggled in the viewer' : (m.visible ? 'Visible by default' : 'Hidden by the mod default state');
+  row.append(cb, labelSpan);
+  const updateStateIndicator = (m) => {
+    cb.textContent = m.userData.manuallyToggled ? (m.visible ? '✅' : '🟨') : (m.visible ? '✅' : '🟥');
+    cb.title = m.userData.manuallyToggled ? 'Manually toggled in the viewer' : (m.visible ? 'Visible by default' : 'Hidden by the mod default state');
   };
-  updateStateIndicator(mesh, state);
+  mesh.userData.updateStateIndicator = updateStateIndicator;
+  updateStateIndicator(mesh);
   labelSpan.title = 'Double-click to rename this mesh in the viewer';
   labelSpan.addEventListener('dblclick', (e) => {
     e.stopPropagation();
@@ -141,12 +142,16 @@ function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
     if (next && next.trim()) {
       mesh.userData.displayName = next.trim();
       labelSpan.textContent = mesh.userData.displayName;
+      mesh.userData.meshNames[name] = mesh.userData.displayName;
+      if (mesh.userData.modPath) {
+        window.pywebview.api.save_mesh_names(mesh.userData.modPath, mesh.userData.meshNames);
+      }
     }
   });
 
   mesh.userData.row = row;
   row.addEventListener('click', (e) => {
-    if (e.target === cb) return; // the checkbox only ever toggles visibility
+    if (e.target === cb) return; // the state button only ever toggles visibility
     selectMesh(mesh);
   });
 
@@ -154,7 +159,7 @@ function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
 }
 
 /** Build the panel and add every mesh in the payload to the scene. */
-export function buildMeshPanel(payload) {
+export function buildMeshPanel(payload, meshNames = {}, modPath = null) {
   const list = document.getElementById('mesh-list');
   list.innerHTML = '';
 
@@ -175,6 +180,9 @@ export function buildMeshPanel(payload) {
       const itemCbs = [], itemObjs = [];
       for (const name of names) {
         const mesh = buildMesh(name, payload[name]);
+        mesh.userData.displayName = meshNames[name] || null;
+        mesh.userData.meshNames = meshNames;
+        mesh.userData.modPath = modPath;
         addMesh(mesh, payload[name].conditions, payload[name].sources, payload[name].texture_variants);
         itemObjs.push(mesh);
         itemsWrap.appendChild(buildDrawRow(name, groupName, payload[name], mesh, itemCbs, masterCb));
@@ -186,7 +194,9 @@ export function buildMeshPanel(payload) {
         itemCbs.forEach((c, i) => {
           c.checked = v;
           itemObjs[i].userData.manualVisible = v;
+          itemObjs[i].userData.manuallyToggled = true;
           applyMeshVisibility(itemObjs[i]);
+          itemObjs[i].userData.updateStateIndicator?.(itemObjs[i]);
         });
       });
 

--- a/src/web/js/payload.js
+++ b/src/web/js/payload.js
@@ -1,4 +1,4 @@
 // Keys reserved by the payload for non-mesh data. Kept in one place because
 // both the mesh panel and the loader need to skip them.
 // Mirrors RESERVED_KEYS in app/mod_loader.py.
-export const RESERVED_KEYS = ['__textures__', '__toggles__', '__menu__'];
+export const RESERVED_KEYS = ['__textures__', '__toggles__', '__menu__', '__mesh_names__'];

--- a/src/web/js/scene.js
+++ b/src/web/js/scene.js
@@ -2,7 +2,7 @@
 // *rendering* rather than about the mod being displayed.
 
 import * as THREE from 'three';
-import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { ArcballControls } from 'three/addons/controls/ArcballControls.js';
 
 const container = document.getElementById('canvas-container');
 
@@ -27,10 +27,11 @@ export const camera = new THREE.PerspectiveCamera(
   45, container.clientWidth / container.clientHeight, 0.001, 1000);
 camera.position.set(0, 1, 3);
 
-export const controls = new OrbitControls(camera, renderer.domElement);
+export const controls = new ArcballControls(camera, renderer.domElement, scene);
 controls.target.set(0, 0, 0);
-controls.enableDamping = true;
-controls.dampingFactor = 0.08;
+controls.enableAnimations = true;
+controls.setGizmosVisible(false);
+let trackballGizmoVisible = false;
 
 new ResizeObserver(() => {
   camera.aspect = container.clientWidth / container.clientHeight;
@@ -49,7 +50,14 @@ export function toggleGrid() {
   document.getElementById('grid-btn').classList.toggle('off', !grid.visible);
 }
 
-export function frameView(direction = 'perspective', meshes = []) {
+export function toggleTrackballGizmo() {
+  const visible = !trackballGizmoVisible;
+  trackballGizmoVisible = visible;
+  controls.setGizmosVisible(visible);
+  document.getElementById('trackball-btn').classList.toggle('active', visible);
+}
+
+export function frameView(meshes = []) {
   const box = new THREE.Box3();
   meshes.forEach(m => box.expandByObject(m));
   if (box.isEmpty()) return;
@@ -57,8 +65,8 @@ export function frameView(direction = 'perspective', meshes = []) {
   const center = box.getCenter(new THREE.Vector3());
   const radius = Math.max(size.length() * 0.5, 0.001);
   const distance = radius / Math.tan(THREE.MathUtils.degToRad(camera.fov * 0.5)) * 1.15;
-  const directions = { front:[0,.08,1], back:[0,.08,-1], left:[-1,.08,0], right:[1,.08,0], top:[0,1,0], bottom:[0,-1,0], perspective:[.3,.5,1] };
-  const offset = new THREE.Vector3(...(directions[direction] || directions.perspective)).normalize();
+  const offset = camera.position.clone().sub(controls.target).normalize();
+  if (offset.lengthSq() < 0.01) offset.set(.3, .5, 1).normalize();
   controls.target.copy(center);
   camera.position.copy(center).addScaledVector(offset, distance);
   camera.near = radius * 0.001;
@@ -89,5 +97,5 @@ export function fitTo(meshes) {
   camera.far  = size * 50;
   camera.updateProjectionMatrix();
 
-  frameView('perspective', meshes);
+  frameView(meshes);
 }

--- a/src/web/js/scene.js
+++ b/src/web/js/scene.js
@@ -28,7 +28,7 @@ export const camera = new THREE.PerspectiveCamera(
 camera.position.set(0, 1, 3);
 
 export const controls = new OrbitControls(camera, renderer.domElement);
-controls.target.set(0, 0.9, 0);
+controls.target.set(0, 0, 0);
 controls.enableDamping = true;
 controls.dampingFactor = 0.08;
 
@@ -47,6 +47,24 @@ new ResizeObserver(() => {
 export function toggleGrid() {
   grid.visible = !grid.visible;
   document.getElementById('grid-btn').classList.toggle('off', !grid.visible);
+}
+
+export function frameView(direction = 'perspective', meshes = []) {
+  const box = new THREE.Box3();
+  meshes.forEach(m => box.expandByObject(m));
+  if (box.isEmpty()) return;
+  const size = box.getSize(new THREE.Vector3());
+  const center = box.getCenter(new THREE.Vector3());
+  const radius = Math.max(size.length() * 0.5, 0.001);
+  const distance = radius / Math.tan(THREE.MathUtils.degToRad(camera.fov * 0.5)) * 1.15;
+  const directions = { front:[0,.08,1], back:[0,.08,-1], left:[-1,.08,0], right:[1,.08,0], top:[0,1,0], bottom:[0,-1,0], perspective:[.3,.5,1] };
+  const offset = new THREE.Vector3(...(directions[direction] || directions.perspective)).normalize();
+  controls.target.copy(center);
+  camera.position.copy(center).addScaledVector(offset, distance);
+  camera.near = radius * 0.001;
+  camera.far = Math.max(radius * 100, 100);
+  camera.updateProjectionMatrix();
+  controls.update();
 }
 
 /** Frame the camera and size the grid to the given meshes. */
@@ -71,8 +89,5 @@ export function fitTo(meshes) {
   camera.far  = size * 50;
   camera.updateProjectionMatrix();
 
-  controls.target.copy(center);
-  camera.position.copy(center).addScaledVector(
-    new THREE.Vector3(0.3, 0.5, 1).normalize(), size * 1.5);
-  controls.update();
+  frameView('perspective', meshes);
 }

--- a/src/web/js/visibility.js
+++ b/src/web/js/visibility.js
@@ -120,10 +120,7 @@ export function syncCheckboxes() {
 }
 
 function updateStateIndicator(mesh) {
-  const indicator = mesh.userData.stateIndicator;
-  if (!indicator) return;
-  indicator.textContent = mesh.userData.manuallyToggled ? (mesh.visible ? '✅' : '🟨') : (mesh.visible ? '✅' : '🟥');
-  indicator.title = mesh.userData.manuallyToggled ? 'Manually toggled in the viewer' : (mesh.visible ? 'Visible by default' : 'Hidden by the mod default state');
+  mesh.userData.updateStateIndicator?.(mesh);
 }
 
 // Re-baseline manualVisible to match the current Toggle panel state, then sync

--- a/src/web/js/visibility.js
+++ b/src/web/js/visibility.js
@@ -34,6 +34,8 @@ export function reset() {
 
 export function addMesh(mesh, conditions, sources, textureVariants) {
   mesh.userData.manualVisible = true;
+  mesh.userData.loadedVisible = true;
+  mesh.userData.manuallyToggled = false;
   mesh.userData.conditions = conditions || [];
   mesh.userData.sources = sources || [];
   mesh.userData.textureVariants = textureVariants || [];
@@ -93,17 +95,35 @@ export function applyMeshVisibility(mesh) {
   mesh.visible = mesh.userData.manualVisible !== false;
 }
 
+export function resetToDefaultState() {
+  activeMeshes.forEach(mesh => {
+    mesh.userData.manuallyToggled = false;
+    mesh.userData.manualVisible = mesh.userData.loadedVisible !== false;
+  });
+  refreshAll();
+}
+
 // Reflect each mesh's actual visibility back onto its MESHES checkbox, so
 // cycling a Toggle value visibly checks/unchecks the affected items and
 // updates each group's master checkbox.
 export function syncCheckboxes() {
   groupsUI.forEach(({ masterCb, itemCbs, itemObjs }) => {
-    itemObjs.forEach((mesh, i) => { itemCbs[i].checked = mesh.visible; });
+    itemObjs.forEach((mesh, i) => {
+      itemCbs[i].checked = mesh.visible;
+      updateStateIndicator(mesh);
+    });
     const any = itemCbs.some(c => c.checked);
     const all = itemCbs.every(c => c.checked);
     masterCb.checked = all;
     masterCb.indeterminate = any && !all;
   });
+}
+
+function updateStateIndicator(mesh) {
+  const indicator = mesh.userData.stateIndicator;
+  if (!indicator) return;
+  indicator.textContent = mesh.userData.manuallyToggled ? (mesh.visible ? '✅' : '🟨') : (mesh.visible ? '✅' : '🟥');
+  indicator.title = mesh.userData.manuallyToggled ? 'Manually toggled in the viewer' : (mesh.visible ? 'Visible by default' : 'Hidden by the mod default state');
 }
 
 // Re-baseline manualVisible to match the current Toggle panel state, then sync
@@ -118,6 +138,10 @@ export function refreshAll() {
       mesh.userData.manualVisible = conditionsSatisfied(mesh);
     }
     applyMeshVisibility(mesh);
+    if (!mesh.userData.defaultCaptured) {
+      mesh.userData.loadedVisible = mesh.visible;
+      mesh.userData.defaultCaptured = true;
+    }
     applyTextureVariant(mesh);
   });
   syncCheckboxes();


### PR DESCRIPTION
## What changed\n\n- Frame loaded models from their actual bounds and orbit around the model center.\n- Add front, back, left, right, top, bottom, frame, reset-view, and reset-state controls.\n- Add viewer-side mesh renaming by double-clicking a mesh label.\n- Distinguish default-hidden meshes from meshes manually toggled off.\n- Add an optional MCP companion exposing mod inspection and staged toggle authoring/export operations.\n\n## Validation\n\n- Python syntax compilation passed.\n- JavaScript syntax checks passed for the changed modules.\n- Git diff whitespace validation passed.\n\nMesh renaming is intentionally viewer-only in this first pass; it does not rewrite INI section names.