### PR TITLE
Packed material response

### DIFF
--- a/context.md
+++ b/context.md
@@ -133,12 +133,12 @@ hashes changed—installing PyInstaller from sdist alone does not rebuild it.
   LightMaps remain packed game data and are retained as toggle-aware keys; the
   passthrough transport preserves authored RGBA for packed auxiliary roles,
   ordinary diffuse passthrough remains RGB, and explicit channel masks read the
-  source channel before conversion. Known Genshin profiles use only LightMap R/B
-  for a restrained material response; LightMap G remains reserved for the
-  later toon-shadow phase and no LightMap is bound as Three.js AO. Known ZZZ
-  profiles use MaterialMap G/B for metallic/specular response while retaining R
-  as material-ID data. Unknown game/API pairs keep packed maps available but
-  do not guess PBR semantics.
+  source channel before conversion. Known Genshin profiles use a bounded
+  LightMap R response; LightMap B/G/A remain packed for later threshold,
+  toon-shadow, and material-ID phases, and no LightMap is bound as Three.js AO.
+  Known ZZZ profiles use MaterialMap G/B for metallic/specular response while
+  retaining R as material-ID data. Unknown game/API pairs keep packed maps
+  available but do not guess PBR semantics.
 - A section with an `ib` but no `drawindexed` uses a synthetic whole-buffer
   draw. It inherits `diffuse_variants_at_end`; do not discard a section’s final
   diffuse. A real draw before the first diffuse legitimately remains untextured.

--- a/context.md
+++ b/context.md
@@ -125,6 +125,10 @@ hashes changed—installing PyInstaller from sdist alone does not rebuild it.
   maps may have Z reconstructed during encoding. SRMI/HSR markers take
   precedence over generic DRAW_TYPE/vb2 heuristics, while ZZZ requires its
   more-specific 2/4 route and ZZMI evidence.
+  Profiles that derive a display normal from packed source data, such as WuWa,
+  publish both `normal_map_key` and an intact `normal_data_key`; the latter is
+  reserved for a future validated material shader and is never silently used
+  as a standard Three.js map.
   LightMaps remain packed game data and are retained as toggle-aware keys; the
   passthrough transport preserves authored RGBA for packed auxiliary roles,
   ordinary diffuse passthrough remains RGB, and explicit channel masks read the
@@ -254,10 +258,10 @@ hashes changed—installing PyInstaller from sdist alone does not rebuild it.
 - Texture source paths are mod-relative, never basenames, because variant
   folders commonly repeat filenames.
 - Rendered texture identity is `role::mod-relative-path`, because one source
-  file may be used as diffuse, normal, light or material data and each role
-  has a different encoding/color-space contract. Diffuse maps are sRGB;
-  auxiliary maps are non-color data. Legacy path-only viewer metadata must be
-  normalized when loaded.
+  file may be used as diffuse, derived normal, retained raw normal data, light
+  or material data and each role has a different encoding/color-space contract.
+  Diffuse maps are sRGB; auxiliary maps are non-color data. Legacy path-only
+  viewer metadata must be normalized when loaded.
 - `safe_resource_path`/`_safe_join` is the one sandbox implementation for both
   geometry and health. Reject absolute/drive paths, allow relative parent climbs
   only up to live `_MAX_ESCAPE_DEPTH`, and do not duplicate these rules.

--- a/context.md
+++ b/context.md
@@ -127,16 +127,18 @@ hashes changed—installing PyInstaller from sdist alone does not rebuild it.
   more-specific 2/4 route and ZZMI evidence.
   Profiles that derive a display normal from packed source data, such as WuWa,
   publish both `normal_map_key` and an intact `normal_data_key`; the latter is
-  reserved for a future validated material shader and is never silently used
-  as a standard Three.js map.
+  available to the selected material adapter and is never silently used as a
+  standard Three.js map. Material interpretation is selected from `(game,
+  texture_api)`, not from a texture name alone.
   LightMaps remain packed game data and are retained as toggle-aware keys; the
   passthrough transport preserves authored RGBA for packed auxiliary roles,
   ordinary diffuse passthrough remains RGB, and explicit channel masks read the
-  source channel before conversion. They are not bound to Three.js AO or RGB
-  light inputs. MaterialMaps remain loaded
-  and toggle-aware but are not guessed into incompatible standard PBR channels
-  without known shader semantics. A future validated AO derivation must use an
-  explicit occlusion role.
+  source channel before conversion. Known Genshin profiles use only LightMap R/B
+  for a restrained material response; LightMap G remains reserved for the
+  later toon-shadow phase and no LightMap is bound as Three.js AO. Known ZZZ
+  profiles use MaterialMap G/B for metallic/specular response while retaining R
+  as material-ID data. Unknown game/API pairs keep packed maps available but
+  do not guess PBR semantics.
 - A section with an `ib` but no `drawindexed` uses a synthetic whole-buffer
   draw. It inherits `diffuse_variants_at_end`; do not discard a section’s final
   diffuse. A real draw before the first diffuse legitimately remains untextured.
@@ -288,7 +290,8 @@ hashes changed—installing PyInstaller from sdist alone does not rebuild it.
   scale from model bounds. Camera framing targets the
   unobstructed viewport: keep orbit target at the true model center and shift
   projection with `setViewOffset`; back up when horizontal space is limiting.
-  Materials use DoubleSide, roughness 1 and flat shading by default.
+  Materials use DoubleSide, roughness 1 and flat shading by default; known
+  packed-material profiles may vary metallic/specular response in their shader.
 
 ## Frontend, hosting and security
 

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -13,6 +13,7 @@ from core.mesh_builder import (GeometryBlob, encode_texture_file,
                                encode_texture_key)
 from core.mod_discovery import discover_ini_paths
 from core.ini_health import analyze_mod
+from core.texture_profiles import texture_profile_for
 
 from . import (edit_session, ini_api, metadata, mod_loader, present_api,
                server, toggle_api)
@@ -70,9 +71,32 @@ class ModViewerAPI:
             file_types=("Textures (*.dds;*.png;*.jpg;*.jpeg;*.tga)",))
         if not result:
             return None
-        return encode_texture_file(
+        texture_source = self._active_texture_source(
+            folder_path, validate=True)
+        encoded = encode_texture_file(
             folder_path, result[0], texture_role,
-            texture_source=self._active_texture_source(folder_path, validate=True))
+            texture_source=texture_source)
+        if (encoded.get("error") or texture_role != "normal_map"):
+            return encoded
+
+        # WuWa's display normal is derived from a packed source. Keep the
+        # original RGBA source paired with a manually selected NormalMap so a
+        # future material shader can consume the exact authored data rather
+        # than whichever normal happened to be selected before it.
+        publication = server.active_texture_publication(folder_path)
+        profile = texture_profile_for(
+            publication.game_profile if publication else None)
+        if not profile.retain_normal_data:
+            return encoded
+        raw = encode_texture_file(
+            folder_path, result[0], "normal_data",
+            texture_source=texture_source, texture_profile=profile)
+        if raw.get("error"):
+            return raw
+        encoded["normal_data_key"] = raw["tex_key"]
+        encoded["normal_data_file"] = raw["file"]
+        encoded["normal_data_uri"] = raw["uri"]
+        return encoded
 
     def load_texture_file(self, folder_path, tex_key):
         """Resolve a known mod-relative picker texture on first use."""

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -80,9 +80,9 @@ class ModViewerAPI:
             return encoded
 
         # WuWa's display normal is derived from a packed source. Keep the
-        # original RGBA source paired with a manually selected NormalMap so a
-        # future material shader can consume the exact authored data rather
-        # than whichever normal happened to be selected before it.
+        # original RGBA source paired with a manually selected NormalMap so
+        # the material adapter can consume the exact authored data rather than
+        # whichever normal happened to be selected before it.
         publication = server.active_texture_publication(folder_path)
         profile = texture_profile_for(
             publication.game_profile if publication else None)

--- a/src/app/metadata.py
+++ b/src/app/metadata.py
@@ -205,7 +205,8 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
         _role, relative_path = split_texture_key(key)
         item = {"tex_key": key, "file": relative_path,
                 "label": label, "manual": manual}
-        for field in ("normal_map", "light_map", "material_map"):
+        for field in ("normal_map", "normal_data", "light_map",
+                      "material_map"):
             value = normalize_texture_key(state.get(field), field)
             if value:
                 item[field] = value
@@ -247,7 +248,8 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
             if old is None:
                 pool.append(opt)
             else:
-                for field in ("normal_map", "light_map", "material_map"):
+                for field in ("normal_map", "normal_data", "light_map",
+                              "material_map"):
                     if opt.get(field):
                         old[field] = opt[field]
                     if opt.get(f"{field}_manual"):
@@ -265,7 +267,8 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
         texture_roles = [(state["tex_key"], None)] if state else []
         if state:
             texture_roles.extend((state.get(field), field) for field in
-                                 ("normal_map", "light_map", "material_map"))
+                                 ("normal_map", "normal_data", "light_map",
+                                  "material_map"))
         for key, role in texture_roles:
             if not key:
                 continue

--- a/src/app/mod_loader.py
+++ b/src/app/mod_loader.py
@@ -283,7 +283,8 @@ def _gating_vars(payload):
             for cond in group:
                 found.add(cond["var"])
         for field in ("texture_variants", "normal_map_variants",
-                      "light_map_variants", "material_map_variants"):
+                      "normal_data_variants", "light_map_variants",
+                      "material_map_variants"):
             for variant in entry.get(field, []):
                 for group in variant.get("conditions", []):
                     for cond in group:
