### PR TITLE
Fix/refactor frontend

### DIFF
--- a/context.md
+++ b/context.md
@@ -312,8 +312,11 @@ hashes changed—installing PyInstaller from sdist alone does not rebuild it.
   `exitRecordingUI()` calls the item’s `describe()` closure to restore its label.
 - Mesh and Toggle panels share `source` grouping: subfolder name, root INI stem,
   or `None` for one INI. Stamp it on groups and payload entries.
-- `#sidebar` and `#tool-panel` share the flex `#left-dock`; do not restore fixed
-  pixel offsets. Tool buttons remain available before load.
+- `#sidebar` participates in the flex `#left-dock` layout. `#tool-panel` remains
+  nested under `#left-dock` for ownership but is intentionally viewport-anchored:
+  center it horizontally and keep it above the fixed `#footer` with responsive
+  clearance. Tool buttons remain available before load; do not move Tools into
+  the dock flow or restore an old fixed-pixel dock offset.
 - The trackball button controls custom `#view-gizmo`. Take pointer capture only
   after drag threshold so click-to-snap works; reorder SVG axes only when depth
   order changes or pressed nodes lose clicks.

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -70,6 +70,25 @@ def _payload(label="A"):
     }
 
 
+def _construction_failure_payload():
+    payload = _payload("Broken")
+    payload["textures"] = {
+        "diffuse::Broken-one.png":
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLkWQAAAABJRU5ErkJggg==",
+    }
+    # Keep one valid mesh first so the frontend has already allocated scene,
+    # material and texture state when the next mesh construction fails.
+    payload["meshes"]["Broken-after-first"] = {
+        "component": "Broken after",
+        "drawindexed": [3, 0, 0],
+        "pos": "!",  # invalid base64: decodeF32 must reject this buffer
+        "idx": _u32(0, 1, 2),
+        "conditions": [],
+        "sources": [{"ini": "Broken.ini", "line": 20}],
+    }
+    return payload
+
+
 def _state_sync_payload():
     payload = _payload("Sync")
     payload["controls"]["menu"]["sibling"] = {
@@ -214,8 +233,38 @@ def test_failed_mod_switch_clears_previous_ui_and_pending_state(
         assert page.locator("#toggle-list .toggle-item").count() == 0
         assert page.locator("#menu-list .menu-item").count() == 0
         assert page.locator("#present-list .toggle-item").count() == 0
+        assert not page.locator("#sidebar").is_visible()
+        assert not page.locator("#camera-panel").is_visible()
         assert page.locator("#pending-indicator.show").count() == 0
         assert page.locator("#export-btn").is_disabled()
+        assert page.locator("#mod-path").inner_text() == "B"
+        assert not page.locator("#ini-view-btn").is_disabled()
+        page.locator("#dialog-ok").click()
+    finally:
+        context.close()
+
+
+def test_frontend_construction_failure_rolls_back_partial_scene(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"A": _payload("A"), "B": _construction_failure_payload()},
+        pending={"A": True, "B": False},
+    )
+    try:
+        _open(page, "A")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("window.__fakeApi.pending.A = false")
+
+        _open(page, "B")
+        page.locator("#dialog-backdrop.show").wait_for()
+        assert page.locator(".draw-item").count() == 0
+        assert page.locator("#mesh-list").inner_text() == ""
+        assert not page.locator("#sidebar").is_visible()
+        assert not page.locator("#camera-panel").is_visible()
+        assert not page.locator("#toggle-panel").is_visible()
+        assert not page.locator("#menu-panel").is_visible()
+        assert not page.locator("#present-panel").is_visible()
         assert page.locator("#mod-path").inner_text() == "B"
         assert not page.locator("#ini-view-btn").is_disabled()
         page.locator("#dialog-ok").click()
@@ -286,7 +335,22 @@ def test_tool_panel_is_in_left_dock_and_available_before_load(edge_browser, fron
     context, page = _page(edge_browser, frontend_url, {})
     try:
         assert page.evaluate("document.querySelector('#tool-panel').parentElement.id") == "left-dock"
-        assert page.evaluate("getComputedStyle(document.querySelector('#tool-panel')).position") != "fixed"
+        placement = page.evaluate("""
+          () => {
+            const panel = document.querySelector('#tool-panel');
+            const footer = document.querySelector('#footer').getBoundingClientRect();
+            const rect = panel.getBoundingClientRect();
+            return {
+              position: getComputedStyle(panel).position,
+              center: rect.left + rect.width / 2,
+              viewportCenter: window.innerWidth / 2,
+              aboveFooter: rect.bottom < footer.top,
+            };
+          }
+        """)
+        assert placement["position"] == "fixed"
+        assert abs(placement["center"] - placement["viewportCenter"]) < 1
+        assert placement["aboveFooter"]
         assert page.locator("#tool-panel").is_visible()
         assert page.locator("#tool-buttons .tool-btn").count() == 6
     finally:

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -69,6 +69,36 @@ def _payload(label="A"):
     }
 
 
+def _state_sync_payload():
+    payload = _payload("Sync")
+    payload["controls"]["menu"]["sibling"] = {
+        "name": "Sibling", "slot": 2, "var": "sibling",
+        "default": "0", "values": ["0", "1"], "effects": [],
+    }
+    payload["controls"]["menu"]["menu"]["effects"] = [
+        {"var": "sibling", "value": "1"},
+    ]
+    payload["controls"]["present"] = {
+        "target_inis": [],
+        "item": {
+            "key": "p", "back": "", "count": 2, "names": ["Base", "Alt"],
+            "vars": [
+                {"var": "toggle", "values": ["0", "1"]},
+                {"var": "menu", "values": ["0", "1"]},
+            ],
+            "capture_vars": ["toggle", "menu"], "missing_inis": [],
+        },
+    }
+    payload["state"] = {
+        "defaults": {"toggle": "0", "menu": "0", "sibling": "0", "shape": "0"},
+        "rules": [{
+            "conditions": [[{"var": "toggle", "value": "1", "negate": False}]],
+            "var": "menu", "value": "1",
+        }],
+    }
+    return payload
+
+
 @pytest.fixture(scope="session")
 def frontend_url():
     if not paths.has_vendored_three():
@@ -203,12 +233,23 @@ def test_record_handler_is_replaced_and_restored(edge_browser, frontend_url):
         _open(page, "A")
         cycle = page.locator("#toggle-list .toggle-cycle-btn")
         cycle.wait_for()
-        page.evaluate("window.__cycleHandler = document.querySelector('#toggle-list .toggle-cycle-btn').onclick")
+        original_label = page.locator("#toggle-list .toggle-value").inner_text()
+        original_state = page.evaluate(
+            "import('./js/visibility.js').then(module => module.getToggleState())")
+        page.evaluate("""
+          () => { window.__cycleHandler = document.querySelector('#toggle-list .toggle-cycle-btn').onclick; }
+        """)
         page.locator("#toggle-list [title^='Record']").click()
         page.locator("#toggle-list .toggle-row.recording").wait_for()
+        recording_state = page.evaluate(
+            "import('./js/visibility.js').then(module => module.getToggleState())")
         assert page.evaluate("window.__cycleHandler !== document.querySelector('#toggle-list .toggle-cycle-btn').onclick")
         page.locator("#toggle-list .toggle-record-cancel").click()
         assert page.evaluate("window.__cycleHandler === document.querySelector('#toggle-list .toggle-cycle-btn').onclick")
+        restored_state = page.evaluate(
+            "import('./js/visibility.js').then(module => module.getToggleState())")
+        assert page.locator("#toggle-list .toggle-value").inner_text() == original_label, (
+            original_state, recording_state, restored_state)
     finally:
         context.close()
 
@@ -220,5 +261,69 @@ def test_tool_panel_is_in_left_dock_and_available_before_load(edge_browser, fron
         assert page.evaluate("getComputedStyle(document.querySelector('#tool-panel')).position") != "fixed"
         assert page.locator("#tool-panel").is_visible()
         assert page.locator("#tool-buttons .tool-btn").count() == 6
+    finally:
+        context.close()
+
+
+def test_control_updates_synchronize_all_current_panels(edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Sync": _state_sync_payload()})
+    try:
+        _open(page, "Sync")
+        page.locator("#present-list .toggle-item").wait_for()
+
+        page.locator("#toggle-list .toggle-cycle-btn").click()
+        assert "toggle=1" in page.locator("#toggle-list .toggle-value").inner_text()
+        menu_values = page.evaluate("""
+          Object.fromEntries([...document.querySelectorAll('#menu-list .menu-item')]
+            .map(item => [item.querySelector('.menu-name').textContent,
+                          item.querySelector('.menu-value').textContent]))
+        """)
+        assert menu_values["Menu"] == "1"
+
+        page.locator("#menu-list .menu-item").filter(has_text="Menu").locator("button").click()
+        menu_values = page.evaluate("""
+          Object.fromEntries([...document.querySelectorAll('#menu-list .menu-item')]
+            .map(item => [item.querySelector('.menu-name').textContent,
+                          item.querySelector('.menu-value').textContent]))
+        """)
+        assert menu_values["Sibling"] == "1"
+
+        page.locator("#present-list .toggle-cycle-btn").click()
+        assert "toggle=0" in page.locator("#toggle-list .toggle-value").inner_text()
+        assert page.locator("#menu-list .menu-item").filter(
+            has_text="Menu").locator(".menu-value").inner_text() == "0"
+    finally:
+        context.close()
+
+
+def test_selection_uses_view_binding_and_reload_replaces_sync_callbacks(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
+    try:
+        _open(page, "A")
+        page.locator(".draw-item").wait_for()
+        page.locator(".group-hdr").click()
+        assert page.locator(".group-items.collapsed").count() == 1
+        page.evaluate("""
+          async () => {
+            const row = document.querySelector('.draw-item');
+            row.scrollIntoView = () => { window.__selectionScrolled = true; };
+            const selection = await import('./js/selection.js');
+            selection.selectMesh(window.modViewer.activeMeshes[0]);
+          }
+        """)
+        assert page.locator(".draw-item.selected").count() == 1
+        assert page.locator(".group-items.collapsed").count() == 0
+        assert page.evaluate("window.__selectionScrolled")
+
+        before = page.evaluate("import('./js/view-sync.js').then(module => module.viewSyncCount())")
+        page.evaluate("window.__oldDrawRow = document.querySelector('.draw-item')")
+        page.evaluate("window.modViewer.reloadCurrentMod()")
+        page.wait_for_function("""
+          document.querySelector('.draw-item') !== window.__oldDrawRow
+            && !document.querySelector('#loading').classList.contains('show')
+        """)
+        after = page.evaluate("import('./js/view-sync.js').then(module => module.viewSyncCount())")
+        assert before == after == 4
     finally:
         context.close()

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -1,6 +1,7 @@
 """Real-server Edge smoke coverage for frontend state transitions."""
 
 import base64
+import copy
 import json
 import struct
 
@@ -99,6 +100,29 @@ def _state_sync_payload():
     return payload
 
 
+def _source_payload():
+    payload = _payload("Source")
+    template = next(iter(payload["meshes"].values()))
+    payload["meshes"] = {}
+    for key, source in [("BodyRoot-0", "Root.ini"),
+                        ("BodyNested-0", "variants/sub"),
+                        ("BodyNested-1", "variants/sub")]:
+        entry = copy.deepcopy(template)
+        entry["component"] = "Body"
+        entry["source"] = source
+        payload["meshes"][key] = entry
+
+    first_toggle = next(iter(payload["controls"]["toggles"].values()))
+    payload["controls"]["toggles"] = {
+        "KeyRoot": {**copy.deepcopy(first_toggle), "name": "Duplicate", "source": "Root.ini"},
+        "KeyNested": {**copy.deepcopy(first_toggle), "name": "Duplicate", "source": "variants/sub"},
+    }
+    menu = payload["controls"]["menu"]
+    menu["menu"]["source"] = "Root.ini"
+    menu["shape"]["source"] = "variants/sub"
+    return payload
+
+
 @pytest.fixture(scope="session")
 def frontend_url():
     if not paths.has_vendored_three():
@@ -140,6 +164,10 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None):
             has_pending_changes: async path => !!state.pending[path],
             discard_changes: async path => { state.pending[path] = false; },
             get_diagnostics: async () => ({summary: {issues: 0, errors: 0}, files: {}, issues: []}),
+            list_toggle_source_inis: async () => [{value: 'A.ini', label: 'A.ini'}],
+            list_ini_files: async () => [{value: 'A.ini', label: 'A.ini', dirty: false}],
+            get_ini_text: async () => ({ini: 'A.ini', text: '[Test]\\nkey = 1\\n', dirty: false}),
+            update_ini_text: async () => ({pending: true}),
             save_mesh_textures: async () => ({}),
             save_mesh_names: async () => ({}),
             pick_texture_file: async () => copy(state.picks.shift() || null),
@@ -325,5 +353,338 @@ def test_selection_uses_view_binding_and_reload_replaces_sync_callbacks(
         """)
         after = page.evaluate("import('./js/view-sync.js').then(module => module.viewSyncCount())")
         assert before == after == 4
+    finally:
+        context.close()
+
+
+def test_view_gizmo_click_drag_wheel_and_keyboard(edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
+    try:
+        _open(page, "A")
+        page.locator(".draw-item").wait_for()
+        page.locator("#view-gizmo .axis-x.positive circle").click()
+        page.wait_for_timeout(240)
+        direction = page.evaluate("""
+          import('./js/scene.js').then(({camera, controls}) =>
+            camera.position.clone().sub(controls.target).normalize().toArray())
+        """)
+        assert direction[0] > 0.98
+
+        capture_count = page.evaluate("""
+          () => {
+            const gizmo = document.querySelector('#view-gizmo');
+            const axis = gizmo.querySelector('.axis-z.positive');
+            window.__gizmoCaptures = 0;
+            gizmo.setPointerCapture = () => { window.__gizmoCaptures += 1; };
+            gizmo.hasPointerCapture = () => false;
+            axis.dispatchEvent(new PointerEvent('pointerdown', {
+              bubbles: true, button: 0, pointerId: 71, clientX: 50, clientY: 50,
+            }));
+            gizmo.dispatchEvent(new PointerEvent('pointermove', {
+              bubbles: true, pointerId: 71, clientX: 51, clientY: 50,
+            }));
+            gizmo.dispatchEvent(new PointerEvent('pointerup', {
+              bubbles: true, pointerId: 71, clientX: 51, clientY: 50,
+            }));
+            return window.__gizmoCaptures;
+          }
+        """)
+        assert capture_count == 0
+        page.wait_for_timeout(240)
+        direction = page.evaluate("""
+          import('./js/scene.js').then(({camera, controls}) =>
+            camera.position.clone().sub(controls.target).normalize().toArray())
+        """)
+        assert direction[2] > 0.98
+
+        drag_result = page.evaluate("""
+          async () => {
+            const {camera} = await import('./js/scene.js');
+            const gizmo = document.querySelector('#view-gizmo');
+            const before = camera.position.toArray();
+            window.__gizmoCaptures = 0;
+            gizmo.setPointerCapture = () => { window.__gizmoCaptures += 1; };
+            gizmo.hasPointerCapture = () => true;
+            gizmo.releasePointerCapture = () => {};
+            gizmo.dispatchEvent(new PointerEvent('pointerdown', {
+              bubbles: true, button: 0, pointerId: 72, clientX: 50, clientY: 50,
+            }));
+            gizmo.dispatchEvent(new PointerEvent('pointermove', {
+              bubbles: true, pointerId: 72, clientX: 64, clientY: 57,
+            }));
+            gizmo.dispatchEvent(new PointerEvent('pointerup', {
+              bubbles: true, pointerId: 72, clientX: 64, clientY: 57,
+            }));
+            return {before, after: camera.position.toArray(), captures: window.__gizmoCaptures};
+          }
+        """)
+        assert drag_result["captures"] == 1
+        assert drag_result["before"] != drag_result["after"]
+        assert page.locator("#view-gizmo.dragging").count() == 0
+
+        distances = page.evaluate("""
+          async () => {
+            const {camera, controls} = await import('./js/scene.js');
+            const before = camera.position.distanceTo(controls.target);
+            document.querySelector('#view-gizmo').dispatchEvent(
+              new WheelEvent('wheel', {bubbles: true, cancelable: true, deltaY: 120}));
+            return [before, camera.position.distanceTo(controls.target)];
+          }
+        """)
+        assert distances[1] > distances[0]
+
+        page.locator("#view-gizmo .axis-y.positive").focus()
+        page.locator("#view-gizmo .axis-y.positive").press("Enter")
+        page.wait_for_timeout(240)
+        direction = page.evaluate("""
+          import('./js/scene.js').then(({camera, controls}) =>
+            camera.position.clone().sub(controls.target).normalize().toArray())
+        """)
+        assert direction[1] > 0.98
+    finally:
+        context.close()
+
+
+def test_key_light_camera_controls_and_narrow_framing(edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
+    try:
+        _open(page, "A")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_timeout(100)
+
+        light_info = page.evaluate("""
+          async () => {
+            const {scene, camera, renderer} = await import('./js/scene.js');
+            const handle = scene.children.find(object => object.isSprite);
+            const light = scene.children.find(object => object.isDirectionalLight);
+            const point = handle.position.clone().project(camera);
+            const rect = renderer.domElement.getBoundingClientRect();
+            return {
+              x: rect.left + (point.x + 1) * rect.width / 2,
+              y: rect.top + (1 - point.y) * rect.height / 2,
+              position: light.position.toArray(),
+            };
+          }
+        """)
+        page.mouse.move(light_info["x"], light_info["y"])
+        assert page.evaluate(
+            "document.querySelector('#canvas-container canvas').style.cursor") == "crosshair"
+        page.mouse.down()
+        page.mouse.move(light_info["x"] + 28, light_info["y"] + 12)
+        page.mouse.up()
+        dragged = page.evaluate("""
+          import('./js/scene.js').then(({scene}) =>
+            scene.children.find(object => object.isDirectionalLight).position.toArray())
+        """)
+        assert dragged != light_info["position"]
+
+        light_info = page.evaluate("""
+          async () => {
+            const {scene, camera, renderer} = await import('./js/scene.js');
+            const handle = scene.children.find(object => object.isSprite);
+            const point = handle.position.clone().project(camera);
+            const rect = renderer.domElement.getBoundingClientRect();
+            return {x: rect.left + (point.x + 1) * rect.width / 2,
+                    y: rect.top + (1 - point.y) * rect.height / 2,
+                    position: handle.position.toArray()};
+          }
+        """)
+        page.keyboard.down("Shift")
+        page.mouse.move(light_info["x"], light_info["y"])
+        page.mouse.down()
+        page.mouse.move(light_info["x"], light_info["y"] - 24)
+        page.mouse.up()
+        page.keyboard.up("Shift")
+        depth_dragged = page.evaluate("""
+          import('./js/scene.js').then(({scene}) =>
+            scene.children.find(object => object.isDirectionalLight).position.toArray())
+        """)
+        assert depth_dragged != light_info["position"]
+
+        occluded = page.evaluate("""
+          async () => {
+            const THREE = await import('three');
+            const {scene, camera, renderer} = await import('./js/scene.js');
+            const handle = scene.children.find(object => object.isSprite);
+            const blocker = new THREE.Mesh(
+              new THREE.PlaneGeometry(100, 100),
+              new THREE.MeshBasicMaterial({side: THREE.DoubleSide}));
+            blocker.position.lerpVectors(camera.position, handle.position, 0.5);
+            blocker.quaternion.copy(camera.quaternion);
+            scene.add(blocker);
+            scene.updateMatrixWorld(true);
+            window.__lightBlocker = blocker;
+            const point = handle.position.clone().project(camera);
+            const rect = renderer.domElement.getBoundingClientRect();
+            return {x: rect.left + (point.x + 1) * rect.width / 2,
+                    y: rect.top + (1 - point.y) * rect.height / 2};
+          }
+        """)
+        page.mouse.move(0, 0)
+        page.mouse.move(occluded["x"], occluded["y"])
+        assert page.evaluate(
+            "document.querySelector('#canvas-container canvas').style.cursor") != "crosshair"
+        page.evaluate("""
+          import('./js/scene.js').then(({scene}) => scene.remove(window.__lightBlocker))
+        """)
+
+        page.locator("#light-btn").click()
+        page.locator("#light-btn").click()
+        off_state = page.evaluate("""
+          import('./js/scene.js').then(({scene}) => ({
+            intensity: scene.children.find(object => object.isDirectionalLight).intensity,
+            visible: scene.children.find(object => object.isSprite).visible,
+          }))
+        """)
+        assert off_state == {"intensity": 0, "visible": False}
+        page.locator("#light-btn").click()
+        before_environment = page.evaluate("""
+          import('./js/scene.js').then(({scene}) =>
+            scene.children.find(object => object.isDirectionalLight).intensity)
+        """)
+        page.evaluate("window.modViewer.setEnvironmentPreset('studio')")
+        page.evaluate("window.modViewer.setEnvironmentPreset('default')")
+        after_environment = page.evaluate("""
+          import('./js/scene.js').then(({scene}) =>
+            scene.children.find(object => object.isDirectionalLight).intensity)
+        """)
+        assert before_environment == after_environment == 1
+
+        home_quaternion = page.evaluate(
+            "window.modViewer.activeMeshes[0].quaternion.toArray()")
+        page.locator("#camera-flip-btn").click()
+        turned = page.evaluate("window.modViewer.activeMeshes[0].quaternion.toArray()")
+        page.locator("#camera-flip-horizontal-btn").click()
+        tilted = page.evaluate("window.modViewer.activeMeshes[0].quaternion.toArray()")
+        assert turned != home_quaternion
+        assert tilted != turned
+        page.locator("#camera-reset-view-btn").click()
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].quaternion.toArray()") == home_quaternion
+
+        page.set_viewport_size({"width": 900, "height": 600})
+        page.evaluate("window.__oldDrawRow = document.querySelector('.draw-item')")
+        page.evaluate("window.modViewer.reloadCurrentMod()")
+        page.wait_for_function("""
+          document.querySelector('.draw-item') !== window.__oldDrawRow
+            && !document.querySelector('#loading').classList.contains('show')
+        """)
+        framing = page.evaluate("""
+          async () => {
+            const THREE = await import('three');
+            const {camera, renderer} = await import('./js/scene.js');
+            const box = new THREE.Box3().setFromObject(window.modViewer.activeMeshes[0]);
+            const projected = box.getCenter(new THREE.Vector3()).project(camera);
+            const canvas = renderer.domElement.getBoundingClientRect();
+            return {
+              x: canvas.left + (projected.x + 1) * canvas.width / 2,
+              left: document.querySelector('#left-dock').getBoundingClientRect().right,
+              right: document.querySelector('#right-dock').getBoundingClientRect().left,
+            };
+          }
+        """)
+        assert framing["left"] < framing["x"] < framing["right"]
+    finally:
+        context.close()
+
+
+def test_source_grouping_and_collapse_are_shared_without_losing_duplicates(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"Single": _payload("Single"), "Sources": _source_payload()},
+    )
+    try:
+        _open(page, "Single")
+        page.locator(".draw-item").wait_for()
+        assert page.locator("#mesh-list .mesh-src-hdr").count() == 0
+        assert page.locator("#toggle-list .toggle-src-hdr").count() == 0
+        assert page.locator("#menu-list .toggle-src-hdr").count() == 0
+
+        page.evaluate("window.__oldDrawRow = document.querySelector('.draw-item')")
+        _open(page, "Sources")
+        page.wait_for_function(
+            "document.querySelector('.draw-item') !== window.__oldDrawRow")
+        expected = ["Root.ini", "variants/sub"]
+        assert page.locator("#mesh-list .mesh-src-hdr .group-name").all_inner_texts() == expected
+        assert page.locator("#toggle-list .toggle-src-hdr .group-name").all_inner_texts() == expected
+        assert page.locator("#menu-list .toggle-src-hdr .group-name").all_inner_texts() == expected
+        assert page.locator("#mesh-list .group-hdr .group-name").all_inner_texts() == ["Body", "Body"]
+        assert page.locator("#toggle-list .toggle-name").all_inner_texts() == ["Duplicate", "Duplicate"]
+
+        first_header = page.locator("#mesh-list .mesh-src-hdr").first
+        first_header.click()
+        assert page.locator("#mesh-list .mesh-src-items.collapsed").count() == 1
+        assert first_header.locator(".group-toggle.collapsed").count() == 1
+        first_header.click()
+        assert page.locator("#mesh-list .mesh-src-items.collapsed").count() == 0
+    finally:
+        context.close()
+
+
+def test_modal_shell_accessibility_and_ace_escape_behavior(edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
+    try:
+        _open(page, "A")
+        page.locator(".draw-item").wait_for()
+
+        page.locator(".group-tex-btn").click()
+        texture_modal = page.locator("#texture-modal-backdrop .modal")
+        assert texture_modal.get_attribute("role") == "dialog"
+        assert texture_modal.get_attribute("aria-modal") == "true"
+        assert texture_modal.get_attribute("aria-labelledby") == "texm-title"
+        page.keyboard.press("Escape")
+        assert page.locator("#texture-modal-backdrop.show").count() == 0
+        page.locator(".group-tex-btn").click()
+        page.locator("#texture-modal-backdrop").dispatch_event("click")
+        assert page.locator("#texture-modal-backdrop.show").count() == 0
+
+        page.locator("#toggle-add-btn").click()
+        page.locator("#toggle-modal-backdrop.show").wait_for()
+        toggle_modal = page.locator("#toggle-modal-backdrop .modal")
+        assert toggle_modal.get_attribute("aria-labelledby") == "tm-title"
+        page.keyboard.press("Escape")
+        assert page.locator("#toggle-modal-backdrop.show").count() == 0
+
+        page.locator("#health-btn").click()
+        page.locator("#health-modal-backdrop.show").wait_for()
+        page.keyboard.press("Escape")
+        assert page.locator("#health-modal-backdrop.show").count() == 0
+
+        page.locator("#ini-view-btn").click()
+        page.locator("#ini-editor-backdrop.show").wait_for()
+        page.evaluate("window.ace.edit(document.querySelector('#ini-editor-text')).focus()")
+        page.keyboard.press("Control+f")
+        page.locator("#ini-editor-text .ace_search").wait_for()
+        page.keyboard.press("Escape")
+        assert page.locator("#ini-editor-backdrop.show").count() == 1
+        assert page.locator("#ini-editor-text .ace_search").is_hidden()
+        page.locator("#ini-editor-close-x").click()
+    finally:
+        context.close()
+
+
+def test_feature_flag_css_keeps_cycle_preview_and_core_invariants(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
+    try:
+        _open(page, "A")
+        page.locator("#toggle-list .toggle-cycle-btn").wait_for()
+        page.evaluate("""
+          document.body.classList.add('feature-export-off', 'feature-modify-toggle-off')
+        """)
+        assert page.locator("#export-btn").is_hidden()
+        assert page.locator("#toggle-add-btn").is_hidden()
+        assert page.locator("#toggle-list .toggle-actions").is_hidden()
+        assert page.locator("#toggle-list .toggle-cycle-btn").is_visible()
+
+        css = (paths.web_dir() + "/css/app.css")
+        with open(css, encoding="utf-8") as handle:
+            source = handle.read().replace(" ", "")
+        assert "#menu-list.image-layout.collapsed{display:none;}" in source
+        with open(paths.web_dir() + "/index.html", encoding="utf-8") as handle:
+            html = handle.read()
+        assert "https://cdn" not in html.lower()
+        assert "http://" not in html.lower()
     finally:
         context.close()

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -1,0 +1,224 @@
+"""Real-server Edge smoke coverage for frontend state transitions."""
+
+import base64
+import json
+import struct
+
+import pytest
+
+from app import paths, server
+
+playwright = pytest.importorskip("playwright.sync_api")
+
+
+def _f32(*values):
+    return base64.b64encode(struct.pack(f"<{len(values)}f", *values)).decode()
+
+
+def _u32(*values):
+    return base64.b64encode(struct.pack(f"<{len(values)}I", *values)).decode()
+
+
+def _payload(label="A"):
+    texture_pool = [
+        {"tex_key": f"diffuse::{label}-one.png", "label": f"{label} one"},
+        {"tex_key": f"diffuse::{label}-two.png", "label": f"{label} two"},
+    ]
+    return {
+        "meshes": {
+            f"Body-{label}-0": {
+                "component": f"Body {label}",
+                "drawindexed": [3, 0, 0],
+                "pos": _f32(0, 0, 0, 1, 0, 0, 0, 1, 0),
+                "idx": _u32(0, 1, 2),
+                "tex_key": texture_pool[0]["tex_key"],
+                "texture_options": texture_pool,
+                "texture_variants": [{
+                    "conditions": [[{"var": "menu", "value": "1", "negate": False}]],
+                    "tex_key": texture_pool[1]["tex_key"],
+                }],
+                "shape_targets": [{
+                    "var": "shape",
+                    "pos": _f32(0, 0, 0, 1.2, 0, 0, 0, 1.2, 0),
+                }],
+                "conditions": [],
+                "sources": [{"ini": f"{label}.ini", "line": 10}],
+            },
+        },
+        "textures": {},
+        "controls": {
+            "toggles": {
+                f"Key{label}": {
+                    "name": f"Toggle {label}", "ini": f"{label}.ini",
+                    "section": f"Key{label}", "wired": True,
+                    "vars": [{"var": "toggle", "default": "0", "values": ["0", "1"]}],
+                },
+            },
+            "menu": {
+                "menu": {"name": "Menu", "slot": 1, "var": "menu",
+                         "default": "0", "values": ["0", "1"], "effects": []},
+                "shape": {"name": "Shape", "var": "shape", "kind": "shape_slider",
+                          "default": "0", "min": "0", "max": "1", "step": "0.1"},
+            },
+            "present": {"target_inis": []},
+        },
+        "state": {"rules": [], "defaults": {"toggle": "0", "menu": "0", "shape": "0"}},
+        "geometry": None,
+        "metadata": {"mesh_names": {}},
+        "health": {"summary": {"issues": 0, "errors": 0}, "files": {}, "issues": []},
+    }
+
+
+@pytest.fixture(scope="session")
+def frontend_url():
+    if not paths.has_vendored_three():
+        pytest.skip("frontend smoke tests require the vendored Three.js assets")
+    return server.start()
+
+
+@pytest.fixture(scope="session")
+def edge_browser():
+    with playwright.sync_playwright() as runtime:
+        try:
+            browser = runtime.chromium.launch(channel="msedge", headless=True)
+        except playwright.Error as error:
+            pytest.skip(f"installed Edge is required for frontend smoke tests: {error}")
+        yield browser
+        browser.close()
+
+
+def _page(edge_browser, frontend_url, responses, pending=None, picks=None):
+    context = edge_browser.new_context()
+    state = {
+        "responses": responses,
+        "pending": pending or {},
+        "picks": picks or [],
+    }
+    encoded_state = json.dumps(json.dumps(state))
+    context.add_init_script(
+        """
+        {
+          const state = window.__fakeApi = JSON.parse(__STATE__);
+          const copy = value => value == null ? value : structuredClone(value);
+          window.pywebview = { api: {
+            select_folder: async () => {
+              const path = state.nextPath || null;
+              state.nextPath = null;
+              return path;
+            },
+            load_mod: async path => copy(state.responses[path]),
+            has_pending_changes: async path => !!state.pending[path],
+            discard_changes: async path => { state.pending[path] = false; },
+            get_diagnostics: async () => ({summary: {issues: 0, errors: 0}, files: {}, issues: []}),
+            save_mesh_textures: async () => ({}),
+            save_mesh_names: async () => ({}),
+            pick_texture_file: async () => copy(state.picks.shift() || null),
+            load_texture_file: async (path, key) => ({tex_key: key, uri: ''}),
+            get_record_positions: async () => ({positions: 2, vars: ['toggle']}),
+          }};
+        }
+        """.replace("__STATE__", encoded_state),
+    )
+    page = context.new_page()
+    page.goto(frontend_url)
+    page.wait_for_function("window.modViewer !== undefined")
+    return context, page
+
+
+def _open(page, path):
+    page.evaluate("path => { window.__fakeApi.nextPath = path; }", path)
+    page.locator("#open-btn").click()
+
+
+@pytest.mark.parametrize("failed_payload", [
+    {"error": "loader failed", "health": {"summary": {"issues": 1, "errors": 1}}},
+    {"meshes": {}, "textures": {}, "controls": {}, "state": {},
+     "geometry": {"url": "/geometry/missing", "length": 12}},
+], ids=["loader-error", "geometry-error"])
+def test_failed_mod_switch_clears_previous_ui_and_pending_state(
+        edge_browser, frontend_url, failed_payload):
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"A": _payload("A"), "B": failed_payload},
+        pending={"A": True, "B": False},
+    )
+    try:
+        _open(page, "A")
+        page.locator(".draw-item").wait_for()
+        page.locator("#pending-indicator.show").wait_for()
+        # Keep the visible indicator stale while allowing the switch itself
+        # to proceed without the discard-confirmation dialog.
+        page.evaluate("window.__fakeApi.pending.A = false")
+
+        _open(page, "B")
+        page.locator("#dialog-backdrop.show").wait_for()
+        assert page.locator(".draw-item").count() == 0
+        assert page.locator("#toggle-list .toggle-item").count() == 0
+        assert page.locator("#menu-list .menu-item").count() == 0
+        assert page.locator("#present-list .toggle-item").count() == 0
+        assert page.locator("#pending-indicator.show").count() == 0
+        assert page.locator("#export-btn").is_disabled()
+        assert page.locator("#mod-path").inner_text() == "B"
+        assert not page.locator("#ini-view-btn").is_disabled()
+        page.locator("#dialog-ok").click()
+    finally:
+        context.close()
+
+
+def test_texture_rows_are_reused_for_control_changes_and_rebuilt_for_pool_changes(
+        edge_browser, frontend_url):
+    pick = {
+        "tex_key": "diffuse::added.png", "file": "added.png", "uri":
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLkWQAAAABJRU5ErkJggg==",
+    }
+    context, page = _page(edge_browser, frontend_url, {"A": _payload("A")}, picks=[pick])
+    try:
+        _open(page, "A")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("window.__textureRows = [...document.querySelectorAll('.tex-item')]")
+
+        page.locator("#toggle-list .toggle-cycle-btn").click()
+        assert page.evaluate("window.__textureRows.every((row, i) => row === document.querySelectorAll('.tex-item')[i])")
+        page.locator("#menu-list .toggle-cycle-btn").click()
+        assert page.evaluate("window.__textureRows.every((row, i) => row === document.querySelectorAll('.tex-item')[i])")
+        page.locator("#menu-list .menu-slider").evaluate(
+            "input => { input.value = '0.5'; input.dispatchEvent(new Event('input', {bubbles: true})); }")
+        assert page.evaluate("window.__textureRows.every((row, i) => row === document.querySelectorAll('.tex-item')[i])")
+
+        page.locator(".group-tex-btn").click()
+        page.locator("#texm-add").click()
+        page.wait_for_function("document.querySelectorAll('.tex-item').length === 3")
+        assert not page.evaluate("window.__textureRows[0] === document.querySelector('.tex-item')")
+        page.evaluate("window.__textureRows = [...document.querySelectorAll('.tex-item')]")
+        page.locator(".texm-row .toggle-icon-btn").last.click()
+        page.wait_for_function("document.querySelectorAll('.tex-item').length === 2")
+        assert not page.evaluate("window.__textureRows[0] === document.querySelector('.tex-item')")
+    finally:
+        context.close()
+
+
+def test_record_handler_is_replaced_and_restored(edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
+    try:
+        _open(page, "A")
+        cycle = page.locator("#toggle-list .toggle-cycle-btn")
+        cycle.wait_for()
+        page.evaluate("window.__cycleHandler = document.querySelector('#toggle-list .toggle-cycle-btn').onclick")
+        page.locator("#toggle-list [title^='Record']").click()
+        page.locator("#toggle-list .toggle-row.recording").wait_for()
+        assert page.evaluate("window.__cycleHandler !== document.querySelector('#toggle-list .toggle-cycle-btn').onclick")
+        page.locator("#toggle-list .toggle-record-cancel").click()
+        assert page.evaluate("window.__cycleHandler === document.querySelector('#toggle-list .toggle-cycle-btn').onclick")
+    finally:
+        context.close()
+
+
+def test_tool_panel_is_in_left_dock_and_available_before_load(edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {})
+    try:
+        assert page.evaluate("document.querySelector('#tool-panel').parentElement.id") == "left-dock"
+        assert page.evaluate("getComputedStyle(document.querySelector('#tool-panel')).position") != "fixed"
+        assert page.locator("#tool-panel").is_visible()
+        assert page.locator("#tool-buttons .tool-btn").count() == 6
+    finally:
+        context.close()

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -151,7 +151,7 @@ body {
 /* ── left dock (meshes panel + toolbox) ──────────────────────────────────── */
 #left-dock {
   position: fixed; top: 58px; left: 12px; z-index: 110;
-  display: flex; flex-direction: column; align-items: flex-start; gap: 10px;
+  display: flex; flex-direction: row; align-items: flex-start; gap: 10px;
   max-height: calc(100vh - 104px);
 }
 
@@ -213,7 +213,7 @@ body {
 }
 
 /* ── toolbox (wireframe / grid) ───────────────────────────────────────────── */
-#tool-panel { display: block; min-width: 166px; padding: 9px 10px; }
+#tool-panel { display: block; min-width: 166px; padding: 9px 10px; position: fixed; left: 50%; transform: translateX(-50%); bottom: calc(28px + 12px); z-index: 200; }
 #tool-panel .panel-hdr { margin-bottom: 7px; }
 #tool-buttons { display: flex; align-items: center; gap: 6px; }
 #tool-buttons.collapsed { display: none; }

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -196,7 +196,8 @@ body {
 }
 
 /* ── toolbox (wireframe / grid) ───────────────────────────────────────────── */
-#tool-panel { position: fixed; left: 50%; bottom: 34px; transform: translateX(-50%); z-index: 200; display: flex !important; align-items: center; gap: 8px; background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 4px 8px; }
+#tool-panel { display: block; min-width: 166px; padding: 9px 10px; }
+#tool-panel .panel-hdr { margin-bottom: 7px; }
 #tool-buttons { display: flex; align-items: center; gap: 6px; }
 #tool-buttons.collapsed { display: none; }
 #camera-buttons.collapsed { display: none; }

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -1,6 +1,21 @@
+:root {
+  --bg-canvas: #0d1117;
+  --bg-panel: #161b22;
+  --bg-control: #21262d;
+  --border: #30363d;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --accent: #1f6feb;
+  --accent-hover: #388bfd;
+  --accent-soft: #58a6ff;
+  --success: #238636;
+  --success-hover: #2ea043;
+  --warning: #e3b341;
+  --danger: #f85149;
+}
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 body {
-  background: #0d1117; color: #e6edf3;
+  background: var(--bg-canvas); color: var(--text);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   overflow: hidden; user-select: none;
 }
@@ -8,25 +23,25 @@ body {
 /* ── toolbar ─────────────────────────────────────────────────────────────── */
 #toolbar {
   position: fixed; top: 0; left: 0; right: 0; height: 46px;
-  background: #161b22; border-bottom: 1px solid #30363d;
+  background: var(--bg-panel); border-bottom: 1px solid var(--border);
   display: flex; align-items: center; padding: 0 14px; gap: 10px; z-index: 100;
 }
 .app-icon  { font-size: 18px; }
-.app-title { font-size: 13px; font-weight: 600; color: #e6edf3; white-space: nowrap; }
+.app-title { font-size: 13px; font-weight: 600; color: var(--text); white-space: nowrap; }
 #mod-path  {
-  flex: 1; font-size: 11px; color: #8b949e;
+  flex: 1; font-size: 11px; color: var(--text-muted);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  padding: 4px 8px; background: #0d1117; border-radius: 6px;
-  border: 1px solid #30363d; min-width: 0;
+  padding: 4px 8px; background: var(--bg-canvas); border-radius: 6px;
+  border: 1px solid var(--border); min-width: 0;
 }
 #open-btn {
-  background: #238636; color: #fff; border: 1px solid rgba(240,246,252,.15);
+  background: var(--success); color: #fff; border: 1px solid rgba(240,246,252,.15);
   border-radius: 6px; padding: 5px 14px; font-size: 13px; cursor: pointer; white-space: nowrap;
 }
-#open-btn:hover:not(:disabled) { background: #2ea043; }
+#open-btn:hover:not(:disabled) { background: var(--success-hover); }
 #open-btn:disabled { opacity: .45; cursor: default; }
 .pending-indicator {
-  display: none; font-size: 11px; color: #e3b341; background: #2b2111;
+  display: none; font-size: 11px; color: var(--warning); background: #2b2111;
   border: 1px solid #4d3a14; border-radius: 6px; padding: 4px 8px; white-space: nowrap;
 }
 .pending-indicator.show { display: inline-block; }
@@ -37,8 +52,8 @@ body {
 #export-btn:hover:not(:disabled) { background: #bb8009; }
 #export-btn:disabled { opacity: .35; cursor: default; background: #21262d; color: #8b949e; }
 #health-btn {
-  display: flex; align-items: center; gap: 6px; color: #e6edf3;
-  background: #21262d; border: 1px solid #30363d; border-radius: 6px;
+  display: flex; align-items: center; gap: 6px; color: var(--text);
+  background: var(--bg-control); border: 1px solid var(--border); border-radius: 6px;
   padding: 5px 9px; font-size: 12px; cursor: pointer; white-space: nowrap;
 }
 #health-btn:disabled { opacity: .4; cursor: default; }
@@ -47,11 +62,11 @@ body {
 #health-btn.error { border-color: #da3633; background: #321b1b; }
 .ini-view-wrap { position: relative; display: flex; align-items: center; }
 #ini-view-btn {
-  background: #1f6feb; color: #fff; border: 1px solid rgba(240,246,252,.15);
+  background: var(--accent); color: #fff; border: 1px solid rgba(240,246,252,.15);
   border-radius: 6px; padding: 5px 14px; font-size: 13px; cursor: pointer;
   white-space: nowrap;
 }
-#ini-view-btn:hover:not(:disabled) { background: #388bfd; }
+#ini-view-btn:hover:not(:disabled) { background: var(--accent-hover); }
 #ini-view-btn:disabled {
   opacity: .35; cursor: default; background: #21262d; color: #8b949e;
 }
@@ -136,7 +151,8 @@ body {
 /* ── left dock (meshes panel + toolbox) ──────────────────────────────────── */
 #left-dock {
   position: fixed; top: 58px; left: 12px; z-index: 110;
-  display: flex; align-items: flex-start; gap: 10px;
+  display: flex; flex-direction: column; align-items: flex-start; gap: 10px;
+  max-height: calc(100vh - 104px);
 }
 
 /* ── right dock (toggle panel + menu panel) ──────────────────────────────── */
@@ -148,12 +164,13 @@ body {
 
 /* ── shared floating panel chrome ────────────────────────────────────────── */
 #sidebar, #camera-panel, #present-panel, #toggle-panel, #tool-panel, #menu-panel {
-  display: none; background: rgba(13,17,23,.88); border: 1px solid #30363d;
+  display: none; background: rgba(13,17,23,.88); border: 1px solid var(--border);
   border-radius: 8px; padding: 10px 14px; backdrop-filter: blur(8px);
 }
 #sidebar {
   box-sizing: border-box; width: 288px; max-width: min(288px, calc(50vw - 36px));
-  max-height: calc(100vh - 104px); overflow-x: hidden; overflow-y: auto;
+  max-height: calc(100vh - 104px); min-height: 0;
+  overflow-x: hidden; overflow-y: auto;
 }
 #camera-panel { min-width: 166px; padding: 9px 10px; }
 #camera-buttons { display: grid; grid-template-columns: repeat(3, 44px); gap: 6px; }
@@ -161,12 +178,12 @@ body {
 .camera-btn {
   width: 44px; height: 46px; padding: 5px 3px 4px;
   display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px;
-  color: #c9d1d9; background: #161b22; border: 1px solid #30363d;
+  color: #c9d1d9; background: var(--bg-panel); border: 1px solid var(--border);
   border-radius: 6px; cursor: pointer; font-family: inherit;
   transition: background .12s, border-color .12s, color .12s, transform .12s;
 }
 .camera-btn:hover {
-  color: #fff; background: #1f6feb; border-color: #388bfd; transform: translateY(-1px);
+  color: #fff; background: var(--accent); border-color: var(--accent-hover); transform: translateY(-1px);
 }
 .camera-btn:active { transform: translateY(0); }
 .camera-btn svg {
@@ -191,7 +208,7 @@ body {
   flex-shrink: 0; overflow-y: hidden;
 }
 #sidebar h3, #camera-panel h3, #present-panel h3, #toggle-panel h3, #tool-panel h3, #menu-panel h3 {
-  font-size: 10px; color: #8b949e; text-transform: uppercase;
+  font-size: 10px; color: var(--text-muted); text-transform: uppercase;
   letter-spacing: .1em; margin: 0; flex: 1;
 }
 
@@ -203,26 +220,26 @@ body {
 #camera-buttons.collapsed { display: none; }
 .tool-btn {
   width: 40px; height: 40px; padding: 0;
-  background: #21262d; border: 1px solid #30363d;
-  color: #e6edf3; border-radius: 6px; cursor: pointer;
+  background: var(--bg-control); border: 1px solid var(--border);
+  color: var(--text); border-radius: 6px; cursor: pointer;
   font-size: 20px; line-height: 1;
   display: flex; align-items: center; justify-content: center;
 }
 .mesh-state-btn { width: 18px; height: 18px; padding: 0; border: 0; background: transparent; font-size: 13px; line-height: 18px; cursor: pointer; flex-shrink: 0; }
 .mesh-state-btn:hover { filter: brightness(1.25); transform: scale(1.08); }
-#wire-btn.active { background: #1f6feb; }
-#grid-btn { background: #1f6feb; }
-#grid-btn.off { background: #21262d; }
-#shading-btn { background: #1f6feb; }
-#shading-btn.off { background: #21262d; }
-#texture-btn { background: #1f6feb; }
+#wire-btn.active { background: var(--accent); }
+#grid-btn { background: var(--accent); }
+#grid-btn.off { background: var(--bg-control); }
+#shading-btn { background: var(--accent); }
+#shading-btn.off { background: var(--bg-control); }
+#texture-btn { background: var(--accent); }
 #texture-btn.diffuse-only { background: #9a6700; }
-#texture-btn.off { background: #21262d; }
-#light-btn.double { background: #1f6feb; color: #fff; }
+#texture-btn.off { background: var(--bg-control); }
+#light-btn.double { background: var(--accent); color: #fff; }
 #light-btn.current { background: #9a6700; color: #fff3b0; }
-#light-btn.off { background: #21262d; color: #e6edf3; }
-#trackball-btn { background: #1f6feb; }
-#trackball-btn.off { background: #21262d; }
+#light-btn.off { background: var(--bg-control); color: var(--text); }
+#trackball-btn { background: var(--accent); }
+#trackball-btn.off { background: var(--bg-control); }
 .nav-gizmo-icon { width: 24px; height: 24px; overflow: visible; }
 .nav-gizmo-icon path { fill: none; stroke-width: 1.7; stroke-linecap: round; }
 .nav-gizmo-icon circle { stroke: none; }
@@ -284,7 +301,7 @@ body.right-dock-visible .environment-control { right: 338px; }
 .group-toggle {
   width: 14px; height: 14px; flex-shrink: 0;
   display: flex; align-items: center; justify-content: center;
-  color: #8b949e; font-size: 9px; transition: transform .15s ease; user-select: none;
+  color: var(--text-muted); font-size: 9px; transition: transform .15s ease; user-select: none;
 }
 .group-toggle.collapsed { transform: rotate(-90deg); }
 .group-name { flex: 1; user-select: none; }
@@ -302,7 +319,7 @@ body.right-dock-visible .environment-control { right: 338px; }
   color: #cdd9e5; font-weight: 600; margin-top: 6px; cursor: pointer;
   position: relative;
 }
-.group-hdr input { width: 14px; height: 14px; cursor: pointer; accent-color: #58a6ff; flex-shrink: 0; }
+.group-hdr input { width: 14px; height: 14px; cursor: pointer; accent-color: var(--accent-soft); flex-shrink: 0; }
 /* Room for .group-tex-btn, absolutely positioned in the top-right corner --
  * keeps the button pinned there regardless of name length, rather than
  * being pushed out of the flex row by a long component name. */
@@ -325,7 +342,7 @@ body.right-dock-visible .environment-control { right: 338px; }
 }
 .draw-item input { width: 12px; height: 12px; cursor: pointer; accent-color: #3fb950; flex-shrink: 0; }
 .mesh-state-btn { width: 18px; height: 18px; padding: 0; border: 0; background: transparent; font-size: 13px; line-height: 18px; cursor: pointer; flex-shrink: 0; }
-.draw-item.selected { background: rgba(88,166,255,.15); outline: 1px solid #58a6ff; border-radius: 4px; }
+.draw-item.selected { background: rgba(88,166,255,.15); outline: 1px solid var(--accent-soft); border-radius: 4px; }
 .mesh-name { min-width: 0; flex: 1; }
 .draw-item .mesh-name-input {
   width: 100%; min-width: 0; box-sizing: border-box; padding: 2px 4px;
@@ -342,7 +359,7 @@ body.right-dock-visible .environment-control { right: 338px; }
   border-radius: 4px;
 }
 .tex-item:hover { background: #21262d; color: #e6edf3; }
-.tex-item.selected { background: rgba(88,166,255,.15); color: #58a6ff; outline: 1px solid #58a6ff; }
+.tex-item.selected { background: rgba(88,166,255,.15); color: var(--accent-soft); outline: 1px solid var(--accent-soft); }
 
 /* Per-component "manage textures" popup (texture-modal.js) -- reuses the
  * toggle modal's .modal-backdrop/.modal chrome. */
@@ -411,7 +428,7 @@ body.right-dock-visible .environment-control { right: 338px; }
   width: 24px; height: 22px; font-size: 13px; cursor: pointer; flex-shrink: 0;
 }
 .toggle-cycle-btn:hover { background: #1f6feb; }
-.toggle-value { font-size: 12px; color: #58a6ff; font-weight: 600; flex: 1; min-width: 0; overflow-wrap: break-word; }
+.toggle-value { font-size: 12px; color: var(--accent-soft); font-weight: 600; flex: 1; min-width: 0; overflow-wrap: break-word; }
 
 /* Recording session: the row being recorded gets an accent outline, and the
  * cycle button + value describe "Position N of M" instead of the live value. */
@@ -477,7 +494,7 @@ body.right-dock-visible .environment-control { right: 338px; }
   font-size: 12px; color: #cdd9e5; font-weight: 600;
   flex: 1; min-width: 0; overflow-wrap: break-word;
 }
-.menu-value { font-size: 12px; color: #58a6ff; font-weight: 600; flex-shrink: 0; }
+.menu-value { font-size: 12px; color: var(--accent-soft); font-weight: 600; flex-shrink: 0; }
 
 /* ── loading overlay ─────────────────────────────────────────────────────── */
 #loading {
@@ -510,38 +527,38 @@ body.right-dock-visible .environment-control { right: 338px; }
 }
 .modal-backdrop.show { display: flex; }
 .modal {
-  background: #161b22; border: 1px solid #30363d; border-radius: 10px;
+  background: var(--bg-panel); border: 1px solid var(--border); border-radius: 10px;
   padding: 18px 20px; width: 320px; max-width: calc(100vw - 40px);
   max-height: calc(100vh - 40px); overflow-y: auto;
   box-shadow: 0 12px 40px rgba(0,0,0,.5);
 }
-.modal h4 { font-size: 14px; color: #e6edf3; margin-bottom: 12px; }
+.modal h4 { font-size: 14px; color: var(--text); margin-bottom: 12px; }
 .modal-error {
-  display: none; font-size: 11px; color: #f85149; background: rgba(248,81,73,.1);
+  display: none; font-size: 11px; color: var(--danger); background: rgba(248,81,73,.1);
   border: 1px solid rgba(248,81,73,.4); border-radius: 6px; padding: 6px 8px; margin-bottom: 10px;
   white-space: pre-wrap;
 }
 .modal-field {
-  display: flex; flex-direction: column; gap: 4px; margin-bottom: 10px; font-size: 11px; color: #8b949e;
+  display: flex; flex-direction: column; gap: 4px; margin-bottom: 10px; font-size: 11px; color: var(--text-muted);
 }
 .modal-field input, .modal-field select {
-  background: #0d1117; border: 1px solid #30363d; color: #e6edf3;
+  background: var(--bg-canvas); border: 1px solid var(--border); color: var(--text);
   border-radius: 6px; padding: 6px 8px; font-size: 12px; font-family: inherit;
 }
 .modal-field input:disabled, .modal-field select:disabled { opacity: .6; }
 .modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; }
 .modal-actions button {
-  border-radius: 6px; padding: 6px 14px; font-size: 12px; cursor: pointer; border: 1px solid #30363d;
+  border-radius: 6px; padding: 6px 14px; font-size: 12px; cursor: pointer; border: 1px solid var(--border);
 }
-#tm-cancel { background: #21262d; color: #e6edf3; }
-#tm-cancel:hover { background: #30363d; }
-#tm-save { background: #238636; color: #fff; border-color: rgba(240,246,252,.15); }
-#tm-save:hover:not(:disabled) { background: #2ea043; }
+#tm-cancel { background: var(--bg-control); color: var(--text); }
+#tm-cancel:hover { background: var(--border); }
+#tm-save { background: var(--success); color: #fff; border-color: rgba(240,246,252,.15); }
+#tm-save:hover:not(:disabled) { background: var(--success-hover); }
 #tm-save:disabled { opacity: .6; cursor: default; }
-#pm-cancel { background: #21262d; color: #e6edf3; }
-#pm-cancel:hover { background: #30363d; }
-#pm-save { background: #238636; color: #fff; border-color: rgba(240,246,252,.15); }
-#pm-save:hover:not(:disabled) { background: #2ea043; }
+#pm-cancel { background: var(--bg-control); color: var(--text); }
+#pm-cancel:hover { background: var(--border); }
+#pm-save { background: var(--success); color: #fff; border-color: rgba(240,246,252,.15); }
+#pm-save:hover:not(:disabled) { background: var(--success-hover); }
 #pm-save:disabled { opacity: .6; cursor: default; }
 
 /* Read-only INI health report. */
@@ -639,21 +656,21 @@ body.right-dock-visible .environment-control { right: 338px; }
 }
 .dialog-backdrop.show { display: flex; }
 .dialog-box {
-  background: #161b22; border: 1px solid #30363d; border-radius: 10px;
+  background: var(--bg-panel); border: 1px solid var(--border); border-radius: 10px;
   padding: 18px 20px; width: 340px; max-width: calc(100vw - 40px);
   max-height: calc(100vh - 40px); overflow-y: auto;
   box-shadow: 0 12px 40px rgba(0,0,0,.5);
 }
-.dialog-message { font-size: 12px; color: #e6edf3; white-space: pre-wrap; line-height: 1.5; }
+.dialog-message { font-size: 12px; color: var(--text); white-space: pre-wrap; line-height: 1.5; }
 .dialog-input {
   display: none; box-sizing: border-box; width: 100%; margin-top: 12px;
-  background: #0d1117; border: 1px solid #30363d; color: #e6edf3;
+  background: var(--bg-canvas); border: 1px solid var(--border); color: var(--text);
   border-radius: 6px; padding: 7px 9px; font-size: 12px; font-family: inherit;
 }
-#dialog-cancel { background: #21262d; color: #e6edf3; }
-#dialog-cancel:hover { background: #30363d; }
-#dialog-ok { background: #238636; color: #fff; border-color: rgba(240,246,252,.15); }
-#dialog-ok:hover { background: #2ea043; }
+#dialog-cancel { background: var(--bg-control); color: var(--text); }
+#dialog-cancel:hover { background: var(--border); }
+#dialog-ok { background: var(--success); color: #fff; border-color: rgba(240,246,252,.15); }
+#dialog-ok:hover { background: var(--success-hover); }
 
 /* ── build-time feature flags (app/features.py) ──────────────────────────── */
 /* Only hides the button; the frontend/backend behind it is unaffected -- see

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -213,7 +213,11 @@ body {
 }
 
 /* ── toolbox (wireframe / grid) ───────────────────────────────────────────── */
-#tool-panel { display: block; min-width: 166px; padding: 9px 10px; position: fixed; left: 50%; transform: translateX(-50%); bottom: calc(28px + 12px); z-index: 200; }
+#tool-panel {
+  display: block; min-width: 166px; padding: 9px 10px;
+  position: fixed; left: 50%; bottom: calc(28px + 12px);
+  transform: translateX(-50%); z-index: 200;
+}
 #tool-panel .panel-hdr { margin-bottom: 7px; }
 #tool-buttons { display: flex; align-items: center; gap: 6px; }
 #tool-buttons.collapsed { display: none; }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -150,7 +150,7 @@
 </div>
 
 <div id="present-modal-backdrop" class="modal-backdrop">
-  <div class="modal">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="pm-title">
     <h4 id="pm-title">Add PRESENT</h4>
     <div id="pm-error" class="modal-error"></div>
     <form id="pm-form">
@@ -171,7 +171,7 @@
 </div>
 
 <div id="toggle-modal-backdrop" class="modal-backdrop">
-  <div class="modal">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="tm-title">
     <h4 id="tm-title">Add Toggle</h4>
     <div id="tm-error" class="modal-error"></div>
     <form id="tm-form">
@@ -215,7 +215,7 @@
 </div>
 
 <div id="texture-modal-backdrop" class="modal-backdrop">
-  <div class="modal texture-modal">
+  <div class="modal texture-modal" role="dialog" aria-modal="true" aria-labelledby="texm-title">
     <h4 id="texm-title">Manage Textures</h4>
     <div id="texm-list" class="texm-list"></div>
     <div class="modal-actions">
@@ -267,7 +267,7 @@
 </div>
 
 <div id="dialog-backdrop" class="dialog-backdrop">
-  <div class="dialog-box">
+  <div class="dialog-box" role="alertdialog" aria-modal="true" aria-describedby="dialog-message">
     <div id="dialog-message" class="dialog-message"></div>
     <input id="dialog-input" class="dialog-input" type="text" autocomplete="off"/>
     <div class="modal-actions">

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -110,7 +110,7 @@
       <button id="grid-btn" class="tool-btn" title="Grid visibility">⊞</button>
       <button id="shading-btn" class="tool-btn" title="Smooth/flat shading">◐</button>
       <button id="texture-btn" class="tool-btn" title="Textures: all maps" aria-label="Textures: all maps">▩</button>
-      <button id="light-btn" class="tool-btn double" title="Key light: normal (drag; Shift-drag for depth)" aria-label="Key light: normal">☀</button>
+      <button id="light-btn" class="tool-btn double" title="Key light: double brightness and handle size" aria-label="Key light: double">☀</button>
       <button id="trackball-btn" class="tool-btn active" title="Toggle navigation gizmo" aria-label="Toggle navigation gizmo">
         <svg class="nav-gizmo-icon" viewBox="0 0 24 24" aria-hidden="true">
           <path class="nav-x" d="M12 12L20 15"/><path class="nav-y" d="M12 12V3"/><path class="nav-z" d="M12 12L5 18"/>

--- a/src/web/js/camera-frame.js
+++ b/src/web/js/camera-frame.js
@@ -1,0 +1,222 @@
+// Camera/model framing, clipping, orientation and unobstructed viewport math.
+
+import * as THREE from 'three';
+
+const INITIAL_CAMERA_DIRECTION = new THREE.Vector3(0, 0, 1);
+const INITIAL_CAMERA_UP = new THREE.Vector3(0, 1, 0);
+
+export function createCameraFrame({
+  camera, renderer, controls, grid, cancelViewSnap, onModelFit,
+}) {
+  let homeView = null;
+  let clipNear = camera.near;
+  let clipFar = camera.far;
+  let uprightApplied = false;
+  let modelQuarterTurns = 0;
+  let modelPivot = null;
+
+  /** Aim projection at the unobstructed region while retaining the real model
+   * center as Arcball's physical orbit target. */
+  function usableViewport() {
+    const canvas = renderer.domElement.getBoundingClientRect();
+    const fullWidth = Math.max(canvas.width, 1);
+    const fullHeight = Math.max(canvas.height, 1);
+    let left = 0;
+    let right = fullWidth;
+    const gap = 14;
+
+    const leftDock = document.getElementById('left-dock');
+    const leftRect = leftDock?.getBoundingClientRect();
+    if (leftDock && leftRect.width > 1) {
+      left = Math.max(left, leftRect.right - canvas.left + gap);
+    }
+    const rightDock = document.getElementById('right-dock');
+    const rightRect = rightDock?.getBoundingClientRect();
+    if (rightDock && rightRect.width > 1) {
+      right = Math.min(right, rightRect.left - canvas.left - gap);
+    }
+    if (right - left < fullWidth * 0.25) {
+      left = 0;
+      right = fullWidth;
+    }
+    return {
+      fullWidth,
+      fullHeight,
+      width: right - left,
+      centerShiftX: (left + right - fullWidth) * 0.5,
+    };
+  }
+
+  function updateViewport() {
+    const viewport = usableViewport();
+    camera.clearViewOffset();
+    if (Math.abs(viewport.centerShiftX) > 0.5) {
+      camera.setViewOffset(
+        viewport.fullWidth, viewport.fullHeight,
+        -viewport.centerShiftX, 0,
+        viewport.fullWidth, viewport.fullHeight);
+    }
+    camera.updateProjectionMatrix();
+    return viewport;
+  }
+
+  function resize(width, height) {
+    camera.aspect = width / height;
+    renderer.setSize(width, height);
+    updateViewport();
+  }
+
+  function updateClipping() {
+    // Arcball can restore startup planes during scaling; reapply model-scaled
+    // clipping after its update.
+    const viewDistance = camera.position.distanceTo(controls.target);
+    const requiredFar = Math.max(clipFar, viewDistance * 4, 100);
+    if (camera.near !== clipNear || camera.far !== requiredFar) {
+      camera.near = clipNear;
+      camera.far = requiredFar;
+      camera.updateProjectionMatrix();
+    }
+  }
+
+  function frameView(meshes = [], direction = null, targetYOffset = 0) {
+    const box = new THREE.Box3();
+    meshes.forEach(mesh => box.expandByObject(mesh));
+    if (box.isEmpty()) return;
+    const size = box.getSize(new THREE.Vector3());
+    const center = box.getCenter(new THREE.Vector3());
+    center.y += targetYOffset;
+    const radius = Math.max(size.length() * 0.5, 0.001);
+    const viewport = updateViewport();
+    const narrowScale = Math.max(1, viewport.fullHeight / viewport.width);
+    const distance = radius / Math.tan(THREE.MathUtils.degToRad(camera.fov * 0.5))
+      * 1.15 * narrowScale;
+    const offset = direction
+      ? direction.clone().normalize()
+      : camera.position.clone().sub(controls.target).normalize();
+    if (offset.lengthSq() < 0.01) offset.set(0.3, 0.5, 1).normalize();
+    controls.target.copy(center);
+    camera.position.copy(center).addScaledVector(offset, distance);
+    camera.near = radius * 0.001;
+    camera.far = Math.max(radius * 100, 100);
+    clipNear = camera.near;
+    clipFar = camera.far;
+    camera.updateProjectionMatrix();
+    controls.update();
+  }
+
+  function rotateMeshesAroundCenter(meshes, rotation) {
+    if (!meshes.length) return;
+    // The post-upright pivot is stable; recomputing an AABB center after each
+    // turn makes asymmetric models drift.
+    let center = modelPivot && modelPivot.clone();
+    if (!center) {
+      const box = new THREE.Box3();
+      meshes.forEach(mesh => box.expandByObject(mesh));
+      if (box.isEmpty()) return;
+      center = box.getCenter(new THREE.Vector3());
+    }
+    meshes.forEach(mesh => {
+      mesh.position.sub(center).applyQuaternion(rotation).add(center);
+      mesh.quaternion.premultiply(rotation);
+    });
+  }
+
+  function rotateModelQuarterTurn(meshes = []) {
+    rotateMeshesAroundCenter(meshes, new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0), Math.PI / 2));
+    modelQuarterTurns = (modelQuarterTurns + 1) % 4;
+  }
+
+  function rotateModelHorizontalQuarterTurn(meshes = []) {
+    rotateMeshesAroundCenter(meshes, new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(1, 0, 0), Math.PI / 2));
+  }
+
+  function resetModelOrientation() {
+    uprightApplied = false;
+    modelQuarterTurns = 0;
+    modelPivot = null;
+  }
+
+  function resetView() {
+    if (!homeView) return;
+    cancelViewSnap?.();
+    homeView.meshes.forEach(({ mesh, quaternion, position }) => {
+      mesh.quaternion.copy(quaternion);
+      mesh.position.copy(position);
+    });
+    const box = new THREE.Box3();
+    homeView.meshes.forEach(({ mesh }) => box.expandByObject(mesh));
+    if (box.isEmpty()) return;
+    const size = box.getSize(new THREE.Vector3());
+    camera.up.copy(INITIAL_CAMERA_UP);
+    frameView(homeView.meshes.map(({ mesh }) => mesh),
+      INITIAL_CAMERA_DIRECTION, size.y * 0.08);
+    camera.updateMatrix();
+    controls.update();
+    controls.saveState();
+  }
+
+  function fitTo(meshes) {
+    if (!uprightApplied && meshes.length) {
+      const rawBox = new THREE.Box3();
+      meshes.forEach(mesh => rawBox.expandByObject(mesh));
+      const rawSize = rawBox.getSize(new THREE.Vector3());
+      if (rawSize.z > rawSize.y * 1.5 && rawSize.z > rawSize.x * 1.15) {
+        meshes.forEach(mesh => {
+          mesh.quaternion.copy(new THREE.Quaternion().setFromAxisAngle(
+            new THREE.Vector3(1, 0, 0), -Math.PI / 2));
+        });
+      }
+      uprightApplied = true;
+    }
+    const box = new THREE.Box3();
+    meshes.forEach(mesh => box.expandByObject(mesh));
+    if (box.isEmpty()) return;
+
+    const boxSize = box.getSize(new THREE.Vector3());
+    const center = box.getCenter(new THREE.Vector3());
+    modelPivot = center.clone();
+    const size = boxSize.length();
+    const dimensions = [boxSize.x, boxSize.y, boxSize.z].sort((a, b) => a - b);
+    grid.scale.setScalar(Math.max(1.5, dimensions[1]));
+    grid.position.set(center.x, box.min.y, center.z);
+
+    camera.near = size * 0.0005;
+    camera.far = size * 50;
+    clipNear = camera.near;
+    clipFar = camera.far;
+    camera.updateProjectionMatrix();
+
+    cancelViewSnap?.();
+    camera.up.copy(INITIAL_CAMERA_UP);
+    frameView(meshes, INITIAL_CAMERA_DIRECTION, boxSize.y * 0.08);
+    onModelFit?.(size);
+    homeView = {
+      position: camera.position.clone(),
+      target: controls.target.clone(),
+      near: camera.near,
+      far: camera.far,
+      meshes: meshes.map(mesh => ({
+        mesh,
+        quaternion: mesh.quaternion.clone(),
+        position: mesh.position.clone(),
+      })),
+    };
+    camera.updateMatrix();
+    controls.update();
+    controls.saveState();
+  }
+
+  return {
+    fitTo,
+    frameView,
+    resetModelOrientation,
+    resetView,
+    resize,
+    rotateModelHorizontalQuarterTurn,
+    rotateModelQuarterTurn,
+    updateClipping,
+    updateViewport,
+  };
+}

--- a/src/web/js/camera-frame.js
+++ b/src/web/js/camera-frame.js
@@ -136,6 +136,7 @@ export function createCameraFrame({
     uprightApplied = false;
     modelQuarterTurns = 0;
     modelPivot = null;
+    homeView = null;
   }
 
   function resetView() {

--- a/src/web/js/control-state.js
+++ b/src/web/js/control-state.js
@@ -1,0 +1,49 @@
+// Mod control values plus safe source-ordered derived-state replay.
+
+let values = {};
+let stateRules = [];
+
+export function resetControlState() {
+  values = {};
+  stateRules = [];
+}
+
+export function setControlValue(variable, value) {
+  values[variable] = value;
+}
+
+export function getControlValue(variable) {
+  return values[variable];
+}
+
+export function getControlState() {
+  return { ...values };
+}
+
+// True if an OR'd list of AND-groups ([[{var,value,negate}, ...], ...]) is
+// satisfied by the current control state.
+export function dnfSatisfied(condGroups) {
+  if (!condGroups || condGroups.length === 0) return true;
+  return condGroups.some(group => group.every(condition => {
+    const current = values[condition.var];
+    if (current === undefined) return true;
+    return condition.negate
+      ? current !== condition.value
+      : current === condition.value;
+  }));
+}
+
+export function setControlStateRules(rules, defaults) {
+  stateRules = rules || [];
+  for (const [variable, value] of Object.entries(defaults || {})) {
+    if (values[variable] === undefined) values[variable] = value;
+  }
+}
+
+/** Replay safe [Present] assignments in source order. Later rules deliberately
+ * observe values written by earlier rules, matching the game's execution. */
+export function replayControlStateRules() {
+  for (const rule of stateRules) {
+    if (dnfSatisfied(rule.conditions)) values[rule.var] = rule.value;
+  }
+}

--- a/src/web/js/health-report.js
+++ b/src/web/js/health-report.js
@@ -2,6 +2,7 @@
 // report even when geometry cannot load, so this module has no scene dependency.
 
 import { openIniEditor } from './ini-editor.js';
+import { bindModalDismiss } from './modal-shell.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -165,8 +166,6 @@ function closeReport() {
 }
 
 $('health-btn').addEventListener('click', openReport);
-$('health-close').addEventListener('click', closeReport);
-$('health-close-x').addEventListener('click', closeReport);
 $('health-filters').addEventListener('click', (event) => {
   const button = event.target.closest('[data-health-filter]');
   if (!button) return;
@@ -176,11 +175,8 @@ $('health-filters').addEventListener('click', (event) => {
   }
   renderReport();
 });
-$('health-modal-backdrop').addEventListener('click', (event) => {
-  if (event.target.id === 'health-modal-backdrop') closeReport();
-});
-document.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape' && $('health-modal-backdrop').classList.contains('show')) {
-    closeReport();
-  }
+bindModalDismiss({
+  backdrop: $('health-modal-backdrop'),
+  close: closeReport,
+  buttons: [$('health-close'), $('health-close-x')],
 });

--- a/src/web/js/key-light-controller.js
+++ b/src/web/js/key-light-controller.js
@@ -147,7 +147,7 @@ export function createKeyLightController({
   function rebase(modelSize) {
     const distance = Math.max(modelSize * 0.55, 0.001);
     light.position.copy(controls.target).addScaledVector(
-      new THREE.Vector3(-0.55, 0.35, 0.82).normalize(), distance);
+      new THREE.Vector3(-0.55, 0.82, 0.35).normalize(), distance);
     handle.position.copy(light.position);
   }
 

--- a/src/web/js/key-light-controller.js
+++ b/src/web/js/key-light-controller.js
@@ -147,7 +147,7 @@ export function createKeyLightController({
   function rebase(modelSize) {
     const distance = Math.max(modelSize * 0.55, 0.001);
     light.position.copy(controls.target).addScaledVector(
-      new THREE.Vector3(-0.55, 0.82, 0.35).normalize(), distance);
+      new THREE.Vector3(-0.55, 0.35, 0.82).normalize(), distance);
     handle.position.copy(light.position);
   }
 

--- a/src/web/js/key-light-controller.js
+++ b/src/web/js/key-light-controller.js
@@ -1,0 +1,165 @@
+// Movable, depth-tested inspection light and its viewport interaction.
+
+import * as THREE from 'three';
+
+function createLightHandle() {
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = 64;
+  const context = canvas.getContext('2d');
+  const glow = context.createRadialGradient(32, 32, 4, 32, 32, 30);
+  glow.addColorStop(0, 'rgba(255,248,190,1)');
+  glow.addColorStop(0.35, 'rgba(255,216,102,.95)');
+  glow.addColorStop(0.7, 'rgba(255,184,70,.4)');
+  glow.addColorStop(1, 'rgba(255,184,70,0)');
+  context.fillStyle = glow;
+  context.fillRect(0, 0, 64, 64);
+  const handle = new THREE.Sprite(new THREE.SpriteMaterial({
+    map: new THREE.CanvasTexture(canvas), transparent: true,
+    // Model depth must occlude the marker instead of showing through meshes.
+    depthTest: true, depthWrite: false,
+  }));
+  handle.renderOrder = 1000;
+  handle.visible = true;
+  return handle;
+}
+
+export function createKeyLightController({
+  scene, camera, renderer, controls, light,
+}) {
+  const handle = createLightHandle();
+  scene.add(handle);
+
+  let drag = null;
+  let pointerInside = false;
+  const modes = ['double', 'current', 'off'];
+  let modeIndex = 0;
+  const raycaster = new THREE.Raycaster();
+  const pointer = new THREE.Vector2();
+  const dragPlane = new THREE.Plane();
+  const hit = new THREE.Vector3();
+
+  function updatePointer(event) {
+    const rect = renderer.domElement.getBoundingClientRect();
+    pointer.set(
+      ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      -((event.clientY - rect.top) / rect.height) * 2 + 1);
+    raycaster.setFromCamera(pointer, camera);
+  }
+
+  function canInteract(event = null) {
+    if (event) {
+      const rect = renderer.domElement.getBoundingClientRect();
+      pointerInside = event.clientX >= rect.left && event.clientX <= rect.right
+        && event.clientY >= rect.top && event.clientY <= rect.bottom;
+      updatePointer(event);
+    }
+    if (!pointerInside || !handle.visible) return false;
+
+    // Only raycast model triangles after the cheap sprite candidate test.
+    const handleHit = raycaster.intersectObject(handle, false)[0];
+    if (!handleHit) return false;
+    const visibleMeshes = [];
+    scene.traverseVisible(object => {
+      if (object.isMesh) visibleMeshes.push(object);
+    });
+    const blocker = raycaster.intersectObjects(visibleMeshes, false)[0];
+    return !blocker || blocker.distance >= handleHit.distance;
+  }
+
+  function updateCursor(event = null) {
+    if (drag) return;
+    renderer.domElement.style.cursor = canInteract(event) ? 'crosshair' : '';
+  }
+
+  renderer.domElement.addEventListener('pointerenter', event => {
+    pointerInside = true;
+    updateCursor(event);
+  });
+  renderer.domElement.addEventListener('pointerleave', () => {
+    pointerInside = false;
+    if (!drag) renderer.domElement.style.cursor = '';
+  });
+  renderer.domElement.addEventListener('pointerdown', event => {
+    if (event.button !== 0 || !canInteract(event)) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    const cameraDirection = camera.getWorldDirection(new THREE.Vector3());
+    dragPlane.setFromNormalAndCoplanarPoint(cameraDirection, light.position);
+    drag = {
+      pointerId: event.pointerId,
+      depthMode: event.shiftKey,
+      startY: event.clientY,
+      startPosition: light.position.clone(),
+      cameraDirection,
+      depthScale: Math.max(camera.position.distanceTo(controls.target) * 0.004, 0.0001),
+    };
+    controls.enabled = false;
+    renderer.domElement.setPointerCapture(event.pointerId);
+    renderer.domElement.style.cursor = 'grabbing';
+  }, { capture: true });
+  renderer.domElement.addEventListener('pointermove', event => {
+    if (!drag) {
+      pointerInside = true;
+      updateCursor(event);
+      return;
+    }
+    if (event.pointerId !== drag.pointerId) return;
+    if (drag.depthMode) {
+      light.position.copy(drag.startPosition).addScaledVector(
+        drag.cameraDirection, (drag.startY - event.clientY) * drag.depthScale);
+      return;
+    }
+    updatePointer(event);
+    if (raycaster.ray.intersectPlane(dragPlane, hit)) light.position.copy(hit);
+  });
+
+  function finishDrag(event) {
+    if (!drag || event.pointerId !== drag.pointerId) return;
+    if (renderer.domElement.hasPointerCapture?.(event.pointerId)) {
+      renderer.domElement.releasePointerCapture(event.pointerId);
+    }
+    drag = null;
+    controls.enabled = true;
+    updateCursor(event);
+  }
+  renderer.domElement.addEventListener('pointerup', finishDrag);
+  renderer.domElement.addEventListener('pointercancel', finishDrag);
+
+  function toggleMode() {
+    modeIndex = (modeIndex + 1) % modes.length;
+    const mode = modes[modeIndex];
+    handle.visible = mode !== 'off';
+    light.intensity = mode === 'double' ? 1 : (mode === 'current' ? 0.5 : 0);
+    const button = document.getElementById('light-btn');
+    button.classList.toggle('double', mode === 'double');
+    button.classList.toggle('current', mode === 'current');
+    button.classList.toggle('off', mode === 'off');
+    const labels = {
+      double: 'Key light: double brightness and handle size',
+      current: 'Key light: normal (drag; Shift-drag for depth)',
+      off: 'Key light: off',
+    };
+    button.title = labels[mode];
+    button.setAttribute('aria-label', labels[mode]);
+    updateCursor();
+  }
+
+  function rebase(modelSize) {
+    const distance = Math.max(modelSize * 0.55, 0.001);
+    light.position.copy(controls.target).addScaledVector(
+      new THREE.Vector3(-0.55, 0.82, 0.35).normalize(), distance);
+    handle.position.copy(light.position);
+  }
+
+  function update() {
+    light.target.position.copy(controls.target);
+    handle.position.copy(light.position);
+    const multiplier = modes[modeIndex] === 'double' ? 2 : 1;
+    const size = Math.max(
+      camera.position.distanceTo(controls.target) * 0.035 * multiplier,
+      0.0001);
+    handle.scale.set(size, size, 1);
+  }
+
+  return { toggleMode, rebase, update };
+}

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -107,8 +107,10 @@ async function refreshPendingState() {
 function clearScene() {
   clearSelection();
   reset();
+  setTextures(null);
   setGeometryBlob(null);
   lastToggles = {};
+  $('sidebar').style.display = 'none';
   $('mesh-list').innerHTML = '';
   $('camera-panel').style.display = 'none';
   $('toggle-list').innerHTML = '';
@@ -184,6 +186,8 @@ async function loadModAt(path) {
   try {
     await displayMeshPayload(data);
   } catch (error) {
+    clearScene();
+    clearPendingState();
     showLoading(false);
     await refreshPendingState();
     await alertDialog('Could not load mod geometry:\n\n' + error.message);

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -60,9 +60,9 @@ function syncViewportControlPlacement() {
   document.body.classList.toggle('right-dock-visible', hasVisiblePanel);
 }
 
-// The currently open mod folder, so the Toggle panel's add/edit/delete
-// actions know which folder to write into and reloadCurrentMod() knows what
-// to reload after a successful write.
+// The currently open mod folder, so the Toggle panel's staged add/edit/delete
+// actions know which session to update and reloadCurrentMod() knows what to
+// refresh afterward.
 let currentModPath = null;
 
 // The last-loaded payload's controls.toggles model, kept
@@ -107,6 +107,7 @@ async function refreshPendingState() {
 function clearScene() {
   clearSelection();
   reset();
+  setGeometryBlob(null);
   lastToggles = {};
   $('mesh-list').innerHTML = '';
   $('camera-panel').style.display = 'none';
@@ -119,10 +120,29 @@ function clearScene() {
   syncViewportControlPlacement();
 }
 
-async function displayMeshPayload(payload) {
-  clearScene();
-  $('hint').style.display = 'none';
+function clearPendingState() {
+  $('pending-indicator').classList.remove('show');
+  $('export-btn').disabled = true;
+  $('export-btn').title = '';
+}
 
+/** Commit the UI to a new folder before asking the backend to load it. This
+ * makes the folder path, editor/diagnostic context, model, panels and pending
+ * state one transition: a failed replacement can never leave the previous
+ * mod visible under the new folder's toolbar state. */
+function beginModLoad(path, message) {
+  currentModPath = path;
+  clearScene();
+  clearPendingState();
+  $('hint').style.display = 'none';
+  $('mod-path').textContent = path;
+  setHealthReport(null);
+  setHealthLoader(() => window.pywebview.api.get_diagnostics(path));
+  setIniEditorContext(path, reloadCurrentMod);
+  showLoading(true, message);
+}
+
+async function displayMeshPayload(payload) {
   const geometry = payload.geometry;
   if (geometry) {
     const response = await fetch(geometry.url, { cache: 'no-store' });
@@ -151,18 +171,13 @@ async function displayMeshPayload(payload) {
 }
 
 async function loadModAt(path) {
-  currentModPath = path;
-  $('ini-view-btn').disabled = true;
-  $('mod-path').textContent = path;
-  showLoading(true, 'Loading Model…');
-  setHealthLoader(null);
-  setHealthReport(null);
+  beginModLoad(path, 'Loading Model…');
 
   const data = await window.pywebview.api.load_mod(path);
   setHealthReport(data?.health);
   if (data && data.error) {
     showLoading(false);
-    setIniEditorContext(path, reloadCurrentMod);
+    await refreshPendingState();
     await alertDialog('Could not load mod:\n\n' + data.error);
     return;
   }
@@ -170,12 +185,10 @@ async function loadModAt(path) {
     await displayMeshPayload(data);
   } catch (error) {
     showLoading(false);
-    setIniEditorContext(path, reloadCurrentMod);
+    await refreshPendingState();
     await alertDialog('Could not load mod geometry:\n\n' + error.message);
     return;
   }
-  setHealthLoader(() => window.pywebview.api.get_diagnostics(path));
-  setIniEditorContext(path, reloadCurrentMod);
   await refreshPendingState();
 
   // Lead with the folder name; the full path is long and rarely the useful part.
@@ -217,7 +230,6 @@ async function openMod() {
 // pick up the change via the exact same path a fresh open would take.
 export async function reloadCurrentMod() {
   if (!currentModPath) return;
-  showLoading(true, 'Reloading mod…');
   try {
     await loadModAt(currentModPath);
   } catch (e) {
@@ -245,7 +257,7 @@ async function exportChanges() {
         `${result.saved.length} ini file(s) exported, but ${result.failed.length} failed ` +
         `and are still pending:\n\n${detail}`);
     }
-    // Refreshes the panel/badges from the now-partly-or-fully-written disk
+    // Refreshes the panel/badges from the now-partly-or-fully-exported session
     // state either way, and re-syncs the indicator via its own call to
     // refreshPendingState (a partial failure leaves those inis' edits
     // pending, so it stays lit rather than clearing, and the button

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -225,9 +225,8 @@ async function openMod() {
   }
 }
 
-// Re-fetches and re-renders the currently open mod folder — used after a
-// toggle add/edit/delete writes to its ini file, so the panel and 3D view
-// pick up the change via the exact same path a fresh open would take.
+// Re-renders the current authoritative edit session after a staged authoring
+// change, using the same load path as an ordinary reopen.
 export async function reloadCurrentMod() {
   if (!currentModPath) return;
   try {

--- a/src/web/js/menu-panel.js
+++ b/src/web/js/menu-panel.js
@@ -7,6 +7,7 @@
 
 import { refreshAll, setToggleValue, getToggleValue } from './visibility.js';
 import { registerViewSync, syncView } from './view-sync.js';
+import { buildSourceSection, groupKeysBySource, usesSourceSections } from './panel-utils.js';
 
 /** Variable names carry a "source::" prefix in multi-ini folders. */
 function displayName(variable) {
@@ -115,32 +116,6 @@ export function refreshMenuValues() {
   syncView('menu-panel');
 }
 
-function buildSourceSection(source, container) {
-  const hdr = document.createElement('div');
-  hdr.className = 'toggle-src-hdr';
-
-  const chevron = document.createElement('span');
-  chevron.className = 'group-toggle';
-  chevron.textContent = '▼';
-
-  const nameSpan = document.createElement('span');
-  nameSpan.className = 'group-name';
-  nameSpan.textContent = source;
-
-  hdr.append(chevron, nameSpan);
-
-  const itemsWrap = document.createElement('div');
-  itemsWrap.className = 'toggle-src-items';
-
-  hdr.addEventListener('click', () => {
-    chevron.classList.toggle('collapsed');
-    itemsWrap.classList.toggle('collapsed');
-  });
-
-  container.append(hdr, itemsWrap);
-  return itemsWrap;
-}
-
 /**
  * Build the panel from the structured controls.menu model. Hidden entirely when the
  * mod has no clickable menu, which is the common case.
@@ -174,13 +149,9 @@ export function buildMenuPanel(menu) {
     setToggleValue(info.var, String(info.default));
   }
 
-  const bySource = {};
-  for (const key of keys) {
-    const src = menu[key].source || '';
-    (bySource[src] = bySource[src] || []).push(key);
-  }
+  const bySource = groupKeysBySource(menu, keys);
   const sources = Object.keys(bySource);
-  const multiSource = sources.length > 1 || (sources.length === 1 && sources[0] !== '');
+  const multiSource = usesSourceSections(bySource);
 
   for (const src of sources) {
     const container = (multiSource && src) ? buildSourceSection(src, list) : list;

--- a/src/web/js/menu-panel.js
+++ b/src/web/js/menu-panel.js
@@ -6,6 +6,7 @@
 // edits, records or exports.
 
 import { refreshAll, setToggleValue, getToggleValue } from './visibility.js';
+import { registerViewSync, syncView } from './view-sync.js';
 
 /** Variable names carry a "source::" prefix in multi-ini folders. */
 function displayName(variable) {
@@ -65,7 +66,6 @@ function buildMenuItem(info) {
       if (guardHolds(e.when)) setToggleValue(e.var, e.value);
     }
     refreshAll();
-    refreshMenuValues();
   });
 
   item.append(btn, nameSpan, valSpan);
@@ -97,7 +97,6 @@ function buildShapeSlider(info) {
   valSpan.textContent = Number(input.value).toFixed(2);
   input.addEventListener('input', () => {
     setToggleValue(info.var, input.value);
-    valSpan.textContent = Number(input.value).toFixed(2);
     refreshAll();
   });
   item.append(nameSpan, input, valSpan);
@@ -113,7 +112,7 @@ function buildShapeSlider(info) {
 // rule, so every displayed value is re-read after any click.
 let syncers = [];
 export function refreshMenuValues() {
-  syncers.forEach((fn) => fn());
+  syncView('menu-panel');
 }
 
 function buildSourceSection(source, container) {
@@ -151,6 +150,9 @@ export function buildMenuPanel(menu) {
   const panel = document.getElementById('menu-panel');
   list.innerHTML = '';
   syncers = [];
+  registerViewSync('menu-panel', () => {
+    syncers.forEach(sync => sync());
+  });
 
   const keys = Object.keys(menu || {});
   if (!keys.length) {

--- a/src/web/js/mesh-factory.js
+++ b/src/web/js/mesh-factory.js
@@ -2,6 +2,7 @@
 
 import * as THREE from 'three';
 import { decodeF32, decodeU32 } from './decode.js';
+import { getMeshView } from './mesh-view-bindings.js';
 
 // Textures arrive as data URIs or same-origin localhost URLs keyed by name;
 // loaders are cached so several meshes sharing a texture share one GPU upload.
@@ -151,7 +152,7 @@ export function refreshMeshTexture(mesh) {
   mesh.material.metalness = 0;
   mesh.material.color.setHex(map ? 0xffffff : mesh.userData.fallbackColor);
   mesh.material.needsUpdate = true;
-  mesh.userData.onTextureChanged?.();
+  getMeshView(mesh)?.onTextureChanged?.();
 }
 
 export function setTextureMode(mode) {

--- a/src/web/js/mesh-factory.js
+++ b/src/web/js/mesh-factory.js
@@ -173,6 +173,15 @@ export function setMeshMaterialMaps(mesh, maps) {
   refreshMeshTexture(mesh);
 }
 
+/** Update the complete resolved texture state with one material refresh. */
+export function setMeshTextureState(mesh, state) {
+  mesh.userData.texKey = state.diffuse || null;
+  mesh.userData.normalMapKey = state.normal_map || null;
+  mesh.userData.lightMapKey = state.light_map || null;
+  mesh.userData.materialMapKey = state.material_map || null;
+  refreshMeshTexture(mesh);
+}
+
 /** Colour for meshes with no texture, guessed from the component name. */
 function fallbackColor(name) {
   const n = name.toLowerCase();

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -11,6 +11,7 @@ import {
 } from './mesh-texture-state.js';
 import { bindMeshView, getMeshView } from './mesh-view-bindings.js';
 import { registerViewSync } from './view-sync.js';
+import { buildSourceSection, groupKeysBySource, usesSourceSections } from './panel-utils.js';
 import { selectMesh } from './selection.js';
 import { openTextureModal } from './texture-modal.js';
 
@@ -33,20 +34,6 @@ function syncMeshPanel() {
   }
 }
 
-/** Bucket mesh names by their ini "source" tag (see app/mod_loader.py's
- * _ini_scope). Single-ini mods carry no tag at all — everything lands in the
- * '' bucket, which buildMeshPanel renders flat with no per-ini header,
- * exactly like the Toggle panel. */
-function groupBySource(meshes) {
-  const grouped = {};
-  for (const name of Object.keys(meshes)) {
-    if (meshes[name]?.error) continue;
-    const src = meshes[name].source || '';
-    (grouped[src] = grouped[src] || []).push(name);
-  }
-  return grouped;
-}
-
 /** Group mesh names by their clean, never-disambiguated component name
  * (see core/mesh_builder.py's `component` field) — falls back to parsing the
  * dict key itself (stripping a trailing "-N" draw index) for the rare case
@@ -66,32 +53,6 @@ function groupByComponent(names, meshes) {
     (grouped[key] = grouped[key] || []).push(name);
   }
   return grouped;
-}
-
-function buildSourceSection(source, container) {
-  const hdr = document.createElement('div');
-  hdr.className = 'mesh-src-hdr';
-
-  const chevron = document.createElement('span');
-  chevron.className = 'group-toggle';
-  chevron.textContent = '▼';
-
-  const nameSpan = document.createElement('span');
-  nameSpan.className = 'group-name';
-  nameSpan.textContent = source;
-
-  hdr.append(chevron, nameSpan);
-
-  const itemsWrap = document.createElement('div');
-  itemsWrap.className = 'mesh-src-items';
-
-  hdr.addEventListener('click', () => {
-    chevron.classList.toggle('collapsed');
-    itemsWrap.classList.toggle('collapsed');
-  });
-
-  container.append(hdr, itemsWrap);
-  return itemsWrap;
 }
 
 function buildGroupHeader(groupName, itemsWrap, texturePool, modPath, onPoolChange) {
@@ -366,12 +327,15 @@ export function buildMeshPanel(meshes, modPath, meshNames = {}) {
   groupsUI = [];
   registerViewSync('mesh-panel', syncMeshPanel);
 
-  const bySource = groupBySource(meshes);
+  const validNames = Object.keys(meshes).filter(name => !meshes[name]?.error);
+  const bySource = groupKeysBySource(meshes, validNames);
   const sources = Object.keys(bySource);
-  const multiSource = sources.length > 1 || (sources.length === 1 && sources[0] !== '');
+  const multiSource = usesSourceSections(bySource);
 
   for (const src of sources) {
-    const container = (multiSource && src) ? buildSourceSection(src, list) : list;
+    const container = (multiSource && src) ? buildSourceSection(src, list, {
+      headerClass: 'mesh-src-hdr', itemsClass: 'mesh-src-items',
+    }) : list;
 
     for (const [groupName, names] of Object.entries(groupByComponent(bySource[src], meshes))) {
       const itemsWrap = document.createElement('div');

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -2,8 +2,7 @@
 // source ini (mirroring the Toggle panel); within each, one collapsible group
 // per component, one checkbox per draw call within it.
 
-import { addTexture, buildMesh, hasTexture, setMeshMaterialMaps,
-         setMeshTexture } from './mesh-factory.js';
+import { addTexture, buildMesh, hasTexture, setMeshTextureState } from './mesh-factory.js';
 import { activeMeshes, addMesh, applyMeshVisibility, registerGroup,
          setManualTexOverride } from './visibility.js';
 import { selectMesh } from './selection.js';
@@ -120,8 +119,8 @@ function buildGroupHeader(groupName, itemsWrap, texturePool, modPath, onPoolChan
  * yet falls back to in buildMeshPanel) -- a radio-style single-select that
  * drives mesh.userData.manualTexOverride (see visibility.js).
  *
- * Returns `{wrap, render}`: `wrap` is the list element (append once);
- * `render()` rebuilds its rows from `pool`'s CURRENT contents and must be
+ * Returns a list element plus separate structural and selection sync calls.
+ * `rebuild()` recreates rows from `pool`'s CURRENT contents and must be
  * re-invoked after the "manage textures" popup adds/removes an entry (see
  * buildMeshPanel's refreshers array), since `pool` starts empty for a
  * component with nothing loaded yet and is mutated in place afterward --
@@ -171,12 +170,12 @@ function recomputeTextureRuns(groupMeshes) {
       }
       activeMaps = null;
     }
-    setMeshTexture(item, activeKey);
-    setMeshMaterialMaps(item, activeMaps || {
+    const maps = activeMaps || {
       normal_map: item.userData.resolvedNormalMapKey,
       light_map: item.userData.resolvedLightMapKey,
       material_map: item.userData.resolvedMaterialMapKey,
-    });
+    };
+    setMeshTextureState(item, { diffuse: activeKey, ...maps });
   }
 }
 
@@ -242,13 +241,29 @@ function saveTextureState(modPath) {
 function buildTextureList(pool, mesh, groupMeshes, onActiveChanged) {
   const wrap = document.createElement('div');
   wrap.className = 'tex-list collapsed';
+  let rows = [];
 
-  function render() {
-    wrap.innerHTML = '';
-    const rows = [];
-    function selectRow(row) {
-      rows.forEach(r => r.classList.toggle('selected', r === row));
-    }
+  function selectedKey() {
+    const current = mesh.userData.manualTexOverride;
+    const autoKey = mesh.userData.automaticTextureBoundary
+      ? mesh.userData.resolvedTexKey
+      : undefined;
+    const isAutomaticBoundary = current === undefined && !!autoKey;
+    return current === undefined && !mesh.userData.textureHighlightDisabled
+      ? (isAutomaticBoundary ? autoKey : undefined)
+      : current;
+  }
+
+  function syncSelection() {
+    const selected = selectedKey();
+    rows.forEach(({ row, value }) => {
+      row.classList.toggle('selected', selected === value);
+    });
+  }
+
+  function rebuild() {
+    wrap.replaceChildren();
+    rows = [];
     function addRow(label, value) {
       const row = document.createElement('div');
       row.className = 'tex-item';
@@ -275,45 +290,29 @@ function buildTextureList(pool, mesh, groupMeshes, onActiveChanged) {
         }
         setManualTexOverride(mesh, newVal);
         recomputeTextureRuns(groupMeshes);
-        selectRow(newVal === undefined ? null : row);
+        syncSelection();
         if (onActiveChanged) onActiveChanged();
         saveTextureState(mesh.userData.modPath);
       });
       wrap.appendChild(row);
-      rows.push(row);
-      return row;
+      rows.push({ row, value });
     }
 
-    // With no manual override, highlight only the first mesh using each
-    // resolved texture. Toggle/menu changes update that boundary's selected
-    // row to its newly resolved texture; followers remain unselected.
-    const current = mesh.userData.manualTexOverride;
-    const autoKey = mesh.userData.automaticTextureBoundary
-      ? mesh.userData.resolvedTexKey
-      : undefined;
-    const isAutomaticBoundary = current === undefined && !!autoKey;
-    const selectedKey = current === undefined && !mesh.userData.textureHighlightDisabled
-      ? (isAutomaticBoundary ? autoKey : undefined)
-      : current;
-    let matched = null;
     for (const opt of pool) {
-      const row = addRow(opt.label, opt.tex_key);
-      if (selectedKey === opt.tex_key) matched = row;
+      addRow(opt.label, opt.tex_key);
     }
-    // A removed option that was the active manual pick has nothing to
-    // highlight -- leave every row unselected rather than falsely claiming
-    // it reverted to automatic, since the mesh's actual texKey is untouched.
-    if (matched) selectRow(matched);
+    // A removed active option has no matching row, so all rows remain clear.
+    syncSelection();
   }
 
-  render();
-  return { wrap, render };
+  rebuild();
+  return { wrap, rebuild, syncSelection };
 }
 
 /** "count, start, base" from the ini's own drawindexed line — falls back to
  * the old bare "#N" numbering for the rare draw with no such line at all
  * (whole index buffer read unconditionally; see mesh_builder.build_mesh_payload).
- * Returns `{wrap, renderTexList}` -- the caller collects `renderTexList`
+ * Returns `{wrap, rebuildTexList}` -- the caller collects `rebuildTexList`
  * alongside every other mesh in the component so the "manage textures"
  * popup can refresh them all after an add/remove (see buildMeshPanel). */
 function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
@@ -339,9 +338,9 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
   });
   itemCbs.push(cb);
 
-  const { wrap: texList, render: renderTexList } = buildTextureList(
+  const { wrap: texList, rebuild: rebuildTexList, syncSelection } = buildTextureList(
     pool, mesh, groupMeshes, onActiveChanged);
-  mesh.userData.updateTextureList = renderTexList;
+  mesh.userData.updateTextureList = syncSelection;
 
   const chevron = document.createElement('span');
   chevron.className = 'group-toggle collapsed';
@@ -425,7 +424,7 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
   const wrap = document.createElement('div');
   wrap.className = 'draw-item-wrap';
   wrap.append(row, texList);
-  return { wrap, renderTexList };
+  return { wrap, rebuildTexList };
 }
 
 /** Reflects whether any mesh in the component currently has a texture
@@ -510,10 +509,10 @@ export function buildMeshPanel(meshes, modPath, meshNames = {}) {
           highlightedDefaults.add(defaultKey);
           mesh.userData.automaticTextureBoundary = true;
         }
-        const { wrap, renderTexList } = buildDrawRow(
+        const { wrap, rebuildTexList } = buildDrawRow(
           name, groupName, meshes[name], mesh, texturePool, itemCbs, masterCb,
           itemObjs, onActiveChanged);
-        texListRenderers.push(renderTexList);
+        texListRenderers.push(rebuildTexList);
         itemsWrap.appendChild(wrap);
       }
       recomputeTextureRuns(itemObjs);

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -2,12 +2,36 @@
 // source ini (mirroring the Toggle panel); within each, one collapsible group
 // per component, one checkbox per draw call within it.
 
-import { addTexture, buildMesh, hasTexture, setMeshTextureState } from './mesh-factory.js';
-import { activeMeshes, addMesh, applyMeshVisibility, registerGroup,
-         setManualTexOverride } from './visibility.js';
+import { buildMesh, hasTexture } from './mesh-factory.js';
+import {
+  activeMeshes, addMesh, applyMeshVisibility, setManualTexOverride,
+} from './mesh-state.js';
+import {
+  ensureTextureLoaded, meshMetadataKey, recomputeTextureRuns, saveTextureState,
+} from './mesh-texture-state.js';
+import { bindMeshView, getMeshView } from './mesh-view-bindings.js';
+import { registerViewSync } from './view-sync.js';
 import { selectMesh } from './selection.js';
 import { openTextureModal } from './texture-modal.js';
-import { setHealthReport } from './health-report.js';
+
+let groupsUI = [];
+
+function syncMeshPanel() {
+  for (const group of groupsUI) {
+    group.applyTextureRuns?.();
+    group.itemObjs.forEach((mesh, index) => {
+      group.itemCbs[index].checked = mesh.visible;
+      const binding = getMeshView(mesh);
+      binding?.syncStateIndicator?.();
+      binding?.syncTextureSelection?.();
+    });
+    const any = group.itemCbs.some(control => control.checked);
+    const all = group.itemCbs.every(control => control.checked);
+    group.masterCb.checked = all;
+    group.masterCb.indeterminate = any && !all;
+    group.onTexChanged?.();
+  }
+}
 
 /** Bucket mesh names by their ini "source" tag (see app/mod_loader.py's
  * _ini_scope). Single-ini mods carry no tag at all — everything lands in the
@@ -131,113 +155,6 @@ function buildGroupHeader(groupName, itemsWrap, texturePool, modPath, onPoolChan
  * de-selects it (clears back to undefined, mesh reverts to its ini
  * default). `groupMeshes` is the ordered list for this component; texture
  * inheritance is recomputed from top to bottom after every selection. */
-function recomputeTextureRuns(groupMeshes) {
-  let activeKey = null;
-  let activeMaps = null;
-  for (const item of groupMeshes) {
-    if (item.userData.manualTexOverride !== undefined) {
-      activeKey = item.userData.manualTexOverride;
-      const option = (item.userData.texturePool || [])
-        .find(opt => opt.tex_key === activeKey);
-      activeMaps = option ? {
-        normal_map: option.normal_map || null,
-        light_map: option.light_map || null,
-        material_map: option.material_map || null,
-      } : null;
-    } else if (item.userData.automaticTextureBoundary
-               && !item.userData.textureHighlightDisabled) {
-      // Follow the texture currently resolved by toggle/menu state, not the
-      // immutable load-time default. This boundary then applies downward only
-      // until the next highlighted boundary in this component.
-      activeKey = item.userData.resolvedTexKey;
-      const diffuseKeys = new Set([
-        activeKey,
-        item.userData.defaultTexKey,
-        ...(item.userData.textureVariants || []).map(variant => variant.tex_key),
-      ].filter(Boolean));
-      for (const option of (item.userData.texturePool || [])) {
-        if (!diffuseKeys.has(option.tex_key)) continue;
-        const resolvedMaps = {
-          normal_map: item.userData.resolvedNormalMapKey,
-          light_map: item.userData.resolvedLightMapKey,
-          material_map: item.userData.resolvedMaterialMapKey,
-        };
-        for (const [field, key] of Object.entries(resolvedMaps)) {
-          if (option[`${field}_manual`]) continue;
-          if (key) option[field] = key;
-          else delete option[field];
-        }
-      }
-      activeMaps = null;
-    }
-    const maps = activeMaps || {
-      normal_map: item.userData.resolvedNormalMapKey,
-      light_map: item.userData.resolvedLightMapKey,
-      material_map: item.userData.resolvedMaterialMapKey,
-    };
-    setMeshTextureState(item, { diffuse: activeKey, ...maps });
-  }
-}
-
-async function ensureTextureLoaded(mesh, texKey) {
-  if (!texKey || hasTexture(texKey)) return true;
-  const api = window.pywebview?.api;
-  // Browser-only fixtures may exercise selection without the native bridge;
-  // keep the state logic testable even though no image can be fetched there.
-  if (!api?.load_texture_file) return true;
-  const result = await api.load_texture_file(
-    mesh.userData.modPath, texKey);
-  if (!result || result.error) return false;
-  addTexture(result.tex_key, result.uri);
-  return true;
-}
-
-function metadataKey(name, entry) {
-  const component = entry.component || name.replace(/-\d+$/, '');
-  const draw = entry.drawindexed ? entry.drawindexed.join(',') : 'whole';
-  return `${component}::${draw}`;
-}
-
-function saveTextureState(modPath) {
-  if (!modPath || !window.pywebview?.api?.save_mesh_textures) return;
-  const state = {};
-  for (const mesh of activeMeshes) {
-    let texKey;
-    let manual = false;
-    if (mesh.userData.manualTexOverride !== undefined) {
-      texKey = mesh.userData.manualTexOverride;
-      manual = true;
-    } else if (mesh.userData.automaticTextureBoundary
-               && !mesh.userData.textureHighlightDisabled) {
-      texKey = mesh.userData.resolvedTexKey;
-    }
-    if (!texKey) continue;
-    const option = (mesh.userData.texturePool || []).find(o => o.tex_key === texKey);
-    // Removing an option also removes its persisted highlight, even though
-    // the already-rendered mesh may keep that texture until the next refresh.
-    if (!option) continue;
-    state[mesh.userData.metadataKey] = {
-      tex_key: texKey,
-      label: option.label,
-      manual,
-      normal_map: option.normal_map || null,
-      light_map: option.light_map || null,
-      material_map: option.material_map || null,
-      normal_map_manual: !!option.normal_map_manual,
-      light_map_manual: !!option.light_map_manual,
-      material_map_manual: !!option.material_map_manual,
-    };
-  }
-  const request = window.pywebview.api.save_mesh_textures(modPath, state);
-  if (request && typeof request.then === 'function') {
-    request.then(result => {
-      if (!result?.error) setHealthReport(null);
-    }, () => {});
-  } else {
-    setHealthReport(null);
-  }
-}
-
 function buildTextureList(pool, mesh, groupMeshes, onActiveChanged) {
   const wrap = document.createElement('div');
   wrap.className = 'tex-list collapsed';
@@ -340,7 +257,6 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
 
   const { wrap: texList, rebuild: rebuildTexList, syncSelection } = buildTextureList(
     pool, mesh, groupMeshes, onActiveChanged);
-  mesh.userData.updateTextureList = syncSelection;
 
   const chevron = document.createElement('span');
   chevron.className = 'group-toggle collapsed';
@@ -364,7 +280,6 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
       cb.title = m.visible ? 'Visible under the current mod state' : 'Hidden under the current mod state';
     }
   };
-  mesh.userData.updateStateIndicator = updateStateIndicator;
   updateStateIndicator(mesh);
   labelSpan.addEventListener('dblclick', (e) => {
     e.stopPropagation();
@@ -410,7 +325,14 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
     input.select();
   });
 
-  mesh.userData.row = row;
+  bindMeshView(mesh, {
+    row,
+    stateButton: cb,
+    syncStateIndicator: () => updateStateIndicator(mesh),
+    syncTextureSelection: syncSelection,
+    rebuildTextureList: rebuildTexList,
+    onTextureChanged: onActiveChanged,
+  });
   row.addEventListener('click', (e) => {
     if (e.target === cb) return; // the state button only ever toggles visibility
     if (e.target === chevron) {
@@ -441,6 +363,8 @@ function updateTexButtonState(texBtn, itemObjs) {
 export function buildMeshPanel(meshes, modPath, meshNames = {}) {
   const list = document.getElementById('mesh-list');
   list.innerHTML = '';
+  groupsUI = [];
+  registerViewSync('mesh-panel', syncMeshPanel);
 
   const bySource = groupBySource(meshes);
   const sources = Object.keys(bySource);
@@ -483,8 +407,7 @@ export function buildMeshPanel(meshes, modPath, meshNames = {}) {
 
       for (const name of names) {
         const mesh = buildMesh(name, meshes[name]);
-        mesh.userData.onTextureChanged = onActiveChanged;
-        mesh.userData.metadataKey = metadataKey(name, meshes[name]);
+        mesh.userData.metadataKey = meshMetadataKey(name, meshes[name]);
         mesh.userData.texturePool = texturePool;
         mesh.userData.displayName = meshNames[mesh.userData.metadataKey] || null;
         mesh.userData.meshNames = meshNames;
@@ -526,11 +449,11 @@ export function buildMeshPanel(meshes, modPath, meshNames = {}) {
           itemObjs[i].userData.manualVisible = v;
           itemObjs[i].userData.manuallyToggled = true;
           applyMeshVisibility(itemObjs[i]);
-          itemObjs[i].userData.updateStateIndicator?.(itemObjs[i]);
+          getMeshView(itemObjs[i])?.syncStateIndicator?.();
         });
       });
 
-      registerGroup({
+      groupsUI.push({
         masterCb, itemCbs, itemObjs, onTexChanged: onActiveChanged,
         applyTextureRuns: () => recomputeTextureRuns(itemObjs),
       });

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -1,0 +1,146 @@
+// Active meshes and the mod control state resolved onto their rendering data.
+
+import { scene, resetModelOrientation } from './scene.js';
+import { dnfSatisfied, getControlValue } from './control-state.js';
+import { setMeshTextureState } from './mesh-factory.js';
+import { initializeMeshRenderModes } from './render-modes.js';
+
+export const activeMeshes = [];
+
+export function resetMeshes() {
+  activeMeshes.forEach(mesh => {
+    scene.remove(mesh);
+    mesh.geometry.dispose();
+    const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    materials.forEach(material => material.dispose());
+  });
+  activeMeshes.length = 0;
+  resetModelOrientation();
+}
+
+export function addMesh(mesh, conditions, sources, textureVariants, materialVariants = {}) {
+  mesh.userData.manualVisible = true;
+  mesh.userData.loadedVisible = true;
+  mesh.userData.manuallyToggled = false;
+  mesh.userData.conditions = conditions || [];
+  mesh.userData.sources = sources || [];
+  mesh.userData.textureVariants = textureVariants || [];
+  mesh.userData.normalMapVariants = materialVariants.normal_map || [];
+  mesh.userData.lightMapVariants = materialVariants.light_map || [];
+  mesh.userData.materialMapVariants = materialVariants.material_map || [];
+  // The texture selected by the INI under the current control state. Ordered
+  // component texture runs may still make a following mesh inherit it.
+  mesh.userData.resolvedTexKey = mesh.userData.defaultTexKey;
+  // undefined = automatic; string = a sticky manual selection.
+  mesh.userData.manualTexOverride = undefined;
+  initializeMeshRenderModes(mesh);
+  scene.add(mesh);
+  activeMeshes.push(mesh);
+  applyTextureVariant(mesh);
+}
+
+export function resetMeshVisibility() {
+  activeMeshes.forEach(mesh => {
+    mesh.userData.manualVisible = mesh.userData.loadedVisible !== false;
+    mesh.userData.manuallyToggled = false;
+    applyMeshVisibility(mesh);
+  });
+}
+
+/** Pin or clear one mesh's highlighted diffuse. Ordered component propagation
+ * remains the texture-state module's responsibility. */
+export function setManualTexOverride(mesh, value) {
+  mesh.userData.manualTexOverride = value;
+  applyTextureVariant(mesh);
+}
+
+export function conditionsSatisfied(mesh) {
+  return dnfSatisfied(mesh.userData.conditions);
+}
+
+export function applyTextureVariant(mesh) {
+  const resolve = (variants, fallback) => {
+    variants = variants || [];
+    const variant = variants.findLast
+      ? variants.findLast(item => dnfSatisfied(item.conditions))
+      : [...variants].reverse().find(item => dnfSatisfied(item.conditions));
+    return variant ? variant.tex_key : fallback;
+  };
+  mesh.userData.resolvedTexKey = resolve(
+    mesh.userData.textureVariants, mesh.userData.defaultTexKey);
+  mesh.userData.resolvedNormalMapKey = resolve(
+    mesh.userData.normalMapVariants, mesh.userData.defaultNormalMapKey);
+  mesh.userData.resolvedLightMapKey = resolve(
+    mesh.userData.lightMapVariants, mesh.userData.defaultLightMapKey);
+  mesh.userData.resolvedMaterialMapKey = resolve(
+    mesh.userData.materialMapVariants, mesh.userData.defaultMaterialMapKey);
+  setMeshTextureState(mesh, {
+    diffuse: mesh.userData.manualTexOverride !== undefined
+      ? mesh.userData.manualTexOverride
+      : mesh.userData.resolvedTexKey,
+    normal_map: mesh.userData.resolvedNormalMapKey,
+    light_map: mesh.userData.resolvedLightMapKey,
+    material_map: mesh.userData.resolvedMaterialMapKey,
+  });
+}
+
+// The MESHES control is the direct visibility source. Gating conditions only
+// re-baseline manualVisible during refreshMeshes(), so a manual click can
+// always reveal a currently gated mesh.
+export function applyMeshVisibility(mesh) {
+  mesh.visible = mesh.userData.manualVisible !== false;
+}
+
+function applyShapeTargets(mesh) {
+  const targets = mesh.userData.shapeTargets || [];
+  if (!targets.length) return;
+  const controlValues = targets.map(target => getControlValue(target.var) ?? 0);
+  const previous = mesh.userData.shapeControlValues;
+  if (previous?.length === controlValues.length
+      && controlValues.every((value, index) => value === previous[index])) return;
+  mesh.userData.shapeControlValues = controlValues;
+
+  const attr = mesh.geometry.attributes.position;
+  const base = mesh.userData.basePositions;
+  attr.array.set(base);
+  const midpointTargets = targets.filter(target => target.mode === 'midpoint_pair');
+  for (const target of targets) {
+    const weight = Number(getControlValue(target.var) ?? 0);
+    if (!Number.isFinite(weight)) continue;
+    if (target.mode === 'midpoint_pair') {
+      const endpoint = weight <= 0.5 ? target.lowPositions : target.positions;
+      // Preserve the shader's endpoint extrapolation. Independently-shaped
+      // midpoint targets are averaged, so each uses a 0..2 delta factor.
+      const factor = weight <= 0.5 ? 2 - weight * 4 : weight * 4 - 2;
+      const divisor = midpointTargets.length || 1;
+      for (let index = 0; index < attr.array.length; index++) {
+        const shaped = base[index] + (endpoint[index] - base[index]) * factor;
+        attr.array[index] += (shaped - base[index]) / divisor;
+      }
+      continue;
+    }
+    if (weight === 0) continue;
+    for (let index = 0; index < attr.array.length; index++) {
+      attr.array[index] += (target.positions[index] - base[index]) * weight;
+    }
+  }
+  attr.needsUpdate = true;
+  mesh.geometry.computeVertexNormals();
+  mesh.geometry.computeBoundingBox();
+  mesh.geometry.computeBoundingSphere();
+}
+
+export function refreshMeshes() {
+  activeMeshes.forEach(mesh => {
+    if ((mesh.userData.conditions || []).length > 0) {
+      mesh.userData.manualVisible = conditionsSatisfied(mesh);
+    }
+    applyMeshVisibility(mesh);
+    if (!mesh.userData.defaultCaptured) {
+      mesh.userData.loadedVisible = mesh.visible;
+      mesh.userData.defaultCaptured = true;
+    }
+    applyTextureVariant(mesh);
+    applyShapeTargets(mesh);
+  });
+}

--- a/src/web/js/mesh-texture-state.js
+++ b/src/web/js/mesh-texture-state.js
@@ -1,0 +1,109 @@
+// Component texture propagation, lazy loading and viewer-only persistence.
+
+import { addTexture, hasTexture, setMeshTextureState } from './mesh-factory.js';
+import { activeMeshes } from './mesh-state.js';
+import { setHealthReport } from './health-report.js';
+
+export function recomputeTextureRuns(groupMeshes) {
+  let activeKey = null;
+  let activeMaps = null;
+  for (const mesh of groupMeshes) {
+    if (mesh.userData.manualTexOverride !== undefined) {
+      activeKey = mesh.userData.manualTexOverride;
+      const option = (mesh.userData.texturePool || [])
+        .find(candidate => candidate.tex_key === activeKey);
+      activeMaps = option ? {
+        normal_map: option.normal_map || null,
+        light_map: option.light_map || null,
+        material_map: option.material_map || null,
+      } : null;
+    } else if (mesh.userData.automaticTextureBoundary
+               && !mesh.userData.textureHighlightDisabled) {
+      // Automatic boundaries use the live resolved diffuse and propagate only
+      // until the next boundary in this ordered component.
+      activeKey = mesh.userData.resolvedTexKey;
+      const diffuseKeys = new Set([
+        activeKey,
+        mesh.userData.defaultTexKey,
+        ...(mesh.userData.textureVariants || []).map(variant => variant.tex_key),
+      ].filter(Boolean));
+      for (const option of (mesh.userData.texturePool || [])) {
+        if (!diffuseKeys.has(option.tex_key)) continue;
+        const resolvedMaps = {
+          normal_map: mesh.userData.resolvedNormalMapKey,
+          light_map: mesh.userData.resolvedLightMapKey,
+          material_map: mesh.userData.resolvedMaterialMapKey,
+        };
+        for (const [field, key] of Object.entries(resolvedMaps)) {
+          if (option[`${field}_manual`]) continue;
+          if (key) option[field] = key;
+          else delete option[field];
+        }
+      }
+      activeMaps = null;
+    }
+    const maps = activeMaps || {
+      normal_map: mesh.userData.resolvedNormalMapKey,
+      light_map: mesh.userData.resolvedLightMapKey,
+      material_map: mesh.userData.resolvedMaterialMapKey,
+    };
+    setMeshTextureState(mesh, { diffuse: activeKey, ...maps });
+  }
+}
+
+export async function ensureTextureLoaded(mesh, texKey) {
+  if (!texKey || hasTexture(texKey)) return true;
+  const api = window.pywebview?.api;
+  // Browser-only fixtures exercise state without the native image bridge.
+  if (!api?.load_texture_file) return true;
+  const result = await api.load_texture_file(mesh.userData.modPath, texKey);
+  if (!result || result.error) return false;
+  addTexture(result.tex_key, result.uri);
+  return true;
+}
+
+export function meshMetadataKey(name, entry) {
+  const component = entry.component || name.replace(/-\d+$/, '');
+  const draw = entry.drawindexed ? entry.drawindexed.join(',') : 'whole';
+  return `${component}::${draw}`;
+}
+
+export function saveTextureState(modPath) {
+  if (!modPath || !window.pywebview?.api?.save_mesh_textures) return;
+  const state = {};
+  for (const mesh of activeMeshes) {
+    let texKey;
+    let manual = false;
+    if (mesh.userData.manualTexOverride !== undefined) {
+      texKey = mesh.userData.manualTexOverride;
+      manual = true;
+    } else if (mesh.userData.automaticTextureBoundary
+               && !mesh.userData.textureHighlightDisabled) {
+      texKey = mesh.userData.resolvedTexKey;
+    }
+    if (!texKey) continue;
+    const option = (mesh.userData.texturePool || [])
+      .find(candidate => candidate.tex_key === texKey);
+    // Removing an option also removes its persisted highlight.
+    if (!option) continue;
+    state[mesh.userData.metadataKey] = {
+      tex_key: texKey,
+      label: option.label,
+      manual,
+      normal_map: option.normal_map || null,
+      light_map: option.light_map || null,
+      material_map: option.material_map || null,
+      normal_map_manual: !!option.normal_map_manual,
+      light_map_manual: !!option.light_map_manual,
+      material_map_manual: !!option.material_map_manual,
+    };
+  }
+  const request = window.pywebview.api.save_mesh_textures(modPath, state);
+  if (request && typeof request.then === 'function') {
+    request.then(result => {
+      if (!result?.error) setHealthReport(null);
+    }, () => {});
+  } else {
+    setHealthReport(null);
+  }
+}

--- a/src/web/js/mesh-view-bindings.js
+++ b/src/web/js/mesh-view-bindings.js
@@ -1,0 +1,12 @@
+// Mesh-to-DOM associations belong to the view, not THREE.Mesh.userData.
+
+const bindings = new WeakMap();
+
+export function bindMeshView(mesh, binding) {
+  bindings.set(mesh, binding);
+  return binding;
+}
+
+export function getMeshView(mesh) {
+  return bindings.get(mesh);
+}

--- a/src/web/js/modal-shell.js
+++ b/src/web/js/modal-shell.js
@@ -1,0 +1,17 @@
+// Small shared behavior for ordinary modals. Ace and confirm dialogs remain
+// specialized because their Escape handling has different semantics.
+
+export function bindModalDismiss({ backdrop, close, buttons = [] }) {
+  buttons.forEach(button => button.addEventListener('click', close));
+  backdrop.addEventListener('click', event => {
+    if (event.target === backdrop) close();
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && backdrop.classList.contains('show')) close();
+  });
+}
+
+export function setModalError(element, message = '') {
+  element.textContent = message;
+  element.style.display = message ? 'block' : 'none';
+}

--- a/src/web/js/panel-utils.js
+++ b/src/web/js/panel-utils.js
@@ -1,0 +1,39 @@
+// Exact shared source grouping/collapse behavior used by the three panels.
+
+export function groupKeysBySource(records, keys = Object.keys(records || {})) {
+  const grouped = {};
+  for (const key of keys) {
+    const source = records[key]?.source || '';
+    (grouped[source] = grouped[source] || []).push(key);
+  }
+  return grouped;
+}
+
+export function usesSourceSections(grouped) {
+  const sources = Object.keys(grouped);
+  return sources.length > 1 || (sources.length === 1 && sources[0] !== '');
+}
+
+export function buildSourceSection(source, container, {
+  headerClass = 'toggle-src-hdr',
+  itemsClass = 'toggle-src-items',
+} = {}) {
+  const header = document.createElement('div');
+  header.className = headerClass;
+  const chevron = document.createElement('span');
+  chevron.className = 'group-toggle';
+  chevron.textContent = '▼';
+  const name = document.createElement('span');
+  name.className = 'group-name';
+  name.textContent = source;
+  header.append(chevron, name);
+
+  const items = document.createElement('div');
+  items.className = itemsClass;
+  header.addEventListener('click', () => {
+    chevron.classList.toggle('collapsed');
+    items.classList.toggle('collapsed');
+  });
+  container.append(header, items);
+  return items;
+}

--- a/src/web/js/present-modal.js
+++ b/src/web/js/present-modal.js
@@ -1,6 +1,7 @@
 // Add/edit dialog for the reserved [KeyModViewerPresent] binding.
 
 import { getToggleState } from './visibility.js';
+import { bindModalDismiss, setModalError } from './modal-shell.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -17,8 +18,7 @@ export function presentSnapshots(present) {
 }
 
 function setError(message) {
-  $('pm-error').textContent = message || '';
-  $('pm-error').style.display = message ? 'block' : 'none';
+  setModalError($('pm-error'), message);
 }
 
 function close() {
@@ -70,10 +70,8 @@ async function submit(event) {
 }
 
 $('pm-form').addEventListener('submit', submit);
-$('pm-cancel').addEventListener('click', close);
-$('present-modal-backdrop').addEventListener('click', (event) => {
-  if (event.target.id === 'present-modal-backdrop') close();
-});
-document.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape' && $('present-modal-backdrop').classList.contains('show')) close();
+bindModalDismiss({
+  backdrop: $('present-modal-backdrop'),
+  close,
+  buttons: [$('pm-cancel')],
 });

--- a/src/web/js/present-panel.js
+++ b/src/web/js/present-panel.js
@@ -1,15 +1,15 @@
 // One logical PRESENT cycle, authored atomically across every eligible INI.
 
-import { refreshAll, setToggleValue } from './visibility.js';
-import { refreshToggleValues } from './toggle-panel.js';
-import { refreshMenuValues } from './menu-panel.js';
+import { getToggleValue, refreshAll, setToggleValue } from './visibility.js';
 import { alertDialog, confirmDialog, inputConfirmDialog } from './dialogs.js';
 import { openPresentModal, presentSnapshots } from './present-modal.js';
+import { registerViewSync } from './view-sync.js';
 
 const $ = (id) => document.getElementById(id);
 const MAX_PRESENTS = 10;
 let current = { modPath: null, present: null, onChange: null };
 let pendingSelection = null;
+let syncCurrentValue = () => {};
 
 async function removeKey() {
   const confirmed = await confirmDialog(
@@ -113,16 +113,25 @@ function buildItem(item) {
       ? (item.names[position] || `Present ${position + 1}`)
       : 'Unavailable';
   };
+  const sync = () => {
+    if (synchronized) {
+      const matches = candidate => item.vars.every(variable =>
+        variable.values[candidate] === getToggleValue(variable.var));
+      if (!matches(position)) {
+        const next = Array.from({ length: item.count }, (_, index) => index)
+          .find(matches);
+        if (next !== undefined) position = next;
+      }
+    }
+    showName();
+  };
   showName();
   cycle.onclick = () => {
     position = (position + 1) % item.count;
     for (const variable of item.vars) {
       setToggleValue(variable.var, variable.values[position]);
     }
-    showName();
     refreshAll();
-    refreshToggleValues();
-    refreshMenuValues();
   };
   row.append(cycle, name);
 
@@ -131,7 +140,7 @@ function buildItem(item) {
     error.className = 'present-sync-error';
     error.textContent = item.sync_error || 'PRESENT has no usable positions.';
     wrap.append(header, row, error);
-    return wrap;
+    return { wrap, sync };
   }
 
   const actions = document.createElement('div');
@@ -184,7 +193,7 @@ function buildItem(item) {
   });
   actions.append(add, replace, remove);
   wrap.append(header, row, actions);
-  return wrap;
+  return { wrap, sync };
 }
 
 export function buildPresentPanel(present, context = {}) {
@@ -194,6 +203,8 @@ export function buildPresentPanel(present, context = {}) {
   const list = $('present-list');
   const action = $('present-action-btn');
   list.innerHTML = '';
+  syncCurrentValue = () => {};
+  registerViewSync('present-panel', () => syncCurrentValue());
   if (!current.modPath) {
     panel.style.display = 'none';
     return;
@@ -217,8 +228,8 @@ export function buildPresentPanel(present, context = {}) {
     return;
   }
 
-  list.appendChild(buildItem(item));
+  const built = buildItem(item);
+  syncCurrentValue = built.sync;
+  list.appendChild(built.wrap);
   refreshAll();
-  refreshToggleValues();
-  refreshMenuValues();
 }

--- a/src/web/js/record-session.js
+++ b/src/web/js/record-session.js
@@ -1,5 +1,5 @@
 // Record mode: assign which meshes are visible at each cycle position of a
-// toggle, then rewrite the ini's gates to match.
+// toggle, then stage a rewrite of the INI gates to match.
 //
 // Repurposes the toggle's own MESHES panel and cycle button rather than a
 // modal: cycling the same ⟳ button steps through positions, and the

--- a/src/web/js/render-modes.js
+++ b/src/web/js/render-modes.js
@@ -1,0 +1,51 @@
+// Viewer-only material display modes and their toolbar state.
+
+import { refreshMeshTexture, setTextureMode } from './mesh-factory.js';
+
+let wireframe = false;
+let smoothShading = true;
+const textureModes = ['all', 'diffuse', 'none'];
+let textureModeIndex = 0;
+
+export function initializeMeshRenderModes(mesh) {
+  mesh.material.wireframe = wireframe;
+  mesh.material.flatShading = !smoothShading;
+}
+
+export function toggleWireframeMode(meshes) {
+  wireframe = !wireframe;
+  document.getElementById('wire-btn').classList.toggle('active', wireframe);
+  meshes.forEach(mesh => {
+    const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    materials.forEach(material => { material.wireframe = wireframe; });
+  });
+}
+
+export function toggleSmoothShadingMode(meshes) {
+  smoothShading = !smoothShading;
+  document.getElementById('shading-btn').classList.toggle('off', !smoothShading);
+  meshes.forEach(mesh => {
+    const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    materials.forEach(material => {
+      material.flatShading = !smoothShading;
+      material.needsUpdate = true;
+    });
+  });
+}
+
+export function toggleTextureDisplayMode(meshes) {
+  textureModeIndex = (textureModeIndex + 1) % textureModes.length;
+  const mode = textureModes[textureModeIndex];
+  const button = document.getElementById('texture-btn');
+  button.classList.toggle('diffuse-only', mode === 'diffuse');
+  button.classList.toggle('off', mode === 'none');
+  const labels = {
+    all: 'Textures: all maps',
+    diffuse: 'Textures: diffuse only',
+    none: 'Textures: none',
+  };
+  button.title = labels[mode];
+  button.setAttribute('aria-label', labels[mode]);
+  setTextureMode(mode);
+  meshes.forEach(refreshMeshTexture);
+}

--- a/src/web/js/scene.js
+++ b/src/web/js/scene.js
@@ -21,7 +21,7 @@ const hemisphereLight = new THREE.HemisphereLight(0xffffff, 0x30343f, 0.35);
 scene.add(ambientLight, hemisphereLight);
 
 // The movable key light remains independent from environment-owned lighting.
-const keyLight = new THREE.DirectionalLight(0xffffff, 0.5);
+const keyLight = new THREE.DirectionalLight(0xffffff, 1);
 keyLight.position.set(5, 10, 7);
 scene.add(keyLight, keyLight.target);
 

--- a/src/web/js/scene.js
+++ b/src/web/js/scene.js
@@ -1,9 +1,11 @@
-// Three.js scene, camera, lighting and grid — everything that is about
-// *rendering* rather than about the mod being displayed.
+// Three.js scene composition and the permanent viewport render loop.
 
 import * as THREE from 'three';
 import { ArcballControls } from 'three/addons/controls/ArcballControls.js';
+import { createCameraFrame } from './camera-frame.js';
 import { createEnvironmentController } from './environment.js';
+import { createKeyLightController } from './key-light-controller.js';
+import { createViewGizmoController } from './view-gizmo-controller.js';
 
 const container = document.getElementById('canvas-container');
 
@@ -14,40 +16,14 @@ container.appendChild(renderer.domElement);
 
 export const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x0d1117);
-// Ambient light alone cannot reveal normal-map detail because it has no
-// direction. Keep a soft neutral base plus a low hemisphere fill so surfaces
-// remain readable when the movable key light is in its Gray/off stage.
 const ambientLight = new THREE.AmbientLight(0xffffff, 0.55);
 const hemisphereLight = new THREE.HemisphereLight(0xffffff, 0x30343f, 0.35);
-scene.add(ambientLight);
-scene.add(hemisphereLight);
+scene.add(ambientLight, hemisphereLight);
 
-const dirLight = new THREE.DirectionalLight(0xffffff, 0.5);
-dirLight.position.set(5, 10, 7);
-scene.add(dirLight);
-scene.add(dirLight.target);
-
-// Compact screen-facing key-light handle. A sprite reads as a viewport control
-// instead of an object in the model, and stays legible from every angle.
-const lightIconCanvas = document.createElement('canvas');
-lightIconCanvas.width = lightIconCanvas.height = 64;
-const lightIconContext = lightIconCanvas.getContext('2d');
-const lightGlow = lightIconContext.createRadialGradient(32, 32, 4, 32, 32, 30);
-lightGlow.addColorStop(0, 'rgba(255,248,190,1)');
-lightGlow.addColorStop(0.35, 'rgba(255,216,102,.95)');
-lightGlow.addColorStop(0.7, 'rgba(255,184,70,.4)');
-lightGlow.addColorStop(1, 'rgba(255,184,70,0)');
-lightIconContext.fillStyle = lightGlow;
-lightIconContext.fillRect(0, 0, 64, 64);
-const lightHandle = new THREE.Sprite(new THREE.SpriteMaterial({
-  map: new THREE.CanvasTexture(lightIconCanvas), transparent: true,
-  // Let model depth occlude the draggable marker so the handle does not
-  // remain visible through the character.
-  depthTest: true, depthWrite: false,
-}));
-lightHandle.renderOrder = 1000;
-lightHandle.visible = true;
-scene.add(lightHandle);
+// The movable key light remains independent from environment-owned lighting.
+const keyLight = new THREE.DirectionalLight(0xffffff, 0.5);
+keyLight.position.set(5, 10, 7);
+scene.add(keyLight, keyLight.target);
 
 const grid = new THREE.GridHelper(4, 20, 0x21262d, 0x161b22);
 scene.add(grid);
@@ -59,24 +35,44 @@ camera.position.set(0, 1, 3);
 export const controls = new ArcballControls(camera, renderer.domElement, scene);
 controls.target.set(0, 0, 0);
 controls.enableAnimations = true;
-// The viewer owns model-scaled clipping planes (fitTo/frameView). Arcball's
-// automatic near/far adjustment is based on the camera values from startup;
-// letting it overwrite our later model-scaled values makes meshes disappear
-// while zooming.
+// Model-scaled clipping belongs to cameraFrame; Arcball must not overwrite it.
 controls.adjustNearFar = false;
 controls.setGizmosVisible(false);
 
-// The key light is deliberately not handed to EnvironmentController: its
-// intensity is an explicit user interaction (double/current/off) and must not
-// be mistaken for environment-owned lighting. Environment presets own the
-// ambient, hemisphere and one accent light; the movable key remains an
-// independent inspection light layered on top.
 const environmentController = createEnvironmentController({
   scene,
   ambientLight,
   hemisphereLight,
-  lightTarget: dirLight.target,
+  lightTarget: keyLight.target,
 });
+const keyLightController = createKeyLightController({
+  scene, camera, renderer, controls, light: keyLight,
+});
+const viewGizmoController = createViewGizmoController({
+  camera, controls, element: document.getElementById('view-gizmo'),
+});
+const cameraFrame = createCameraFrame({
+  camera,
+  renderer,
+  controls,
+  grid,
+  cancelViewSnap: viewGizmoController.cancelSnap,
+  onModelFit: keyLightController.rebase,
+});
+
+new ResizeObserver(() => {
+  cameraFrame.resize(container.clientWidth, container.clientHeight);
+}).observe(container);
+
+(function tick() {
+  requestAnimationFrame(tick);
+  viewGizmoController.updateSnap();
+  controls.update();
+  keyLightController.update();
+  cameraFrame.updateClipping();
+  viewGizmoController.updateAxes();
+  renderer.render(scene, camera);
+})();
 
 export function setEnvironmentPreset(id) {
   return environmentController.setPreset(id);
@@ -86,551 +82,39 @@ export function getEnvironmentPreset() {
   return environmentController.getPreset();
 }
 
-let trackballGizmoVisible = true;
-const viewGizmo = document.getElementById('view-gizmo');
-const gizmoAxes = [...viewGizmo.querySelectorAll('.gizmo-axis')];
-const _axisVectors = {
-  x: new THREE.Vector3(1, 0, 0),
-  y: new THREE.Vector3(0, 1, 0),
-  z: new THREE.Vector3(0, 0, 1),
-};
-const _gizmoLocal = new THREE.Vector3();
-const _inverseCamera = new THREE.Quaternion();
-let viewSnap = null;
-let gizmoDrag = null;
-let homeView = null;
-let clipNear = camera.near;
-let clipFar = camera.far;
-let uprightApplied = false;
-let modelQuarterTurns = 0;
-let modelPivot = null;
-let lightDrag = null;
-let lightPointerInside = false;
-const lightModes = ['double', 'current', 'off'];
-let lightModeIndex = 0;
-const lightRaycaster = new THREE.Raycaster();
-const lightPointer = new THREE.Vector2();
-const lightDragPlane = new THREE.Plane();
-const lightHit = new THREE.Vector3();
-const INITIAL_CAMERA_DIRECTION = new THREE.Vector3(0, 0, 1);
-const INITIAL_CAMERA_UP = new THREE.Vector3(0, 1, 0);
-
-export function resetModelOrientation() {
-  uprightApplied = false;
-  modelQuarterTurns = 0;
-  modelPivot = null;
-}
-
-/** Rotate the current model one quarter-turn around the viewer/world Y axis. */
-export function rotateModelQuarterTurn(meshes = []) {
-  const yaw = new THREE.Quaternion().setFromAxisAngle(
-    new THREE.Vector3(0, 1, 0), Math.PI / 2);
-  rotateMeshesAroundCenter(meshes, yaw);
-  modelQuarterTurns = (modelQuarterTurns + 1) % 4;
-}
-
-/** Rotate the current model one quarter-turn around the viewer/world X axis. */
-export function rotateModelHorizontalQuarterTurn(meshes = []) {
-  const pitch = new THREE.Quaternion().setFromAxisAngle(
-    new THREE.Vector3(1, 0, 0), Math.PI / 2);
-  rotateMeshesAroundCenter(meshes, pitch);
-}
-
-function rotateMeshesAroundCenter(meshes, rotation) {
-  if (!meshes.length) return;
-  // Use the center captured after the initial upright correction. Recomputing
-  // an axis-aligned bounding-box center after every turn causes asymmetric
-  // models to drift because that center changes with orientation.
-  let center = modelPivot && modelPivot.clone();
-  if (!center) {
-    const box = new THREE.Box3();
-    meshes.forEach(m => box.expandByObject(m));
-    if (box.isEmpty()) return;
-    center = box.getCenter(new THREE.Vector3());
-  }
-  meshes.forEach(m => {
-    m.position.sub(center).applyQuaternion(rotation).add(center);
-    m.quaternion.premultiply(rotation);
-  });
-}
-
-new ResizeObserver(() => {
-  camera.aspect = container.clientWidth / container.clientHeight;
-  renderer.setSize(container.clientWidth, container.clientHeight);
-  updateCameraViewport();
-}).observe(container);
-
-(function tick() {
-  requestAnimationFrame(tick);
-  updateViewSnap();
-  controls.update();
-  dirLight.target.position.copy(controls.target);
-  lightHandle.position.copy(dirLight.position);
-  const handleMultiplier = lightModes[lightModeIndex] === 'double' ? 2 : 1;
-  const handleSize = Math.max(
-    camera.position.distanceTo(controls.target) * 0.035 * handleMultiplier,
-    0.0001);
-  lightHandle.scale.set(handleSize, handleSize, 1);
-  // ArcballControls may restore its startup clip values during a scale
-  // operation. Reapply the viewer's model-scaled planes after that update.
-  const viewDistance = camera.position.distanceTo(controls.target);
-  const requiredFar = Math.max(clipFar, viewDistance * 4, 100);
-  if (camera.near !== clipNear || camera.far !== requiredFar) {
-    camera.near = clipNear;
-    camera.far = requiredFar;
-    camera.updateProjectionMatrix();
-  }
-  updateViewGizmo();
-  renderer.render(scene, camera);
-})();
-
 export function toggleGrid() {
   grid.visible = !grid.visible;
   document.getElementById('grid-btn').classList.toggle('off', !grid.visible);
 }
 
 export function toggleTrackballGizmo() {
-  const visible = !trackballGizmoVisible;
-  trackballGizmoVisible = visible;
-  viewGizmo.classList.toggle('hidden', !visible);
-  document.getElementById('trackball-btn').classList.toggle('active', visible);
-  document.getElementById('trackball-btn').classList.toggle('off', !visible);
+  viewGizmoController.toggle();
 }
 
 export function toggleLightHandle() {
-  lightModeIndex = (lightModeIndex + 1) % lightModes.length;
-  const mode = lightModes[lightModeIndex];
-  const visible = mode !== 'off';
-  lightHandle.visible = visible;
-  dirLight.intensity = mode === 'double' ? 1 : (mode === 'current' ? 0.5 : 0);
-  const button = document.getElementById('light-btn');
-  button.classList.toggle('double', mode === 'double');
-  button.classList.toggle('current', mode === 'current');
-  button.classList.toggle('off', mode === 'off');
-  const labels = {
-    double: 'Key light: double brightness and handle size',
-    current: 'Key light: normal (drag; Shift-drag for depth)',
-    off: 'Key light: off',
-  };
-  button.title = labels[mode];
-  button.setAttribute('aria-label', labels[mode]);
-  updateLightCursor();
+  keyLightController.toggleMode();
 }
-
-function updateLightPointer(event) {
-  const rect = renderer.domElement.getBoundingClientRect();
-  lightPointer.set(
-    ((event.clientX - rect.left) / rect.width) * 2 - 1,
-    -((event.clientY - rect.top) / rect.height) * 2 + 1);
-  lightRaycaster.setFromCamera(lightPointer, camera);
-}
-
-function canInteractWithLight(event = null) {
-  if (event) {
-    const rect = renderer.domElement.getBoundingClientRect();
-    lightPointerInside = event.clientX >= rect.left && event.clientX <= rect.right &&
-      event.clientY >= rect.top && event.clientY <= rect.bottom;
-    updateLightPointer(event);
-  }
-  if (!lightPointerInside || !lightHandle.visible) return false;
-
-  // Hovering the small sprite is cheap. Only build/raycast the visible model
-  // set after it is a candidate, so ordinary pointer movement never tests all
-  // of a mod's triangles.
-  const handleHit = lightRaycaster.intersectObject(lightHandle, false)[0];
-  if (!handleHit) return false;
-
-  const visibleMeshes = [];
-  scene.traverseVisible(object => {
-    if (object.isMesh) visibleMeshes.push(object);
-  });
-  const blocker = lightRaycaster.intersectObjects(visibleMeshes, false)[0];
-  return !blocker || blocker.distance >= handleHit.distance;
-}
-
-function updateLightCursor(event = null) {
-  if (lightDrag) return;
-  renderer.domElement.style.cursor = canInteractWithLight(event) ? 'crosshair' : '';
-}
-
-renderer.domElement.addEventListener('pointerenter', event => {
-  lightPointerInside = true;
-  updateLightCursor(event);
-});
-renderer.domElement.addEventListener('pointerleave', () => {
-  lightPointerInside = false;
-  if (!lightDrag) renderer.domElement.style.cursor = '';
-});
-
-renderer.domElement.addEventListener('pointerdown', event => {
-  if (event.button !== 0 || !canInteractWithLight(event)) return;
-  event.preventDefault();
-  event.stopImmediatePropagation();
-  const cameraDirection = camera.getWorldDirection(new THREE.Vector3());
-  lightDragPlane.setFromNormalAndCoplanarPoint(cameraDirection, dirLight.position);
-  lightDrag = {
-    pointerId: event.pointerId,
-    depthMode: event.shiftKey,
-    startY: event.clientY,
-    startPosition: dirLight.position.clone(),
-    cameraDirection,
-    depthScale: Math.max(camera.position.distanceTo(controls.target) * 0.004,
-      0.0001),
-  };
-  controls.enabled = false;
-  renderer.domElement.setPointerCapture(event.pointerId);
-  renderer.domElement.style.cursor = 'grabbing';
-}, { capture: true });
-
-renderer.domElement.addEventListener('pointermove', event => {
-  if (!lightDrag) {
-    lightPointerInside = true;
-    updateLightCursor(event);
-    return;
-  }
-  if (event.pointerId !== lightDrag.pointerId) return;
-  if (lightDrag.depthMode) {
-    dirLight.position.copy(lightDrag.startPosition).addScaledVector(
-      lightDrag.cameraDirection,
-      (lightDrag.startY - event.clientY) * lightDrag.depthScale);
-    return;
-  }
-  updateLightPointer(event);
-  if (lightRaycaster.ray.intersectPlane(lightDragPlane, lightHit)) {
-    dirLight.position.copy(lightHit);
-  }
-});
-
-function finishLightDrag(event) {
-  if (!lightDrag || event.pointerId !== lightDrag.pointerId) return;
-  renderer.domElement.releasePointerCapture(event.pointerId);
-  lightDrag = null;
-  controls.enabled = true;
-  updateLightCursor(event);
-}
-renderer.domElement.addEventListener('pointerup', finishLightDrag);
-renderer.domElement.addEventListener('pointercancel', finishLightDrag);
-
-/** The canvas runs behind the floating side panels. Aim the projection at the
- * center of the unobstructed region while leaving controls.target on the
- * model itself, so orbiting still uses the correct physical pivot. */
-function usableViewport() {
-  const canvas = renderer.domElement.getBoundingClientRect();
-  const fullWidth = Math.max(canvas.width, 1);
-  const fullHeight = Math.max(canvas.height, 1);
-  let left = 0;
-  let right = fullWidth;
-  const gap = 14;
-
-  for (const id of ['sidebar', 'camera-panel']) {
-    const element = document.getElementById(id);
-    const rect = element?.getBoundingClientRect();
-    if (element && getComputedStyle(element).display !== 'none' && rect.width > 1) {
-      left = Math.max(left, rect.right - canvas.left + gap);
-    }
-  }
-  const rightDock = document.getElementById('right-dock');
-  const dockRect = rightDock?.getBoundingClientRect();
-  if (rightDock && getComputedStyle(rightDock).display !== 'none' && dockRect.width > 1) {
-    right = Math.min(right, dockRect.left - canvas.left - gap);
-  }
-
-  // A pathological narrow window should degrade to ordinary full-canvas
-  // framing rather than create a nearly zero-width projection.
-  if (right - left < fullWidth * 0.25) {
-    left = 0;
-    right = fullWidth;
-  }
-  return {
-    fullWidth,
-    fullHeight,
-    width: right - left,
-    centerShiftX: (left + right - fullWidth) * 0.5,
-  };
-}
-
-function updateCameraViewport() {
-  const viewport = usableViewport();
-  camera.clearViewOffset();
-  if (Math.abs(viewport.centerShiftX) > 0.5) {
-    // A negative view offset shifts the world's projected center right.
-    camera.setViewOffset(
-      viewport.fullWidth, viewport.fullHeight,
-      -viewport.centerShiftX, 0,
-      viewport.fullWidth, viewport.fullHeight);
-  }
-  camera.updateProjectionMatrix();
-  return viewport;
-}
-
-/** Keep the compass aligned with the world while its projection follows the
- * live camera, matching Blender's viewport navigation gizmo. */
-function updateViewGizmo() {
-  if (!trackballGizmoVisible) return;
-  _inverseCamera.copy(camera.quaternion).invert();
-  const projected = gizmoAxes.map(axis => {
-    const sign = Number(axis.dataset.sign);
-    _gizmoLocal.copy(_axisVectors[axis.dataset.axis]).multiplyScalar(sign)
-      .applyQuaternion(_inverseCamera);
-    return {
-      axis,
-      x: 52 + _gizmoLocal.x * 34,
-      y: 52 - _gizmoLocal.y * 34,
-      depth: _gizmoLocal.z,
-    };
-  });
-  // Far endpoints paint first so the near-facing axis stays legible where
-  // axes overlap in front/top/side views.
-  const svg = viewGizmo.querySelector('svg');
-  projected.sort((a, b) => a.depth - b.depth);
-  const currentOrder = [...svg.querySelectorAll(':scope > .gizmo-axis')];
-  if (projected.some(({ axis }, index) => currentOrder[index] !== axis)) {
-    projected.forEach(({ axis }) => svg.appendChild(axis));
-    // Re-appending axes changes SVG paint order, so keep the origin cap on top.
-    svg.appendChild(viewGizmo.querySelector('.gizmo-origin'));
-  }
-  projected.forEach(({ axis, x, y, depth }) => {
-    const line = axis.querySelector('line');
-    line.setAttribute('x1', '52');
-    line.setAttribute('y1', '52');
-    line.setAttribute('x2', x.toFixed(2));
-    line.setAttribute('y2', y.toFixed(2));
-    const circle = axis.querySelector('circle');
-    circle.setAttribute('cx', x.toFixed(2));
-    circle.setAttribute('cy', y.toFixed(2));
-    const label = axis.querySelector('text');
-    if (label) {
-      label.setAttribute('x', x.toFixed(2));
-      label.setAttribute('y', y.toFixed(2));
-    }
-    axis.style.opacity = String(0.48 + (depth + 1) * 0.26);
-  });
-}
-
-function snapToAxis(axisName, sign) {
-  const targetDirection = _axisVectors[axisName].clone().multiplyScalar(sign);
-  const startDirection = camera.position.clone().sub(controls.target).normalize();
-  const turn = new THREE.Quaternion().setFromUnitVectors(startDirection, targetDirection);
-  const endUp = axisName === 'y'
-    ? new THREE.Vector3(0, 0, sign > 0 ? -1 : 1)
-    : new THREE.Vector3(0, 1, 0);
-  viewSnap = {
-    started: performance.now(),
-    duration: 190,
-    distance: camera.position.distanceTo(controls.target),
-    startDirection,
-    turn,
-    startUp: camera.up.clone().normalize(),
-    endUp,
-  };
-}
-
-function updateViewSnap() {
-  if (!viewSnap) return;
-  const raw = Math.min(1, (performance.now() - viewSnap.started) / viewSnap.duration);
-  const t = 1 - Math.pow(1 - raw, 3);
-  const rotation = new THREE.Quaternion().slerpQuaternions(
-    new THREE.Quaternion(), viewSnap.turn, t);
-  const direction = viewSnap.startDirection.clone().applyQuaternion(rotation).normalize();
-  camera.position.copy(controls.target).addScaledVector(direction, viewSnap.distance);
-  camera.up.lerpVectors(viewSnap.startUp, viewSnap.endUp, t).normalize();
-  camera.lookAt(controls.target);
-  if (raw === 1) viewSnap = null;
-}
-
-gizmoAxes.forEach(axis => {
-  axis.addEventListener('keydown', event => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      snapToAxis(axis.dataset.axis, Number(axis.dataset.sign));
-    }
-  });
-});
-
-viewGizmo.addEventListener('pointerdown', event => {
-  if (event.button !== 0) return;
-  viewSnap = null;
-  gizmoDrag = {
-    x: event.clientX,
-    y: event.clientY,
-    moved: false,
-    pointerId: event.pointerId,
-    axis: event.target.closest?.('.gizmo-axis') || null,
-  };
-});
-
-viewGizmo.addEventListener('pointermove', event => {
-  if (!gizmoDrag) return;
-  const dx = event.clientX - gizmoDrag.x;
-  const dy = event.clientY - gizmoDrag.y;
-  if (Math.abs(dx) + Math.abs(dy) > 2 && !gizmoDrag.moved) {
-    gizmoDrag.moved = true;
-    viewGizmo.setPointerCapture(gizmoDrag.pointerId);
-    viewGizmo.classList.add('dragging');
-  }
-  if (!gizmoDrag.moved) return;
-  const offset = camera.position.clone().sub(controls.target);
-  const spherical = new THREE.Spherical().setFromVector3(offset);
-  spherical.theta -= dx * 0.012;
-  spherical.phi = THREE.MathUtils.clamp(
-    spherical.phi + dy * 0.012, 0.025, Math.PI - 0.025);
-  camera.position.copy(controls.target).add(offset.setFromSpherical(spherical));
-  camera.up.set(0, 1, 0);
-  camera.lookAt(controls.target);
-  gizmoDrag.x = event.clientX;
-  gizmoDrag.y = event.clientY;
-});
-
-function finishGizmoDrag(event, cancelled = false) {
-  if (!gizmoDrag) return;
-  const finished = gizmoDrag;
-  if (!cancelled && !finished.moved && finished.axis) {
-    snapToAxis(finished.axis.dataset.axis, Number(finished.axis.dataset.sign));
-  }
-  if (viewGizmo.hasPointerCapture?.(event.pointerId)) {
-    viewGizmo.releasePointerCapture(event.pointerId);
-  }
-  viewGizmo.classList.remove('dragging');
-  gizmoDrag = null;
-}
-viewGizmo.addEventListener('pointerup', finishGizmoDrag);
-viewGizmo.addEventListener('pointercancel', event => finishGizmoDrag(event, true));
-
-viewGizmo.addEventListener('wheel', event => {
-  event.preventDefault();
-  viewSnap = null;
-  const offset = camera.position.clone().sub(controls.target);
-  const scale = Math.exp(event.deltaY * 0.0015);
-  const distance = THREE.MathUtils.clamp(
-    offset.length() * scale, Math.max(camera.near * 4, 0.0001), camera.far * 0.8);
-  camera.position.copy(controls.target).addScaledVector(offset.normalize(), distance);
-}, { passive: false });
 
 export function frameView(meshes = [], direction = null, targetYOffset = 0) {
-  const box = new THREE.Box3();
-  meshes.forEach(m => box.expandByObject(m));
-  if (box.isEmpty()) return;
-  const size = box.getSize(new THREE.Vector3());
-  const center = box.getCenter(new THREE.Vector3());
-  center.y += targetYOffset;
-  const radius = Math.max(size.length() * 0.5, 0.001);
-  const viewport = updateCameraViewport();
-  // The vertical FOV normally limits a bounding sphere. If side panels leave
-  // a viewport narrower than it is tall, back the camera up proportionally so
-  // the model also fits horizontally instead of disappearing under a panel.
-  const narrowScale = Math.max(1, viewport.fullHeight / viewport.width);
-  const distance = radius / Math.tan(THREE.MathUtils.degToRad(camera.fov * 0.5))
-    * 1.15 * narrowScale;
-  const offset = direction
-    ? direction.clone().normalize()
-    : camera.position.clone().sub(controls.target).normalize();
-  if (offset.lengthSq() < 0.01) offset.set(.3, .5, 1).normalize();
-  controls.target.copy(center);
-  camera.position.copy(center).addScaledVector(offset, distance);
-  camera.near = radius * 0.001;
-  camera.far = Math.max(radius * 100, 100);
-  clipNear = camera.near;
-  clipFar = camera.far;
-  camera.updateProjectionMatrix();
-  controls.update();
+  cameraFrame.frameView(meshes, direction, targetYOffset);
 }
 
-/** Restore the camera framing captured for the current model. */
 export function resetView() {
-  if (!homeView) return;
-  viewSnap = null;
-  // Restore the orientation captured after automatic upright correction.
-  if (homeView.meshes) {
-    homeView.meshes.forEach(({ mesh, quaternion, position }) => {
-      mesh.quaternion.copy(quaternion);
-      mesh.position.copy(position);
-    });
-  }
-  // Recompute framing from the restored model bounds. Arcball's saved matrix
-  // can become stale after model turns, zoom animation, or viewport changes;
-  // using it directly can place some models (notably Beidou) outside view.
-  const box = new THREE.Box3();
-  homeView.meshes.forEach(({ mesh }) => box.expandByObject(mesh));
-  if (box.isEmpty()) return;
-  const size = box.getSize(new THREE.Vector3());
-  camera.up.copy(INITIAL_CAMERA_UP);
-  frameView(homeView.meshes.map(({ mesh }) => mesh),
-            INITIAL_CAMERA_DIRECTION, size.y * 0.08);
-  camera.updateMatrix();
-  controls.update();
-  controls.saveState();
+  cameraFrame.resetView();
 }
 
-/** Frame the camera and size the grid to the given meshes. */
 export function fitTo(meshes) {
-  if (!uprightApplied && meshes.length) {
-    const rawBox = new THREE.Box3();
-    meshes.forEach(m => rawBox.expandByObject(m));
-    const rawSize = rawBox.getSize(new THREE.Vector3());
-    // Some mods are authored Z-up. A clearly dominant Z extent is a reliable
-    // signal for a lying-down model; rotate it once so Z becomes viewer Y.
-    if (rawSize.z > rawSize.y * 1.5 && rawSize.z > rawSize.x * 1.15) {
-      meshes.forEach(m => {
-        const pitch = new THREE.Quaternion().setFromAxisAngle(
-          new THREE.Vector3(1, 0, 0), -Math.PI / 2);
-        m.quaternion.copy(pitch);
-      });
-    }
-    uprightApplied = true;
-  }
-  const box = new THREE.Box3();
-  meshes.forEach(m => box.expandByObject(m));
-  if (box.isEmpty()) return;
+  cameraFrame.fitTo(meshes);
+}
 
-  const bSize  = box.getSize(new THREE.Vector3());
-  const center = box.getCenter(new THREE.Vector3());
-  modelPivot = center.clone();
-  const size   = bSize.length();
+export function resetModelOrientation() {
+  cameraFrame.resetModelOrientation();
+}
 
-  // Median dimension filters wing/tail outliers (ZZMI) while still covering
-  // large WWMI models. GridHelper is 4 units wide before scaling, so this
-  // produces a footprint of max(6, median * 4).
-  const dims = [bSize.x, bSize.y, bSize.z].sort((a, b) => a - b);
-  grid.scale.setScalar(Math.max(1.5, dims[1]));
-  grid.position.set(center.x, box.min.y, center.z);
+export function rotateModelQuarterTurn(meshes = []) {
+  cameraFrame.rotateModelQuarterTurn(meshes);
+}
 
-  // Clipping planes have to track model scale or big models z-fight and small
-  // ones vanish into the near plane.
-  camera.near = size * 0.0005;
-  camera.far  = size * 50;
-  clipNear = camera.near;
-  clipFar = camera.far;
-  camera.updateProjectionMatrix();
-
-  // A new model always establishes its home view from the application's
-  // startup camera, never from the orbit/zoom left behind by the previous
-  // model. Otherwise Reset merely returns to that inherited, already-moved
-  // orientation.
-  viewSnap = null;
-  camera.up.copy(INITIAL_CAMERA_UP);
-  frameView(meshes, INITIAL_CAMERA_DIRECTION, bSize.y * 0.08);
-  // Directional lights ignore distance, but their draggable helper does not.
-  // Rebase it for every model so tiny, huge, or far-from-origin meshes keep
-  // the marker inside the newly fitted view (Beidou exposed the fixed-world
-  // position bug).
-  const lightDistance = Math.max(size * 0.55, 0.001);
-  dirLight.position.copy(controls.target).addScaledVector(
-    new THREE.Vector3(-0.55, 0.82, 0.35).normalize(), lightDistance);
-  lightHandle.position.copy(dirLight.position);
-  homeView = {
-    position: camera.position.clone(),
-    target: controls.target.clone(),
-    near: camera.near,
-    far: camera.far,
-    meshes: meshes.map(mesh => ({
-      mesh,
-      quaternion: mesh.quaternion.clone(),
-      position: mesh.position.clone(),
-    })),
-  };
-  // The controller's constructor saved the generic startup camera. Replace
-  // that baseline with this model's fitted view so Reset returns here.
-  camera.updateMatrix();
-  controls.update();
-  controls.saveState();
+export function rotateModelHorizontalQuarterTurn(meshes = []) {
+  cameraFrame.rotateModelHorizontalQuarterTurn(meshes);
 }

--- a/src/web/js/selection.js
+++ b/src/web/js/selection.js
@@ -6,6 +6,7 @@
 import * as THREE from 'three';
 import { camera, renderer } from './scene.js';
 import { activeMeshes } from './visibility.js';
+import { getMeshView } from './mesh-view-bindings.js';
 
 const HIGHLIGHT_COLOR = 0xffd60a; // selection yellow
 const HIGHLIGHT_INTENSITY = 0.22;  // kept low so the mesh's own texture reads through
@@ -20,7 +21,7 @@ function setHighlight(mesh, on) {
 }
 
 function setRowSelected(mesh, on) {
-  const row = mesh.userData.row;
+  const row = getMeshView(mesh)?.row;
   if (!row) return;
   row.classList.toggle('selected', on);
   if (on) expandAncestorsAndScrollTo(row);

--- a/src/web/js/texture-modal.js
+++ b/src/web/js/texture-modal.js
@@ -4,6 +4,7 @@
 // or remove an option. Changes persist in .mod_viewer.json, never in the ini.
 
 import { addTexture } from './mesh-factory.js';
+import { bindModalDismiss } from './modal-shell.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -149,10 +150,8 @@ function close() {
   onChange = null;
 }
 
-$('texm-close').addEventListener('click', close);
-$('texture-modal-backdrop').addEventListener('click', (evt) => {
-  if (evt.target.id === 'texture-modal-backdrop') close();
-});
-document.addEventListener('keydown', (evt) => {
-  if (evt.key === 'Escape' && $('texture-modal-backdrop').classList.contains('show')) close();
+bindModalDismiss({
+  backdrop: $('texture-modal-backdrop'),
+  close,
+  buttons: [$('texm-close')],
 });

--- a/src/web/js/toggle-modal.js
+++ b/src/web/js/toggle-modal.js
@@ -7,19 +7,18 @@
 // remove one (see toggle_editor.add_toggle / edit_toggle).
 
 import { confirmDialog } from './dialogs.js';
+import { bindModalDismiss, setModalError } from './modal-shell.js';
 
 const $ = (id) => document.getElementById(id);
 
 let currentMode = null;    // 'add' | 'edit'
 let currentModPath = null;
 let currentInfo = null;    // the payload entry being edited (add: null)
-let onSaved = null;        // callback invoked after a successful write
+let onSaved = null;        // callback invoked after a successful staged edit
 let editVarRows = [];      // [{var, original, input}] built for edit mode
 
 function setError(message) {
-  const box = $('tm-error');
-  box.textContent = message || '';
-  box.style.display = message ? 'block' : 'none';
+  setModalError($('tm-error'), message);
 }
 
 function closeModal() {
@@ -74,7 +73,7 @@ async function populateIniPicker(modPath, selected, editable) {
  *   add:  { mode: 'add', modPath, onSaved }
  *   edit: { mode: 'edit', modPath, info, onSaved }  — info is a controls.toggles
  *         payload entry (needs .ini, .section, .name); the real field values
- *         are re-read fresh from disk via get_toggle_details.
+ *         are read from the authoritative edit session via get_toggle_details.
  */
 export async function openToggleModal({ mode, modPath, info, onSaved: cb }) {
   currentMode = mode;
@@ -189,10 +188,8 @@ async function handleSubmit(evt) {
 }
 
 $('tm-form').addEventListener('submit', handleSubmit);
-$('tm-cancel').addEventListener('click', closeModal);
-$('toggle-modal-backdrop').addEventListener('click', (evt) => {
-  if (evt.target.id === 'toggle-modal-backdrop') closeModal();
-});
-document.addEventListener('keydown', (evt) => {
-  if (evt.key === 'Escape' && $('toggle-modal-backdrop').classList.contains('show')) closeModal();
+bindModalDismiss({
+  backdrop: $('toggle-modal-backdrop'),
+  close: closeModal,
+  buttons: [$('tm-cancel')],
 });

--- a/src/web/js/toggle-panel.js
+++ b/src/web/js/toggle-panel.js
@@ -11,6 +11,7 @@ import { openToggleModal } from './toggle-modal.js';
 import { startRecordSession } from './record-session.js';
 import { alertDialog, confirmDialog } from './dialogs.js';
 import { registerViewSync, syncView } from './view-sync.js';
+import { buildSourceSection, groupKeysBySource, usesSourceSections } from './panel-utils.js';
 
 /** Variable names carry a "source::" prefix in multi-ini folders. */
 function displayName(variable) {
@@ -208,32 +209,6 @@ function buildToggleItem(info, ctx) {
   return item;
 }
 
-function buildSourceSection(source, container) {
-  const hdr = document.createElement('div');
-  hdr.className = 'toggle-src-hdr';
-
-  const chevron = document.createElement('span');
-  chevron.className = 'group-toggle';
-  chevron.textContent = '▼';
-
-  const nameSpan = document.createElement('span');
-  nameSpan.className = 'group-name';
-  nameSpan.textContent = source;
-
-  hdr.append(chevron, nameSpan);
-
-  const itemsWrap = document.createElement('div');
-  itemsWrap.className = 'toggle-src-items';
-
-  hdr.addEventListener('click', () => {
-    chevron.classList.toggle('collapsed');
-    itemsWrap.classList.toggle('collapsed');
-  });
-
-  container.append(hdr, itemsWrap);
-  return itemsWrap;
-}
-
 /**
  * Build the panel from the structured controls.toggles model.
  *
@@ -241,9 +216,9 @@ function buildSourceSection(source, container) {
  * same-named keys are grouped under a collapsible per-ini sub-section instead
  * of lengthening every toggle's display name with a prefix.
  *
- * `ctx` carries what the add/edit/delete actions need: `modPath` (which
- * folder to write into) and `onChange` (called after a successful write to
- * reload the mod and refresh the 3D view). The panel is shown whenever a mod
+ * `ctx` carries what the add/edit/delete actions need: `modPath` (which edit
+ * session to update) and `onChange` (called after a successful staged change
+ * to refresh the model and controls). The panel is shown whenever a mod
  * is loaded — even with zero toggles — since "Add" must stay reachable.
  */
 export function buildTogglePanel(toggles, ctx = {}) {
@@ -274,14 +249,9 @@ export function buildTogglePanel(toggles, ctx = {}) {
 
   // Sections with no source (single-ini mods) go in a '' bucket rendered flat,
   // with no header.
-  const bySource = {};
-  for (const section of sections) {
-    const src = toggles[section].source || '';
-    (bySource[src] = bySource[src] || []).push(section);
-  }
-
+  const bySource = groupKeysBySource(toggles, sections);
   const sources = Object.keys(bySource);
-  const multiSource = sources.length > 1 || (sources.length === 1 && sources[0] !== '');
+  const multiSource = usesSourceSections(bySource);
 
   for (const src of sources) {
     const container = (multiSource && src) ? buildSourceSection(src, list) : list;

--- a/src/web/js/toggle-panel.js
+++ b/src/web/js/toggle-panel.js
@@ -10,6 +10,7 @@ import { refreshAll, setToggleValue, getToggleValue } from './visibility.js';
 import { openToggleModal } from './toggle-modal.js';
 import { startRecordSession } from './record-session.js';
 import { alertDialog, confirmDialog } from './dialogs.js';
+import { registerViewSync, syncView } from './view-sync.js';
 
 /** Variable names carry a "source::" prefix in multi-ini folders. */
 function displayName(variable) {
@@ -37,7 +38,7 @@ let currentCtx = { modPath: null, onChange: null };
 let valueSyncers = [];
 
 export function refreshToggleValues() {
-  valueSyncers.forEach((sync) => sync());
+  syncView('toggle-panel');
 }
 
 document.getElementById('toggle-add-btn').addEventListener('click', () => {
@@ -170,7 +171,6 @@ function buildToggleItem(info, ctx) {
       setToggleValue(v.var, v.values[next % v.values.length]);
     }
     cyclePosition = next;
-    valSpan.textContent = describe();
     refreshAll();
   };
   valueSyncers.push(() => {
@@ -253,6 +253,9 @@ export function buildTogglePanel(toggles, ctx = {}) {
   const panel = document.getElementById('toggle-panel');
   list.innerHTML = '';
   valueSyncers = [];
+  registerViewSync('toggle-panel', () => {
+    valueSyncers.forEach(sync => sync());
+  });
 
   if (!currentCtx.modPath) {
     panel.style.display = 'none';

--- a/src/web/js/view-gizmo-controller.js
+++ b/src/web/js/view-gizmo-controller.js
@@ -1,0 +1,171 @@
+// Blender-style DOM view gizmo: snap, orbit drag, keyboard and wheel zoom.
+
+import * as THREE from 'three';
+
+export function createViewGizmoController({ camera, controls, element }) {
+  const axes = [...element.querySelectorAll('.gizmo-axis')];
+  const axisVectors = {
+    x: new THREE.Vector3(1, 0, 0),
+    y: new THREE.Vector3(0, 1, 0),
+    z: new THREE.Vector3(0, 0, 1),
+  };
+  const local = new THREE.Vector3();
+  const inverseCamera = new THREE.Quaternion();
+  let visible = true;
+  let snap = null;
+  let drag = null;
+
+  function snapToAxis(axisName, sign) {
+    const targetDirection = axisVectors[axisName].clone().multiplyScalar(sign);
+    const startDirection = camera.position.clone().sub(controls.target).normalize();
+    const turn = new THREE.Quaternion().setFromUnitVectors(startDirection, targetDirection);
+    const endUp = axisName === 'y'
+      ? new THREE.Vector3(0, 0, sign > 0 ? -1 : 1)
+      : new THREE.Vector3(0, 1, 0);
+    snap = {
+      started: performance.now(),
+      duration: 190,
+      distance: camera.position.distanceTo(controls.target),
+      startDirection,
+      turn,
+      startUp: camera.up.clone().normalize(),
+      endUp,
+    };
+  }
+
+  function updateSnap() {
+    if (!snap) return;
+    const raw = Math.min(1, (performance.now() - snap.started) / snap.duration);
+    const progress = 1 - Math.pow(1 - raw, 3);
+    const rotation = new THREE.Quaternion().slerpQuaternions(
+      new THREE.Quaternion(), snap.turn, progress);
+    const direction = snap.startDirection.clone().applyQuaternion(rotation).normalize();
+    camera.position.copy(controls.target).addScaledVector(direction, snap.distance);
+    camera.up.lerpVectors(snap.startUp, snap.endUp, progress).normalize();
+    camera.lookAt(controls.target);
+    if (raw === 1) snap = null;
+  }
+
+  function updateAxes() {
+    if (!visible) return;
+    inverseCamera.copy(camera.quaternion).invert();
+    const projected = axes.map(axis => {
+      const sign = Number(axis.dataset.sign);
+      local.copy(axisVectors[axis.dataset.axis]).multiplyScalar(sign)
+        .applyQuaternion(inverseCamera);
+      return {
+        axis,
+        x: 52 + local.x * 34,
+        y: 52 - local.y * 34,
+        depth: local.z,
+      };
+    });
+    // Reorder only when depth order changes; needless SVG reparenting can make
+    // a pressed axis lose its click before pointerup.
+    const svg = element.querySelector('svg');
+    projected.sort((a, b) => a.depth - b.depth);
+    const currentOrder = [...svg.querySelectorAll(':scope > .gizmo-axis')];
+    if (projected.some(({ axis }, index) => currentOrder[index] !== axis)) {
+      projected.forEach(({ axis }) => svg.appendChild(axis));
+      svg.appendChild(element.querySelector('.gizmo-origin'));
+    }
+    projected.forEach(({ axis, x, y, depth }) => {
+      const line = axis.querySelector('line');
+      line.setAttribute('x1', '52');
+      line.setAttribute('y1', '52');
+      line.setAttribute('x2', x.toFixed(2));
+      line.setAttribute('y2', y.toFixed(2));
+      const circle = axis.querySelector('circle');
+      circle.setAttribute('cx', x.toFixed(2));
+      circle.setAttribute('cy', y.toFixed(2));
+      const label = axis.querySelector('text');
+      if (label) {
+        label.setAttribute('x', x.toFixed(2));
+        label.setAttribute('y', y.toFixed(2));
+      }
+      axis.style.opacity = String(0.48 + (depth + 1) * 0.26);
+    });
+  }
+
+  axes.forEach(axis => {
+    axis.addEventListener('keydown', event => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        snapToAxis(axis.dataset.axis, Number(axis.dataset.sign));
+      }
+    });
+  });
+
+  element.addEventListener('pointerdown', event => {
+    if (event.button !== 0) return;
+    snap = null;
+    drag = {
+      x: event.clientX,
+      y: event.clientY,
+      moved: false,
+      pointerId: event.pointerId,
+      axis: event.target.closest?.('.gizmo-axis') || null,
+    };
+  });
+  element.addEventListener('pointermove', event => {
+    if (!drag) return;
+    const dx = event.clientX - drag.x;
+    const dy = event.clientY - drag.y;
+    // Do not capture until the threshold is crossed: tiny movement remains a
+    // click-to-snap gesture.
+    if (Math.abs(dx) + Math.abs(dy) > 2 && !drag.moved) {
+      drag.moved = true;
+      element.setPointerCapture(drag.pointerId);
+      element.classList.add('dragging');
+    }
+    if (!drag.moved) return;
+    const offset = camera.position.clone().sub(controls.target);
+    const spherical = new THREE.Spherical().setFromVector3(offset);
+    spherical.theta -= dx * 0.012;
+    spherical.phi = THREE.MathUtils.clamp(
+      spherical.phi + dy * 0.012, 0.025, Math.PI - 0.025);
+    camera.position.copy(controls.target).add(offset.setFromSpherical(spherical));
+    camera.up.set(0, 1, 0);
+    camera.lookAt(controls.target);
+    drag.x = event.clientX;
+    drag.y = event.clientY;
+  });
+
+  function finishDrag(event, cancelled = false) {
+    if (!drag) return;
+    const finished = drag;
+    if (!cancelled && !finished.moved && finished.axis) {
+      snapToAxis(finished.axis.dataset.axis, Number(finished.axis.dataset.sign));
+    }
+    if (element.hasPointerCapture?.(event.pointerId)) {
+      element.releasePointerCapture(event.pointerId);
+    }
+    element.classList.remove('dragging');
+    drag = null;
+  }
+  element.addEventListener('pointerup', finishDrag);
+  element.addEventListener('pointercancel', event => finishDrag(event, true));
+  element.addEventListener('wheel', event => {
+    event.preventDefault();
+    snap = null;
+    const offset = camera.position.clone().sub(controls.target);
+    const scale = Math.exp(event.deltaY * 0.0015);
+    const distance = THREE.MathUtils.clamp(
+      offset.length() * scale, Math.max(camera.near * 4, 0.0001), camera.far * 0.8);
+    camera.position.copy(controls.target).addScaledVector(offset.normalize(), distance);
+  }, { passive: false });
+
+  function toggle() {
+    visible = !visible;
+    element.classList.toggle('hidden', !visible);
+    const button = document.getElementById('trackball-btn');
+    button.classList.toggle('active', visible);
+    button.classList.toggle('off', !visible);
+  }
+
+  function cancelSnap() {
+    snap = null;
+  }
+
+  return { cancelSnap, toggle, updateAxes, updateSnap };
+}

--- a/src/web/js/view-sync.js
+++ b/src/web/js/view-sync.js
@@ -1,0 +1,24 @@
+// Tiny keyed registry for synchronizing current panel views after model state.
+
+const syncers = new Map();
+
+export function registerViewSync(name, sync) {
+  if (typeof sync === 'function') syncers.set(name, sync);
+  else syncers.delete(name);
+}
+
+export function syncView(name) {
+  syncers.get(name)?.();
+}
+
+export function syncViews() {
+  for (const sync of syncers.values()) sync();
+}
+
+export function clearViewSyncs() {
+  syncers.clear();
+}
+
+export function viewSyncCount() {
+  return syncers.size;
+}

--- a/src/web/js/visibility.js
+++ b/src/web/js/visibility.js
@@ -1,287 +1,57 @@
-// Mesh visibility: the interaction between the MESHES checkboxes (manual) and
-// the Toggle panel (ini key conditions).
-//
-// These two controls deliberately do NOT have equal authority — see
-// applyMeshVisibility and refreshAll below. Both rules there exist to fix real
-// bugs; changing either one will reintroduce them.
+// Compatibility facade coordinating control state, mesh state and current UI.
 
-import { scene, resetModelOrientation } from './scene.js';
-import { setMeshTexture, setMeshTextureState, refreshMeshTexture, setTextureMode } from './mesh-factory.js';
+import {
+  getControlState, getControlValue, replayControlStateRules,
+  resetControlState, setControlStateRules, setControlValue,
+} from './control-state.js';
+import {
+  activeMeshes, refreshMeshes, resetMeshes, resetMeshVisibility,
+} from './mesh-state.js';
+import {
+  toggleSmoothShadingMode, toggleTextureDisplayMode, toggleWireframeMode,
+} from './render-modes.js';
+import { clearViewSyncs, syncView, syncViews } from './view-sync.js';
 
-/** Every mesh currently in the scene. */
-export const activeMeshes = [];
+export {
+  activeMeshes, addMesh, applyMeshVisibility, conditionsSatisfied,
+  setManualTexOverride,
+} from './mesh-state.js';
 
-/** {variable: currentValueString} — the Toggle panel's state. */
-let toggleState = {};
-let stateRules = [];
-
-/** [{masterCb, itemCbs, itemObjs}] — registered by the meshes panel. */
-let groupsUI = [];
-
-let wireframe = false;
-let smoothShading = true;
-const textureModes = ['all', 'diffuse', 'none'];
-let textureModeIndex = 0;
+export const setToggleValue = setControlValue;
+export const getToggleValue = getControlValue;
+export const getToggleState = getControlState;
+export const setStateRules = setControlStateRules;
 
 export function reset() {
-  activeMeshes.forEach(m => {
-    scene.remove(m);
-    m.geometry.dispose();
-    (Array.isArray(m.material) ? m.material : [m.material]).forEach(mt => mt.dispose());
-  });
-  activeMeshes.length = 0;
-  groupsUI = [];
-  toggleState = {};
-  stateRules = [];
-  resetModelOrientation();
+  resetMeshes();
+  resetControlState();
+  clearViewSyncs();
 }
 
-/** Return meshes to the visibility state established when the mod loaded. */
 export function resetMeshState() {
-  activeMeshes.forEach(mesh => {
-    mesh.userData.manualVisible = mesh.userData.loadedVisible !== false;
-    mesh.userData.manuallyToggled = false;
-    applyMeshVisibility(mesh);
-  });
-  syncCheckboxes();
+  resetMeshVisibility();
+  syncViews();
 }
 
-export function addMesh(mesh, conditions, sources, textureVariants, materialVariants = {}) {
-  mesh.userData.manualVisible = true;
-  mesh.userData.loadedVisible = true;
-  mesh.userData.manuallyToggled = false;
-  mesh.userData.conditions = conditions || [];
-  mesh.userData.sources = sources || [];
-  mesh.userData.textureVariants = textureVariants || [];
-  mesh.userData.normalMapVariants = materialVariants.normal_map || [];
-  mesh.userData.lightMapVariants = materialVariants.light_map || [];
-  mesh.userData.materialMapVariants = materialVariants.material_map || [];
-  // The texture selected by the ini under the current toggle/menu state.
-  // Kept separately from texKey because the component's ordered texture-run
-  // pass may make this mesh follow a highlighted boundary above it.
-  mesh.userData.resolvedTexKey = mesh.userData.defaultTexKey;
-  // undefined = unselected (follows leader/toggle resolution), a string =
-  // user explicitly picked this tex_key (sticky until de-selected). No
-  // "(None)" state -- de-selecting reverts to the ini's own default.
-  mesh.userData.manualTexOverride = undefined;
-  mesh.material.wireframe = wireframe;
-  mesh.material.flatShading = !smoothShading;
-  scene.add(mesh);
-  activeMeshes.push(mesh);
-  applyTextureVariant(mesh);
-}
-
-/** Pin or clear one mesh's highlighted texture. Component-local downward
- * propagation is handled by mesh-panel.js's ordered boundary pass. */
-export function setManualTexOverride(mesh, value) {
-  mesh.userData.manualTexOverride = value;
-  applyTextureVariant(mesh);
-}
-
-export function registerGroup(group) {
-  groupsUI.push(group);
-}
-
-export function setToggleValue(variable, value) {
-  toggleState[variable] = value;
-}
-
-export function getToggleValue(variable) {
-  return toggleState[variable];
-}
-
-export function getToggleState() {
-  return { ...toggleState };
-}
-
-// True if an OR'd list of AND-groups ([[{var,value,negate}, ...], ...]) is
-// satisfied by the current Toggle panel state.
-function dnfSatisfied(condGroups) {
-  if (!condGroups || condGroups.length === 0) return true;
-  return condGroups.some(group => group.every(c => {
-    const cur = toggleState[c.var];
-    if (cur === undefined) return true;
-    return c.negate ? (cur !== c.value) : (cur === c.value);
-  }));
-}
-
-// True if this mesh's gating conditions (an OR'd list of AND-groups:
-// [[{var,value,negate}, ...], ...]) are satisfied by the current Toggle panel
-// state. Meshes with no conditions are never gated. Exported for record mode,
-// which needs to answer this same question against a hypothetical toggle
-// value (a recording position) rather than only the live one.
-export function conditionsSatisfied(mesh) {
-  return dnfSatisfied(mesh.userData.conditions);
-}
-
-// A toggle can reassign a mesh's diffuse texture -- unless the user has
-// manually pinned one via the per-mesh texture list, which wins until
-// explicitly de-selected. Falls back to the draw's own resolved default
-// (mesh.userData.defaultTexKey) when no variant's condition currently
-// matches -- a draw whose toggle only swaps texture under a specific value
-// (or that has no texture_variants at all) must still revert cleanly.
-export function applyTextureVariant(mesh) {
-  const resolve = (variants, fallback) => {
-    variants = variants || [];
-    const variant = variants.findLast
-      ? variants.findLast(v => dnfSatisfied(v.conditions))
-      : [...variants].reverse().find(v => dnfSatisfied(v.conditions));
-    return variant ? variant.tex_key : fallback;
-  };
-  const variants = mesh.userData.textureVariants || [];
-  // Diffuse assignments execute in source order; later matching writes
-  // override earlier ones (including nested, independent condition chains).
-  mesh.userData.resolvedTexKey = resolve(variants, mesh.userData.defaultTexKey);
-  mesh.userData.resolvedNormalMapKey = resolve(mesh.userData.normalMapVariants,
-    mesh.userData.defaultNormalMapKey);
-  mesh.userData.resolvedLightMapKey = resolve(mesh.userData.lightMapVariants,
-    mesh.userData.defaultLightMapKey);
-  mesh.userData.resolvedMaterialMapKey = resolve(mesh.userData.materialMapVariants,
-    mesh.userData.defaultMaterialMapKey);
-  setMeshTextureState(mesh, {
-    diffuse: mesh.userData.manualTexOverride !== undefined
-      ? mesh.userData.manualTexOverride
-      : mesh.userData.resolvedTexKey,
-    normal_map: mesh.userData.resolvedNormalMapKey,
-    light_map: mesh.userData.resolvedLightMapKey,
-    material_map: mesh.userData.resolvedMaterialMapKey,
-  });
-}
-
-export function setStateRules(rules, defaults) {
-  stateRules = rules || [];
-  for (const [variable, value] of Object.entries(defaults || {})) {
-    if (toggleState[variable] === undefined) toggleState[variable] = value;
-  }
-}
-
-// The MESHES checkbox is the sole, direct source of truth for a mesh's
-// visibility — clicking it always shows/hides the mesh immediately. Toggle
-// conditions only come into play when refreshAll() re-baselines manualVisible
-// after a Toggle panel value changes (see below); they must never re-gate a
-// manual click, or an already-hidden gated mesh could never be shown again by
-// checking its box.
-export function applyMeshVisibility(mesh) {
-  mesh.visible = mesh.userData.manualVisible !== false;
-}
-
-function applyShapeTargets(mesh) {
-  const targets = mesh.userData.shapeTargets || [];
-  if (!targets.length) return;
-  const controlValues = targets.map(target => toggleState[target.var] ?? 0);
-  const previous = mesh.userData.shapeControlValues;
-  if (previous?.length === controlValues.length
-      && controlValues.every((value, index) => value === previous[index])) return;
-  mesh.userData.shapeControlValues = controlValues;
-  const attr = mesh.geometry.attributes.position;
-  const base = mesh.userData.basePositions;
-  attr.array.set(base);
-  const midpointTargets = targets.filter(target => target.mode === 'midpoint_pair');
-  for (const target of targets) {
-    const weight = Number(toggleState[target.var] ?? 0);
-    if (!Number.isFinite(weight)) continue;
-    if (target.mode === 'midpoint_pair') {
-      const endpoint = weight <= 0.5 ? target.lowPositions : target.positions;
-      // Match the shader's deliberate endpoint extrapolation. Each of the two
-      // independently-shaped results is averaged below, so it uses a 0..2
-      // delta factor to retain the authored full range after that division.
-      // This remains monotonic as long as the high branch moves base->bigger.
-      const factor = weight <= 0.5 ? 2 - weight * 4 : weight * 4 - 2;
-      const divisor = midpointTargets.length || 1;
-      for (let i = 0; i < attr.array.length; i++) {
-        const shaped = base[i] + (endpoint[i] - base[i]) * factor;
-        attr.array[i] += (shaped - base[i]) / divisor;
-      }
-      continue;
-    }
-    if (weight === 0) continue;
-    for (let i = 0; i < attr.array.length; i++) {
-      attr.array[i] += (target.positions[i] - base[i]) * weight;
-    }
-  }
-  attr.needsUpdate = true;
-  mesh.geometry.computeVertexNormals();
-  mesh.geometry.computeBoundingBox();
-  mesh.geometry.computeBoundingSphere();
-}
-
-// Reflect each mesh's actual visibility back onto its MESHES checkbox, so
-// cycling a Toggle value visibly checks/unchecks the affected items and
-// updates each group's master checkbox.
+// Kept for Record mode compatibility while mesh-panel owns the actual DOM.
 export function syncCheckboxes() {
-  groupsUI.forEach(({ masterCb, itemCbs, itemObjs, onTexChanged, applyTextureRuns }) => {
-    if (applyTextureRuns) applyTextureRuns();
-    itemObjs.forEach((mesh, i) => {
-      itemCbs[i].checked = mesh.visible;
-      mesh.userData.updateStateIndicator?.(mesh);
-      mesh.userData.updateTextureList?.();
-    });
-    const any = itemCbs.some(c => c.checked);
-    const all = itemCbs.every(c => c.checked);
-    masterCb.checked = all;
-    masterCb.indeterminate = any && !all;
-    if (onTexChanged) onTexChanged();
-  });
+  syncView('mesh-panel');
 }
 
-// Re-baseline manualVisible to match the current Toggle panel state, then sync
-// checkboxes. Only meshes actually GATED by a toggle (non-empty conditions) are
-// re-baselined here — a mesh with no conditions isn't affected by any key
-// toggle at all, so it must stay checked by default and keep whatever manual
-// show/hide state the user gave it, undisturbed by clicking toggles elsewhere
-// in the panel.
 export function refreshAll() {
-  // [Present] derives literal draw flags from menu variables every frame in
-  // many WWMI mods. Replay those safe rules in source order first.
-  for (const rule of stateRules) {
-    if (dnfSatisfied(rule.conditions)) toggleState[rule.var] = rule.value;
-  }
-  activeMeshes.forEach(mesh => {
-    if ((mesh.userData.conditions || []).length > 0) {
-      mesh.userData.manualVisible = conditionsSatisfied(mesh);
-    }
-    applyMeshVisibility(mesh);
-    if (!mesh.userData.defaultCaptured) {
-      mesh.userData.loadedVisible = mesh.visible;
-      mesh.userData.defaultCaptured = true;
-    }
-    applyTextureVariant(mesh);
-    applyShapeTargets(mesh);
-  });
-  syncCheckboxes();
+  replayControlStateRules();
+  refreshMeshes();
+  syncViews();
 }
 
 export function toggleWireframe() {
-  wireframe = !wireframe;
-  document.getElementById('wire-btn').classList.toggle('active', wireframe);
-  activeMeshes.forEach(m => {
-    const mats = Array.isArray(m.material) ? m.material : [m.material];
-    mats.forEach(mt => { mt.wireframe = wireframe; });
-  });
+  toggleWireframeMode(activeMeshes);
 }
 
 export function toggleSmoothShading() {
-  smoothShading = !smoothShading;
-  document.getElementById('shading-btn').classList.toggle('off', !smoothShading);
-  activeMeshes.forEach(m => {
-    const mats = Array.isArray(m.material) ? m.material : [m.material];
-    mats.forEach(mt => { mt.flatShading = !smoothShading; mt.needsUpdate = true; });
-  });
+  toggleSmoothShadingMode(activeMeshes);
 }
 
 export function toggleTextures() {
-  textureModeIndex = (textureModeIndex + 1) % textureModes.length;
-  const mode = textureModes[textureModeIndex];
-  const button = document.getElementById('texture-btn');
-  button.classList.toggle('diffuse-only', mode === 'diffuse');
-  button.classList.toggle('off', mode === 'none');
-  const labels = {
-    all: 'Textures: all maps',
-    diffuse: 'Textures: diffuse only',
-    none: 'Textures: none',
-  };
-  button.title = labels[mode];
-  button.setAttribute('aria-label', labels[mode]);
-  setTextureMode(mode);
-  activeMeshes.forEach(refreshMeshTexture);
+  toggleTextureDisplayMode(activeMeshes);
 }

--- a/src/web/js/visibility.js
+++ b/src/web/js/visibility.js
@@ -6,7 +6,7 @@
 // bugs; changing either one will reintroduce them.
 
 import { scene, resetModelOrientation } from './scene.js';
-import { setMeshTexture, setMeshMaterialMaps, refreshMeshTexture, setTextureMode } from './mesh-factory.js';
+import { setMeshTexture, setMeshTextureState, refreshMeshTexture, setTextureMode } from './mesh-factory.js';
 
 /** Every mesh currently in the scene. */
 export const activeMeshes = [];
@@ -138,10 +138,10 @@ export function applyTextureVariant(mesh) {
     mesh.userData.defaultLightMapKey);
   mesh.userData.resolvedMaterialMapKey = resolve(mesh.userData.materialMapVariants,
     mesh.userData.defaultMaterialMapKey);
-  setMeshTexture(mesh, mesh.userData.manualTexOverride !== undefined
-    ? mesh.userData.manualTexOverride
-    : mesh.userData.resolvedTexKey);
-  setMeshMaterialMaps(mesh, {
+  setMeshTextureState(mesh, {
+    diffuse: mesh.userData.manualTexOverride !== undefined
+      ? mesh.userData.manualTexOverride
+      : mesh.userData.resolvedTexKey,
     normal_map: mesh.userData.resolvedNormalMapKey,
     light_map: mesh.userData.resolvedLightMapKey,
     material_map: mesh.userData.resolvedMaterialMapKey,
@@ -168,6 +168,11 @@ export function applyMeshVisibility(mesh) {
 function applyShapeTargets(mesh) {
   const targets = mesh.userData.shapeTargets || [];
   if (!targets.length) return;
+  const controlValues = targets.map(target => toggleState[target.var] ?? 0);
+  const previous = mesh.userData.shapeControlValues;
+  if (previous?.length === controlValues.length
+      && controlValues.every((value, index) => value === previous[index])) return;
+  mesh.userData.shapeControlValues = controlValues;
   const attr = mesh.geometry.attributes.position;
   const base = mesh.userData.basePositions;
   attr.array.set(base);


### PR DESCRIPTION
- Atomic mod-load transitions, stale-state fixes, left-docked Tools, texture DOM reuse, shape caching, and batched material refreshes.
- Introduced control-state, mesh-state, render-modes, view-sync, WeakMap view bindings, and extracted texture-state logic.
- Decomposed scene.js into camera-frame.js, key-light-controller.js, and view-gizmo-controller.js. The permanent render loop and camera/light behavior remain unchanged.
- Hared source grouping and modal helpers, dialog accessibility, CSS palette tokens, and corrected staged-edit comments. Ace Escape handling, feature flags, source grouping, and #menu-list.image-layout.collapsed remain intact.