### PR TITLE
Fix asynchronous texture loading

### DIFF
--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -422,7 +422,7 @@ def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
         assert state["isWebGPUBackend"]
         assert state["compatibilityMode"] is False
         assert state["samples"] == 4
-        assert state["animationLoop"]
+        assert not state["animationLoop"]
         assert state["outputColorSpace"] == "srgb"
         assert state["toneMapping"] == 0
         assert state["clearAlpha"] == 1
@@ -490,9 +490,12 @@ def test_texture_stays_fallback_until_png_load_completes(
         edge_browser, frontend_url):
     payload = _payload("Delayed")
     entry = payload["meshes"]["Body-Delayed-0"]
-    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    entry["pos"] = _f32(-1, -1, 0, 1, -1, 0, 1, 1, 0, -1, 1, 0)
+    entry["idx"] = _u32(0, 1, 2, 0, 2, 3)
+    entry["uv"] = _f32(0, 0, 1, 0, 1, 1, 0, 1)
     key = entry["tex_key"]
     payload["textures"][key] = f"{frontend_url}/delayed.png"
+    texture_uri = _flat_png_uri((236, 42, 38, 255))
     pending = {"requests": 0, "route": None}
 
     context, page = _page(edge_browser, frontend_url, {"Delayed": payload})
@@ -512,6 +515,7 @@ def test_texture_stays_fallback_until_png_load_completes(
               ?.bindings?.diffuse?.enabledNode?.value === false;
           }
         """)
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
         state = page.evaluate("""() => {
           const mesh = window.modViewer.activeMeshes[0];
           const game = mesh.material.userData.gameMaterial;
@@ -522,20 +526,65 @@ def test_texture_stays_fallback_until_png_load_completes(
         }""")
         assert pending["requests"] == 1
         assert state == {"diffuseEnabled": False, "fallbackColor": 0xcccccc}
+        pending_pixel = _sample_mesh_pixel(page)
+        assert min(pending_pixel) > 20
+        assert max(pending_pixel) - min(pending_pixel) < 30
+
+        idle_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.wait_for_timeout(200)
+        assert page.evaluate("window.modViewer.getRenderCount()") == idle_count
+
+        page.evaluate("window.modViewer.setEnvironmentPreset('studio')")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=idle_count)
+        changed_count = page.evaluate("window.modViewer.getRenderCount()")
 
         pending["route"].fulfill(
             status=200,
             content_type="image/png",
-            body=base64.b64decode(_PNG_URI.split(",", 1)[1]),
+            body=base64.b64decode(texture_uri.split(",", 1)[1]),
         )
         page.wait_for_function("""
           () => {
             const binding = window.modViewer.activeMeshes[0]?.material
               ?.userData?.gameMaterial?.bindings?.diffuse;
             return binding?.enabledNode?.value === true
-              && binding.textureNode.value?.image?.width === 1;
+              && binding.textureNode.value?.image?.width === 4;
           }
         """)
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=changed_count)
+        loaded_pixel = _sample_mesh_pixel(page)
+        assert loaded_pixel[0] > loaded_pixel[1] * 1.5, loaded_pixel
+        assert loaded_pixel != pending_pixel, (pending_pixel, loaded_pixel)
+    finally:
+        context.close()
+
+
+def test_view_gizmo_snap_renders_only_during_animation(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Snap": _payload("Snap")})
+    try:
+        _open(page, "Snap")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        page.wait_for_timeout(200)
+        idle_count = page.evaluate("window.modViewer.getRenderCount()")
+
+        page.evaluate("""
+          () => document.querySelector('.gizmo-axis.positive')
+            .dispatchEvent(new KeyboardEvent('keydown', {
+              key: 'Enter', bubbles: true,
+            }))
+        """)
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() >= count + 2",
+            arg=idle_count)
+        page.wait_for_timeout(350)
+        settled_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.wait_for_timeout(200)
+        assert page.evaluate("window.modViewer.getRenderCount()") == settled_count
+        assert settled_count > idle_count + 2
     finally:
         context.close()
 
@@ -1301,6 +1350,7 @@ def test_wuwa_body_b_threshold_controls_toon_classification(
           async () => {
             const THREE = await import('three');
             const {scene, controls} = await import('./js/scene.js');
+            const {requestRender} = await import('./js/render-scheduler.js');
             scene.traverse(object => {
               if (object.isAmbientLight || object.isHemisphereLight) object.intensity = 0;
               if (object.isSprite || object.isGridHelper) object.visible = false;
@@ -1309,6 +1359,7 @@ def test_wuwa_body_b_threshold_controls_toon_classification(
             key.target.position.copy(controls.target);
             key.position.copy(controls.target).add(new THREE.Vector3(0, 0, 3));
             key.intensity = 3;
+            requestRender();
           }
         """)
         page.wait_for_timeout(400)