@@ -412,7 +413,8 @@ def _gating_vars_from_groups(groups):
                 for cond in cond_group:
                     found.add(cond["var"])
             for field in ("texture_variants", "normal_map_variants",
-                          "light_map_variants", "material_map_variants"):
+                          "normal_data_variants", "light_map_variants",
+                          "material_map_variants"):
                 for variant in draw.get(field, []):
                     for cond_group in variant.get("conditions", []):
                         for cond in cond_group:

--- a/src/app/mod_loader.py
+++ b/src/app/mod_loader.py
@@ -23,6 +23,7 @@ from core.ini_menu import attach_menu_images
 from core.ini_health import analyze_mod
 from core.present_editor import SECTION_NAME as PRESENT_SECTION
 from core.game_profile import GameDetection, resolve_game_detection
+from core.material_profiles import material_profile_for
 
 # Kept for scripts that still inspect the low-level mesh-builder result.  These
 # keys are no longer emitted by load_mod's public application payload.
@@ -504,6 +505,8 @@ def _structured_payload(meshes=None, textures=None, toggles=None, menu=None,
     }
     if game is not None:
         payload["metadata"]["game"] = game.to_metadata()
+        payload["metadata"]["material_profile"] = \
+            material_profile_for(game).to_metadata()
     if error:
         payload["error"] = error
     return payload

--- a/src/core/ini_health.py
+++ b/src/core/ini_health.py
@@ -228,7 +228,8 @@ def _viewer_texture_paths(mod_dir):
         for state in textures.values() if isinstance(textures, dict) else ():
             if not isinstance(state, dict):
                 continue
-            for field in ("tex_key", "normal_map", "light_map", "material_map"):
+            for field in ("tex_key", "normal_map", "normal_data",
+                          "light_map", "material_map"):
                 key = state.get(field)
                 _role, relative_path = split_texture_key(key)
                 resolved = safe_resource_path(mod_dir, relative_path)

--- a/src/core/material_profiles.py
+++ b/src/core/material_profiles.py
@@ -1,0 +1,127 @@
+"""Game-and-texture-API material interpretations for packed map shaders.
+
+Texture profiles decide how an image is transported and optionally derive a
+stock normal map.  Material interpretations are a separate concern: they
+describe which channels in an intact packed texture have a meaning for the
+viewer shader.  Keeping the two tables separate prevents a transport recipe
+from silently becoming a rendering assumption.
+"""
+
+from dataclasses import dataclass
+
+
+_SOURCES = frozenset(("normal_data", "light_map", "material_map"))
+_CHANNELS = frozenset("rgba")
+
+
+@dataclass(frozen=True)
+class ChannelRef:
+    """One semantic channel in one role-aware packed texture."""
+
+    source: str
+    channel: str
+    invert: bool = False
+
+    def __post_init__(self):
+        if self.source not in _SOURCES:
+            raise ValueError(f"Unknown packed material source: {self.source}")
+        if self.channel not in _CHANNELS:
+            raise ValueError(f"Unknown packed material channel: {self.channel}")
+
+    def to_metadata(self):
+        return {
+            "source": self.source,
+            "channel": self.channel,
+            "invert": self.invert,
+        }
+
+
+@dataclass(frozen=True)
+class MaterialInterpretation:
+    """Semantic packed-map channels understood by the frontend adapter."""
+
+    id: str
+    game: str
+    texture_api: str
+    normal_xy: tuple[str, str] | None = None
+    shadow_mask: ChannelRef | None = None
+    material_id: ChannelRef | None = None
+    metalness: ChannelRef | None = None
+    gloss: ChannelRef | None = None
+    specular: ChannelRef | None = None
+    ao: ChannelRef | None = None
+    # Genshin's R/B response is deliberately capped until the later LightMap
+    # toon-shadow and material-ID work. The source channels are classification
+    # data on some face materials, not a literal full-range metalness map.
+    metalness_scale: float = 1.0
+    specular_scale: float = 1.0
+
+    def to_metadata(self):
+        result = {
+            "id": self.id,
+            "game": self.game,
+            "texture_api": self.texture_api,
+            "normal_xy": list(self.normal_xy) if self.normal_xy else None,
+            "shadow_mask": (self.shadow_mask.to_metadata()
+                            if self.shadow_mask else None),
+            "material_id": (self.material_id.to_metadata()
+                            if self.material_id else None),
+            "metalness": (self.metalness.to_metadata()
+                          if self.metalness else None),
+            "gloss": self.gloss.to_metadata() if self.gloss else None,
+            "specular": (self.specular.to_metadata()
+                          if self.specular else None),
+            "ao": self.ao.to_metadata() if self.ao else None,
+            "metalness_scale": self.metalness_scale,
+            "specular_scale": self.specular_scale,
+        }
+        return result
+
+
+def _profile_for(game, texture_api):
+    if game == "zzz" and texture_api in ("zzmi", "rabbitfx"):
+        return MaterialInterpretation(
+            id=f"zzz:{texture_api}", game=game, texture_api=texture_api,
+            material_id=ChannelRef("material_map", "r"),
+            metalness=ChannelRef("material_map", "g"),
+            specular=ChannelRef("material_map", "b"),
+        )
+    if game == "genshin" and texture_api in ("gimi", "rabbitfx"):
+        return MaterialInterpretation(
+            id=f"genshin:{texture_api}", game=game,
+            texture_api=texture_api,
+            metalness=ChannelRef("light_map", "r"),
+            specular=ChannelRef("light_map", "b"),
+            metalness_scale=0.08,
+            specular_scale=0.15,
+        )
+    if game == "wuwa":
+        # RabbitFX/WuWa's packed normal/material layout is retained for the
+        # shader adapter, but Z/W semantics remain unguessed in this PR.
+        return MaterialInterpretation(
+            id=f"wuwa:{texture_api}", game=game, texture_api=texture_api,
+            normal_xy=("r", "g"),
+        )
+    return None
+
+
+def material_profile_for(game=None, texture_api=None):
+    """Resolve a conservative material interpretation from full detection.
+
+    Accepts a ``GameDetection`` object or metadata dictionary as ``game`` for
+    callers that already carry the complete detection, while retaining the
+    explicit two-axis form for tests and small core integrations.
+    """
+    if hasattr(game, "game"):
+        detection = game
+        game, texture_api = detection.game, detection.texture_api
+    elif isinstance(game, dict):
+        game, texture_api = (game.get("game") or game.get("id"),
+                             game.get("texture_api", texture_api))
+    game = str(game or "unknown").lower()
+    texture_api = str(texture_api or "unknown").lower()
+    profile = _profile_for(game, texture_api)
+    if profile is not None:
+        return profile
+    return MaterialInterpretation(
+        id="none", game=game, texture_api=texture_api)

--- a/src/core/material_profiles.py
+++ b/src/core/material_profiles.py
@@ -50,11 +50,16 @@ class MaterialInterpretation:
     gloss: ChannelRef | None = None
     specular: ChannelRef | None = None
     ao: ChannelRef | None = None
-    # Genshin's R/B response is deliberately capped until the later LightMap
-    # toon-shadow and material-ID work. The source channels are classification
-    # data on some face materials, not a literal full-range metalness map.
+    # Genshin's R response is deliberately capped until the later LightMap
+    # threshold, toon-shadow, and material-ID work. The source channel is
+    # classification data on some face materials, not a literal full-range
+    # metalness map.
     metalness_scale: float = 1.0
     specular_scale: float = 1.0
+    # An optional influence blend keeps a mask from replacing the stock
+    # response outright. This is useful for Genshin's classification-like R
+    # channel; ZZZ's authored specular mask remains a direct response.
+    specular_influence: float | None = None
 
     def to_metadata(self):
         result = {
@@ -74,6 +79,7 @@ class MaterialInterpretation:
             "ao": self.ao.to_metadata() if self.ao else None,
             "metalness_scale": self.metalness_scale,
             "specular_scale": self.specular_scale,
+            "specular_influence": self.specular_influence,
         }
         return result
 
@@ -91,9 +97,12 @@ def _profile_for(game, texture_api):
             id=f"genshin:{texture_api}", game=game,
             texture_api=texture_api,
             metalness=ChannelRef("light_map", "r"),
-            specular=ChannelRef("light_map", "b"),
+            # R is the first-pass specular mask. B controls the toon
+            # highlight threshold and remains reserved for that later phase.
+            specular=ChannelRef("light_map", "r"),
             metalness_scale=0.08,
-            specular_scale=0.15,
+            specular_scale=1.0,
+            specular_influence=0.15,
         )
     if game == "wuwa":
         # RabbitFX/WuWa's packed normal/material layout is retained for the

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -20,7 +20,8 @@ _MAX_BUFFER_FILE_BYTES = 512 * 1024 * 1024
 _MAX_TOTAL_BUFFER_BYTES = 2 * 1024 * 1024 * 1024
 _MAX_DRAWS = 10_000
 _MAX_IMAGE_PIXELS = 100_000_000
-TEXTURE_ROLES = ("diffuse", "normal_map", "light_map", "material_map")
+TEXTURE_ROLES = (
+    "diffuse", "normal_map", "normal_data", "light_map", "material_map")
 TEXTURE_TRANSFORMS = (
     "passthrough", "normal_xy_reconstruct", "channel_r", "channel_g",
     "channel_b", "channel_a",
@@ -842,6 +843,12 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 tex_uris[key] = value or ""
             return key
 
+        def _ensure_normal_data(dds_path):
+            """Retain a raw authored normal source when the profile needs it."""
+            if not texture_profile.retain_normal_data:
+                return None
+            return _ensure_texture(dds_path, "normal_data")
+
         # Every diffuse this component's ini ever references, resolved once
         # and shared by every draw in the group -- the UI's per-mesh texture
         # picker list (core/ini_parser.py's build_draw_groups). Uses the same
@@ -961,6 +968,11 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                     mod_dir, draw.get(f"{channel}_default_file")), channel)
                 if key:
                     entry[f"{channel}_key"] = key
+            normal_path = _safe_join(
+                mod_dir, draw.get("normal_map_default_file"))
+            normal_data_key = _ensure_normal_data(normal_path)
+            if normal_data_key:
+                entry["normal_data_key"] = normal_data_key
             # The manager presents one row per diffuse. Seed that row with the
             # auxiliary maps resolved alongside this draw so authored maps can
             # be inspected/replaced with the same controls as manual ones.
@@ -970,7 +982,8 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 option = next((item for item in texture_options
                                if item["tex_key"] == diffuse_key), None)
                 if option:
-                    for channel in ("normal_map", "light_map", "material_map"):
+                    for channel in ("normal_map", "light_map", "normal_data",
+                                    "material_map"):
                         key = entry.get(f"{channel}_key")
                         if key and not option.get(channel):
                             option[channel] = key
@@ -1020,6 +1033,18 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                         })
                 if variants:
                     entry[f"{channel}_variants"] = variants
+                if channel == "normal_map" and texture_profile.retain_normal_data:
+                    data_variants = []
+                    for variant in rules:
+                        key = _ensure_normal_data(_safe_join(
+                            mod_dir, variant["file"]))
+                        if key:
+                            data_variants.append({
+                                "conditions": variant["conditions"],
+                                "tex_key": key,
+                            })
+                    if data_variants:
+                        entry["normal_data_variants"] = data_variants
             # Keep even a single resolved texture in the UI pool. A component
             # with one diffuse still has a useful texture to display/manage;
             # only components with no resolved textures need the frontend's

--- a/src/core/texture_profiles.py
+++ b/src/core/texture_profiles.py
@@ -3,7 +3,8 @@
 from dataclasses import dataclass
 
 
-TEXTURE_ROLES = ("diffuse", "normal_map", "light_map", "material_map")
+TEXTURE_ROLES = (
+    "diffuse", "normal_map", "normal_data", "light_map", "material_map")
 
 
 @dataclass(frozen=True)
@@ -15,6 +16,7 @@ class TextureProfile:
     bind_normal_map: bool
     bind_light_map: bool = False
     bind_material_map: bool = False
+    retain_normal_data: bool = False
 
     @property
     def game(self):
@@ -25,13 +27,15 @@ class TextureProfile:
         role = role if role in TEXTURE_ROLES else "diffuse"
         if role == "normal_map" and self.bind_normal_map:
             return "normal_xy_reconstruct"