@@ -1372,6 +1423,7 @@ def test_wuwa_body_missing_toon_mask_keeps_physical_direct_specular(
               async () => {
                 const THREE = await import('three');
                 const {scene, controls} = await import('./js/scene.js');
+                const {requestRender} = await import('./js/render-scheduler.js');
                 scene.traverse(object => {
                   if (object.isAmbientLight || object.isHemisphereLight) {
                     object.intensity = 0;
@@ -1384,6 +1436,7 @@ def test_wuwa_body_missing_toon_mask_keeps_physical_direct_specular(
                 key.position.copy(controls.target).add(new THREE.Vector3(0, 0, 3));
                 key.intensity = 3;
                 window.modViewer.activeMeshes[0].material.roughness = 0.2;
+                requestRender();
               }
             """)
             page.wait_for_timeout(400)
@@ -1418,8 +1471,9 @@ def test_wuwa_packed_rg_normal_matches_derived_reference_and_y_sign(
     def configure_light(page):
         page.evaluate("""
           async () => {
-            const THREE = await import('three');
-            const {scene, controls} = await import('./js/scene.js');
+                const THREE = await import('three');
+                const {scene, controls} = await import('./js/scene.js');
+                const {requestRender} = await import('./js/render-scheduler.js');
             let key = null;
             scene.traverse(object => {
               if (object.isAmbientLight || object.isHemisphereLight) {
@@ -1435,6 +1489,7 @@ def test_wuwa_packed_rg_normal_matches_derived_reference_and_y_sign(
             key.position.copy(controls.target)
               .add(new THREE.Vector3(0.8, 0.4, 2.0));
             key.intensity = 1;
+            requestRender();
           }
         """)
         page.wait_for_timeout(400)
@@ -1577,6 +1632,7 @@ def test_wuwa_missing_lightmap_disables_shadow_mask_without_rebuilding(
           async () => {
             const THREE = await import('three');
             const {scene, controls} = await import('./js/scene.js');
+            const {requestRender} = await import('./js/render-scheduler.js');
             scene.traverse(object => {
               if (object.isAmbientLight || object.isHemisphereLight) {
                 object.intensity = 0;
@@ -1588,6 +1644,7 @@ def test_wuwa_missing_lightmap_disables_shadow_mask_without_rebuilding(
             key.target.position.copy(controls.target);
             key.position.copy(controls.target).add(new THREE.Vector3(0.8, 0, 0.35));
             key.intensity = 1;
+            requestRender();
           }
         """)
         page.wait_for_timeout(400)

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -486,6 +486,279 @@ def test_direct_dds_matches_png_orientation_and_diffuse_color(
 
 
 
+def test_texture_stays_fallback_until_png_load_completes(
+        edge_browser, frontend_url):
+    payload = _payload("Delayed")
+    entry = payload["meshes"]["Body-Delayed-0"]
+    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    key = entry["tex_key"]
+    payload["textures"][key] = f"{frontend_url}/delayed.png"
+    pending = {"requests": 0, "route": None}
+
+    context, page = _page(edge_browser, frontend_url, {"Delayed": payload})
+
+    def hold(route):
+        pending["requests"] += 1
+        pending["route"] = route
+
+    page.route("**/delayed.png", hold)
+    try:
+        _open(page, "Delayed")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("""
+          () => {
+            const mesh = window.modViewer.activeMeshes[0];
+            return mesh?.material?.userData?.gameMaterial
+              ?.bindings?.diffuse?.enabledNode?.value === false;
+          }
+        """)
+        state = page.evaluate("""() => {
+          const mesh = window.modViewer.activeMeshes[0];
+          const game = mesh.material.userData.gameMaterial;
+          return {
+            diffuseEnabled: game.bindings.diffuse.enabledNode.value,
+            fallbackColor: mesh.material.color.getHex(),
+          };
+        }""")
+        assert pending["requests"] == 1
+        assert state == {"diffuseEnabled": False, "fallbackColor": 0xcccccc}
+
+        pending["route"].fulfill(
+            status=200,
+            content_type="image/png",
+            body=base64.b64decode(_PNG_URI.split(",", 1)[1]),
+        )
+        page.wait_for_function("""
+          () => {
+            const binding = window.modViewer.activeMeshes[0]?.material
+              ?.userData?.gameMaterial?.bindings?.diffuse;
+            return binding?.enabledNode?.value === true
+              && binding.textureNode.value?.image?.width === 1;
+          }
+        """)
+    finally:
+        context.close()
+
+
+def test_shared_texture_waits_once_and_updates_all_meshes(
+        edge_browser, frontend_url):
+    payload = _payload("Shared")
+    entry = payload["meshes"]["Body-Shared-0"]
+    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    second = copy.deepcopy(entry)
+    second["component"] = "Face Shared"
+    payload["meshes"]["Face-Shared-0"] = second
+    key = entry["tex_key"]
+    payload["textures"][key] = f"{frontend_url}/shared.png"
+    pending = {"requests": 0, "route": None}
+
+    context, page = _page(edge_browser, frontend_url, {"Shared": payload})
+
+    def hold(route):
+        pending["requests"] += 1
+        pending["route"] = route
+
+    page.route("**/shared.png", hold)
+    try:
+        _open(page, "Shared")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 2")
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes.every(mesh =>
+            mesh.material.userData.gameMaterial.bindings.diffuse.enabledNode.value
+              === false)
+        """)
+        assert pending["requests"] == 1
+
+        pending["route"].fulfill(
+            status=200,
+            content_type="image/png",
+            body=base64.b64decode(_PNG_URI.split(",", 1)[1]),
+        )
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes.every(mesh =>
+            mesh.material.userData.gameMaterial.bindings.diffuse.enabledNode.value
+              === true)
+        """)
+    finally:
+        context.close()
+
+
+def test_failed_texture_stays_fallback_without_retrying(
+        edge_browser, frontend_url):
+    payload = _payload("FailedTexture")
+    entry = payload["meshes"]["Body-FailedTexture-0"]
+    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    key = entry["tex_key"]
+    payload["textures"][key] = f"{frontend_url}/failed.png"
+    pending = {"requests": 0, "route": None}
+
+    context, page = _page(
+        edge_browser, frontend_url, {"FailedTexture": payload})
+
+    def hold(route):
+        pending["requests"] += 1
+        pending["route"] = route
+
+    page.route("**/failed.png", hold)
+    try:
+        _open(page, "FailedTexture")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.bindings?.diffuse?.enabledNode?.value === false
+        """)
+        pending["route"].abort()
+        page.wait_for_function(
+            """async key => {
+              const {hasTexture} = await import('./js/mesh-factory.js');
+              return hasTexture(key) === false;
+            }""",
+            arg=key,
+        )
+        page.wait_for_timeout(100)
+        assert pending["requests"] == 1
+        assert page.evaluate("""() => {
+          const mesh = window.modViewer.activeMeshes[0];
+          return {
+            enabled: mesh.material.userData.gameMaterial
+              .bindings.diffuse.enabledNode.value,
+            fallbackColor: mesh.material.color.getHex(),
+          };
+        }""") == {"enabled": False, "fallbackColor": 0xcccccc}
+    finally:
+        context.close()
+
+
+def test_native_dds_failure_falls_back_without_black_frame(
+        edge_browser, frontend_url):
+    payload = _payload("NativeDDS")
+    entry = payload["meshes"]["Body-NativeDDS-0"]
+    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    key = "diffuse::NativeDDS.dds"
+    entry["tex_key"] = key
+    payload["textures"] = {key: f"{frontend_url}/native.dds"}
+    pending = {"dds": None}
+    requests = {"dds": 0, "png": 0}
+
+    context, page = _page(edge_browser, frontend_url, {"NativeDDS": payload})
+    try:
+        supported = page.evaluate("""
+          async () => {
+            const {supportsBCTextureCompression} =
+              await import('./js/renderer-capabilities.js');
+            return supportsBCTextureCompression();
+          }
+        """)
+        if not supported:
+            pytest.skip("native DDS is not supported by the test renderer")
+
+        def hold_dds(route):
+            requests["dds"] += 1
+            pending["dds"] = route
+
+        def fulfill_png(route):
+            requests["png"] += 1
+            route.fulfill(
+                status=200,
+                content_type="image/png",
+                body=base64.b64decode(_PNG_URI.split(",", 1)[1]),
+            )
+
+        page.route("**/native.dds", hold_dds)
+        page.route("**/native.png", fulfill_png)
+        _open(page, "NativeDDS")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.bindings?.diffuse?.enabledNode?.value === false
+        """)
+        assert requests == {"dds": 1, "png": 0}
+
+        pending["dds"].abort()
+        page.wait_for_function("""
+          () => {
+            const binding = window.modViewer.activeMeshes[0]?.material
+              ?.userData?.gameMaterial?.bindings?.diffuse;
+            return binding?.enabledNode?.value === true
+              && binding.textureNode.value?.isCompressedTexture !== true
+              && binding.textureNode.value?.image?.width === 1;
+          }
+        """)
+        assert requests == {"dds": 1, "png": 1}
+    finally:
+        context.close()
+
+
+def test_replaced_pending_texture_ignores_stale_completion(
+        edge_browser, frontend_url):
+    payload = _payload("Replacement")
+    entry = payload["meshes"]["Body-Replacement-0"]
+    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    key = entry["tex_key"]
+    payload["textures"][key] = f"{frontend_url}/old.png"
+    pending = {"old": None}
+    requests = {"old": 0, "new": 0}
+
+    context, page = _page(edge_browser, frontend_url, {"Replacement": payload})
+    try:
+        def hold_old(route):
+            requests["old"] += 1
+            pending["old"] = route
+
+        def fulfill_new(route):
+            requests["new"] += 1
+            route.fulfill(
+                status=200,
+                content_type="image/png",
+                body=base64.b64decode(_PNG_URI.split(",", 1)[1]),
+            )
+
+        page.route("**/old.png", hold_old)
+        page.route("**/new.png", fulfill_new)
+        _open(page, "Replacement")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.bindings?.diffuse?.enabledNode?.value === false
+        """)
+        assert requests == {"old": 1, "new": 0}
+
+        page.evaluate("""async ({key, uri}) => {
+          const {addTexture, refreshMeshTexture} =
+            await import('./js/mesh-factory.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          addTexture(key, uri);
+          refreshMeshTexture(mesh);
+        }""", {"key": key, "uri": f"{frontend_url}/new.png"})
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.bindings?.diffuse?.enabledNode?.value === true
+        """)
+        assert requests == {"old": 1, "new": 1}
+        page.evaluate("""() => {
+          window.__replacementTexture = window.modViewer.activeMeshes[0]
+            .material.userData.gameMaterial.bindings.diffuse.textureNode.value;
+        }""")
+
+        pending["old"].fulfill(
+            status=200,
+            content_type="image/png",
+            body=base64.b64decode(_flat_png_uri((255, 0, 0, 255))
+                                 .split(",", 1)[1]),
+        )
+        page.wait_for_timeout(200)
+        assert page.evaluate("""
+          () => {
+            const binding = window.modViewer.activeMeshes[0].material
+              .userData.gameMaterial.bindings.diffuse;
+            return binding.enabledNode.value === true
+              && binding.textureNode.value === window.__replacementTexture;
+          }
+        """)
+    finally:
+        context.close()
+
+
 def test_webgpu_unsupported_state_is_visible_and_never_falls_back(
         edge_browser, frontend_url):
     context = edge_browser.new_context(bypass_csp=True)
@@ -852,11 +1125,21 @@ def test_wuwa_debug_modes_are_capability_gated_and_uniform_only(
         assert state["hasDebugNodes"]
 
         page.evaluate("window.modViewer.setMaterialDebugMode('normal-data-b')")
+        page.wait_for_function("""
+          () => {
+            const binding = window.modViewer.activeMeshes[0]?.material
+              ?.userData?.gameMaterial?.bindings?.normal_data;
+            return binding?.enabledNode?.value === true
+              && binding.textureNode.value?.image?.width === 4;
+          }
+        """)
         page.wait_for_timeout(300)
         low_pixel = _sample_mesh_pixel(page)
         page.evaluate("""async key => {
           const {setMeshTextureState} = await import('./js/mesh-factory.js');
           const mesh = window.modViewer.activeMeshes[0];
+          window.__normalLowTexture = mesh.material.userData.gameMaterial
+            .bindings.normal_data.textureNode.value;
           setMeshTextureState(mesh, {
             diffuse: mesh.userData.texKey,
             normal_map: null,
@@ -865,7 +1148,16 @@ def test_wuwa_debug_modes_are_capability_gated_and_uniform_only(
             material_map: null,
           });
         }""", normal_high)
-        page.wait_for_timeout(400)
+        page.wait_for_function("""
+          () => {
+            const binding = window.modViewer.activeMeshes[0]?.material
+              ?.userData?.gameMaterial?.bindings?.normal_data;
+            return binding?.enabledNode?.value === true
+              && binding.textureNode.value !== window.__normalLowTexture
+              && binding.textureNode.value?.image?.width === 4;
+          }
+        """)
+        page.wait_for_timeout(300)
         high_pixel = _sample_mesh_pixel(page)
         assert sum(high_pixel) > sum(low_pixel), (low_pixel, high_pixel)
     finally:
@@ -1272,6 +1564,15 @@ def test_wuwa_missing_lightmap_disables_shadow_mask_without_rebuilding(
         page.wait_for_function(
             "window.modViewer.activeMeshes[0]?.material?.userData?.gameMaterial"
             "?.bindings.light_map.enabledNode.value === true")
+        page.wait_for_function("""
+          () => {
+            const game = window.modViewer.activeMeshes[0]?.material
+              ?.userData?.gameMaterial;
+            return game?.bindings?.diffuse?.enabledNode?.value === true
+              && game.bindings.normal_data.enabledNode.value === true
+              && game.bindings.light_map.enabledNode.value === true;
+          }
+        """)
         page.evaluate("""
           async () => {
             const THREE = await import('three');
@@ -1307,7 +1608,10 @@ def test_wuwa_missing_lightmap_disables_shadow_mask_without_rebuilding(
             material_map: null,
           });
         }""")
-        page.wait_for_timeout(400)
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.bindings?.light_map?.enabledNode?.value === false
+        """)
         state = page.evaluate("""() => {
           const mesh = window.modViewer.activeMeshes[0];
           return {

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -589,6 +589,62 @@ def test_view_gizmo_snap_renders_only_during_animation(
         context.close()
 
 
+def test_mesh_row_selection_invalidates_on_demand_renderer(
+        edge_browser, frontend_url):
+    payload = _payload("Selection")
+    second = copy.deepcopy(payload["meshes"]["Body-Selection-0"])
+    second["component"] = "Face Selection"
+    payload["meshes"]["Face-Selection-0"] = second
+    context, page = _page(edge_browser, frontend_url, {"Selection": payload})
+    try:
+        _open(page, "Selection")
+        rows = page.locator(".draw-item")
+        rows.nth(0).wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        page.wait_for_timeout(300)
+        idle_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.wait_for_timeout(200)
+        assert page.evaluate("window.modViewer.getRenderCount()") == idle_count
+
+        rows.nth(0).click()
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=idle_count)
+        first_state = page.evaluate("""() => {
+          return window.modViewer.activeMeshes.map(mesh => ({
+            emissive: mesh.material.emissive.getHex(),
+            intensity: mesh.material.emissiveIntensity,
+          }));
+        }""")
+        assert first_state == [
+            {"emissive": 0xffd60a, "intensity": 0.22},
+            {"emissive": 0x000000, "intensity": 1},
+        ]
+
+        selected_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.wait_for_timeout(200)
+        assert page.evaluate("window.modViewer.getRenderCount()") == selected_count
+
+        rows.nth(1).click()
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=selected_count)
+        second_state = page.evaluate("""() => {
+          return window.modViewer.activeMeshes.map(mesh => ({
+            emissive: mesh.material.emissive.getHex(),
+            intensity: mesh.material.emissiveIntensity,
+          }));
+        }""")
+        assert second_state == [
+            {"emissive": 0x000000, "intensity": 1},
+            {"emissive": 0xffd60a, "intensity": 0.22},
+        ]
+
+        final_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.wait_for_timeout(200)
+        assert page.evaluate("window.modViewer.getRenderCount()") == final_count
+    finally:
+        context.close()
+
+
 def test_shared_texture_waits_once_and_updates_all_meshes(
         edge_browser, frontend_url):
     payload = _payload("Shared")

--- a/src/web/js/key-light-controller.js
+++ b/src/web/js/key-light-controller.js
@@ -24,7 +24,7 @@ function createLightHandle() {
 }
 
 export function createKeyLightController({
-  scene, camera, renderer, controls, light,
+  scene, camera, renderer, controls, light, onChange,
 }) {
   const handle = createLightHandle();
   scene.add(handle);
@@ -109,10 +109,14 @@ export function createKeyLightController({
     if (drag.depthMode) {
       light.position.copy(drag.startPosition).addScaledVector(
         drag.cameraDirection, (drag.startY - event.clientY) * drag.depthScale);
+      onChange?.();
       return;
     }
     updatePointer(event);
-    if (raycaster.ray.intersectPlane(dragPlane, hit)) light.position.copy(hit);
+    if (raycaster.ray.intersectPlane(dragPlane, hit)) {
+      light.position.copy(hit);
+      onChange?.();
+    }
   });
 
   function finishDrag(event) {
@@ -144,6 +148,7 @@ export function createKeyLightController({
     button.title = labels[mode];
     button.setAttribute('aria-label', labels[mode]);
     updateCursor();
+    onChange?.();
   }
 
   function rebase(modelSize) {
@@ -151,6 +156,7 @@ export function createKeyLightController({
     light.position.copy(controls.target).addScaledVector(
       new THREE.Vector3(-0.55, 0.82, 0.35).normalize(), distance);
     handle.position.copy(light.position);
+    onChange?.();
   }
 
   function update() {

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -3,7 +3,7 @@
 import { fitTo, resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
          toggleGrid, toggleLightHandle, toggleTrackballGizmo,
          getEnvironmentPreset, isRendererAvailable, rendererReady,
-         setEnvironmentPreset } from './scene.js';
+         setEnvironmentPreset, getRenderCount } from './scene.js';
 import { ENVIRONMENT_PRESETS } from './environment.js';
 import { refreshMeshTexture, setTextures } from './mesh-factory.js';
 import { activeMeshes, reset, resetMeshState, setStateRules, toggleWireframe, toggleSmoothShading, toggleGlossy, toggleTextures } from './visibility.js';
@@ -18,6 +18,7 @@ import { setGeometryBlob } from './decode.js';
 import { refreshHealthReport, setHealthLoader, setHealthReport } from './health-report.js';
 import { setIniEditorContext } from './ini-editor.js';
 import { getMaterialDebugMode, setMaterialDebugMode } from './material-profile.js';
+import { requestRender } from './render-scheduler.js';
 import {
   getOutlineState as getMeshOutlineState,
   setOutlineSuppressedByDebug,
@@ -419,12 +420,14 @@ rendererReady.then(ready => {
     // WuWa's packed normal is already resident when debug mode changes, so a
     // B/A view only changes the diagnostic uniform and binding selection.
     activeMeshes.forEach(refreshMeshTexture);
+    requestRender();
     return normalized;
   };
   window.modViewer = {
     displayMeshPayload, openMod, switchMod, reloadCurrentMod, exportChanges, activeMeshes,
     setEnvironmentPreset: applyEnvironmentPreset, getEnvironmentPreset,
-    getMaterialState, setMaterialDebugMode: setMaterialDebugModeForMeshes,
+    getMaterialState, getRenderCount,
+    setMaterialDebugMode: setMaterialDebugModeForMeshes,
     setOutlineEnabled: value => {
       const enabled = setOutlinesEnabled(value);
       $('outline-btn').classList.toggle('active', enabled);

--- a/src/web/js/material-profile.js
+++ b/src/web/js/material-profile.js
@@ -758,17 +758,18 @@ export function configureGameMaterial(material, profile, options = {}) {
   return material;
 }
 
-function updateBinding(binding, value) {
+function updateBinding(binding, value, enabled = !!value) {
   const next = value || binding.placeholder;
+  const isEnabled = enabled && !!value;
   const changed = binding.textureNode.value !== next
-    || binding.enabledNode.value !== !!value;
+    || binding.enabledNode.value !== isEnabled;
   binding.textureNode.value = next;
-  binding.enabledNode.value = !!value;
+  binding.enabledNode.value = isEnabled;
   return changed;
 }
 
 /** Update texture bindings without invalidating or rebuilding the material. */
-export function updateGameMaterialTextures(mesh, maps = {}) {
+export function updateGameMaterialTextures(mesh, maps = {}, options = {}) {
   const state = mesh.material?.userData?.gameMaterial;
   if (!state) return false;
   let changed = false;
@@ -780,7 +781,9 @@ export function updateGameMaterialTextures(mesh, maps = {}) {
     material_map: maps.material_map,
   };
   for (const [role, value] of Object.entries(values)) {
-    changed = updateBinding(state.bindings[role], value) || changed;
+    if (!Object.hasOwn(maps, role)) continue;
+    const pending = options.pending?.[role] === true;
+    changed = updateBinding(state.bindings[role], value, !pending) || changed;
   }
   if (Object.hasOwn(maps, 'normal_map_y_sign')) {
     state.normalScaleNode.value.set(

--- a/src/web/js/mesh-factory.js
+++ b/src/web/js/mesh-factory.js
@@ -15,6 +15,7 @@ import { splitTextureKey } from './texture-key.js';
 // loaders are cached so several meshes sharing a texture share one GPU upload.
 let registry = {};
 const loaders = {};
+const readyTextures = new Set();
 const failedTextures = new Set();
 const nativeDDSFallbacks = new Set();
 const textureUsers = new Map();
@@ -35,6 +36,7 @@ export function setTextures(textures) {
     delete loaders[key];
   }
   failedTextures.clear();
+  readyTextures.clear();
   nativeDDSFallbacks.clear();
   textureUsers.clear();
 }
@@ -47,6 +49,7 @@ export function addTexture(key, uri) {
   registry[key] = uri;
   disposeTexture(loaders[key]);
   delete loaders[key];
+  readyTextures.delete(key);
   failedTextures.delete(key);
   nativeDDSFallbacks.delete(key);
   textureUsers.delete(key);
@@ -67,15 +70,34 @@ function trackTextureUser(mesh, key) {
   users.add(mesh);
 }
 
+function primePendingTexture(mesh, role, texture) {
+  updateGameMaterialTextures(mesh, {[role]: texture}, {
+    pending: {[role]: true},
+  });
+}
+
+function handleTextureReady(key, texture, uri) {
+  // A manual replacement or a newer model may have evicted this request
+  // before the browser reported success. Do not revive the stale texture or
+  // mark the replacement as ready.
+  if (registry[key] !== uri || loaders[key] !== texture) {
+    disposeTexture(texture);
+    return;
+  }
+  readyTextures.add(key);
+  texture.needsUpdate = true;
+  for (const mesh of textureUsers.get(key) || []) refreshMeshTexture(mesh);
+}
+
 function handleTextureError(key, texture, uri) {
   // A manual replacement or a newer model may have evicted this request
   // before the browser reported its failure. Do not mark the replacement as
   // unavailable in that case.
-  if (registry[key] !== uri
-      || (loaders[key] && loaders[key] !== texture)) {
+  if (registry[key] !== uri || loaders[key] !== texture) {
     disposeTexture(texture);
     return;
   }
+  readyTextures.delete(key);
   failedTextures.add(key);
   if (loaders[key] === texture) delete loaders[key];
   disposeTexture(texture);
@@ -99,6 +121,7 @@ function handleNativeDDSFailure(key, texture, uri) {
   }
   if (nativeDDSFallbacks.has(key)) return;
   nativeDDSFallbacks.add(key);
+  readyTextures.delete(key);
   if (loaders[key] === texture) delete loaders[key];
   disposeTexture(texture);
   for (const mesh of textureUsers.get(key) || []) refreshMeshTexture(mesh);
@@ -118,6 +141,7 @@ function getTexture(mesh, key) {
       : isDDSUri(uri) ? pngFallbackUri(uri) : uri;
     let texture;
     let failedBeforeAssignment = false;
+    let readyBeforeAssignment = false;
     const onError = () => {
       if (!texture) {
         failedBeforeAssignment = true;
@@ -125,13 +149,20 @@ function getTexture(mesh, key) {
       }
       handleTextureError(key, texture, uri);
     };
+    const onReady = () => {
+      if (!texture) {
+        readyBeforeAssignment = true;
+        return;
+      }
+      handleTextureReady(key, texture, uri);
+    };
     if (nativeDDS) {
       texture = loadDDSTexture(
-        requestUri, undefined,
+        requestUri, onReady,
         () => handleNativeDDSFailure(key, texture, uri));
     } else {
       texture = new THREE.TextureLoader().load(
-        requestUri, undefined, undefined, onError);
+        requestUri, onReady, undefined, onError);
     }
     texture.colorSpace = parsed.role === 'diffuse'
       ? THREE.SRGBColorSpace : THREE.NoColorSpace;
@@ -139,8 +170,21 @@ function getTexture(mesh, key) {
     if (failedBeforeAssignment) {
       handleTextureError(key, texture, uri);
     }
+    if (readyBeforeAssignment) {
+      handleTextureReady(key, texture, uri);
+    }
   }
-  return loaders[key];
+  if (!readyTextures.has(key) && loaders[key]) {
+    const texture = loaders[key];
+    const uri = registry[key];
+    queueMicrotask(() => {
+      if (registry[key] === uri && loaders[key] === texture
+          && !readyTextures.has(key) && !failedTextures.has(key)) {
+        primePendingTexture(mesh, parsed.role, texture);
+      }
+    });
+  }
+  return readyTextures.has(key) ? loaders[key] : null;
 }
 
 /** Bind whatever diffuse map the mesh currently wants, honouring the global

--- a/src/web/js/mesh-factory.js
+++ b/src/web/js/mesh-factory.js
@@ -8,6 +8,7 @@ import {
 } from './material-profile.js';
 import { getMeshView } from './mesh-view-bindings.js';
 import { loadDDSTexture } from './dds-loader.js';
+import { requestRender } from './render-scheduler.js';
 import { supportsBCTextureCompression } from './renderer-capabilities.js';
 import { splitTextureKey } from './texture-key.js';
 
@@ -216,6 +217,7 @@ export function refreshMeshTexture(mesh) {
   });
   if (!changed) return;
   getMeshView(mesh)?.onTextureChanged?.();
+  if (mesh.visible) requestRender();
 }
 
 export function setTextureMode(mode) {

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -6,6 +6,7 @@ import { disposeGameMaterial } from './material-profile.js';
 import { setMeshTextureState } from './mesh-factory.js';
 import { attachOutline, detachOutline } from './outline-renderer.js';
 import { initializeMeshRenderModes } from './render-modes.js';
+import { requestRender } from './render-scheduler.js';
 
 export const activeMeshes = [];
 
@@ -22,6 +23,7 @@ export function resetMeshes() {
   });
   activeMeshes.length = 0;
   resetModelOrientation();
+  requestRender();
 }
 
 export function addMesh(mesh, conditions, sources, textureVariants, materialVariants = {}) {
@@ -53,6 +55,7 @@ export function resetMeshVisibility() {
     mesh.userData.manuallyToggled = false;
     applyMeshVisibility(mesh);
   });
+  requestRender();
 }
 
 /** Pin or clear one mesh's highlighted diffuse. Ordered component propagation
@@ -60,6 +63,7 @@ export function resetMeshVisibility() {
 export function setManualTexOverride(mesh, value) {
   mesh.userData.manualTexOverride = value;
   applyTextureVariant(mesh);
+  requestRender();
 }
 
 export function conditionsSatisfied(mesh) {
@@ -100,6 +104,7 @@ export function applyTextureVariant(mesh) {
 // always reveal a currently gated mesh.
 export function applyMeshVisibility(mesh) {
   mesh.visible = mesh.userData.manualVisible !== false;
+  requestRender();
 }
 
 function applyShapeTargets(mesh) {
@@ -154,4 +159,5 @@ export function refreshMeshes() {
     applyTextureVariant(mesh);
     applyShapeTargets(mesh);
   });
+  requestRender();
 }

--- a/src/web/js/mod-folder-panel.js
+++ b/src/web/js/mod-folder-panel.js
@@ -1,6 +1,7 @@
 // Persistent Mod Folder registry and lazy directory navigator.
 
 import { confirmDialog } from './dialogs.js';
+import { requestRender } from './render-scheduler.js';
 
 const $ = id => document.getElementById(id);
 
@@ -232,8 +233,14 @@ export function initModFolderPanel({ switchMod }) {
     applyRegistryResponse(response);
   }
 
-  toggle.addEventListener('click', () => setExpanded(!dock.classList.contains('expanded')));
-  close.addEventListener('click', () => setExpanded(false));
+  toggle.addEventListener('click', () => {
+    setExpanded(!dock.classList.contains('expanded'));
+    requestRender();
+  });
+  close.addEventListener('click', () => {
+    setExpanded(false);
+    requestRender();
+  });
   add.addEventListener('click', () => openEditor('add'));
   cancel.addEventListener('click', closeEditor);
   backdrop.addEventListener('click', event => {

--- a/src/web/js/outline-renderer.js
+++ b/src/web/js/outline-renderer.js
@@ -2,6 +2,7 @@
 
 import * as THREE from 'three/webgpu';
 import { normalLocal, positionLocal, uniform } from 'three/tsl';
+import { requestRender } from './render-scheduler.js';
 
 const OUTLINE_WIDTH_PIXELS = 1.5;
 const outlineWidthWorldNode = uniform(0);
@@ -63,6 +64,7 @@ export function detachOutline(mesh) {
 export function setOutlinesEnabled(value) {
   outlinesEnabled = value === undefined ? !outlinesEnabled : !!value;
   syncOutlineVisibility();
+  requestRender();
   return outlinesEnabled;
 }
 
@@ -73,11 +75,13 @@ export function isOutlineEnabled() {
 export function setOutlineSuppressedByWireframe(value) {
   suppressedByWireframe = !!value;
   syncOutlineVisibility();
+  requestRender();
 }
 
 export function setOutlineSuppressedByDebug(value) {
   suppressedByDebug = !!value;
   syncOutlineVisibility();
+  requestRender();
 }
 
 /** Update the shared world-space extrusion from the current CSS viewport. */

--- a/src/web/js/render-modes.js
+++ b/src/web/js/render-modes.js
@@ -2,6 +2,7 @@
 
 import { refreshMeshTexture, setTextureMode } from './mesh-factory.js';
 import { setOutlineSuppressedByWireframe } from './outline-renderer.js';
+import { requestRender } from './render-scheduler.js';
 
 let wireframe = false;
 let smoothShading = true;
@@ -32,6 +33,7 @@ export function toggleWireframeMode(meshes) {
     const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
     materials.forEach(material => { material.wireframe = wireframe; });
   });
+  requestRender();
 }
 
 export function toggleSmoothShadingMode(meshes) {
@@ -44,6 +46,7 @@ export function toggleSmoothShadingMode(meshes) {
       material.needsUpdate = true;
     });
   });
+  requestRender();
 }
 
 export function toggleGlossyMode(meshes) {
@@ -61,6 +64,7 @@ export function toggleGlossyMode(meshes) {
   meshes.forEach(mesh => {
     setMeshRoughness(mesh, glossy ? GLOSSY_ROUGHNESS : DEFAULT_ROUGHNESS);
   });
+  requestRender();
 }
 
 export function toggleTextureDisplayMode(meshes) {
@@ -78,4 +82,5 @@ export function toggleTextureDisplayMode(meshes) {
   button.setAttribute('aria-label', labels[mode]);
   setTextureMode(mode);
   meshes.forEach(refreshMeshTexture);
+  requestRender();
 }

--- a/src/web/js/render-scheduler.js
+++ b/src/web/js/render-scheduler.js
@@ -1,0 +1,29 @@
+// Coalesced on-demand viewport rendering.
+
+let renderCallback = null;
+let dirty = false;
+let frameId = null;
+
+function schedule() {
+  if (frameId !== null || !renderCallback) return;
+  frameId = requestAnimationFrame(() => {
+    frameId = null;
+    if (!renderCallback || !dirty) return;
+    dirty = false;
+    renderCallback();
+    if (dirty) schedule();
+  });
+}
+
+/** Request one viewport render. Multiple changes before the next animation
+ * frame are coalesced so idle scenes submit no new GPU work. */
+export function requestRender() {
+  dirty = true;
+  schedule();
+}
+
+/** Install the scene renderer after its dependencies have been created. */
+export function setRenderCallback(callback) {
+  renderCallback = callback;
+  schedule();
+}

--- a/src/web/js/scene.js
+++ b/src/web/js/scene.js
@@ -1,4 +1,4 @@
-// Three.js scene composition and the WebGPU-native viewport render loop.
+// Three.js scene composition and the WebGPU-native on-demand viewport renderer.
 
 import * as THREE from 'three/webgpu';
 import { ArcballControls } from 'three/addons/controls/ArcballControls.js';
@@ -7,6 +7,7 @@ import { createEnvironmentController } from './environment.js';
 import { createKeyLightController } from './key-light-controller.js';
 import { updateOutlineCameraScale } from './outline-renderer.js';
 import { setBCTextureCompression } from './renderer-capabilities.js';
+import { requestRender, setRenderCallback } from './render-scheduler.js';
 import { createViewGizmoController } from './view-gizmo-controller.js';
 
 const container = document.getElementById('canvas-container');
@@ -44,7 +45,6 @@ function showRendererError(message) {
 function failRenderer(message) {
   if (rendererStopped) return;
   rendererStopped = true;
-  if (renderer._animation) renderer.setAnimationLoop(null);
   showRendererError(message);
 }
 
@@ -105,7 +105,7 @@ export const rendererReady = initializeRenderer()
     if (!isRendererAvailable()) {
       throw new Error('The renderer is not using the required WebGPU core backend.');
     }
-    renderer.setAnimationLoop(tick);
+    requestRender();
     openButton.disabled = !isRendererAvailable();
     return true;
   })
@@ -146,10 +146,11 @@ const environmentController = createEnvironmentController({
   lightTarget: keyLight.target,
 });
 const keyLightController = createKeyLightController({
-  scene, camera, renderer, controls, light: keyLight,
+  scene, camera, renderer, controls, light: keyLight, onChange: requestRender,
 });
 const viewGizmoController = createViewGizmoController({
   camera, controls, element: document.getElementById('view-gizmo'),
+  onChange: requestRender,
 });
 const cameraFrame = createCameraFrame({
   camera,
@@ -162,22 +163,32 @@ const cameraFrame = createCameraFrame({
 
 new ResizeObserver(() => {
   cameraFrame.resize(container.clientWidth, container.clientHeight);
+  requestRender();
 }).observe(container);
 
-function tick() {
+let renderCount = 0;
+
+function renderFrame() {
   if (rendererStopped || renderer.backend?.isWebGPUBackend !== true) return;
-  viewGizmoController.updateSnap();
-  controls.update();
+  const snapActive = viewGizmoController.updateSnap();
   keyLightController.update();
+  cameraFrame.updateViewport();
   cameraFrame.updateClipping();
   updateOutlineCameraScale(camera, controls.target,
     renderer.domElement.clientHeight);
   viewGizmoController.updateAxes();
   renderer.render(scene, camera);
+  renderCount += 1;
+  if (snapActive) requestRender();
 }
 
+setRenderCallback(renderFrame);
+controls.addEventListener('change', requestRender);
+
 export function setEnvironmentPreset(id) {
-  return environmentController.setPreset(id);
+  const changed = environmentController.setPreset(id);
+  if (changed) requestRender();
+  return changed;
 }
 
 export function getEnvironmentPreset() {
@@ -187,6 +198,7 @@ export function getEnvironmentPreset() {
 export function toggleGrid() {
   grid.visible = !grid.visible;
   document.getElementById('grid-btn').classList.toggle('off', !grid.visible);
+  requestRender();
 }
 
 export function toggleTrackballGizmo() {
@@ -195,18 +207,22 @@ export function toggleTrackballGizmo() {
 
 export function toggleLightHandle() {
   keyLightController.toggleMode();
+  requestRender();
 }
 
 export function frameView(meshes = [], direction = null, targetYOffset = 0) {
   cameraFrame.frameView(meshes, direction, targetYOffset);
+  requestRender();
 }
 
 export function resetView() {
   cameraFrame.resetView();
+  requestRender();
 }
 
 export function fitTo(meshes) {
   cameraFrame.fitTo(meshes);
+  requestRender();
 }
 
 export function resetModelOrientation() {
@@ -215,8 +231,14 @@ export function resetModelOrientation() {
 
 export function rotateModelQuarterTurn(meshes = []) {
   cameraFrame.rotateModelQuarterTurn(meshes);
+  requestRender();
 }
 
 export function rotateModelHorizontalQuarterTurn(meshes = []) {
   cameraFrame.rotateModelHorizontalQuarterTurn(meshes);
+  requestRender();
+}
+
+export function getRenderCount() {
+  return renderCount;
 }

--- a/src/web/js/selection.js
+++ b/src/web/js/selection.js
@@ -7,6 +7,7 @@ import * as THREE from 'three';
 import { camera, renderer } from './scene.js';
 import { activeMeshes } from './visibility.js';
 import { getMeshView } from './mesh-view-bindings.js';
+import { requestRender } from './render-scheduler.js';
 
 const HIGHLIGHT_COLOR = 0xffd60a; // selection yellow
 const HIGHLIGHT_INTENSITY = 0.22;  // kept low so the mesh's own texture reads through
@@ -53,6 +54,7 @@ export function selectMesh(mesh) {
     setHighlight(mesh, true);
     setRowSelected(mesh, true);
   }
+  requestRender();
 }
 
 export function clearSelection() {

--- a/src/web/js/view-gizmo-controller.js
+++ b/src/web/js/view-gizmo-controller.js
@@ -2,7 +2,7 @@
 
 import * as THREE from 'three';
 
-export function createViewGizmoController({ camera, controls, element }) {
+export function createViewGizmoController({ camera, controls, element, onChange }) {
   const axes = [...element.querySelectorAll('.gizmo-axis')];
   const axisVectors = {
     x: new THREE.Vector3(1, 0, 0),
@@ -31,10 +31,11 @@ export function createViewGizmoController({ camera, controls, element }) {
       startUp: camera.up.clone().normalize(),
       endUp,
     };
+    onChange?.();
   }
 
   function updateSnap() {
-    if (!snap) return;
+    if (!snap) return false;
     const raw = Math.min(1, (performance.now() - snap.started) / snap.duration);
     const progress = 1 - Math.pow(1 - raw, 3);
     const rotation = new THREE.Quaternion().slerpQuaternions(
@@ -44,6 +45,7 @@ export function createViewGizmoController({ camera, controls, element }) {
     camera.up.lerpVectors(snap.startUp, snap.endUp, progress).normalize();
     camera.lookAt(controls.target);
     if (raw === 1) snap = null;
+    return !!snap;
   }
 
   function updateAxes() {
@@ -127,6 +129,7 @@ export function createViewGizmoController({ camera, controls, element }) {
     camera.position.copy(controls.target).add(offset.setFromSpherical(spherical));
     camera.up.set(0, 1, 0);
     camera.lookAt(controls.target);
+    onChange?.();
     drag.x = event.clientX;
     drag.y = event.clientY;
   });
@@ -153,6 +156,7 @@ export function createViewGizmoController({ camera, controls, element }) {
     const distance = THREE.MathUtils.clamp(
       offset.length() * scale, Math.max(camera.near * 4, 0.0001), camera.far * 0.8);
     camera.position.copy(controls.target).addScaledVector(offset.normalize(), distance);
+    onChange?.();
   }, { passive: false });
 
   function toggle() {


### PR DESCRIPTION
## Summary

- Keep shared texture requests cached but leave diffuse and auxiliary bindings disabled until their image or DDS data is ready.
- Refresh every mesh using a texture when the shared load completes, while preserving stale-replacement protection and DDS-to-PNG fallback.
- Prebind pending textures through the existing stable material bindings so WebGPU does not render a black frame when the real texture becomes available.
- Add browser regression coverage for delayed, shared, failed, native DDS fallback, and replaced texture requests.

## Validation

- `pytest -q src/tests/test_frontend.py` — 33 passed
- `pytest -q` — 224 passed
- `git diff --check` — clean