+        if role == "normal_data":
+            return "passthrough"
         return "passthrough"
 
 
 _PROFILES = {
     "genshin": TextureProfile("genshin", -1, True),
     "zzz": TextureProfile("zzz", -1, True),
-    "wuwa": TextureProfile("wuwa", -1, True),
+    "wuwa": TextureProfile("wuwa", -1, True, retain_normal_data=True),
     # SRMI/HSR texture semantics are intentionally conservative until the
     # runtime's packed normal/material layout is modeled explicitly.
     "hsr": TextureProfile("hsr", 1, False),

--- a/src/core/texture_profiles.py
+++ b/src/core/texture_profiles.py
@@ -39,8 +39,9 @@ _PROFILES = {
     # SRMI/HSR texture semantics are intentionally conservative until the
     # runtime's packed normal/material layout is modeled explicitly.
     "hsr": TextureProfile("hsr", 1, False),
-    # Unknown mods retain authored keys for inspection, but the renderer only
-    # binds the diffuse until a known recipe is justified.
+    # Unknown mods retain authored keys for inspection; the renderer only
+    # applies a semantic packed-map response when a separate material profile
+    # justifies it.
     "unknown": TextureProfile("unknown", 1, False),
 }
 

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -95,10 +95,25 @@ def _packed_material_payload(profile_id="zzz:zzmi"):
             "metalness": {"source": "light_map", "channel": "r",
                            "invert": False},
             "gloss": None,
-            "specular": {"source": "light_map", "channel": "b",
+            "specular": {"source": "light_map", "channel": "r",
                           "invert": False},
             "ao": None, "metalness_scale": 0.08,
-            "specular_scale": 0.15,
+            "specular_scale": 1.0, "specular_influence": 0.15,
+        }
+    elif profile_id == "wuwa:rabbitfx":
+        profile = {
+            "id": profile_id, "game": "wuwa", "texture_api": "rabbitfx",
+            "normal_xy": ["r", "g"], "shadow_mask": None,
+            "material_id": None, "metalness": None, "gloss": None,
+            "specular": None, "ao": None, "metalness_scale": 1,
+            "specular_scale": 1,
+        }
+    elif profile_id == "none":
+        profile = {
+            "id": "none", "game": "unknown", "texture_api": "unknown",
+            "normal_xy": None, "shadow_mask": None, "material_id": None,
+            "metalness": None, "gloss": None, "specular": None,
+            "ao": None, "metalness_scale": 1, "specular_scale": 1,
         }
     else:
         profile = {
@@ -344,6 +359,7 @@ def test_packed_material_profile_compiles_and_toggles_update_uniforms(
             materialMap: !!game.uniforms.gameMaterialMap.value,
             metalnessScale: game.uniforms.gameMaterialMetalnessScale.value,
             specularScale: game.uniforms.gameMaterialSpecularScale.value,
+            specularInfluence: game.uniforms.gameMaterialSpecularInfluence.value,
             version: material.version,
           };
         }""")
@@ -355,7 +371,8 @@ def test_packed_material_profile_compiles_and_toggles_update_uniforms(
                          else "gameLightMapSample")
         assert source_sample in state["fragment"]
         assert state["metalnessScale"] == (1 if profile_id == "zzz:zzmi" else 0.08)
-        assert state["specularScale"] == (1 if profile_id == "zzz:zzmi" else 0.15)
+        assert state["specularScale"] == 1
+        assert state["specularInfluence"] == (0 if profile_id == "zzz:zzmi" else 0.15)
         assert state["materialMap"] if profile_id == "zzz:zzmi" else state["lightMap"]
 
         after = page.evaluate("""async () => {
@@ -380,6 +397,51 @@ def test_packed_material_profile_compiles_and_toggles_update_uniforms(
         }""")
         assert after == {"sameShader": True, "sameVersion": True,
                          "mapEnabled": False}
+    finally:
+        context.close()
+
+
+@pytest.mark.parametrize(("profile_id", "expected"), [
+    ("zzz:zzmi", {
+        "physical": True, "profile": "zzz:zzmi", "normalData": False,
+        "lightMap": False, "materialMap": True,
+    }),
+    ("genshin:gimi", {
+        "physical": True, "profile": "genshin:gimi", "normalData": False,
+        "lightMap": True, "materialMap": False,
+    }),
+    ("wuwa:rabbitfx", {
+        "physical": False, "profile": "wuwa:rabbitfx", "normalData": False,
+        "lightMap": False, "materialMap": False,
+    }),
+    ("none", {
+        "physical": False, "profile": None, "normalData": False,
+        "lightMap": False, "materialMap": False,
+    }),
+])
+def test_packed_material_sources_are_loaded_only_when_sampled(
+        edge_browser, frontend_url, profile_id, expected):
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"Packed": _packed_material_payload(profile_id)},
+    )
+    try:
+        _open(page, "Packed")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_timeout(300)
+        state = page.evaluate("""() => {
+          const material = window.modViewer.activeMeshes[0].material;
+          const game = material.userData.gameMaterial;
+          const uniforms = game?.uniforms || {};
+          return {
+            physical: !!material.isMeshPhysicalMaterial,
+            profile: game?.profile?.id || null,
+            normalData: !!uniforms.gameNormalData?.value,
+            lightMap: !!uniforms.gameLightMap?.value,
+            materialMap: !!uniforms.gameMaterialMap?.value,
+          };
+        }""")
+        assert state == expected
     finally:
         context.close()
 

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -8,6 +8,7 @@ import struct
 import pytest
 
 from app import paths, server
+from core.material_profiles import material_profile_for
 
 playwright = pytest.importorskip("playwright.sync_api")
 
@@ -88,46 +89,14 @@ def _packed_material_payload(profile_id="zzz:zzmi"):
         "material_map::Packed-material.png": _PNG_URI,
         "normal_data::Packed-normal.png": _PNG_URI,
     }
-    if profile_id == "genshin:gimi":
-        profile = {
-            "id": profile_id, "game": "genshin", "texture_api": "gimi",
-            "normal_xy": None, "shadow_mask": None, "material_id": None,
-            "metalness": {"source": "light_map", "channel": "r",
-                           "invert": False},
-            "gloss": None,
-            "specular": {"source": "light_map", "channel": "r",
-                          "invert": False},
-            "ao": None, "metalness_scale": 0.08,
-            "specular_scale": 1.0, "specular_influence": 0.15,
-        }
-    elif profile_id == "wuwa:rabbitfx":
-        profile = {
-            "id": profile_id, "game": "wuwa", "texture_api": "rabbitfx",
-            "normal_xy": ["r", "g"], "shadow_mask": None,
-            "material_id": None, "metalness": None, "gloss": None,
-            "specular": None, "ao": None, "metalness_scale": 1,
-            "specular_scale": 1,
-        }
-    elif profile_id == "none":
-        profile = {
-            "id": "none", "game": "unknown", "texture_api": "unknown",
-            "normal_xy": None, "shadow_mask": None, "material_id": None,
-            "metalness": None, "gloss": None, "specular": None,
-            "ao": None, "metalness_scale": 1, "specular_scale": 1,
-        }
-    else:
-        profile = {
-            "id": profile_id, "game": "zzz", "texture_api": "zzmi",
-            "normal_xy": None, "shadow_mask": None,
-            "material_id": {"source": "material_map", "channel": "r",
-                             "invert": False},
-            "metalness": {"source": "material_map", "channel": "g",
-                           "invert": False},
-            "gloss": None,
-            "specular": {"source": "material_map", "channel": "b",
-                          "invert": False},
-            "ao": None, "metalness_scale": 1, "specular_scale": 1,
-        }
+    profile_args = {
+        "zzz:zzmi": ("zzz", "zzmi"),
+        "genshin:gimi": ("genshin", "gimi"),
+        "wuwa:rabbitfx": ("wuwa", "rabbitfx"),
+    }
+    profile = (material_profile_for(*profile_args[profile_id]).to_metadata()
+               if profile_id in profile_args
+               else material_profile_for("unknown", "unknown").to_metadata())
     payload["metadata"]["material_profile"] = profile
     return payload
 
@@ -360,6 +329,8 @@ def test_packed_material_profile_compiles_and_toggles_update_uniforms(
             metalnessScale: game.uniforms.gameMaterialMetalnessScale.value,
             specularScale: game.uniforms.gameMaterialSpecularScale.value,
             specularInfluence: game.uniforms.gameMaterialSpecularInfluence.value,
+            usesInfluenceBlend: game.shader.fragmentShader
+              .includes('gameMaterialSpecularResponse = mix('),
             version: material.version,
           };
         }""")
@@ -373,6 +344,7 @@ def test_packed_material_profile_compiles_and_toggles_update_uniforms(
         assert state["metalnessScale"] == (1 if profile_id == "zzz:zzmi" else 0.08)
         assert state["specularScale"] == 1
         assert state["specularInfluence"] == (0 if profile_id == "zzz:zzmi" else 0.15)
+        assert state["usesInfluenceBlend"] == (profile_id == "genshin:gimi")
         assert state["materialMap"] if profile_id == "zzz:zzmi" else state["lightMap"]
 
         after = page.evaluate("""async () => {

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -11,6 +11,11 @@ from app import paths, server
 
 playwright = pytest.importorskip("playwright.sync_api")
 
+_PNG_URI = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/"
+    "ScLkWQAAAABJRU5ErkJggg==")
+
 
 def _f32(*values):
     return base64.b64encode(struct.pack(f"<{len(values)}f", *values)).decode()
@@ -68,6 +73,48 @@ def _payload(label="A"):
         "metadata": {"mesh_names": {}},
         "health": {"summary": {"issues": 0, "errors": 0}, "files": {}, "issues": []},
     }
+
+
+def _packed_material_payload(profile_id="zzz:zzmi"):
+    payload = _payload("Packed")
+    entry = payload["meshes"]["Body-Packed-0"]
+    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    entry["light_map_key"] = "light_map::Packed-light.png"
+    entry["material_map_key"] = "material_map::Packed-material.png"
+    entry["normal_data_key"] = "normal_data::Packed-normal.png"
+    payload["textures"] = {
+        "diffuse::Packed-one.png": _PNG_URI,
+        "light_map::Packed-light.png": _PNG_URI,
+        "material_map::Packed-material.png": _PNG_URI,
+        "normal_data::Packed-normal.png": _PNG_URI,
+    }
+    if profile_id == "genshin:gimi":
+        profile = {
+            "id": profile_id, "game": "genshin", "texture_api": "gimi",
+            "normal_xy": None, "shadow_mask": None, "material_id": None,
+            "metalness": {"source": "light_map", "channel": "r",
+                           "invert": False},
+            "gloss": None,
+            "specular": {"source": "light_map", "channel": "b",
+                          "invert": False},
+            "ao": None, "metalness_scale": 0.08,
+            "specular_scale": 0.15,
+        }
+    else:
+        profile = {
+            "id": profile_id, "game": "zzz", "texture_api": "zzmi",
+            "normal_xy": None, "shadow_mask": None,
+            "material_id": {"source": "material_map", "channel": "r",
+                             "invert": False},
+            "metalness": {"source": "material_map", "channel": "g",
+                           "invert": False},
+            "gloss": None,
+            "specular": {"source": "material_map", "channel": "b",
+                          "invert": False},
+            "ao": None, "metalness_scale": 1, "specular_scale": 1,
+        }
+    payload["metadata"]["material_profile"] = profile
+    return payload
 
 
 def _construction_failure_payload():
@@ -268,6 +315,71 @@ def test_frontend_construction_failure_rolls_back_partial_scene(
         assert page.locator("#mod-path").inner_text() == "B"
         assert not page.locator("#ini-view-btn").is_disabled()
         page.locator("#dialog-ok").click()
+    finally:
+        context.close()
+
+
+@pytest.mark.parametrize("profile_id", ["zzz:zzmi", "genshin:gimi"])
+def test_packed_material_profile_compiles_and_toggles_update_uniforms(
+        edge_browser, frontend_url, profile_id):
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"Packed": _packed_material_payload(profile_id)},
+    )
+    try:
+        _open(page, "Packed")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0]?.material?.userData?.gameMaterial?.shader")
+
+        state = page.evaluate("""() => {
+          const material = window.modViewer.activeMeshes[0].material;
+          const game = material.userData.gameMaterial;
+          return {
+            physical: material.isMeshPhysicalMaterial,
+            profile: game.profile.id,
+            shader: !!game.shader,
+            fragment: game.shader.fragmentShader,
+            lightMap: !!game.uniforms.gameLightMap.value,
+            materialMap: !!game.uniforms.gameMaterialMap.value,
+            metalnessScale: game.uniforms.gameMaterialMetalnessScale.value,
+            specularScale: game.uniforms.gameMaterialSpecularScale.value,
+            version: material.version,
+          };
+        }""")
+        assert state["physical"]
+        assert state["profile"] == profile_id
+        assert "gameMaterialSpecularResponse" in state["fragment"]
+        assert "gameMaterialMetalnessResponse" in state["fragment"]
+        source_sample = ("gameMaterialMapSample" if profile_id == "zzz:zzmi"
+                         else "gameLightMapSample")
+        assert source_sample in state["fragment"]
+        assert state["metalnessScale"] == (1 if profile_id == "zzz:zzmi" else 0.08)
+        assert state["specularScale"] == (1 if profile_id == "zzz:zzmi" else 0.15)
+        assert state["materialMap"] if profile_id == "zzz:zzmi" else state["lightMap"]
+
+        after = page.evaluate("""async () => {
+          const {setMeshTextureState} = await import('./js/mesh-factory.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          const material = mesh.material;
+          const shader = material.userData.gameMaterial.shader;
+          const version = material.version;
+          setMeshTextureState(mesh, {
+            diffuse: mesh.userData.texKey,
+            normal_map: mesh.userData.normalMapKey,
+            normal_data: null,
+            light_map: null,
+            material_map: null,
+          });
+          return {
+            sameShader: material.userData.gameMaterial.shader === shader,
+            sameVersion: material.version === version,
+            mapEnabled: material.userData.gameMaterial.uniforms
+              .gameMaterialMapEnabled.value,
+          };
+        }""")
+        assert after == {"sameShader": True, "sameVersion": True,
+                         "mapEnabled": False}
     finally:
         context.close()
 

--- a/src/tests/test_game_profile.py
+++ b/src/tests/test_game_profile.py
@@ -189,3 +189,10 @@ def test_texture_profiles_keep_auxiliary_maps_packed():
     assert not profile.bind_light_map
     assert not profile.bind_material_map
     assert profile.normal_y_sign == -1
+
+
+def test_wuwa_profile_retains_raw_normal_data_for_future_material_shaders():
+    profile = texture_profile_for("wuwa")
+    assert profile.recipe_for("normal_map") == "normal_xy_reconstruct"
+    assert profile.recipe_for("normal_data") == "passthrough"
+    assert profile.retain_normal_data

--- a/src/tests/test_load_pipeline.py
+++ b/src/tests/test_load_pipeline.py
@@ -165,6 +165,41 @@ def test_texture_registry_identity_includes_role():
               and entry["normal_map_key"] == "normal_map::shared.png"), ("mesh building keeps shared diffuse and normal roles separate")
 
 
+def test_wuwa_retains_raw_normal_data_alongside_derived_display_normal():
+    from PIL import Image
+
+    def uri_mode(uri):
+        payload = base64.b64decode(uri.split(",", 1)[1])
+        return Image.open(io.BytesIO(payload)).mode
+
+    with tempfile.TemporaryDirectory() as root:
+        Image.new("RGBA", (1, 1), (128, 128, 12, 34)).save(
+            os.path.join(root, "normal.png"))
+        with open(os.path.join(root, "p.buf"), "wb") as fh:
+            fh.write(struct.pack("<9f", 0, 0, 0, 1, 0, 0, 0, 1, 0))
+        with open(os.path.join(root, "t.buf"), "wb") as fh:
+            fh.write(struct.pack("<6f", 0, 0, 1, 0, 0, 1))
+        with open(os.path.join(root, "i.buf"), "wb") as fh:
+            fh.write(struct.pack("<3I", 0, 1, 2))
+        group = [{
+            "name": "Body", "display_name": "Body",
+            "position_file": "p.buf", "texcoord_file": "t.buf",
+            "position_stride": 12, "texcoord_stride": 8,
+            "ib_file": "i.buf", "index_size": 4,
+            "draws": [{"label": "Body-1", "count": 3,
+                        "start": 0, "base": 0, "conditions": [],
+                        "normal_map_default_file": "normal.png"}],
+        }]
+        built = build_mesh_result(group, root, geometry=GeometryBlob(),
+                                  game_profile="wuwa")
+        entry = built.meshes["Body-1"]
+
+        assert entry["normal_map_key"] == "normal_map::normal.png"
+        assert entry["normal_data_key"] == "normal_data::normal.png"
+        assert uri_mode(built.textures[entry["normal_map_key"]]) == "RGB"
+        assert uri_mode(built.textures[entry["normal_data_key"]]) == "RGBA"
+
+
 def test_legacy_texture_metadata_is_normalized_by_role():
     from PIL import Image
 

--- a/src/tests/test_material_profiles.py
+++ b/src/tests/test_material_profiles.py
@@ -1,0 +1,67 @@
+"""Packed material interpretation regressions."""
+
+from core.game_profile import GameDetection
+from core.material_profiles import ChannelRef, material_profile_for
+
+
+def test_zzz_uses_material_map_g_for_metalness_and_b_for_specular():
+    profile = material_profile_for("zzz", "zzmi")
+
+    assert profile.id == "zzz:zzmi"
+    assert profile.metalness == ChannelRef("material_map", "g")
+    assert profile.specular == ChannelRef("material_map", "b")
+    assert profile.material_id == ChannelRef("material_map", "r")
+
+
+def test_zzz_rabbitfx_profile_is_separate_from_zzmi_but_keeps_semantics():
+    profile = material_profile_for("zzz", "rabbitfx")
+
+    assert profile.id == "zzz:rabbitfx"
+    assert profile.texture_api == "rabbitfx"
+    assert profile.metalness.source == "material_map"
+    assert profile.specular.channel == "b"
+
+
+def test_genshin_uses_conservative_light_map_r_and_b_response():
+    profile = material_profile_for("genshin", "gimi")
+
+    assert profile.id == "genshin:gimi"
+    assert profile.metalness == ChannelRef("light_map", "r")
+    assert profile.specular == ChannelRef("light_map", "b")
+    assert profile.metalness_scale == 0.08
+    assert profile.specular_scale == 0.15
+
+
+def test_material_profile_accepts_complete_detection_without_guessing_unknown_api():
+    detection = GameDetection(
+        game="zzz", runtime="zzmi", texture_api="unknown",
+        confidence="high", scores={})
+
+    profile = material_profile_for(detection)
+
+    assert profile.id == "none"
+    assert profile.game == "zzz"
+    assert profile.texture_api == "unknown"
+
+
+def test_wuwa_keeps_normal_data_available_for_raw_or_unknown_api():
+    for texture_api in ("raw", "unknown"):
+        profile = material_profile_for("wuwa", texture_api)
+
+        assert profile.id == f"wuwa:{texture_api}"
+        assert profile.normal_xy == ("r", "g")
+        assert profile.metalness is None
+        assert profile.specular is None
+
+
+def test_structured_payload_exposes_material_profile_metadata():
+    from app.mod_loader import _structured_payload
+
+    detection = GameDetection(
+        game="genshin", runtime="gimi", texture_api="gimi",
+        confidence="high", scores={})
+    payload = _structured_payload(game=detection)
+
+    assert payload["metadata"]["material_profile"]["id"] == "genshin:gimi"
+    assert payload["metadata"]["material_profile"]["metalness"] == {
+        "source": "light_map", "channel": "r", "invert": False}

--- a/src/tests/test_material_profiles.py
+++ b/src/tests/test_material_profiles.py
@@ -27,9 +27,10 @@ def test_genshin_uses_conservative_light_map_r_and_b_response():
 
     assert profile.id == "genshin:gimi"
     assert profile.metalness == ChannelRef("light_map", "r")
-    assert profile.specular == ChannelRef("light_map", "b")
+    assert profile.specular == ChannelRef("light_map", "r")
     assert profile.metalness_scale == 0.08
-    assert profile.specular_scale == 0.15
+    assert profile.specular_scale == 1.0
+    assert profile.specular_influence == 0.15
 
 
 def test_material_profile_accepts_complete_detection_without_guessing_unknown_api():

--- a/src/tests/test_material_profiles.py
+++ b/src/tests/test_material_profiles.py
@@ -11,6 +11,7 @@ def test_zzz_uses_material_map_g_for_metalness_and_b_for_specular():
     assert profile.metalness == ChannelRef("material_map", "g")
     assert profile.specular == ChannelRef("material_map", "b")
     assert profile.material_id == ChannelRef("material_map", "r")
+    assert profile.to_metadata()["specular_influence"] is None
 
 
 def test_zzz_rabbitfx_profile_is_separate_from_zzmi_but_keeps_semantics():

--- a/src/tests/test_texture_transport.py
+++ b/src/tests/test_texture_transport.py
@@ -14,6 +14,7 @@ import pytest
 from PIL import Image
 
 from app import metadata, mod_loader, server
+from app.api import ModViewerAPI
 from core.ini_document import IniDocument
 from core.mesh_builder import (GeometryBlob, _encode_texture,
                                _render_texture_png, build_mesh_result,
@@ -105,6 +106,30 @@ def test_mesh_builder_publishes_sources_without_rendering(tmp_path):
         ("shared.png", "diffuse"),
         ("shared.png", "normal_map"),
         ("shared.png", "light_map"),
+    ]
+
+
+def test_wuwa_mesh_builder_publishes_raw_normal_source_separately(tmp_path):
+    _write_geometry(str(tmp_path))
+    Image.new("RGBA", (1, 1), (128, 128, 12, 34)).save(tmp_path / "normal.png")
+    registered = []
+
+    def register(path, role):
+        registered.append((os.path.basename(path), role))
+        return f"/texture/test/raw-{len(registered) - 1}"
+
+    with patch("core.mesh_builder._render_texture_png",
+               side_effect=AssertionError("lazy app path rendered a texture")):
+        built = build_mesh_result(
+            _group({"normal_map": "normal.png"}), str(tmp_path),
+            geometry=GeometryBlob(), texture_source=register,
+            game_profile="wuwa")
+
+    assert set(built.textures) == {
+        "normal_map::normal.png", "normal_data::normal.png"}
+    assert registered == [
+        ("normal.png", "normal_map"),
+        ("normal.png", "normal_data"),
     ]
 
 
@@ -211,6 +236,32 @@ def test_publication_profile_selects_manual_normal_recipe(tmp_path):
     publication.register(str(path), "normal_map")
     assert server._lookup_texture(publication.token, "0").transform == (
         "normal_xy_reconstruct")
+
+
+def test_wuwa_manual_normal_pick_returns_paired_raw_source(tmp_path):
+    path = tmp_path / "normal.png"
+    Image.new("RGBA", (1, 1), (128, 128, 12, 34)).save(path)
+    publication = server.begin_texture_publication(str(tmp_path))
+    publication.set_game_profile("wuwa")
+    publication.commit()
+
+    class Dialog:
+        def create_file_dialog(self, *_args, **_kwargs):
+            return [str(path)]
+
+    api = ModViewerAPI()
+    api._window = Dialog()
+    api._authorized_folders.add(os.path.normcase(os.path.abspath(tmp_path)))
+
+    result = api.pick_texture_file(str(tmp_path), "normal_map")
+
+    assert result["tex_key"] == "normal_map::normal.png"
+    assert result["normal_data_key"] == "normal_data::normal.png"
+    assert result["normal_data_uri"].startswith("/texture/")
+    assert server._lookup_texture(publication.token, "0").transform == (
+        "normal_xy_reconstruct")
+    assert server._lookup_texture(publication.token, "1").transform == (
+        "passthrough")
 
 
 def test_explicit_manual_validation_rejects_invalid_image(tmp_path):

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -162,7 +162,9 @@ async function displayMeshPayload(payload) {
   lastToggles = controls.toggles || {};
   setStateRules(state.rules || [], state.defaults || {});
   setTextures(payload.textures);
-  buildMeshPanel(meshes, currentModPath, payload.metadata?.mesh_names || {});
+  buildMeshPanel(
+    meshes, currentModPath, payload.metadata?.mesh_names || {},
+    payload.metadata?.material_profile || null);
   buildTogglePanel(controls.toggles, { modPath: currentModPath, onChange: reloadCurrentMod });
   buildMenuPanel(controls.menu);
   buildPresentPanel(controls.present, { modPath: currentModPath, onChange: reloadCurrentMod });

--- a/src/web/js/material-profile.js
+++ b/src/web/js/material-profile.js
@@ -38,6 +38,10 @@ function validRef(ref) {
   return !!ref && SOURCE_INFO[ref.source] && CHANNELS.has(ref.channel);
 }
 
+function hasNumericValue(value) {
+  return value != null && Number.isFinite(Number(value));
+}
+
 function refExpression(ref) {
   if (!validRef(ref)) return null;
   const sample = SOURCE_INFO[ref.source].sample;
@@ -79,8 +83,8 @@ if ( ${info.enabled} ) {
     ? (() => {
       const info = SOURCE_INFO[profile.specular.source];
       const sample = refExpression(profile.specular);
-      const influence = Number(profile.specular_influence);
-      const response = Number.isFinite(influence)
+      const hasInfluence = hasNumericValue(profile.specular_influence);
+      const response = hasInfluence
         ? `mix(
 		1.0,
 		clamp( ${sample} * gameMaterialSpecularScale, 0.0, 1.0 ),
@@ -177,7 +181,7 @@ function materialUniforms(profile) {
         ? Number(profile.specular_scale) : 1,
     },
     gameMaterialSpecularInfluence: {
-      value: Number.isFinite(Number(profile?.specular_influence))
+      value: hasNumericValue(profile?.specular_influence)
         ? Number(profile.specular_influence) : 0,
     },
   };

--- a/src/web/js/material-profile.js
+++ b/src/web/js/material-profile.js
@@ -1,0 +1,245 @@
+// Packed material interpretation for the pinned Three.js r165 renderer.
+// Texture roles stay intact; this adapter samples their channels directly in
+// the built-in physical shader instead of creating one derived texture per
+// semantic channel.
+
+import {
+  DoubleSide, MeshPhysicalMaterial, MeshStandardMaterial, ShaderChunk,
+} from 'three';
+
+const SHADER_VERSION = 'r165-packed-material-v1';
+const SOURCE_INFO = Object.freeze({
+  normal_data: { uniform: 'gameNormalData', enabled: 'gameNormalDataEnabled', sample: 'gameNormalDataSample' },
+  light_map: { uniform: 'gameLightMap', enabled: 'gameLightMapEnabled', sample: 'gameLightMapSample' },
+  material_map: { uniform: 'gameMaterialMap', enabled: 'gameMaterialMapEnabled', sample: 'gameMaterialMapSample' },
+});
+const CHANNELS = new Set(['r', 'g', 'b', 'a']);
+
+const PACKED_UNIFORM_DECLARATIONS = `
+uniform sampler2D gameNormalData;
+uniform sampler2D gameLightMap;
+uniform sampler2D gameMaterialMap;
+uniform bool gameNormalDataEnabled;
+uniform bool gameLightMapEnabled;
+uniform bool gameMaterialMapEnabled;
+uniform float gameMaterialMetalnessScale;
+uniform float gameMaterialSpecularScale;
+`;
+
+function requiredReplace(source, marker, replacement, label) {
+  if (!source.includes(marker)) {
+    throw new Error(`Packed material shader marker missing in Three.js r165: ${label}`);
+  }
+  return source.replace(marker, replacement);
+}
+
+function validRef(ref) {
+  return !!ref && SOURCE_INFO[ref.source] && CHANNELS.has(ref.channel);
+}
+
+function refExpression(ref) {
+  if (!validRef(ref)) return null;
+  const sample = SOURCE_INFO[ref.source].sample;
+  const channel = `${sample}.${ref.channel}`;
+  return ref.invert ? `( 1.0 - ${channel} )` : channel;
+}
+
+function profileSources(profile) {
+  return [profile.metalness, profile.specular]
+    .filter(validRef)
+    .map(ref => ref.source)
+    .filter((source, index, all) => all.indexOf(source) === index);
+}
+
+function packedSampleCode(profile) {
+  const sources = profileSources(profile);
+  return sources.map(source => {
+    const info = SOURCE_INFO[source];
+    return `
+vec4 ${info.sample} = vec4( 0.0 );
+if ( ${info.enabled} ) {
+	${info.sample} = texture2D( ${info.uniform}, vUv );
+}`;
+  }).join('\n');
+}
+
+function responseCode(profile) {
+  const metalness = validRef(profile.metalness)
+    ? (() => {
+      const info = SOURCE_INFO[profile.metalness.source];
+      return `
+if ( ${info.enabled} ) {
+	gameMaterialMetalnessResponse = clamp(
+		${refExpression(profile.metalness)} * gameMaterialMetalnessScale,
+		0.0, 1.0 );
+}`;
+    })() : '';
+  const specular = validRef(profile.specular)
+    ? (() => {
+      const info = SOURCE_INFO[profile.specular.source];
+      return `
+if ( ${info.enabled} ) {
+	gameMaterialSpecularResponse = clamp(
+		${refExpression(profile.specular)} * gameMaterialSpecularScale,
+		0.0, 1.0 );
+}`;
+    })() : '';
+  return {
+    metalness,
+    specular,
+    declarations: `
+float gameMaterialMetalnessResponse = 0.0;
+float gameMaterialSpecularResponse = 1.0;
+${metalness}
+${specular}
+`,
+  };
+}
+
+function patchPackedMaterialShader(shader, profile) {
+  let fragment = shader.fragmentShader;
+  fragment = requiredReplace(
+    fragment,
+    '#include <uv_pars_fragment>',
+    `#include <uv_pars_fragment>\n${PACKED_UNIFORM_DECLARATIONS}`,
+    'uv_pars_fragment');
+
+  const responses = responseCode(profile);
+  fragment = requiredReplace(
+    fragment,
+    '#include <roughnessmap_fragment>',
+    `${packedSampleCode(profile)}\n${responses.declarations}\n#include <roughnessmap_fragment>`,
+    'roughnessmap_fragment');
+
+  if (validRef(profile.metalness)) {
+    const info = SOURCE_INFO[profile.metalness.source];
+    fragment = requiredReplace(
+      fragment,
+      '#include <metalnessmap_fragment>',
+      `#include <metalnessmap_fragment>\nif ( ${info.enabled} ) {\n\tmetalnessFactor = gameMaterialMetalnessResponse;\n}`,
+      'metalnessmap_fragment');
+  }
+
+  let physicalLights = ShaderChunk.lights_physical_fragment;
+  if (!physicalLights) {
+    throw new Error('Three.js r165 physical lighting shader is unavailable.');
+  }
+  if (validRef(profile.specular)) {
+    physicalLights = requiredReplace(
+      physicalLights,
+      'float specularIntensityFactor = specularIntensity;',
+      'float specularIntensityFactor = specularIntensity * gameMaterialSpecularResponse;',
+      'lights_physical_fragment.specularIntensityFactor');
+  }
+  fragment = requiredReplace(
+    fragment,
+    '#include <lights_physical_fragment>',
+    physicalLights,
+    'lights_physical_fragment');
+  shader.fragmentShader = fragment;
+}
+
+function declarePackedUniforms(shader) {
+  shader.fragmentShader = requiredReplace(
+    shader.fragmentShader,
+    '#include <common>',
+    `#include <common>\n${PACKED_UNIFORM_DECLARATIONS}`,
+    'common');
+}
+
+function hasPackedResponse(profile) {
+  return validRef(profile?.metalness) || validRef(profile?.specular);
+}
+
+function materialUniforms(profile) {
+  return {
+    gameNormalData: { value: null },
+    gameLightMap: { value: null },
+    gameMaterialMap: { value: null },
+    gameNormalDataEnabled: { value: false },
+    gameLightMapEnabled: { value: false },
+    gameMaterialMapEnabled: { value: false },
+    gameMaterialMetalnessScale: {
+      value: Number.isFinite(Number(profile?.metalness_scale))
+        ? Number(profile.metalness_scale) : 1,
+    },
+    gameMaterialSpecularScale: {
+      value: Number.isFinite(Number(profile?.specular_scale))
+        ? Number(profile.specular_scale) : 1,
+    },
+  };
+}
+
+/** Create the stock or physical material appropriate for one profile. */
+export function createGameMaterial(profile, fallbackColor, options = {}) {
+  const packedResponse = hasPackedResponse(profile) && options.hasUv !== false;
+  const materialOptions = {
+    side: DoubleSide,
+    roughness: 1.0,
+    metalness: 0.0,
+    color: fallbackColor,
+  };
+  const material = packedResponse
+    ? new MeshPhysicalMaterial({ ...materialOptions, specularIntensity: 1.0 })
+    : new MeshStandardMaterial(materialOptions);
+  configureGameMaterial(material, profile, { packedResponse });
+  return material;
+}
+
+/** Attach a stable profile-specific shader adapter to a material. */
+export function configureGameMaterial(material, profile, options = {}) {
+  if (!profile || !profile.id || profile.id === 'none') return material;
+  const uniforms = materialUniforms(profile);
+  const packedResponse = options.packedResponse ?? hasPackedResponse(profile);
+  const state = { profile, uniforms, shader: null, packedResponse };
+  material.userData.gameMaterial = state;
+  if (packedResponse) {
+    // The packed maps use the same primary UV set as the authored diffuse.
+    // Force the built-in UV varying even when a fixture has no diffuse map.
+    material.defines = { ...(material.defines || {}), USE_UV: '' };
+  }
+  material.customProgramCacheKey = () =>
+    `mod-viewer:${SHADER_VERSION}:${profile.id}`;
+  material.onBeforeCompile = shader => {
+    state.shader = shader;
+    Object.assign(shader.uniforms, uniforms);
+    if (state.packedResponse) patchPackedMaterialShader(shader, profile);
+    else declarePackedUniforms(shader);
+  };
+  return material;
+}
+
+/** Update packed texture uniforms without invalidating/recompiling the shader. */
+export function updateGameMaterialTextures(mesh, maps) {
+  const state = mesh.material?.userData?.gameMaterial;
+  if (!state) return false;
+  const values = {
+    gameNormalData: maps.normal_data || null,
+    gameLightMap: maps.light_map || null,
+    gameMaterialMap: maps.material_map || null,
+  };
+  let changed = false;
+  for (const [name, value] of Object.entries(values)) {
+    if (state.uniforms[name].value !== value) changed = true;
+    state.uniforms[name].value = value;
+  }
+  const enabled = {
+    gameNormalDataEnabled: !!values.gameNormalData,
+    gameLightMapEnabled: !!values.gameLightMap,
+    gameMaterialMapEnabled: !!values.gameMaterialMap,
+  };
+  for (const [name, value] of Object.entries(enabled)) {
+    if (state.uniforms[name].value !== value) changed = true;
+    state.uniforms[name].value = value;
+  }
+  return changed;
+}
+
+/** Release adapter-side references before the owning material is disposed. */
+export function disposeGameMaterial(material) {
+  const state = material?.userData?.gameMaterial;
+  if (!state) return;
+  for (const uniform of Object.values(state.uniforms)) uniform.value = null;
+  state.shader = null;
+  delete material.userData.gameMaterial;
+}

--- a/src/web/js/material-profile.js
+++ b/src/web/js/material-profile.js
@@ -24,6 +24,7 @@ uniform bool gameLightMapEnabled;
 uniform bool gameMaterialMapEnabled;
 uniform float gameMaterialMetalnessScale;
 uniform float gameMaterialSpecularScale;
+uniform float gameMaterialSpecularInfluence;
 `;
 
 function requiredReplace(source, marker, replacement, label) {
@@ -77,11 +78,19 @@ if ( ${info.enabled} ) {
   const specular = validRef(profile.specular)
     ? (() => {
       const info = SOURCE_INFO[profile.specular.source];
+      const sample = refExpression(profile.specular);
+      const influence = Number(profile.specular_influence);
+      const response = Number.isFinite(influence)
+        ? `mix(
+		1.0,
+		clamp( ${sample} * gameMaterialSpecularScale, 0.0, 1.0 ),
+		clamp( gameMaterialSpecularInfluence, 0.0, 1.0 ) )`
+        : `clamp(
+		${sample} * gameMaterialSpecularScale,
+		0.0, 1.0 )`;
       return `
 if ( ${info.enabled} ) {
-	gameMaterialSpecularResponse = clamp(
-		${refExpression(profile.specular)} * gameMaterialSpecularScale,
-		0.0, 1.0 );
+	gameMaterialSpecularResponse = ${response};
 }`;
     })() : '';
   return {
@@ -167,6 +176,10 @@ function materialUniforms(profile) {
       value: Number.isFinite(Number(profile?.specular_scale))
         ? Number(profile.specular_scale) : 1,
     },
+    gameMaterialSpecularInfluence: {
+      value: Number.isFinite(Number(profile?.specular_influence))
+        ? Number(profile.specular_influence) : 0,
+    },
   };
 }
 
@@ -233,6 +246,13 @@ export function updateGameMaterialTextures(mesh, maps) {
     state.uniforms[name].value = value;
   }
   return changed;
+}
+
+/** Return the packed roles sampled by this material's current shader. */
+export function getGameMaterialSources(material) {
+  const state = material?.userData?.gameMaterial;
+  if (!state?.packedResponse) return new Set();
+  return new Set(profileSources(state.profile));
 }
 
 /** Release adapter-side references before the owning material is disposed. */

--- a/src/web/js/mesh-factory.js
+++ b/src/web/js/mesh-factory.js
@@ -2,6 +2,9 @@
 
 import * as THREE from 'three';
 import { decodeF32, decodeU32 } from './decode.js';
+import {
+  createGameMaterial, updateGameMaterialTextures,
+} from './material-profile.js';
 import { getMeshView } from './mesh-view-bindings.js';
 
 // Textures arrive as data URIs or same-origin localhost URLs keyed by name;
@@ -124,27 +127,38 @@ export function refreshMeshTexture(mesh) {
   const map = showDiffuse ? getTexture(mesh, mesh.userData.texKey, 'diffuse') : null;
   const normalMap = showMaterialMaps && mesh.userData.normalMapEnabled !== false
     ? getTexture(mesh, mesh.userData.normalMapKey, 'normal_map') : null;
-  // LightMap and MaterialMap are retained as authored, toggle-aware keys but
-  // are packed game data rather than standard Three.js light/PBR inputs.
-  // There is no validated derived AO slot in the baseline profile yet.
+  const normalData = showMaterialMaps
+    ? getTexture(mesh, mesh.userData.normalDataKey, 'normal_data') : null;
+  const lightMap = showMaterialMaps
+    ? getTexture(mesh, mesh.userData.lightMapKey, 'light_map') : null;
+  const materialMap = showMaterialMaps
+    ? getTexture(mesh, mesh.userData.materialMapKey, 'material_map') : null;
   const aoMap = showMaterialMaps
     ? getTexture(mesh, mesh.userData.aoMapKey, 'occlusion_map') : null;
-  if (map === mesh.material.map
-      && normalMap === mesh.material.normalMap
-      && aoMap === mesh.material.aoMap) return;
-  mesh.material.map = map;
-  mesh.material.normalMap = normalMap;
-  mesh.material.normalScale.set(
-    1, normalMap ? (mesh.userData.normalMapYSign ?? -1) : 1);
-  mesh.material.aoMap = aoMap;
-  mesh.material.aoMapIntensity = 1.0;
-  mesh.material.lightMap = null;
-  mesh.material.roughnessMap = null;
-  mesh.material.metalnessMap = null;
-  mesh.material.roughness = 1;
-  mesh.material.metalness = 0;
-  mesh.material.color.setHex(map ? 0xffffff : mesh.userData.fallbackColor);
-  mesh.material.needsUpdate = true;
+  const packedChanged = updateGameMaterialTextures(mesh, {
+    normal_data: normalData, light_map: lightMap, material_map: materialMap,
+  });
+  const stockChanged = map !== mesh.material.map
+    || normalMap !== mesh.material.normalMap
+    || aoMap !== mesh.material.aoMap;
+  if (!stockChanged && !packedChanged) return;
+  if (stockChanged) {
+    mesh.material.map = map;
+    mesh.material.normalMap = normalMap;
+    mesh.material.normalScale.set(
+      1, normalMap ? (mesh.userData.normalMapYSign ?? -1) : 1);
+    mesh.material.aoMap = aoMap;
+    mesh.material.aoMapIntensity = 1.0;
+    mesh.material.lightMap = null;
+    mesh.material.roughnessMap = null;
+    mesh.material.metalnessMap = null;
+    mesh.material.roughness = 1;
+    mesh.material.metalness = 0;
+    mesh.material.color.setHex(map ? 0xffffff : mesh.userData.fallbackColor);
+    // Stock map defines can change when a derived normal/diffuse appears or
+    // disappears. Packed map changes above only mutate shader uniforms.
+    mesh.material.needsUpdate = true;
+  }
   getMeshView(mesh)?.onTextureChanged?.();
 }
 
@@ -193,7 +207,7 @@ function fallbackColor(name) {
   return 0xcccccc;
 }
 
-export function buildMesh(name, data) {
+export function buildMesh(name, data, materialProfile = null) {
   const geo = new THREE.BufferGeometry();
   geo.setAttribute('position', new THREE.BufferAttribute(decodeF32(data.pos), 3));
   if (data.uv) {
@@ -211,8 +225,8 @@ export function buildMesh(name, data) {
   geo.computeVertexNormals();
 
   const fallback = fallbackColor(name);
-  const mat = new THREE.MeshStandardMaterial({
-    side: THREE.DoubleSide, roughness: 1.0, metalness: 0.0, color: fallback });
+  const mat = createGameMaterial(materialProfile, fallback,
+    { hasUv: !!data.uv });
 
   const mesh = new THREE.Mesh(geo, mat);
   mesh.userData.basePositions = new Float32Array(geo.attributes.position.array);
@@ -232,6 +246,7 @@ export function buildMesh(name, data) {
   mesh.userData.normalDataKey = data.normal_data_key || null;
   mesh.userData.lightMapKey = data.light_map_key || null;
   mesh.userData.materialMapKey = data.material_map_key || null;
+  mesh.userData.materialProfile = materialProfile;
   mesh.userData.aoMapKey = data.ao_map_key || null;
   mesh.userData.normalMapEnabled = data.normal_map_enabled !== false;
   mesh.userData.normalMapYSign = Number.isFinite(data.normal_map_y_sign)

--- a/src/web/js/mesh-factory.js
+++ b/src/web/js/mesh-factory.js
@@ -3,7 +3,7 @@
 import * as THREE from 'three';
 import { decodeF32, decodeU32 } from './decode.js';
 import {
-  createGameMaterial, updateGameMaterialTextures,
+  createGameMaterial, getGameMaterialSources, updateGameMaterialTextures,
 } from './material-profile.js';
 import { getMeshView } from './mesh-view-bindings.js';
 
@@ -124,14 +124,17 @@ function getTexture(mesh, key, role = 'diffuse') {
 export function refreshMeshTexture(mesh) {
   const showDiffuse = textureMode !== 'none';
   const showMaterialMaps = textureMode === 'all';
+  const gameMaterialSources = getGameMaterialSources(mesh.material);
+  const usePackedSource = role =>
+    showMaterialMaps && gameMaterialSources.has(role);
   const map = showDiffuse ? getTexture(mesh, mesh.userData.texKey, 'diffuse') : null;
   const normalMap = showMaterialMaps && mesh.userData.normalMapEnabled !== false
     ? getTexture(mesh, mesh.userData.normalMapKey, 'normal_map') : null;
-  const normalData = showMaterialMaps
+  const normalData = usePackedSource('normal_data')
     ? getTexture(mesh, mesh.userData.normalDataKey, 'normal_data') : null;
-  const lightMap = showMaterialMaps
+  const lightMap = usePackedSource('light_map')
     ? getTexture(mesh, mesh.userData.lightMapKey, 'light_map') : null;
-  const materialMap = showMaterialMaps
+  const materialMap = usePackedSource('material_map')
     ? getTexture(mesh, mesh.userData.materialMapKey, 'material_map') : null;
   const aoMap = showMaterialMaps
     ? getTexture(mesh, mesh.userData.aoMapKey, 'occlusion_map') : null;

--- a/src/web/js/mesh-factory.js
+++ b/src/web/js/mesh-factory.js
@@ -162,6 +162,9 @@ export function setMeshTexture(mesh, texKey) {
  * selection intentionally remains diffuse-only for now. */
 export function setMeshMaterialMaps(mesh, maps) {
   mesh.userData.normalMapKey = maps.normal_map || null;
+  if (Object.hasOwn(maps, 'normal_data')) {
+    mesh.userData.normalDataKey = maps.normal_data || null;
+  }
   mesh.userData.lightMapKey = maps.light_map || null;
   mesh.userData.materialMapKey = maps.material_map || null;
   refreshMeshTexture(mesh);
@@ -171,6 +174,9 @@ export function setMeshMaterialMaps(mesh, maps) {
 export function setMeshTextureState(mesh, state) {
   mesh.userData.texKey = state.diffuse || null;
   mesh.userData.normalMapKey = state.normal_map || null;
+  if (Object.hasOwn(state, 'normal_data')) {
+    mesh.userData.normalDataKey = state.normal_data || null;
+  }
   mesh.userData.lightMapKey = state.light_map || null;
   mesh.userData.materialMapKey = state.material_map || null;
   refreshMeshTexture(mesh);
@@ -223,6 +229,7 @@ export function buildMesh(name, data) {
   // applyTextureVariant). Immutable; setMeshTexture only ever touches texKey.
   mesh.userData.defaultTexKey = data.tex_key || null;
   mesh.userData.normalMapKey = data.normal_map_key || null;
+  mesh.userData.normalDataKey = data.normal_data_key || null;
   mesh.userData.lightMapKey = data.light_map_key || null;
   mesh.userData.materialMapKey = data.material_map_key || null;
   mesh.userData.aoMapKey = data.ao_map_key || null;
@@ -230,6 +237,7 @@ export function buildMesh(name, data) {
   mesh.userData.normalMapYSign = Number.isFinite(data.normal_map_y_sign)
     ? data.normal_map_y_sign : -1;
   mesh.userData.defaultNormalMapKey = mesh.userData.normalMapKey;
+  mesh.userData.defaultNormalDataKey = mesh.userData.normalDataKey;
   mesh.userData.defaultLightMapKey = mesh.userData.lightMapKey;
   mesh.userData.defaultMaterialMapKey = mesh.userData.materialMapKey;
   mesh.userData.fallbackColor = fallback;

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -379,6 +379,7 @@ export function buildMeshPanel(meshes, modPath, meshNames = {}) {
         addMesh(mesh, meshes[name].conditions, meshes[name].sources,
           meshes[name].texture_variants, {
             normal_map: meshes[name].normal_map_variants,
+            normal_data: meshes[name].normal_data_variants,
             light_map: meshes[name].light_map_variants,
             material_map: meshes[name].material_map_variants,
           });

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -321,7 +321,8 @@ function updateTexButtonState(texBtn, itemObjs) {
 /** Build the panel and add every mesh in the mesh map to the scene. `modPath`
  * is threaded through to the per-component texture popup, which needs it to
  * open the native file picker rooted at the mod folder. */
-export function buildMeshPanel(meshes, modPath, meshNames = {}) {
+export function buildMeshPanel(meshes, modPath, meshNames = {},
+                               materialProfile = null) {
   const list = document.getElementById('mesh-list');
   list.innerHTML = '';
   groupsUI = [];
@@ -370,7 +371,7 @@ export function buildMeshPanel(meshes, modPath, meshNames = {}) {
       container.append(hdr, itemsWrap);
 
       for (const name of names) {
-        const mesh = buildMesh(name, meshes[name]);
+        const mesh = buildMesh(name, meshes[name], materialProfile);
         mesh.userData.metadataKey = meshMetadataKey(name, meshes[name]);
         mesh.userData.texturePool = texturePool;
         mesh.userData.displayName = meshNames[mesh.userData.metadataKey] || null;

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -2,6 +2,7 @@
 
 import { scene, resetModelOrientation } from './scene.js';
 import { dnfSatisfied, getControlValue } from './control-state.js';
+import { disposeGameMaterial } from './material-profile.js';
 import { setMeshTextureState } from './mesh-factory.js';
 import { initializeMeshRenderModes } from './render-modes.js';
 
@@ -12,7 +13,10 @@ export function resetMeshes() {
     scene.remove(mesh);
     mesh.geometry.dispose();
     const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-    materials.forEach(material => material.dispose());
+    materials.forEach(material => {
+      disposeGameMaterial(material);
+      material.dispose();
+    });
   });
   activeMeshes.length = 0;
   resetModelOrientation();

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -26,6 +26,7 @@ export function addMesh(mesh, conditions, sources, textureVariants, materialVari
   mesh.userData.sources = sources || [];
   mesh.userData.textureVariants = textureVariants || [];
   mesh.userData.normalMapVariants = materialVariants.normal_map || [];
+  mesh.userData.normalDataVariants = materialVariants.normal_data || [];
   mesh.userData.lightMapVariants = materialVariants.light_map || [];
   mesh.userData.materialMapVariants = materialVariants.material_map || [];
   // The texture selected by the INI under the current control state. Ordered
@@ -70,6 +71,8 @@ export function applyTextureVariant(mesh) {
     mesh.userData.textureVariants, mesh.userData.defaultTexKey);
   mesh.userData.resolvedNormalMapKey = resolve(
     mesh.userData.normalMapVariants, mesh.userData.defaultNormalMapKey);
+  mesh.userData.resolvedNormalDataKey = resolve(
+    mesh.userData.normalDataVariants, mesh.userData.defaultNormalDataKey);
   mesh.userData.resolvedLightMapKey = resolve(
     mesh.userData.lightMapVariants, mesh.userData.defaultLightMapKey);
   mesh.userData.resolvedMaterialMapKey = resolve(
@@ -79,6 +82,7 @@ export function applyTextureVariant(mesh) {
       ? mesh.userData.manualTexOverride
       : mesh.userData.resolvedTexKey,
     normal_map: mesh.userData.resolvedNormalMapKey,
+    normal_data: mesh.userData.resolvedNormalDataKey,
     light_map: mesh.userData.resolvedLightMapKey,
     material_map: mesh.userData.resolvedMaterialMapKey,
   });

--- a/src/web/js/mesh-texture-state.js
+++ b/src/web/js/mesh-texture-state.js
@@ -14,6 +14,7 @@ export function recomputeTextureRuns(groupMeshes) {
         .find(candidate => candidate.tex_key === activeKey);
       activeMaps = option ? {
         normal_map: option.normal_map || null,
+        normal_data: option.normal_data || null,
         light_map: option.light_map || null,
         material_map: option.material_map || null,
       } : null;
@@ -31,6 +32,7 @@ export function recomputeTextureRuns(groupMeshes) {
         if (!diffuseKeys.has(option.tex_key)) continue;
         const resolvedMaps = {
           normal_map: mesh.userData.resolvedNormalMapKey,
+          normal_data: mesh.userData.resolvedNormalDataKey,
           light_map: mesh.userData.resolvedLightMapKey,
           material_map: mesh.userData.resolvedMaterialMapKey,
         };
@@ -44,6 +46,7 @@ export function recomputeTextureRuns(groupMeshes) {
     }
     const maps = activeMaps || {
       normal_map: mesh.userData.resolvedNormalMapKey,
+      normal_data: mesh.userData.resolvedNormalDataKey,
       light_map: mesh.userData.resolvedLightMapKey,
       material_map: mesh.userData.resolvedMaterialMapKey,
     };
@@ -91,9 +94,11 @@ export function saveTextureState(modPath) {
       label: option.label,
       manual,
       normal_map: option.normal_map || null,
+      normal_data: option.normal_data || null,
       light_map: option.light_map || null,
       material_map: option.material_map || null,
       normal_map_manual: !!option.normal_map_manual,
+      normal_data_manual: !!option.normal_data_manual,
       light_map_manual: !!option.light_map_manual,
       material_map_manual: !!option.material_map_manual,
     };

--- a/src/web/js/texture-modal.js
+++ b/src/web/js/texture-modal.js
@@ -39,6 +39,16 @@ async function pickInto(opt, field) {
   addTexture(result.tex_key, result.uri);
   opt[field] = result.tex_key;
   opt[`${field}_manual`] = true;
+  if (field === 'normal_map') {
+    if (result.normal_data_key) {
+      addTexture(result.normal_data_key, result.normal_data_uri);
+      opt.normal_data = result.normal_data_key;
+      opt.normal_data_manual = true;
+    } else {
+      delete opt.normal_data;
+      delete opt.normal_data_manual;
+    }
+  }
   render();
   if (onChange) onChange();
 }
@@ -90,6 +100,10 @@ function render() {
           evt.stopPropagation();
           delete opt[field];
           opt[`${field}_manual`] = true;
+          if (field === 'normal_map') {
+            delete opt.normal_data;
+            delete opt.normal_data_manual;
+          }
           render();
           if (onChange) onChange();
         });


### PR DESCRIPTION
Packed material response: preserve RGBA, introduce (game, texture_api) material profiles, add the frontend shader adapter, and implement ZZZ MaterialMap + conservative Genshin material response.