### PR TITLE
Modernize viewer UI and accessibility

### DIFF
--- a/context.md
+++ b/context.md
@@ -207,6 +207,19 @@ machine-specific paths or facts that are obvious from the source.
   They must not reinterpret INI materials or become part of staged edits.
   Outlines remain child inverted-hull passes sharing base geometry, and
   wireframe/debug suppression must not change the user's outline preference.
+- Inspector/Controls tab choice, panel collapse state and Mod Library expansion
+  are presentation preferences stored in browser localStorage only. They are
+  not mod state, are not loaded from or written to INI/session edits, and must
+  never affect geometry, materials or export.
+- MESHES is the navigation surface: component and mesh selection should not
+  duplicate editing controls there. Inspector owns material kind, texture pool
+  management, per-mesh texture overrides and draw details; Controls owns
+  Present, Toggle and Menu state. Keep selection changes event-driven so the
+  Inspector follows the selected component or mesh without taking ownership of
+  mesh creation or texture state.
+- Viewport camera actions (Reset, Turn and Tilt) belong in the compact viewport
+  toolbar with the render and navigation tools. Do not restore a separate
+  Orientation panel when changing camera behavior.
 
 ## Feature flags and test strategy
 

--- a/context.md
+++ b/context.md
@@ -217,6 +217,9 @@ machine-specific paths or facts that are obvious from the source.
   Present, Toggle and Menu state. Keep selection changes event-driven so the
   Inspector follows the selected component or mesh without taking ownership of
   mesh creation or texture state.
+- Authoritative mesh visibility, reset, refresh and texture-override mutations
+  must publish one shared frontend state notification so Inspector values cannot
+  drift from the rendered model or MESHES state.
 - Viewport camera actions (Reset, Turn and Tilt) belong in the compact viewport
   toolbar with the render and navigation tools. Do not restore a separate
   Orientation panel when changing camera behavior.

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -2500,8 +2500,13 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
     try:
+        page.evaluate(
+            "localStorage.setItem('mod-viewer.panel.tool-panel.collapsed', 'true')")
+        page.reload()
+        page.wait_for_function("window.modViewer !== undefined")
         _open(page, "A")
         page.locator(".draw-item").first.wait_for()
+        assert page.locator("#tool-buttons").is_visible()
         toolbar_geometry = page.evaluate("""() => {
           const style = selector => getComputedStyle(document.querySelector(selector));
           return {

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -372,6 +372,9 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
 def _open(page, path):
     page.evaluate("path => { window.__fakeApi.nextPath = path; }", path)
     page.locator("#open-btn").click()
+    # Existing control-state tests exercise the Controls tab explicitly. The
+    # production default remains Inspector for a newly loaded mod.
+    page.locator("#controls-tab").evaluate("button => button.click()")
 
 
 def _sample_mesh_pixel(page):
@@ -1283,7 +1286,9 @@ def test_wuwa_body_profile_binds_normal_data_without_stock_pbr_mapping(
         page.wait_for_function(
             "window.modViewer.activeMeshes[0]?.material?.userData?.gameMaterial")
         page.wait_for_timeout(300)
-        assert page.locator(".component-material-kind-control").count() == 1
+        page.locator("#inspector-tab").click()
+        page.locator(".group-hdr .group-name").first.click()
+        assert page.locator(".inspector-material-kind-control").count() == 1
         assert page.locator(".draw-item .material-kind-select").count() == 0
         layout = page.evaluate("""
           () => {
@@ -1293,8 +1298,8 @@ def test_wuwa_body_profile_binds_normal_data_without_stock_pbr_mapping(
             const texture = header.querySelector('.group-tex-btn');
             return {
               hasMaterialLabel: !!header.querySelector('label'),
-              selectBeforeTexture: select.compareDocumentPosition(texture)
-                & Node.DOCUMENT_POSITION_FOLLOWING ? true : false,
+              hasMaterialControl: !!select,
+              hasTextureControl: !!texture,
               nameTitle: name.title,
               nameOverflow: getComputedStyle(name).textOverflow,
               nameWhiteSpace: getComputedStyle(name).whiteSpace,
@@ -1303,7 +1308,8 @@ def test_wuwa_body_profile_binds_normal_data_without_stock_pbr_mapping(
         """)
         assert layout == {
             "hasMaterialLabel": False,
-            "selectBeforeTexture": True,
+            "hasMaterialControl": False,
+            "hasTextureControl": False,
             "nameTitle": "Body Packed",
             "nameOverflow": "ellipsis",
             "nameWhiteSpace": "nowrap",
@@ -1768,29 +1774,33 @@ def test_texture_rows_are_reused_for_control_changes_and_rebuilt_for_pool_change
     try:
         _open(page, "A")
         page.locator(".draw-item").wait_for()
-        page.locator(".draw-item .group-toggle").click()
-        page.locator(".tex-item").nth(1).click()
+        page.locator("#inspector-tab").click()
+        page.locator(".group-hdr .group-name").first.click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-option", has_text="A two").click()
         assert page.evaluate(
             "window.modViewer.activeMeshes[0].userData.manualTexOverride"
             " === 'diffuse::A-two.png'")
-        page.evaluate("window.__textureRows = [...document.querySelectorAll('.tex-item')]")
+        page.evaluate("window.__textureRows = [...document.querySelectorAll('.inspector-texture-option')]")
 
+        page.locator("#controls-tab").click()
         page.locator("#toggle-list .toggle-cycle-btn").click()
-        assert page.evaluate("window.__textureRows.every((row, i) => row === document.querySelectorAll('.tex-item')[i])")
+        assert page.evaluate("window.__textureRows.every((row, i) => row === document.querySelectorAll('.inspector-texture-option')[i])")
         page.locator("#menu-list .toggle-cycle-btn").click()
-        assert page.evaluate("window.__textureRows.every((row, i) => row === document.querySelectorAll('.tex-item')[i])")
+        assert page.evaluate("window.__textureRows.every((row, i) => row === document.querySelectorAll('.inspector-texture-option')[i])")
         page.locator("#menu-list .menu-slider").evaluate(
             "input => { input.value = '0.5'; input.dispatchEvent(new Event('input', {bubbles: true})); }")
-        assert page.evaluate("window.__textureRows.every((row, i) => row === document.querySelectorAll('.tex-item')[i])")
+        assert page.evaluate("window.__textureRows.every((row, i) => row === document.querySelectorAll('.inspector-texture-option')[i])")
 
-        page.locator(".group-tex-btn").click()
+        page.locator("#inspector-tab").click()
+        page.locator(".inspector-manage-textures").click()
         page.locator("#texm-add").click()
-        page.wait_for_function("document.querySelectorAll('.tex-item').length === 3")
-        assert not page.evaluate("window.__textureRows[0] === document.querySelector('.tex-item')")
-        page.evaluate("window.__textureRows = [...document.querySelectorAll('.tex-item')]")
+        page.wait_for_function("document.querySelectorAll('.inspector-texture-option').length === 5")
+        assert not page.evaluate("window.__textureRows[0] === document.querySelector('.inspector-texture-option')")
+        page.evaluate("window.__textureRows = [...document.querySelectorAll('.inspector-texture-option')]")
         page.locator(".texm-row .toggle-icon-btn").last.click()
-        page.wait_for_function("document.querySelectorAll('.tex-item').length === 2")
-        assert not page.evaluate("window.__textureRows[0] === document.querySelector('.tex-item')")
+        page.wait_for_function("document.querySelectorAll('.inspector-texture-option').length === 4")
+        assert not page.evaluate("window.__textureRows[0] === document.querySelector('.inspector-texture-option')")
     finally:
         context.close()
 
@@ -2087,7 +2097,7 @@ def test_empty_mod_folder_panel_keeps_fixed_height_above_navigation_hint(
         page.locator("#mod-folder-toggle").click()
         page.locator("#mod-folder-dock.expanded").wait_for()
         panel = page.locator("#mod-folder-panel").bounding_box()
-        info = page.locator("#info").bounding_box()
+        info = page.locator("#footer").bounding_box()
         viewport_height = page.evaluate("window.innerHeight")
         handle_style = page.evaluate("""() => {
           const style = getComputedStyle(document.querySelector('#mod-folder-toggle'));
@@ -2097,8 +2107,13 @@ def test_empty_mod_folder_panel_keeps_fixed_height_above_navigation_hint(
         assert abs(panel["height"] - (viewport_height - 116)) < 1
         assert panel["y"] + panel["height"] <= info["y"]
         assert page.locator("#mod-folder-list").inner_text() == ""
+        assert page.evaluate("""() => {
+          const panel = document.querySelector('#mod-folder-panel');
+          return {inert: panel.inert, ariaHidden: panel.getAttribute('aria-hidden')};
+        }""") == {"inert": False, "ariaHidden": "false"}
         page.locator("#mod-folder-close").click()
         assert "expanded" not in page.locator("#mod-folder-dock").get_attribute("class")
+        assert page.evaluate("document.querySelector('#mod-folder-panel').inert")
     finally:
         context.close()
 
@@ -2276,17 +2291,114 @@ def test_mod_folder_add_edit_delete_modal_flow(
         page.locator("#mod-folder-modal-backdrop.show").wait_for(state="hidden")
         page.locator(".mod-folder-select", has_text="Replacement").wait_for()
 
-        page.locator("[aria-label='Edit Original']").click()
+        page.locator("[aria-label='More actions for Original']").click()
+        page.locator(".mod-folder-node").filter(has_text="Original").locator(
+            ".mod-folder-action-menu button", has_text="Edit").click()
         page.locator("#mfm-name").fill("Renamed")
         page.locator("#mfm-save").click()
         page.locator(".mod-folder-select", has_text="Renamed").wait_for()
 
-        page.locator("[aria-label='Remove Renamed']").click()
+        page.locator("[aria-label='More actions for Renamed']").click()
+        page.locator(".mod-folder-node").filter(has_text="Renamed").locator(
+            ".mod-folder-action-menu button", has_text="Remove").click()
         page.locator("#dialog-backdrop.show").wait_for()
         assert "Files on disk will not be deleted." in page.locator(
             "#dialog-message").inner_text()
         page.locator("#dialog-ok").click()
         assert page.locator(".mod-folder-select", has_text="Renamed").count() == 0
         assert page.locator(".mod-folder-select", has_text="Replacement").count() == 1
+    finally:
+        context.close()
+
+
+def test_inspector_follows_component_and_mesh_selection(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
+    try:
+        _open(page, "A")
+        assert page.evaluate("document.querySelector('#camera-buttons').parentElement.id") == (
+            "viewport-camera-buttons")
+        assert not page.locator("#camera-panel").is_visible()
+        assert page.locator("#tool-panel").evaluate(
+            "panel => getComputedStyle(panel).flexDirection") == "column"
+        assert page.locator("#health-btn .ui-icon").count() == 1
+        assert page.locator("#wire-btn").get_attribute("aria-pressed") == "false"
+        assert page.locator("#interaction-help").inner_text() == "LMB Orbit · RMB Pan · Wheel Zoom"
+        assert page.locator("#sidebar > .panel-hdr .group-toggle").evaluate(
+            "button => button.tagName") == "BUTTON"
+        page.locator("#inspector-tab").click()
+        page.locator(".group-hdr .group-name").first.click()
+        page.locator("#inspector-content").wait_for()
+        assert "Draw calls" in page.locator("#inspector-content").inner_text()
+
+        page.locator(".draw-item").first.click()
+        assert page.locator("#inspector-content .inspector-header h3").inner_text()
+        assert "Body A >" in page.locator("#selected-mesh-status").inner_text()
+
+        page.locator("#controls-tab").click()
+        assert page.locator("#inspector-panel").is_hidden()
+        page.locator("#inspector-tab").click()
+        assert not page.locator("#inspector-panel").is_hidden()
+    finally:
+        context.close()
+
+
+def test_viewport_toolbar_popovers_and_responsive_overflow(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
+    try:
+        _open(page, "A")
+        page.locator(".draw-item").first.wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        page.wait_for_timeout(250)
+
+        for button_id in ("camera-reset-view-btn", "camera-flip-btn",
+                          "camera-flip-horizontal-btn"):
+            before = page.evaluate("window.modViewer.getRenderCount()")
+            page.locator(f"#{button_id}").click()
+            page.wait_for_function(
+                "count => window.modViewer.getRenderCount() > count", arg=before)
+
+        page.locator("#environment-btn").click()
+        page.locator("#environment-popover:not([hidden])").wait_for()
+        page.locator("#environment-popover .ui-popover-option", has_text="Studio").click()
+        assert page.locator("#environment-label").inner_text() == "Studio"
+        assert page.locator("#environment-popover").is_hidden()
+
+        page.locator("#texture-btn").click()
+        page.locator("#texture-popover:not([hidden])").wait_for()
+        page.locator("#texture-popover .ui-popover-option", has_text="Diffuse only").click()
+        assert page.locator("#texture-btn").get_attribute("aria-label") == (
+            "Textures: diffuse only")
+        assert page.locator("#texture-popover").is_hidden()
+
+        page.locator("#light-btn").click()
+        page.locator("#light-popover:not([hidden])").wait_for()
+        page.locator("#light-popover .ui-popover-option").click()
+        assert page.locator("#light-popover").is_hidden()
+
+        page.locator("#environment-btn").click()
+        page.locator("#environment-popover:not([hidden])").wait_for()
+        page.keyboard.press("Escape")
+        assert page.locator("#environment-popover").is_hidden()
+
+        page.set_viewport_size({"width": 640, "height": 720})
+        page.locator("#toolbar-more").wait_for()
+        assert page.locator("#health-btn .health-label").is_hidden()
+        page.locator("#toolbar-more").click()
+        assert not page.locator("#toolbar-overflow").is_hidden()
+        assert page.locator("#toolbar-overflow [data-toolbar-target='health-btn']").count() == 1
+
+        assert page.evaluate("""() => {
+          const panel = document.querySelector('#mod-folder-panel');
+          return panel.inert && panel.getAttribute('aria-hidden') === 'true';
+        }""")
+        page.locator("#mod-folder-toggle").click()
+        assert page.evaluate("document.querySelector('#mod-folder-panel').inert === false")
+        page.locator("#mod-folder-close").click()
+        assert page.evaluate("""() => {
+          const panel = document.querySelector('#mod-folder-panel');
+          return panel.inert && panel.getAttribute('aria-hidden') === 'true';
+        }""")
     finally:
         context.close()

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -377,6 +377,20 @@ def _open(page, path):
     page.locator("#controls-tab").evaluate("button => button.click()")
 
 
+def _open_library(page):
+    launcher = page.locator("#mod-folder-toggle")
+    if launcher.is_visible():
+        launcher.click()
+    else:
+        action = page.locator("#empty-add-folder-btn")
+        opens_dialog = action.inner_text() == "Add Mod Folder"
+        action.click()
+        page.locator("#mod-folder-dock.expanded").wait_for()
+        if opens_dialog:
+            page.locator("#mfm-cancel").click()
+    page.locator("#mod-folder-dock.expanded").wait_for()
+
+
 def _sample_mesh_pixel(page):
     return _sample_mesh_pixel_at(page, 0.25, 0.25)
 
@@ -1777,7 +1791,14 @@ def test_texture_rows_are_reused_for_control_changes_and_rebuilt_for_pool_change
         page.locator("#inspector-tab").click()
         page.locator(".group-hdr .group-name").first.click()
         page.locator(".draw-item").first.click()
+        page.evaluate("""() => {
+          window.__meshStateEvents = 0;
+          window.addEventListener('mod-viewer-mesh-state-changed', () => {
+            window.__meshStateEvents += 1;
+          });
+        }""")
         page.locator(".inspector-texture-option", has_text="A two").click()
+        assert page.evaluate("window.__meshStateEvents") == 1
         assert page.evaluate(
             "window.modViewer.activeMeshes[0].userData.manualTexOverride"
             " === 'diffuse::A-two.png'")
@@ -2038,6 +2059,9 @@ def test_feature_flag_css_keeps_cycle_preview_and_core_invariants(
     try:
         _open(page, "A")
         page.locator("#toggle-list .toggle-cycle-btn").wait_for()
+        assert page.locator("#present-list").inner_text() == (
+            "No key or menu toggle is available for PRESENT.")
+        assert page.locator("#present-action-btn").is_enabled()
         page.evaluate("""
           document.body.classList.add('feature-export-off', 'feature-modify-toggle-off')
         """)
@@ -2079,8 +2103,9 @@ def test_mod_folder_panel_overlays_sidebar_and_browses_children_lazily(
         sidebar_before = page.locator("#sidebar").bounding_box()
         assert "expanded" not in page.locator("#mod-folder-dock").get_attribute("class")
 
-        page.locator("#mod-folder-toggle").click()
-        page.locator("#mod-folder-dock.expanded").wait_for()
+        assert page.locator("#empty-add-folder-btn").inner_text() == "Open Mod Folder"
+        _open_library(page)
+        assert page.locator("#mod-folder-modal-backdrop.show").count() == 0
         sidebar_after = page.locator("#sidebar").bounding_box()
         assert sidebar_after == sidebar_before
         z_indices = page.evaluate("""() => ({
@@ -2122,17 +2147,17 @@ def test_empty_mod_folder_panel_keeps_fixed_height_above_navigation_hint(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {}, mod_folders=[])
     try:
-        page.locator("#mod-folder-toggle").click()
+        assert page.locator("#empty-add-folder-btn").inner_text() == "Add Mod Folder"
+        page.locator("#empty-add-folder-btn").click()
         page.locator("#mod-folder-dock.expanded").wait_for()
+        page.locator("#mod-folder-modal-backdrop.show").wait_for()
+        page.locator("#mfm-cancel").click()
         panel = page.locator("#mod-folder-panel").bounding_box()
         info = page.locator("#footer").bounding_box()
         viewport_height = page.evaluate("window.innerHeight")
-        handle_style = page.evaluate("""() => {
-          const style = getComputedStyle(document.querySelector('#mod-folder-toggle'));
-          return {width: style.width, height: style.height, fontSize: style.fontSize};
-        }""")
-        assert handle_style == {"width": "32px", "height": "36px", "fontSize": "23px"}
-        assert abs(panel["height"] - (viewport_height - 104)) < 1
+        assert page.locator("#sidebar > .panel-hdr #mod-folder-toggle").count() == 1
+        assert page.locator("#mod-folder-dock > #mod-folder-toggle").count() == 0
+        assert abs(panel["height"] - (viewport_height - 112)) < 1
         assert panel["y"] + panel["height"] <= info["y"]
         assert page.locator("#mod-folder-list").inner_text() == ""
         assert page.evaluate("""() => {
@@ -2157,7 +2182,7 @@ def test_mod_folder_name_selection_preserves_dock_state_across_reload(
     )
     try:
         page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
-        page.locator("#mod-folder-toggle").click()
+        _open_library(page)
         page.locator("#mod-folder-list > .mod-folder-node .mod-folder-expand").click()
         page.locator(".mod-folder-select", has_text="Alice").click()
         page.locator(".draw-item").wait_for()
@@ -2194,7 +2219,7 @@ def test_reload_and_tree_selection_share_one_transition_guard(
     )
     try:
         page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
-        page.locator("#mod-folder-toggle").click()
+        _open_library(page)
         page.locator("#mod-folder-list > .mod-folder-node .mod-folder-expand").click()
         page.locator(".mod-folder-select", has_text="Alice").click()
         page.locator(".draw-item").wait_for()
@@ -2235,7 +2260,7 @@ def test_mod_folder_failed_selection_keeps_panel_open_and_reports_error(
     )
     try:
         page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
-        page.locator("#mod-folder-toggle").click()
+        _open_library(page)
         page.locator(".mod-folder-select", has_text="Alice").click()
         page.locator(".draw-item").wait_for()
         assert page.locator(".mod-folder-row.active").count() == 1
@@ -2267,7 +2292,7 @@ def test_mod_folder_tree_switch_respects_pending_change_confirmation(
     )
     try:
         page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
-        page.locator("#mod-folder-toggle").click()
+        _open_library(page)
         page.locator("#mod-folder-list > .mod-folder-node .mod-folder-expand").click()
         page.locator(".mod-folder-select", has_text="First").click()
         page.locator(".draw-item").wait_for()
@@ -2293,7 +2318,7 @@ def test_mod_folder_add_edit_delete_modal_flow(
     )
     try:
         page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
-        page.locator("#mod-folder-toggle").click()
+        _open_library(page)
 
         page.locator("#mod-folder-add").click()
         page.locator("#mod-folder-modal-backdrop.show").wait_for()
@@ -2357,6 +2382,38 @@ def test_inspector_follows_component_and_mesh_selection(
         assert page.locator("#interaction-help").inner_text() == "LMB Orbit · RMB Pan · Wheel Zoom"
         assert page.locator("#sidebar > .panel-hdr .group-toggle").evaluate(
             "button => button.tagName") == "BUTTON"
+        assert page.locator("#sidebar > .panel-hdr #mod-folder-toggle").count() == 1
+        assert page.locator("#mod-folder-dock > #mod-folder-toggle").count() == 0
+        assert page.locator("#sidebar > .panel-hdr #reset-state-btn").count() == 1
+        assert page.locator("#sidebar > .panel-hdr > *").evaluate_all(
+            "nodes => nodes.map(node => node.id || node.tagName)") == [
+                "BUTTON", "H3", "reset-state-btn", "mod-folder-toggle"]
+        header_positions = page.evaluate("""() => {
+          const rect = selector => document.querySelector(selector).getBoundingClientRect();
+          const label = rect('#sidebar > .panel-hdr h3');
+          const reset = rect('#reset-state-btn');
+          const library = rect('#mod-folder-toggle');
+              return {
+                resetAfterLabel: reset.left >= label.right,
+                libraryAfterReset: library.left >= reset.right,
+                libraryAtRight: library.right >=
+                  document.querySelector('#sidebar').getBoundingClientRect().right - 16,
+              };
+            }""")
+        assert header_positions == {
+            "resetAfterLabel": True,
+            "libraryAfterReset": True,
+            "libraryAtRight": True,
+        }, header_positions
+        assert page.locator("#sidebar > .panel-hdr .group-toggle").get_attribute(
+            "aria-expanded") == "true"
+        page.locator("#mod-folder-toggle").click()
+        assert page.locator("#sidebar > .panel-hdr .group-toggle").get_attribute(
+            "aria-expanded") == "true"
+        page.locator("#mod-folder-close").click()
+        page.locator("#reset-state-btn").click()
+        assert page.locator("#sidebar > .panel-hdr .group-toggle").get_attribute(
+            "aria-expanded") == "true"
         page.locator("#inspector-tab").click()
         page.locator(".group-hdr .group-name").first.click()
         page.locator("#inspector-content").wait_for()
@@ -2396,6 +2453,24 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
     try:
         _open(page, "A")
         page.locator(".draw-item").first.wait_for()
+        toolbar_geometry = page.evaluate("""() => {
+          const style = selector => getComputedStyle(document.querySelector(selector));
+          return {
+            token: getComputedStyle(document.documentElement)
+              .getPropertyValue('--toolbar-height').trim(),
+            toolbarHeight: style('#toolbar').height,
+            canvasTop: style('#canvas-container').top,
+            leftDockTop: style('#left-dock').top,
+            rightDockTop: style('#right-dock').top,
+          };
+        }""")
+        assert toolbar_geometry == {
+            "token": "54px",
+            "toolbarHeight": "54px",
+            "canvasTop": "54px",
+            "leftDockTop": "58px",
+            "rightDockTop": "58px",
+        }
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
         page.wait_for_timeout(250)
 
@@ -2414,23 +2489,29 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
 
         page.locator("#texture-btn").click()
         page.locator("#texture-popover:not([hidden])").wait_for()
+        assert page.locator("#texture-btn").get_attribute("aria-expanded") == "true"
         page.locator("#texture-popover .ui-popover-option", has_text="Diffuse only").click()
         assert page.locator("#texture-btn").get_attribute("aria-label") == (
             "Textures: diffuse only")
+        assert page.locator("#texture-btn").get_attribute("aria-expanded") == "false"
         assert page.locator("#texture-popover").is_hidden()
 
         page.locator("#light-btn").click()
         page.locator("#light-popover:not([hidden])").wait_for()
+        assert page.locator("#light-btn").get_attribute("aria-expanded") == "true"
         assert page.locator("#light-popover .ui-popover-option").all_inner_texts() == [
             "Bright", "Normal", "Off"]
         page.locator("#light-popover .ui-popover-option", has_text="Normal").click()
         assert page.locator("#light-popover").is_hidden()
+        assert page.locator("#light-btn").get_attribute("aria-expanded") == "false"
         assert page.locator("#light-btn").get_attribute("aria-label").startswith("Key light: normal")
 
         page.locator("#environment-btn").click()
         page.locator("#environment-popover:not([hidden])").wait_for()
+        assert page.locator("#environment-btn").get_attribute("aria-expanded") == "true"
         page.keyboard.press("Escape")
         assert page.locator("#environment-popover").is_hidden()
+        assert page.locator("#environment-btn").get_attribute("aria-expanded") == "false"
 
         page.set_viewport_size({"width": 640, "height": 720})
         page.locator("#toolbar-more").wait_for()

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -2004,6 +2004,34 @@ def test_source_grouping_and_collapse_are_shared_without_losing_duplicates(
 
 
 
+def test_toggle_panel_headers_collapse_and_expand_their_content(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
+    try:
+        _open(page, "A")
+        page.locator("#toggle-list .toggle-item").wait_for()
+        page.locator("#menu-list .menu-item").first.wait_for()
+
+        for panel_id, content_id in (("toggle-panel", "toggle-list"),
+                                     ("menu-panel", "menu-list")):
+            panel = page.locator(f"#{panel_id}")
+            content = page.locator(f"#{content_id}")
+            chevron = panel.locator(".panel-hdr .group-toggle")
+
+            assert "collapsed" not in (content.get_attribute("class") or "")
+            chevron.click()
+            assert "collapsed" in (content.get_attribute("class") or "")
+            assert chevron.get_attribute("aria-expanded") == "false"
+            assert not content.is_visible()
+
+            chevron.click()
+            assert "collapsed" not in (content.get_attribute("class") or "")
+            assert chevron.get_attribute("aria-expanded") == "true"
+            assert content.is_visible()
+    finally:
+        context.close()
+
+
 def test_feature_flag_css_keeps_cycle_preview_and_core_invariants(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})
@@ -2104,7 +2132,7 @@ def test_empty_mod_folder_panel_keeps_fixed_height_above_navigation_hint(
           return {width: style.width, height: style.height, fontSize: style.fontSize};
         }""")
         assert handle_style == {"width": "32px", "height": "36px", "fontSize": "23px"}
-        assert abs(panel["height"] - (viewport_height - 116)) < 1
+        assert abs(panel["height"] - (viewport_height - 104)) < 1
         assert panel["y"] + panel["height"] <= info["y"]
         assert page.locator("#mod-folder-list").inner_text() == ""
         assert page.evaluate("""() => {
@@ -2135,6 +2163,9 @@ def test_mod_folder_name_selection_preserves_dock_state_across_reload(
         page.locator(".draw-item").wait_for()
         assert page.evaluate("window.__fakeApi.calls.loadMod") == [alice]
         assert "expanded" in page.locator("#mod-folder-dock").get_attribute("class")
+        page.locator("#mod-folder-list > .mod-folder-node > .mod-folder-row > .mod-folder-expand").click()
+        assert "active-descendant" in page.locator(
+            "#mod-folder-list > .mod-folder-node > .mod-folder-row").get_attribute("class")
 
         page.evaluate("window.modViewer.reloadCurrentMod()")
         page.wait_for_function("window.__fakeApi.calls.loadMod.length === 2")
@@ -2334,9 +2365,25 @@ def test_inspector_follows_component_and_mesh_selection(
         page.locator(".draw-item").first.click()
         assert page.locator("#inspector-content .inspector-header h3").inner_text()
         assert "Body A >" in page.locator("#selected-mesh-status").inner_text()
+        assert page.locator(".draw-item.selected").count() == 1
+
+        page.locator(".group-hdr .group-name").first.click()
+        assert page.locator(".draw-item.selected").count() == 0
+        assert "selected" in page.locator(".group-hdr").first.get_attribute("class")
+        assert page.locator("#inspector-content .inspector-row", has_text="1 of 1").count() == 1
+
+        page.locator(".draw-item .mesh-state-btn").first.click()
+        assert page.locator("#inspector-content .inspector-row", has_text="0 of 1").count() == 1
+        page.locator("#reset-state-btn").click()
+        assert page.locator("#inspector-content .inspector-row", has_text="1 of 1").count() == 1
+
+        assert page.locator(".group-hdr .material-kind-select").count() == 0
+        assert page.locator(".group-hdr .group-tex-btn").count() == 0
 
         page.locator("#controls-tab").click()
         assert page.locator("#inspector-panel").is_hidden()
+        assert page.locator("#controls-panel").evaluate(
+            "panel => getComputedStyle(panel).overflowY") == "auto"
         page.locator("#inspector-tab").click()
         assert not page.locator("#inspector-panel").is_hidden()
     finally:
@@ -2374,8 +2421,11 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
 
         page.locator("#light-btn").click()
         page.locator("#light-popover:not([hidden])").wait_for()
-        page.locator("#light-popover .ui-popover-option").click()
+        assert page.locator("#light-popover .ui-popover-option").all_inner_texts() == [
+            "Bright", "Normal", "Off"]
+        page.locator("#light-popover .ui-popover-option", has_text="Normal").click()
         assert page.locator("#light-popover").is_hidden()
+        assert page.locator("#light-btn").get_attribute("aria-label").startswith("Key light: normal")
 
         page.locator("#environment-btn").click()
         page.locator("#environment-popover:not([hidden])").wait_for()

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -2348,8 +2348,30 @@ def test_mod_folder_add_edit_delete_modal_flow(
         page.locator(".mod-folder-select", has_text="Replacement").wait_for()
 
         page.locator("[aria-label='More actions for Original']").click()
+        original_menu = page.locator(
+            ".mod-folder-node", has_text="Original").locator(
+            ".mod-folder-action-menu")
+        assert page.locator(
+            "[aria-label='More actions for Original']").get_attribute(
+                "aria-expanded") == "true"
+        assert original_menu.evaluate("menu => getComputedStyle(menu).position") == "absolute"
+        assert original_menu.evaluate(
+            "menu => getComputedStyle(menu).flexDirection") == "column"
+        menu_widths = original_menu.evaluate("""menu => {
+          const menuBox = menu.getBoundingClientRect();
+          return [...menu.querySelectorAll('button')].map(button => ({
+            button: button.getBoundingClientRect().width,
+            menu: menuBox.width,
+          }));
+        }""")
+        assert all(item["button"] >= item["menu"] - 12 for item in menu_widths)
+        assert original_menu.locator("button").all_inner_texts() == [
+            "Edit", "Remove from Mod Library"]
         page.locator(".mod-folder-node").filter(has_text="Original").locator(
             ".mod-folder-action-menu button", has_text="Edit").click()
+        assert page.locator(
+            "[aria-label='More actions for Original']").get_attribute(
+                "aria-expanded") == "false"
         page.locator("#mfm-name").fill("Renamed")
         page.locator("#mfm-save").click()
         page.locator(".mod-folder-select", has_text="Renamed").wait_for()
@@ -2376,7 +2398,7 @@ def test_inspector_follows_component_and_mesh_selection(
             "viewport-camera-buttons")
         assert not page.locator("#camera-panel").is_visible()
         assert page.locator("#tool-panel").evaluate(
-            "panel => getComputedStyle(panel).flexDirection") == "column"
+            "panel => getComputedStyle(panel).flexDirection") == "row"
         assert page.locator("#health-btn .ui-icon").count() == 1
         assert page.locator("#wire-btn").get_attribute("aria-pressed") == "false"
         assert page.locator("#interaction-help").inner_text() == "LMB Orbit · RMB Pan · Wheel Zoom"
@@ -2418,21 +2440,48 @@ def test_inspector_follows_component_and_mesh_selection(
         page.locator(".group-hdr .group-name").first.click()
         page.locator("#inspector-content").wait_for()
         assert "Draw calls" in page.locator("#inspector-content").inner_text()
+        assert page.locator("#inspector-empty").is_hidden()
 
         page.locator(".draw-item").first.click()
         assert page.locator("#inspector-content .inspector-header h3").inner_text()
         assert "Body A >" in page.locator("#selected-mesh-status").inner_text()
         assert page.locator(".draw-item.selected").count() == 1
+        page.evaluate("import('./js/selection.js').then(({clearSelection}) => clearSelection())")
+        assert page.locator("#inspector-empty").is_visible()
+        assert page.locator("#inspector-content").is_hidden()
 
         page.locator(".group-hdr .group-name").first.click()
         assert page.locator(".draw-item.selected").count() == 0
         assert "selected" in page.locator(".group-hdr").first.get_attribute("class")
         assert page.locator("#inspector-content .inspector-row", has_text="1 of 1").count() == 1
+        assert page.locator("#inspector-empty").is_hidden()
 
         page.locator(".draw-item .mesh-state-btn").first.click()
         assert page.locator("#inspector-content .inspector-row", has_text="0 of 1").count() == 1
+        eye = page.locator(".draw-item .mesh-state-btn").first
+        assert eye.get_attribute("aria-pressed") == "false"
+        assert "state-hidden" in eye.get_attribute("class")
+        assert "state-manual" in eye.get_attribute("class")
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].userData.manuallyToggled") is True
         page.locator("#reset-state-btn").click()
         assert page.locator("#inspector-content .inspector-row", has_text="1 of 1").count() == 1
+        assert eye.get_attribute("aria-pressed") == "true"
+        assert "state-hidden" not in eye.get_attribute("class")
+        assert "state-manual" not in eye.get_attribute("class")
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].userData.manuallyToggled") is False
+
+        eye.click()
+        eye.click()
+        assert eye.get_attribute("aria-pressed") == "true"
+        assert "state-manual" not in eye.get_attribute("class")
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].userData.manuallyToggled") is False
+        page.evaluate("import('./js/visibility.js').then(({refreshAll}) => refreshAll())")
+        assert eye.get_attribute("aria-pressed") == "true"
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].userData.manuallyToggled") is False
 
         assert page.locator(".group-hdr .material-kind-select").count() == 0
         assert page.locator(".group-hdr .group-tex-btn").count() == 0
@@ -2471,6 +2520,44 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
             "leftDockTop": "58px",
             "rightDockTop": "58px",
         }
+        toolbar_layout = page.evaluate("""() => {
+          const rect = selector => document.querySelector(selector).getBoundingClientRect();
+          const style = selector => getComputedStyle(document.querySelector(selector));
+          const toolbar = rect('#tool-panel');
+          const camera = rect('#viewport-camera-buttons');
+          const tools = rect('#tool-buttons');
+          return {
+            centered: Math.abs(toolbar.left + toolbar.width / 2 - window.innerWidth / 2) < 1,
+            sameRow: Math.abs(camera.top + camera.height / 2
+              - tools.top - tools.height / 2) < 1,
+            toolbarDirection: style('#tool-panel').flexDirection,
+            toolbarWrap: style('#tool-panel').flexWrap,
+            toolsDisplay: style('#tool-buttons').display,
+            toolsDirection: style('#tool-buttons').flexDirection,
+            cameraLabelsHidden: [...document.querySelectorAll(
+              '#viewport-camera-buttons .camera-btn span')]
+              .every(span => getComputedStyle(span).display === 'none'),
+          };
+        }""")
+        assert toolbar_layout == {
+            "centered": True,
+            "sameRow": True,
+            "toolbarDirection": "row",
+            "toolbarWrap": "nowrap",
+            "toolsDisplay": "flex",
+            "toolsDirection": "row",
+            "cameraLabelsHidden": True,
+        }
+        toolbar_center = page.evaluate("""() => {
+          const box = document.querySelector('#tool-panel').getBoundingClientRect();
+          return box.left + box.width / 2;
+        }""")
+        page.locator("#inspector-tab").click()
+        page.wait_for_function("document.querySelector('#inspector-panel').hidden === false")
+        assert abs(page.evaluate("""() => {
+          const box = document.querySelector('#tool-panel').getBoundingClientRect();
+          return box.left + box.width / 2;
+        }""") - toolbar_center) < 1
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
         page.wait_for_timeout(250)
 
@@ -2490,6 +2577,16 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
         page.locator("#texture-btn").click()
         page.locator("#texture-popover:not([hidden])").wait_for()
         assert page.locator("#texture-btn").get_attribute("aria-expanded") == "true"
+        texture_position = page.evaluate("""() => {
+          const button = document.querySelector('#texture-btn').getBoundingClientRect();
+          const popover = document.querySelector('#texture-popover').getBoundingClientRect();
+          return {
+            above: popover.bottom <= button.top,
+            within: popover.left >= 0 && popover.right <= window.innerWidth
+              && popover.top >= 0 && popover.bottom <= window.innerHeight,
+          };
+        }""")
+        assert texture_position == {"above": True, "within": True}
         page.locator("#texture-popover .ui-popover-option", has_text="Diffuse only").click()
         assert page.locator("#texture-btn").get_attribute("aria-label") == (
             "Textures: diffuse only")
@@ -2499,12 +2596,29 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
         page.locator("#light-btn").click()
         page.locator("#light-popover:not([hidden])").wait_for()
         assert page.locator("#light-btn").get_attribute("aria-expanded") == "true"
+        light_position = page.evaluate("""() => {
+          const button = document.querySelector('#light-btn').getBoundingClientRect();
+          const popover = document.querySelector('#light-popover').getBoundingClientRect();
+          return {
+            above: popover.bottom <= button.top,
+            within: popover.left >= 0 && popover.right <= window.innerWidth
+              && popover.top >= 0 && popover.bottom <= window.innerHeight,
+          };
+        }""")
+        assert light_position == {"above": True, "within": True}
         assert page.locator("#light-popover .ui-popover-option").all_inner_texts() == [
             "Bright", "Normal", "Off"]
         page.locator("#light-popover .ui-popover-option", has_text="Normal").click()
         assert page.locator("#light-popover").is_hidden()
         assert page.locator("#light-btn").get_attribute("aria-expanded") == "false"
         assert page.locator("#light-btn").get_attribute("aria-label").startswith("Key light: normal")
+
+        page.locator("#light-btn").click()
+        page.locator("#light-popover:not([hidden])").wait_for()
+        assert page.locator("#light-popover .ui-popover-option").all_inner_texts() == [
+            "Bright", "Normal", "Off"]
+        page.locator("#light-btn").click()
+        assert page.locator("#light-popover").is_hidden()
 
         page.locator("#environment-btn").click()
         page.locator("#environment-popover:not([hidden])").wait_for()
@@ -2515,6 +2629,10 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
 
         page.set_viewport_size({"width": 640, "height": 720})
         page.locator("#toolbar-more").wait_for()
+        assert page.locator("#tool-panel").evaluate(
+            "panel => getComputedStyle(panel).flexWrap") == "nowrap"
+        assert page.locator("#tool-panel").evaluate(
+            "panel => getComputedStyle(panel).overflowX") == "auto"
         assert page.locator("#health-btn .health-label").is_hidden()
         page.locator("#toolbar-more").click()
         assert not page.locator("#toolbar-overflow").is_hidden()

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -187,7 +187,7 @@ body {
 
 /* ── left dock (meshes panel + toolbox) ──────────────────────────────────── */
 #left-dock {
-  position: fixed; top: 58px; left: 12px; z-index: 110;
+  position: fixed; top: calc(var(--toolbar-height) + 4px); left: 12px; z-index: 110;
   display: flex; flex-direction: row; align-items: flex-start; gap: 10px;
   max-height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
 }
@@ -195,7 +195,7 @@ body {
 /* Mod Folders is an overlay owned by the left dock. It must not become a
  * flex item: opening it covers MESHES instead of moving the model panel. */
 #mod-folder-dock {
-  position: fixed; top: 58px; left: 12px; z-index: 130;
+  position: fixed; top: calc(var(--toolbar-height) + 4px); left: 12px; z-index: 130;
   width: 288px; max-width: min(288px, calc(50vw - 36px));
   height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
   pointer-events: none;
@@ -214,18 +214,13 @@ body {
 #mod-folder-dock .panel-hdr { margin-bottom: 8px; cursor: default; }
 #mod-folder-dock h3 { font-size: 10px; color: var(--text-muted); text-transform: uppercase;
   letter-spacing: .1em; margin: 0; flex: 1; }
-.mod-folder-handle, .mod-folder-close {
+.mod-folder-close {
   width: 32px; height: 36px; padding: 0; border: 1px solid var(--border);
   border-radius: 5px; background: var(--bg-panel); color: var(--text);
   cursor: pointer; font-size: 23px; font-weight: 700; line-height: 1;
 }
-.mod-folder-handle {
-  position: absolute; top: 0; left: 0; pointer-events: auto;
-  box-shadow: 0 4px 12px rgba(0,0,0,.3);
-}
-#mod-folder-dock.expanded .mod-folder-handle { display: none; }
-.mod-folder-handle:hover, .mod-folder-close:hover { background: var(--accent); }
-.mod-folder-handle .ui-icon, .mod-folder-close .ui-icon { width: 20px; height: 20px; }
+.mod-folder-close:hover { background: var(--accent); }
+.mod-folder-close .ui-icon { width: 20px; height: 20px; }
 .mod-folder-error {
   display: none; margin-bottom: 8px; padding: 6px 8px; border-radius: 5px;
   color: var(--danger); background: rgba(248,81,73,.1);
@@ -285,7 +280,7 @@ body {
 
 /* ── right dock (toggle panel + menu panel) ──────────────────────────────── */
 #right-dock {
-  position: fixed; top: 58px; right: 12px; z-index: 10;
+  position: fixed; top: calc(var(--toolbar-height) + 4px); right: 12px; z-index: 10;
   max-height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
   display: flex; flex-direction: column; align-items: stretch; gap: 10px;
 }
@@ -342,6 +337,8 @@ body {
   font-size: 10px; color: var(--text-muted); text-transform: uppercase;
   letter-spacing: .1em; margin: 0; flex: 1;
 }
+#sidebar > .panel-hdr h3 { flex: 0 0 auto; }
+#sidebar > .panel-hdr #mod-folder-toggle { margin-left: auto; }
 
 /* ── toolbox (wireframe / grid) ───────────────────────────────────────────── */
 #tool-panel {
@@ -881,7 +878,7 @@ body.feature-modify-toggle-off .present-author-actions { display: none; }
  * behavior contract for the viewer modules; these tokens provide the shared
  * visual language around them. */
 :root {
-  --toolbar-height: 46px;
+  --toolbar-height: 54px;
   --footer-height: 28px;
   --dock-gap: 30px;
   --viewport-toolbar-width: 146px;
@@ -899,7 +896,7 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 [tabindex]:focus-visible { outline: none; box-shadow: var(--focus-ring); }
 
 #toolbar {
-  height: 54px; padding: 0 16px; gap: 14px;
+  height: var(--toolbar-height); padding: 0 16px; gap: 14px;
   background: rgba(22,27,34,.94); backdrop-filter: blur(14px);
 }
 .app-icon {
@@ -924,7 +921,11 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 #open-btn {
   color: var(--text); background: var(--surface-raised); border-color: var(--border);
 }
+#ini-view-btn {
+  color: var(--text); background: var(--surface-raised); border-color: var(--border);
+}
 #open-btn:hover:not(:disabled) { background: var(--surface-hover); border-color: #485363; }
+#ini-view-btn:hover:not(:disabled) { background: var(--surface-hover); border-color: #485363; }
 #open-btn:hover:not(:disabled), #ini-view-btn:hover:not(:disabled),
 #health-btn:hover:not(:disabled), #export-btn:hover:not(:disabled) { transform: translateY(-1px); }
 #export-btn { background: #9e6a03; }

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -246,7 +246,9 @@ body {
   background: transparent; color: var(--text); text-align: left; cursor: pointer;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: inherit; }
 .mod-folder-select:hover { color: var(--accent-soft); }
-.mod-folder-actions { display: flex; gap: 3px; flex: 0 0 auto; }
+.mod-folder-actions {
+  position: relative; display: inline-flex; align-items: center; gap: 4px; flex: 0 0 auto;
+}
 .mod-folder-actions button { width: 20px; height: 20px; padding: 0; border: 0;
   border-radius: 4px; background: transparent; color: var(--text-muted); cursor: pointer; }
 .mod-folder-actions button .ui-icon { width: 16px; height: 16px; }
@@ -255,15 +257,20 @@ body {
 .mod-folder-actions > .mod-folder-remove { display: none; }
 .mod-folder-more { display: flex; }
 .mod-folder-action-menu {
-  position: absolute; top: calc(100% + 3px); right: 0; z-index: 180;
-  display: flex; flex-direction: column; gap: 2px; min-width: 100px; padding: 4px;
-  background: var(--bg-panel); border: 1px solid var(--border); border-radius: var(--radius-sm);
-  box-shadow: 0 8px 20px rgba(0,0,0,.45);
+  position: absolute; top: calc(100% + 5px); right: 0; z-index: 180;
+  display: flex; flex-direction: column; gap: 2px; width: max-content;
+  min-width: 170px; max-width: calc(100vw - 16px); padding: 5px;
+  background: rgba(22,27,34,.98); border: 1px solid var(--border);
+  border-radius: var(--radius-md); box-shadow: 0 10px 28px rgba(0,0,0,.45);
 }
 .mod-folder-action-menu[hidden] { display: none; }
 .mod-folder-action-menu button {
-  width: auto; height: 28px; padding: 0 8px; text-align: left; color: var(--text);
+  display: block; width: 100%; height: auto; min-height: 30px; padding: 5px 8px;
+  border: 0; border-radius: var(--radius-sm); color: var(--text);
+  background: transparent; text-align: left; cursor: pointer;
+  font: inherit; font-size: 11px; white-space: nowrap;
 }
+.mod-folder-action-menu button:hover { background: var(--surface-active); }
 .mod-folder-children { display: flex; flex-direction: column; gap: 1px; margin-left: 20px; }
 .mod-folder-children[hidden] { display: none; }
 .mod-folder-child-error { padding: 4px 4px 4px 20px; color: var(--danger); font-size: 10px; }
@@ -359,7 +366,7 @@ body {
 .mesh-state-btn { width: 22px; height: 22px; min-height: 22px; padding: 0; border: 0; background: transparent; color: var(--text); cursor: pointer; flex-shrink: 0; }
 .mesh-state-btn .ui-icon { width: 16px; height: 16px; }
 .mesh-state-btn.state-hidden { color: var(--text-muted); opacity: .7; }
-.mesh-state-btn.state-manual { color: var(--accent-soft); }
+.mesh-state-btn.state-manual { color: var(--accent-soft); opacity: 1; }
 .mesh-state-btn:hover { filter: brightness(1.25); transform: scale(1.08); }
 #wire-btn.active { background: var(--accent); }
 #outline-btn.active { background: var(--accent); }
@@ -881,7 +888,6 @@ body.feature-modify-toggle-off .present-author-actions { display: none; }
   --toolbar-height: 54px;
   --footer-height: 28px;
   --dock-gap: 30px;
-  --viewport-toolbar-width: 146px;
   --surface-raised: #1c232d;
   --surface-hover: #263241;
   --surface-active: rgba(88,166,255,.16);
@@ -984,6 +990,7 @@ button:focus-visible, input:focus-visible, select:focus-visible,
   gap: 7px; min-height: 150px; padding: 20px; text-align: center; color: var(--text-muted);
   font-size: 11px; line-height: 1.4;
 }
+#inspector-empty[hidden] { display: none; }
 .inspector-empty strong, .mod-folder-empty strong { color: var(--text); font-size: 12px; }
 .empty-icon {
   display: grid; place-items: center; width: 34px; height: 34px; margin-bottom: 3px;
@@ -1020,9 +1027,11 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 .mod-folder-row { min-height: 32px; padding: 3px 0; }
 .mod-folder-select { min-height: 28px; }
 .mod-folder-expand { min-height: 0; }
-.mod-folder-actions button { width: 28px; height: 28px; }
-.mod-folder-actions button { min-height: 0; }
-.mod-folder-actions { gap: 4px; }
+.mod-folder-actions > .mod-folder-edit,
+.mod-folder-actions > .mod-folder-remove,
+.mod-folder-actions > .mod-folder-more {
+  width: 28px; height: 28px; min-height: 0;
+}
 
 #empty-actions {
   position: fixed; top: calc(50% + 54px); left: 50%; z-index: 20;
@@ -1057,35 +1066,34 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 }
 .ui-popover-option:hover, .ui-popover-option.selected { color: var(--text); background: var(--surface-active); }
 #tool-panel.viewport-toolbar {
-  left: auto; right: 12px; bottom: 40px; transform: none;
-  width: var(--viewport-toolbar-width); min-width: 0;
-  display: flex; flex-direction: column; align-items: center;
-  max-height: calc(100vh - var(--toolbar-height) - var(--footer-height) - 36px);
-  overflow-y: auto;
-  padding: 7px; border-radius: var(--radius-md); background: rgba(13,17,23,.9);
+  left: 50%; right: auto; bottom: calc(var(--footer-height) + 10px);
+  transform: translateX(-50%);
+  width: auto; max-width: calc(100vw - 24px); min-width: 0;
+  display: flex; flex-direction: row; align-items: center; flex-wrap: nowrap;
+  max-height: none; overflow-x: auto; overflow-y: hidden;
+  padding: 5px 6px; border-radius: var(--radius-md); background: rgba(13,17,23,.9);
 }
 #tool-panel.viewport-toolbar .panel-hdr { display: none; }
 #tool-panel.viewport-toolbar #tool-buttons {
-  display: grid; grid-template-columns: repeat(3, 38px); gap: 5px;
+  display: flex; flex: 0 0 auto; flex-direction: row; align-items: center; gap: 4px;
 }
 #tool-panel.viewport-toolbar .viewport-camera-buttons {
-  flex-direction: row; padding: 0 0 7px; margin: 0 0 7px;
-  border-right: 0; border-bottom: 1px solid var(--border);
+  flex: 0 0 auto; flex-direction: row; align-items: center; gap: 4px;
+  padding: 0 6px 0 0; margin: 0 6px 0 0;
+  border-right: 1px solid var(--border); border-bottom: 0;
 }
 #tool-panel.viewport-toolbar .camera-btn {
-  width: 38px; height: 38px; padding: 4px 2px 3px;
+  width: 32px; height: 32px; min-width: 32px; min-height: 32px; padding: 0;
 }
-#tool-panel.viewport-toolbar .camera-btn svg { width: 17px; height: 17px; }
-#tool-panel.viewport-toolbar .camera-btn span { font-size: 8px; }
+#tool-panel.viewport-toolbar .camera-btn svg,
+#tool-panel.viewport-toolbar .tool-btn .ui-icon { width: 17px; height: 17px; }
+#tool-panel.viewport-toolbar .camera-btn span { display: none; }
+#tool-panel.viewport-toolbar .tool-btn {
+  width: 32px; height: 32px; min-width: 32px; min-height: 32px; font-size: 16px;
+}
 .tool-popover {
-  position: fixed; top: auto;
-  right: calc(var(--viewport-toolbar-width) + 20px);
-  bottom: calc(var(--footer-height) + 76px);
-  min-width: 170px;
-}
-body.right-dock-visible #tool-panel.viewport-toolbar { right: 338px; }
-body.right-dock-visible .tool-popover {
-  right: calc(338px + var(--viewport-toolbar-width) + 8px);
+  position: fixed; top: auto; right: auto; bottom: auto; left: auto;
+  min-width: 170px; max-width: calc(100vw - 16px);
 }
 
 @media (max-width: 760px) {
@@ -1098,14 +1106,12 @@ body.right-dock-visible .tool-popover {
   #ini-view-btn { font-size: 0; }
   #ini-view-btn::before { content: 'INI'; font-size: 12px; }
   #right-dock { right: 8px; width: min(316px, calc(100vw - 16px)); }
-  #tool-panel.viewport-toolbar { right: 8px; }
-  body.right-dock-visible #tool-panel.viewport-toolbar { right: min(324px, calc(100vw - 8px)); }
-  #tool-panel.viewport-toolbar { right: 8px; }
-  .tool-popover { right: calc(var(--viewport-toolbar-width) + 16px); }
-  body.right-dock-visible .tool-popover {
-    right: min(478px, calc(100vw - 8px));
-  }
   body.right-dock-visible #environment-popover { right: min(324px, calc(100vw - 8px)); }
+  #tool-panel.viewport-toolbar { max-width: calc(100vw - 16px); padding: 4px 5px; }
+  #tool-panel.viewport-toolbar .camera-btn,
+  #tool-panel.viewport-toolbar .tool-btn {
+    width: 30px; height: 30px; min-width: 30px; min-height: 30px;
+  }
   #empty-actions { flex-direction: column; width: 160px; }
   .footer-status { max-width: 70vw; }
   #interaction-help { display: none; }

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -14,6 +14,15 @@
   --danger: #f85149;
 }
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+#ui-icon-sprite { position: absolute; width: 0; height: 0; overflow: hidden; }
+.ui-icon {
+  width: 18px; height: 18px; flex: 0 0 auto; fill: none; stroke: currentColor;
+  stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round;
+}
+.tool-btn .ui-icon { width: 22px; height: 22px; }
+.icon-btn .ui-icon, #toolbar-more .ui-icon { width: 16px; height: 16px; }
+#health-btn .ui-icon { width: 15px; height: 15px; }
+#texm-add .ui-icon { width: 14px; height: 14px; vertical-align: -2px; }
 body {
   background: var(--bg-canvas); color: var(--text);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -197,6 +206,7 @@ body {
 }
 #mod-folder-dock.expanded .mod-folder-handle { display: none; }
 .mod-folder-handle:hover, .mod-folder-close:hover { background: var(--accent); }
+.mod-folder-handle .ui-icon, .mod-folder-close .ui-icon { width: 20px; height: 20px; }
 .mod-folder-error {
   display: none; margin-bottom: 8px; padding: 6px 8px; border-radius: 5px;
   color: var(--danger); background: rgba(248,81,73,.1);
@@ -205,7 +215,7 @@ body {
 .mod-folder-error.show { display: block; }
 .mod-folder-list { flex: 1; overflow-y: auto; min-height: 0; }
 .mod-folder-node { min-width: 0; }
-.mod-folder-row { display: flex; align-items: center; gap: 4px; min-height: 26px;
+.mod-folder-row { position: relative; display: flex; align-items: center; gap: 4px; min-height: 26px;
   padding: 2px 0; border-radius: 5px; }
 .mod-folder-row.active { background: rgba(31,111,235,.24); }
 .mod-folder-row.missing { opacity: .58; }
@@ -222,11 +232,26 @@ body {
 .mod-folder-actions { display: flex; gap: 3px; flex: 0 0 auto; }
 .mod-folder-actions button { width: 20px; height: 20px; padding: 0; border: 0;
   border-radius: 4px; background: transparent; color: var(--text-muted); cursor: pointer; }
+.mod-folder-actions button .ui-icon { width: 16px; height: 16px; }
 .mod-folder-actions button:hover { color: var(--text); background: var(--accent); }
+.mod-folder-actions > .mod-folder-edit,
+.mod-folder-actions > .mod-folder-remove { display: none; }
+.mod-folder-more { display: flex; }
+.mod-folder-action-menu {
+  position: absolute; top: calc(100% + 3px); right: 0; z-index: 180;
+  display: flex; flex-direction: column; gap: 2px; min-width: 100px; padding: 4px;
+  background: var(--bg-panel); border: 1px solid var(--border); border-radius: var(--radius-sm);
+  box-shadow: 0 8px 20px rgba(0,0,0,.45);
+}
+.mod-folder-action-menu[hidden] { display: none; }
+.mod-folder-action-menu button {
+  width: auto; height: 28px; padding: 0 8px; text-align: left; color: var(--text);
+}
 .mod-folder-children { display: flex; flex-direction: column; gap: 1px; margin-left: 20px; }
 .mod-folder-children[hidden] { display: none; }
 .mod-folder-child-error { padding: 4px 4px 4px 20px; color: var(--danger); font-size: 10px; }
-.mod-folder-missing { padding: 0 4px 4px 24px; color: var(--text-muted); font-size: 10px; }
+.mod-folder-missing { display: flex; align-items: center; gap: 4px; padding: 0 4px 4px 24px; color: var(--text-muted); font-size: 10px; }
+.mod-folder-missing .ui-icon { width: 13px; height: 13px; color: var(--warning); }
 .mod-folder-path-field { display: flex; gap: 6px; }
 .mod-folder-path-field input { min-width: 0; flex: 1; }
 .mod-folder-path-field button {
@@ -253,9 +278,12 @@ body {
   max-height: calc(100vh - 104px); min-height: 0;
   overflow-x: hidden; overflow-y: auto;
 }
-#camera-panel { min-width: 166px; padding: 9px 10px; }
-#camera-buttons { display: grid; grid-template-columns: repeat(3, 44px); gap: 6px; }
-#camera-panel .panel-hdr { margin-bottom: 7px; }
+#camera-panel { display: none !important; }
+#camera-buttons { display: flex; align-items: center; gap: 5px; }
+.viewport-camera-buttons {
+  display: flex; align-items: center; gap: 5px; padding-right: 7px;
+  margin-right: 2px; border-right: 1px solid var(--border);
+}
 .camera-btn {
   width: 44px; height: 46px; padding: 5px 3px 4px;
   display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px;
@@ -288,7 +316,7 @@ body {
 #menu-panel:has(> #menu-list.collapsed) {
   flex-shrink: 0; overflow-y: hidden;
 }
-#sidebar h3, #camera-panel h3, #present-panel h3, #toggle-panel h3, #tool-panel h3, #menu-panel h3 {
+#sidebar h3, #present-panel h3, #toggle-panel h3, #tool-panel h3, #menu-panel h3 {
   font-size: 10px; color: var(--text-muted); text-transform: uppercase;
   letter-spacing: .1em; margin: 0; flex: 1;
 }
@@ -302,7 +330,6 @@ body {
 #tool-panel .panel-hdr { margin-bottom: 7px; }
 #tool-buttons { display: flex; align-items: center; gap: 6px; }
 #tool-buttons.collapsed { display: none; }
-#camera-buttons.collapsed { display: none; }
 .tool-btn {
   width: 40px; height: 40px; padding: 0;
   background: var(--bg-control); border: 1px solid var(--border);
@@ -310,7 +337,10 @@ body {
   font-size: 20px; line-height: 1;
   display: flex; align-items: center; justify-content: center;
 }
-.mesh-state-btn { width: 18px; height: 18px; padding: 0; border: 0; background: transparent; font-size: 13px; line-height: 18px; cursor: pointer; flex-shrink: 0; }
+.mesh-state-btn { width: 22px; height: 22px; min-height: 22px; padding: 0; border: 0; background: transparent; color: var(--text); cursor: pointer; flex-shrink: 0; }
+.mesh-state-btn .ui-icon { width: 16px; height: 16px; }
+.mesh-state-btn.state-hidden { color: var(--text-muted); opacity: .7; }
+.mesh-state-btn.state-manual { color: var(--accent-soft); }
 .mesh-state-btn:hover { filter: brightness(1.25); transform: scale(1.08); }
 #wire-btn.active { background: var(--accent); }
 #outline-btn.active { background: var(--accent); }
@@ -376,6 +406,7 @@ body {
 }
 body.right-dock-visible #view-gizmo,
 body.right-dock-visible .environment-control { right: 338px; }
+body.right-dock-visible #environment-popover { right: 338px; }
 .panel-hdr { display: flex; align-items: center; gap: 7px; margin-bottom: 8px; cursor: pointer; }
 #mesh-list.collapsed, #present-list.collapsed, #toggle-list.collapsed, #menu-list.collapsed { display: none; }
 .icon-btn {
@@ -387,11 +418,17 @@ body.right-dock-visible .environment-control { right: 338px; }
 
 /* Collapse chevron, shared by both panels. */
 .group-toggle {
-  width: 14px; height: 14px; flex-shrink: 0;
+  width: 28px; height: 28px; min-height: 28px; flex-shrink: 0;
   display: flex; align-items: center; justify-content: center;
   color: var(--text-muted); font-size: 9px; transition: transform .15s ease; user-select: none;
+  border: 0; border-radius: var(--radius-sm); background: transparent; cursor: pointer;
 }
 .group-toggle.collapsed { transform: rotate(-90deg); }
+.group-toggle:hover { color: var(--text); background: var(--surface-hover); }
+.group-hdr .group-toggle {
+  min-height: 0; padding: 0; border: 0; background: transparent; cursor: pointer;
+}
+.group-toggle .ui-icon { width: 14px; height: 14px; }
 .group-name { flex: 1; user-select: none; }
 
 /* ── meshes panel (left) ─────────────────────────────────────────────────── */
@@ -412,7 +449,7 @@ body.right-dock-visible .environment-control { right: 338px; }
  * reaching the material selector or texture button. */
 .group-hdr .group-name {
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  padding-right: 102px;
+  padding-right: 0;
 }
 .group-tex-btn {
   position: absolute; top: 0; right: 0;
@@ -474,7 +511,8 @@ body.right-dock-visible .environment-control { right: 338px; }
 .texm-diffuse, .texm-map-cell span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .texm-map-cell { min-width: 0; display: flex; align-items: center; justify-content: space-between; gap: 4px; padding: 3px 6px; background: #161b22; color: #8b949e; border: 1px dashed #30363d; }
 .texm-map-cell:hover { color: #cdd9e5; border-color: #58a6ff; }
-.texm-map-clear { flex: 0 0 auto; color: #f85149; font-size: 15px; line-height: 1; }
+.texm-map-clear { flex: 0 0 auto; display: inline-flex; color: #f85149; font-size: 15px; line-height: 1; cursor: pointer; }
+.texm-map-clear .ui-icon { width: 14px; height: 14px; }
 .texm-empty { font-size: 11px; color: #8b949e; font-style: italic; padding: 4px 6px; }
 #texm-add { background: #21262d; color: #e6edf3; }
 #texm-add:hover { background: #30363d; }
@@ -521,12 +559,15 @@ body.right-dock-visible .environment-control { right: 338px; }
   display: flex; align-items: center; justify-content: center;
 }
 .toggle-icon-btn:hover { background: #21262d; color: #e6edf3; }
+.toggle-icon-btn .ui-icon { width: 15px; height: 15px; }
 .toggle-empty { font-size: 11px; color: #8b949e; font-style: italic; }
 .toggle-row { display: flex; align-items: center; gap: 8px; }
 .toggle-cycle-btn {
   background: #21262d; border: 1px solid #30363d; color: #e6edf3; border-radius: 4px;
-  width: 24px; height: 22px; font-size: 13px; cursor: pointer; flex-shrink: 0;
+  width: 28px; height: 28px; min-height: 28px; display: inline-flex; align-items: center;
+  justify-content: center; cursor: pointer; flex-shrink: 0;
 }
+.toggle-cycle-btn .ui-icon { width: 16px; height: 16px; }
 .toggle-cycle-btn:hover { background: #1f6feb; }
 .toggle-value { font-size: 12px; color: var(--accent-soft); font-weight: 600; flex: 1; min-width: 0; overflow-wrap: break-word; }
 
@@ -615,10 +656,10 @@ body.right-dock-visible .environment-control { right: 338px; }
   position: fixed; top: 50%; left: 50%; transform: translate(-50%,-50%);
   text-align: center; color: #30363d; pointer-events: none;
 }
-#hint .big { font-size: 48px; }
+#hint .big { display: grid; place-items: center; color: var(--accent-soft); }
+#hint .big .ui-icon { width: 44px; height: 44px; stroke-width: 1.2; }
 #hint .msg { font-size: 14px; margin-top: 10px; }
 
-#info { position: fixed; bottom: 38px; left: 12px; font-size: 11px; color: #30363d; z-index: 10; }
 
 /* ── toggle add/edit modal ───────────────────────────────────────────────── */
 .modal-backdrop {
@@ -806,4 +847,226 @@ body.feature-modify-toggle-off .present-author-actions { display: none; }
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
   #view-gizmo, .environment-control { right: 272px; }
+  .mod-folder-actions > .mod-folder-edit,
+  .mod-folder-actions > .mod-folder-remove { display: none; }
+  .mod-folder-actions > .mod-folder-more { display: flex; }
+}
+
+/* UI modernization layer.  Existing IDs and panel classes remain the
+ * behavior contract for the viewer modules; these tokens provide the shared
+ * visual language around them. */
+:root {
+  --surface-raised: #1c232d;
+  --surface-hover: #263241;
+  --surface-active: rgba(88,166,255,.16);
+  --focus-ring: 0 0 0 2px var(--bg-canvas), 0 0 0 4px var(--accent-soft);
+  --radius-sm: 6px;
+  --radius-md: 9px;
+}
+
+button, input, select { font: inherit; }
+button { min-height: 30px; }
+button:focus-visible, input:focus-visible, select:focus-visible,
+[tabindex]:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+#toolbar {
+  height: 54px; padding: 0 16px; gap: 14px;
+  background: rgba(22,27,34,.94); backdrop-filter: blur(14px);
+}
+.app-icon {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; border: 1px solid rgba(88,166,255,.45);
+  border-radius: 8px; color: var(--accent-soft); background: var(--surface-active);
+  font-size: 13px; font-weight: 800;
+}
+.app-icon .icon-glyph { line-height: 1; }
+.app-title { font-size: 12px; letter-spacing: .01em; }
+#mod-path {
+  flex: 1 1 auto; max-width: 420px; min-height: 30px; display: flex;
+  align-items: center; padding: 0 10px; border-radius: var(--radius-sm);
+  color: var(--text); background: rgba(13,17,23,.58);
+}
+#toolbar > #open-btn, #toolbar > .ini-view-wrap, #toolbar > #health-btn,
+#toolbar > #export-btn { flex: 0 0 auto; }
+#open-btn, #ini-view-btn, #health-btn, #export-btn {
+  min-height: 32px; padding: 5px 12px; border-radius: var(--radius-sm);
+  font-size: 12px; font-weight: 600; transition: background .12s, border-color .12s, transform .12s;
+}
+#open-btn {
+  color: var(--text); background: var(--surface-raised); border-color: var(--border);
+}
+#open-btn:hover:not(:disabled) { background: var(--surface-hover); border-color: #485363; }
+#open-btn:hover:not(:disabled), #ini-view-btn:hover:not(:disabled),
+#health-btn:hover:not(:disabled), #export-btn:hover:not(:disabled) { transform: translateY(-1px); }
+#export-btn { background: #9e6a03; }
+.pending-indicator { padding: 5px 9px; font-size: 10px; }
+#toolbar-more { display: none; width: 32px; padding: 0; font-size: 16px; }
+#toolbar-overflow {
+  position: absolute; top: 48px; right: 10px; z-index: 260; min-width: 150px;
+  display: flex; flex-direction: column; gap: 2px; padding: 5px;
+  background: rgba(22,27,34,.98); border: 1px solid var(--border);
+  border-radius: var(--radius-md); box-shadow: 0 10px 28px rgba(0,0,0,.45);
+}
+#toolbar-overflow[hidden] { display: none; }
+#toolbar-overflow button {
+  min-height: 30px; padding: 5px 8px; border: 0; border-radius: var(--radius-sm);
+  color: var(--text); background: transparent; text-align: left; cursor: pointer;
+  font-size: 11px;
+}
+#toolbar-overflow button:hover { background: var(--surface-active); }
+
+#right-dock {
+  display: none; width: 316px; max-width: min(316px, calc(50vw - 24px));
+  gap: 8px; max-height: calc(100vh - 104px);
+}
+#right-dock.ui-visible { display: flex; }
+.right-dock-tabs {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 3px; padding: 3px;
+  background: rgba(13,17,23,.9); border: 1px solid var(--border);
+  border-radius: var(--radius-md); backdrop-filter: blur(8px);
+}
+.right-dock-tab {
+  min-height: 32px; border: 0; border-radius: var(--radius-sm);
+  color: var(--text-muted); background: transparent; cursor: pointer;
+  font-size: 11px; font-weight: 700; letter-spacing: .04em;
+}
+.right-dock-tab:hover { color: var(--text); background: var(--surface-hover); }
+.right-dock-tab.active { color: var(--text); background: var(--accent); }
+#inspector-panel {
+  display: flex; flex-direction: column; min-height: 180px; max-height: calc(100vh - 152px);
+  width: 100%; overflow: hidden; padding: 12px 14px;
+  background: rgba(13,17,23,.92); border: 1px solid var(--border);
+  border-radius: var(--radius-md); backdrop-filter: blur(8px);
+}
+#inspector-panel[hidden], #controls-panel[hidden] { display: none !important; }
+#controls-panel {
+  display: flex; flex-direction: column; align-items: stretch; gap: 10px;
+  min-height: 0; max-height: calc(100vh - 104px); overflow: hidden;
+}
+#controls-panel > #present-panel, #controls-panel > #toggle-panel,
+#controls-panel > #menu-panel { width: 100%; max-width: none; }
+.inspector-empty, .mod-folder-empty {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 7px; min-height: 150px; padding: 20px; text-align: center; color: var(--text-muted);
+  font-size: 11px; line-height: 1.4;
+}
+.inspector-empty strong, .mod-folder-empty strong { color: var(--text); font-size: 12px; }
+.empty-icon {
+  display: grid; place-items: center; width: 34px; height: 34px; margin-bottom: 3px;
+  border: 1px solid var(--border); border-radius: 10px; color: var(--accent-soft);
+  background: var(--surface-active); font-size: 20px; font-weight: 300;
+}
+#inspector-content { min-height: 0; overflow-y: auto; }
+.inspector-header { padding-bottom: 11px; border-bottom: 1px solid var(--border); }
+.inspector-kicker, .inspector-section-title {
+  color: var(--text-muted); font-size: 9px; font-weight: 700;
+  letter-spacing: .1em; text-transform: uppercase;
+}
+.inspector-header h3 { margin-top: 4px; color: var(--text); font-size: 15px; overflow-wrap: anywhere; }
+.inspector-section { display: flex; flex-direction: column; gap: 7px; padding: 12px 0; border-bottom: 1px solid rgba(48,54,61,.72); }
+.inspector-row { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; font-size: 11px; }
+.inspector-label { color: var(--text-muted); }
+.inspector-value { color: var(--text); text-align: right; overflow-wrap: anywhere; }
+.inspector-muted { color: var(--text-muted); font-size: 11px; }
+.inspector-material-kind-control { width: 100%; min-height: 30px; }
+.inspector-manage-textures { width: 100%; color: var(--text); background: var(--surface-raised); border: 1px solid var(--border); }
+.inspector-manage-textures:hover { background: var(--surface-hover); }
+.inspector-texture-list { display: flex; flex-direction: column; gap: 4px; }
+.inspector-texture-option {
+  min-height: 30px; padding: 5px 8px; border: 1px solid var(--border); border-radius: var(--radius-sm);
+  color: var(--text-muted); background: var(--bg-canvas); text-align: left; cursor: pointer;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11px;
+}
+.inspector-texture-option:hover, .inspector-texture-option.selected {
+  color: var(--accent-soft); border-color: var(--accent-soft); background: var(--surface-active);
+}
+
+#mod-folder-empty[hidden] { display: none; }
+#mod-folder-empty .ui-button { margin-top: 5px; }
+.mod-folder-row { min-height: 32px; padding: 3px 0; }
+.mod-folder-select { min-height: 28px; }
+.mod-folder-expand { min-height: 0; }
+.mod-folder-actions button { width: 28px; height: 28px; }
+.mod-folder-actions button { min-height: 0; }
+.mod-folder-actions { gap: 4px; }
+
+#empty-actions {
+  position: fixed; top: calc(50% + 54px); left: 50%; z-index: 20;
+  display: flex; justify-content: center; gap: 8px; transform: translateX(-50%);
+}
+.empty-actions .ui-button { min-width: 112px; }
+#hint .msg { display: flex; flex-direction: column; gap: 6px; color: var(--text-muted); }
+#hint .msg strong { color: var(--text); font-size: 15px; }
+#hint .msg span { font-size: 11px; }
+.ui-button {
+  min-height: 32px; padding: 5px 11px; border: 1px solid var(--border);
+  border-radius: var(--radius-sm); color: var(--text); background: var(--surface-raised);
+  cursor: pointer; font-size: 12px; transition: background .12s, border-color .12s, transform .12s;
+}
+.ui-button:hover:not(:disabled) { background: var(--surface-hover); border-color: #485363; }
+.ui-button-primary { color: #fff; background: var(--success); border-color: rgba(240,246,252,.18); }
+.ui-button-primary:hover:not(:disabled) { background: var(--success-hover); }
+.ui-button:disabled { opacity: .45; cursor: default; }
+.footer-status { display: flex; align-items: center; gap: 12px; min-width: 0; }
+#interaction-help, #selected-mesh-status { color: var(--text-muted); font-size: 10px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+#selected-mesh-status { color: var(--accent-soft); }
+.ui-popover {
+  position: absolute; top: 48px; right: 12px; z-index: 240; display: flex;
+  flex-direction: column; gap: 3px; min-width: 132px; padding: 5px;
+  background: rgba(22,27,34,.98); border: 1px solid var(--border);
+  border-radius: var(--radius-md); box-shadow: 0 10px 28px rgba(0,0,0,.45);
+}
+.ui-popover[hidden] { display: none; }
+.ui-popover-option {
+  min-height: 30px; border: 0; border-radius: var(--radius-sm); color: var(--text-muted);
+  background: transparent; text-align: left; padding: 5px 9px; cursor: pointer; font-size: 11px;
+}
+.ui-popover-option:hover, .ui-popover-option.selected { color: var(--text); background: var(--surface-active); }
+#tool-panel.viewport-toolbar {
+  left: auto; right: 12px; bottom: 40px; transform: none; min-width: 0;
+  display: flex; flex-direction: column; align-items: center;
+  max-height: calc(100vh - 112px); overflow-y: auto;
+  padding: 7px; border-radius: var(--radius-md); background: rgba(13,17,23,.9);
+}
+#tool-panel.viewport-toolbar .panel-hdr { display: none; }
+#tool-panel.viewport-toolbar #tool-buttons { flex-direction: column; gap: 5px; }
+#tool-panel.viewport-toolbar .viewport-camera-buttons {
+  flex-direction: column; padding: 0 0 7px; margin: 0 0 2px;
+  border-right: 0; border-bottom: 1px solid var(--border);
+}
+#tool-panel.viewport-toolbar .camera-btn {
+  width: 38px; height: 38px; padding: 4px 2px 3px;
+}
+#tool-panel.viewport-toolbar .camera-btn svg { width: 17px; height: 17px; }
+#tool-panel.viewport-toolbar .camera-btn span { font-size: 8px; }
+.tool-popover {
+  position: fixed; top: auto; right: 72px; bottom: 104px;
+  min-width: 170px;
+}
+body.right-dock-visible #tool-panel.viewport-toolbar,
+body.right-dock-visible #tool-panel.viewport-toolbar { right: 338px; }
+body.right-dock-visible .tool-popover { right: 398px; }
+
+@media (max-width: 760px) {
+  #toolbar { gap: 8px; padding: 0 10px; }
+  .app-title { display: none; }
+  #mod-path { max-width: none; }
+  #health-btn { padding-inline: 8px; }
+  #health-btn .health-label { display: none; }
+  #health-btn { gap: 4px; }
+  #ini-view-btn { font-size: 0; }
+  #ini-view-btn::before { content: 'INI'; font-size: 12px; }
+  #right-dock { right: 8px; width: min(316px, calc(100vw - 16px)); }
+  #tool-panel.viewport-toolbar { right: 8px; }
+  body.right-dock-visible #tool-panel.viewport-toolbar { right: min(324px, calc(100vw - 8px)); }
+  body.right-dock-visible .tool-popover { right: min(384px, calc(100vw - 8px)); }
+  body.right-dock-visible #environment-popover { right: min(324px, calc(100vw - 8px)); }
+  #empty-actions { flex-direction: column; width: 160px; }
+  .footer-status { max-width: 70vw; }
+  #interaction-help { display: none; }
+}
+
+@media (max-width: 680px) {
+  #toolbar-more { display: inline-grid; place-items: center; }
+  #toolbar .toolbar-secondary { display: none; }
 }

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -29,9 +29,23 @@ body {
   overflow: hidden; user-select: none;
 }
 
+/* Keep every scrollable surface consistent across the app: docks, library
+ * lists, inspector content, menus, dialogs, and future panels. */
+* {
+  scrollbar-color: #485363 rgba(13,17,23,.45);
+  scrollbar-width: thin;
+}
+*::-webkit-scrollbar { width: 8px; height: 8px; }
+*::-webkit-scrollbar-track { background: rgba(13,17,23,.45); }
+*::-webkit-scrollbar-thumb {
+  background: #485363; border: 2px solid rgba(13,17,23,.45); border-radius: 8px;
+}
+*::-webkit-scrollbar-thumb:hover { background: #66758a; }
+*::-webkit-scrollbar-corner { background: transparent; }
+
 /* ── toolbar ─────────────────────────────────────────────────────────────── */
 #toolbar {
-  position: fixed; top: 0; left: 0; right: 0; height: 46px;
+  position: fixed; top: 0; left: 0; right: 0; height: var(--toolbar-height);
   background: var(--bg-panel); border-bottom: 1px solid var(--border);
   display: flex; align-items: center; padding: 0 14px; gap: 10px; z-index: 100;
 }
@@ -40,8 +54,8 @@ body {
 #mod-path  {
   flex: 1; font-size: 11px; color: var(--text-muted);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  padding: 4px 8px; background: var(--bg-canvas); border-radius: 6px;
-  border: 1px solid var(--border); min-width: 0;
+  padding: 4px 2px; background: transparent; border-radius: 4px;
+  border: 1px solid transparent; min-width: 0;
 }
 #open-btn {
   background: var(--success); color: #fff; border: 1px solid rgba(240,246,252,.15);
@@ -99,7 +113,10 @@ body {
 }
 
 /* ── canvas ──────────────────────────────────────────────────────────────── */
-#canvas-container { position: fixed; top: 46px; left: 0; right: 0; bottom: 28px; }
+#canvas-container {
+  position: fixed; top: var(--toolbar-height); left: 0; right: 0;
+  bottom: var(--footer-height);
+}
 
 #renderer-error {
   display: none; position: absolute; inset: 0; z-index: 180;
@@ -115,7 +132,8 @@ body {
  * no right-side panel is visible and moves left to clear the dock otherwise.
  * It remains a DOM overlay so it stays crisp at every WebView scale factor. */
 #view-gizmo {
-  position: absolute; top: 86px; right: 12px; width: 104px; height: 104px;
+  position: absolute; top: calc(var(--toolbar-height) + 40px); right: 12px;
+  width: 104px; height: 104px;
   z-index: 9; border-radius: 50%; cursor: grab; touch-action: none;
   filter: drop-shadow(0 4px 10px rgba(0,0,0,.34));
   transition: opacity .16s ease, transform .16s ease;
@@ -152,7 +170,7 @@ body {
 
 /* ── footer ──────────────────────────────────────────────────────────────── */
 #footer {
-  position: fixed; bottom: 0; left: 0; right: 0; height: 28px;
+  position: fixed; bottom: 0; left: 0; right: 0; height: var(--footer-height);
   background: #161b22; border-top: 1px solid #30363d;
   display: flex; align-items: center; justify-content: space-between;
   padding: 0 14px; z-index: 100;
@@ -171,7 +189,7 @@ body {
 #left-dock {
   position: fixed; top: 58px; left: 12px; z-index: 110;
   display: flex; flex-direction: row; align-items: flex-start; gap: 10px;
-  max-height: calc(100vh - 104px);
+  max-height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
 }
 
 /* Mod Folders is an overlay owned by the left dock. It must not become a
@@ -179,7 +197,8 @@ body {
 #mod-folder-dock {
   position: fixed; top: 58px; left: 12px; z-index: 130;
   width: 288px; max-width: min(288px, calc(50vw - 36px));
-  height: calc(100vh - 116px); pointer-events: none;
+  height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
+  pointer-events: none;
 }
 #mod-folder-panel {
   width: 100%; height: 100%; min-height: 0;
@@ -218,6 +237,9 @@ body {
 .mod-folder-row { position: relative; display: flex; align-items: center; gap: 4px; min-height: 26px;
   padding: 2px 0; border-radius: 5px; }
 .mod-folder-row.active { background: rgba(31,111,235,.24); }
+.mod-folder-row.active-descendant {
+  box-shadow: inset 2px 0 0 var(--accent-soft); background: rgba(31,111,235,.09);
+}
 .mod-folder-row.missing { opacity: .58; }
 .mod-folder-expand { width: 20px; height: 22px; flex: 0 0 20px; padding: 0;
   border: 0; background: transparent; color: var(--text-muted); cursor: pointer;
@@ -264,7 +286,7 @@ body {
 /* ── right dock (toggle panel + menu panel) ──────────────────────────────── */
 #right-dock {
   position: fixed; top: 58px; right: 12px; z-index: 10;
-  max-height: calc(100vh - 104px);
+  max-height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
   display: flex; flex-direction: column; align-items: stretch; gap: 10px;
 }
 
@@ -275,7 +297,7 @@ body {
 }
 #sidebar {
   box-sizing: border-box; width: 288px; max-width: min(288px, calc(50vw - 36px));
-  max-height: calc(100vh - 104px); min-height: 0;
+  max-height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap)); min-height: 0;
   overflow-x: hidden; overflow-y: auto;
 }
 #camera-panel { display: none !important; }
@@ -324,7 +346,7 @@ body {
 /* ── toolbox (wireframe / grid) ───────────────────────────────────────────── */
 #tool-panel {
   display: block; min-width: 166px; padding: 9px 10px;
-  position: fixed; left: 50%; bottom: calc(28px + 12px);
+  position: fixed; left: 50%; bottom: calc(var(--footer-height) + 12px);
   transform: translateX(-50%); z-index: 200;
 }
 #tool-panel .panel-hdr { margin-bottom: 7px; }
@@ -358,6 +380,15 @@ body {
 #light-btn.off { background: var(--bg-control); color: var(--text); }
 #trackball-btn { background: var(--accent); }
 #trackball-btn.off { background: var(--bg-control); }
+.tool-btn.active,
+#grid-btn:not(.off), #shading-btn:not(.off), #glossy-btn:not(.off),
+#texture-btn:not(.off), #trackball-btn:not(.off),
+#light-btn.double, #light-btn.current {
+  background: rgba(31,111,235,.22); border-color: var(--accent-soft); color: var(--accent-soft);
+}
+#texture-btn.diffuse-only, #light-btn.current {
+  background: rgba(227,179,65,.18); border-color: var(--warning); color: #f2cc72;
+}
 .nav-gizmo-icon { width: 24px; height: 24px; overflow: visible; }
 .nav-gizmo-icon path { fill: none; stroke-width: 1.7; stroke-linecap: round; }
 .nav-gizmo-icon circle { stroke: none; }
@@ -415,6 +446,21 @@ body.right-dock-visible #environment-popover { right: 338px; }
   display: flex; align-items: center; justify-content: center; flex-shrink: 0; padding: 0;
 }
 .icon-btn:hover { background: #1f6feb; }
+.panel-actions { position: relative; display: inline-flex; align-items: center; }
+.panel-action-menu {
+  position: absolute; top: calc(100% + 5px); right: 0; z-index: 260;
+  display: flex; flex-direction: column; gap: 2px; min-width: 170px; padding: 5px;
+  background: rgba(22,27,34,.98); border: 1px solid var(--border);
+  border-radius: var(--radius-md); box-shadow: 0 10px 28px rgba(0,0,0,.45);
+}
+.panel-action-menu[hidden] { display: none; }
+.panel-action-menu button {
+  min-height: 30px; padding: 5px 8px; border: 0; border-radius: var(--radius-sm);
+  color: var(--text); background: transparent; text-align: left; cursor: pointer;
+  font: inherit; font-size: 11px; white-space: nowrap;
+}
+.panel-action-menu button:hover:not(:disabled) { background: var(--surface-active); }
+.panel-action-menu button:disabled { color: var(--text-muted); opacity: .55; cursor: default; }
 
 /* Collapse chevron, shared by both panels. */
 .group-toggle {
@@ -451,15 +497,7 @@ body.right-dock-visible #environment-popover { right: 338px; }
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   padding-right: 0;
 }
-.group-tex-btn {
-  position: absolute; top: 0; right: 0;
-  background: #21262d; border: 1px solid #30363d; color: #8b949e;
-  border-radius: 4px; width: 18px; height: 18px; font-size: 11px; padding: 0;
-  cursor: pointer; display: flex; align-items: center; justify-content: center;
-  flex-shrink: 0;
-}
-.group-tex-btn:hover { background: #30363d; color: #e6edf3; }
-.group-tex-btn.active { background: #1f6feb; color: #fff; border-color: rgba(240,246,252,.15); }
+.group-hdr.selected { color: var(--accent-soft); background: rgba(31,111,235,.12); border-radius: 4px; }
 .group-items { display: flex; flex-direction: column; gap: 3px; overflow: hidden; }
 .group-items.collapsed { display: none; }
 .draw-item-wrap { display: flex; flex-direction: column; }
@@ -478,25 +516,11 @@ body.right-dock-visible #environment-popover { right: 338px; }
   border-radius: 3px; font: inherit; outline: none;
 }
 
-.component-material-kind-control {
-  position: absolute; top: 0; right: 24px; width: 78px; min-width: 0;
-  box-sizing: border-box;
-}
 .material-kind-select {
   min-width: 0; width: 78px; padding: 1px 3px; color: #cdd9e5; background: #161b22;
   border: 1px solid #30363d; border-radius: 3px; font: inherit; cursor: pointer;
 }
 .material-kind-select:focus { border-color: #58a6ff; outline: none; }
-
-/* Per-mesh texture picker: one level deeper than .draw-item's own indent. */
-.tex-list { display: flex; flex-direction: column; gap: 2px; padding-left: 38px; margin: 2px 0 4px; }
-.tex-list.collapsed { display: none; }
-.tex-item {
-  font-size: 10px; color: #8b949e; cursor: pointer; padding: 2px 6px;
-  border-radius: 4px;
-}
-.tex-item:hover { background: #21262d; color: #e6edf3; }
-.tex-item.selected { background: rgba(88,166,255,.15); color: var(--accent-soft); outline: 1px solid var(--accent-soft); }
 
 /* Per-component "manage textures" popup (texture-modal.js) -- reuses the
  * toggle modal's .modal-backdrop/.modal chrome. */
@@ -639,7 +663,8 @@ body.right-dock-visible #environment-popover { right: 338px; }
 
 /* ── loading overlay ─────────────────────────────────────────────────────── */
 #loading {
-  display: none; position: fixed; inset: 46px 0 28px; z-index: 200;
+  display: none; position: fixed;
+  inset: var(--toolbar-height) 0 var(--footer-height); z-index: 200;
   background: rgba(13,17,23,.8); backdrop-filter: blur(4px);
   flex-direction: column; align-items: center; justify-content: center; gap: 16px;
 }
@@ -856,6 +881,10 @@ body.feature-modify-toggle-off .present-author-actions { display: none; }
  * behavior contract for the viewer modules; these tokens provide the shared
  * visual language around them. */
 :root {
+  --toolbar-height: 46px;
+  --footer-height: 28px;
+  --dock-gap: 30px;
+  --viewport-toolbar-width: 146px;
   --surface-raised: #1c232d;
   --surface-hover: #263241;
   --surface-active: rgba(88,166,255,.16);
@@ -917,7 +946,7 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 
 #right-dock {
   display: none; width: 316px; max-width: min(316px, calc(50vw - 24px));
-  gap: 8px; max-height: calc(100vh - 104px);
+  gap: 8px; max-height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
 }
 #right-dock.ui-visible { display: flex; }
 .right-dock-tabs {
@@ -941,10 +970,14 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 #inspector-panel[hidden], #controls-panel[hidden] { display: none !important; }
 #controls-panel {
   display: flex; flex-direction: column; align-items: stretch; gap: 10px;
-  min-height: 0; max-height: calc(100vh - 104px); overflow: hidden;
+  min-height: 0;
+  max-height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
+  overflow-y: auto; overflow-x: hidden;
 }
 #controls-panel > #present-panel, #controls-panel > #toggle-panel,
-#controls-panel > #menu-panel { width: 100%; max-width: none; }
+#controls-panel > #menu-panel {
+  width: 100%; max-width: none; flex: 0 0 auto; max-height: none; overflow: visible;
+}
 .inspector-empty, .mod-folder-empty {
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 7px; min-height: 150px; padding: 20px; text-align: center; color: var(--text-muted);
@@ -1023,15 +1056,19 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 }
 .ui-popover-option:hover, .ui-popover-option.selected { color: var(--text); background: var(--surface-active); }
 #tool-panel.viewport-toolbar {
-  left: auto; right: 12px; bottom: 40px; transform: none; min-width: 0;
+  left: auto; right: 12px; bottom: 40px; transform: none;
+  width: var(--viewport-toolbar-width); min-width: 0;
   display: flex; flex-direction: column; align-items: center;
-  max-height: calc(100vh - 112px); overflow-y: auto;
+  max-height: calc(100vh - var(--toolbar-height) - var(--footer-height) - 36px);
+  overflow-y: auto;
   padding: 7px; border-radius: var(--radius-md); background: rgba(13,17,23,.9);
 }
 #tool-panel.viewport-toolbar .panel-hdr { display: none; }
-#tool-panel.viewport-toolbar #tool-buttons { flex-direction: column; gap: 5px; }
+#tool-panel.viewport-toolbar #tool-buttons {
+  display: grid; grid-template-columns: repeat(3, 38px); gap: 5px;
+}
 #tool-panel.viewport-toolbar .viewport-camera-buttons {
-  flex-direction: column; padding: 0 0 7px; margin: 0 0 2px;
+  flex-direction: row; padding: 0 0 7px; margin: 0 0 7px;
   border-right: 0; border-bottom: 1px solid var(--border);
 }
 #tool-panel.viewport-toolbar .camera-btn {
@@ -1040,12 +1077,15 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 #tool-panel.viewport-toolbar .camera-btn svg { width: 17px; height: 17px; }
 #tool-panel.viewport-toolbar .camera-btn span { font-size: 8px; }
 .tool-popover {
-  position: fixed; top: auto; right: 72px; bottom: 104px;
+  position: fixed; top: auto;
+  right: calc(var(--viewport-toolbar-width) + 20px);
+  bottom: calc(var(--footer-height) + 76px);
   min-width: 170px;
 }
-body.right-dock-visible #tool-panel.viewport-toolbar,
 body.right-dock-visible #tool-panel.viewport-toolbar { right: 338px; }
-body.right-dock-visible .tool-popover { right: 398px; }
+body.right-dock-visible .tool-popover {
+  right: calc(338px + var(--viewport-toolbar-width) + 8px);
+}
 
 @media (max-width: 760px) {
   #toolbar { gap: 8px; padding: 0 10px; }
@@ -1059,7 +1099,11 @@ body.right-dock-visible .tool-popover { right: 398px; }
   #right-dock { right: 8px; width: min(316px, calc(100vw - 16px)); }
   #tool-panel.viewport-toolbar { right: 8px; }
   body.right-dock-visible #tool-panel.viewport-toolbar { right: min(324px, calc(100vw - 8px)); }
-  body.right-dock-visible .tool-popover { right: min(384px, calc(100vw - 8px)); }
+  #tool-panel.viewport-toolbar { right: 8px; }
+  .tool-popover { right: calc(var(--viewport-toolbar-width) + 16px); }
+  body.right-dock-visible .tool-popover {
+    right: min(478px, calc(100vw - 8px));
+  }
   body.right-dock-visible #environment-popover { right: min(324px, calc(100vw - 8px)); }
   #empty-actions { flex-direction: column; width: 160px; }
   .footer-status { max-width: 70vw; }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -10,20 +10,51 @@
      shown -- see app/server.py and the matching CSS rules in app.css. -->
 <body class="__BODY_CLASS__">
 
+<svg id="ui-icon-sprite" aria-hidden="true" focusable="false">
+  <symbol id="icon-library" viewBox="0 0 24 24"><path d="M4 6h6l2 2h8v11H4z"/><path d="M4 9h16"/></symbol>
+  <symbol id="icon-inspector" viewBox="0 0 24 24"><path d="M5 4h14v16H5zM8 8h8M8 12h5M8 16h8"/></symbol>
+  <symbol id="icon-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></symbol>
+  <symbol id="icon-more" viewBox="0 0 24 24"><circle cx="5" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="19" cy="12" r="1.5"/></symbol>
+  <symbol id="icon-reset" viewBox="0 0 24 24"><path d="M4 9V4h5M4.6 4.6A9 9 0 1 1 3 14"/></symbol>
+  <symbol id="icon-diagnostics" viewBox="0 0 24 24"><path d="M12 4 21 20H3L12 4Z"/><path d="M12 9v5M12 17v.5"/></symbol>
+  <symbol id="icon-edit" viewBox="0 0 24 24"><path d="m4 17-.8 4 4-.8L19 8.4 15.6 5 4 17Z"/><path d="m14 6.6 3.4 3.4M16.8 3.8l3.4 3.4"/></symbol>
+  <symbol id="icon-delete" viewBox="0 0 24 24"><path d="M5 7h14M9 7V4h6v3M7 7l1 13h8l1-13M10 11v5M14 11v5"/></symbol>
+  <symbol id="icon-visibility" viewBox="0 0 24 24"><path d="M3 12s3.2-5 9-5 9 5 9 5-3.2 5-9 5-9-5-9-5Z"/><circle cx="12" cy="12" r="2"/></symbol>
+  <symbol id="icon-texture" viewBox="0 0 24 24"><path d="M4 5h16v14H4zM7 16l3-4 2 2 2-3 3 5H7Z"/><circle cx="9" cy="9" r="1"/></symbol>
+  <symbol id="icon-wireframe" viewBox="0 0 24 24"><path d="m12 3 8 4.5v9L12 21l-8-4.5v-9L12 3ZM4 7.5l8 4.5 8-4.5M12 12v9"/></symbol>
+  <symbol id="icon-outline" viewBox="0 0 24 24"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="3"/></symbol>
+  <symbol id="icon-glossy" viewBox="0 0 24 24"><path d="m12 3 1.8 6.2L20 11l-6.2 1.8L12 19l-1.8-6.2L4 11l6.2-1.8L12 3Z"/><path d="m19 16 .7 2.3L22 19l-2.3.7L19 22l-.7-2.3L16 19l2.3-.7L19 16Z"/></symbol>
+  <symbol id="icon-grid" viewBox="0 0 24 24"><path d="M4 4h16v16H4zM4 10h16M4 16h16M10 4v16M16 4v16"/></symbol>
+  <symbol id="icon-shading" viewBox="0 0 24 24"><path d="M12 4a8 8 0 1 0 0 16 8 8 0 0 0 0-16Z"/><path d="M12 4v16"/></symbol>
+  <symbol id="icon-light" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3M4.9 4.9 7 7M17 17l2.1 2.1M19.1 4.9 17 7M7 17l-2.1 2.1"/></symbol>
+  <symbol id="icon-cycle" viewBox="0 0 24 24"><path d="M5 8h11l-3-3M19 16H8l3 3M16 8a6 6 0 0 1 3 5M8 16a6 6 0 0 1-3-5"/></symbol>
+  <symbol id="icon-record" viewBox="0 0 24 24"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="3" fill="currentColor" stroke="none"/></symbol>
+  <symbol id="icon-chevron-down" viewBox="0 0 24 24"><path d="m5 9 7 7 7-7"/></symbol>
+  <symbol id="icon-chevron-right" viewBox="0 0 24 24"><path d="m9 5 7 7-7 7"/></symbol>
+  <symbol id="icon-close" viewBox="0 0 24 24"><path d="m5 5 14 14M19 5 5 19"/></symbol>
+</svg>
+
 <div id="toolbar">
-  <span class="app-icon">🎮</span>
-  <span class="app-title">3DMigoto Mod Viewer</span>
+  <span class="app-icon" aria-hidden="true"><span class="icon-glyph">M</span></span>
+  <span class="app-title">Mod Viewer</span>
   <span id="mod-path">No mod loaded</span>
-  <span id="pending-indicator" class="pending-indicator">● Unsaved changes</span>
-  <button id="open-btn" disabled>📂 Open Mod</button>
-  <div class="ini-view-wrap">
-    <button id="ini-view-btn" disabled>📄 View INI</button>
+  <span id="pending-indicator" class="pending-indicator" role="status">Edited</span>
+  <button id="open-btn" class="ui-button" disabled>Open Mod</button>
+  <div class="ini-view-wrap toolbar-secondary">
+    <button id="ini-view-btn" class="ui-button" disabled>View INI</button>
     <div id="ini-file-menu" class="ini-file-menu" role="menu"></div>
   </div>
-  <button id="health-btn" class="healthy" disabled>
-    Diagnostics <span id="health-count" class="health-count">0</span>
+  <button id="health-btn" class="ui-button healthy toolbar-secondary" aria-label="Open INI diagnostics" disabled>
+    <svg class="ui-icon" aria-hidden="true"><use href="#icon-diagnostics"></use></svg><span class="health-label">Diagnostics</span><span id="health-count" class="health-count">0</span>
   </button>
-  <button id="export-btn" disabled>💾 Export</button>
+  <button id="export-btn" class="ui-button ui-button-export toolbar-secondary" disabled>Export</button>
+  <button id="toolbar-more" class="icon-btn" type="button" aria-label="More toolbar actions"
+          aria-expanded="false" aria-haspopup="menu"><svg class="ui-icon" aria-hidden="true"><use href="#icon-more"></use></svg></button>
+  <div id="toolbar-overflow" class="toolbar-overflow" role="menu" hidden>
+    <button type="button" role="menuitem" data-toolbar-target="ini-view-btn">View INI</button>
+    <button type="button" role="menuitem" data-toolbar-target="health-btn">Diagnostics</button>
+    <button type="button" role="menuitem" data-toolbar-target="export-btn">Export</button>
+  </div>
 </div>
 
 <div id="canvas-container">
@@ -59,6 +90,7 @@
     </button>
     <span id="environment-label" class="environment-label">Default</span>
   </div>
+  <div id="environment-popover" class="ui-popover" role="menu" aria-label="Environment presets" hidden></div>
   <div id="view-gizmo" title="Drag to orbit · Click an axis to snap · Scroll to zoom">
     <svg viewBox="0 0 104 104" aria-label="Camera navigation gizmo">
       <circle class="gizmo-backdrop" cx="52" cy="52" r="46"/>
@@ -76,32 +108,38 @@
 <div id="left-dock">
   <div id="mod-folder-dock" class="mod-folder-dock">
     <button id="mod-folder-toggle" class="mod-folder-handle" type="button"
-            aria-label="Open Mod Folders" aria-expanded="false">▶</button>
-    <section id="mod-folder-panel" class="mod-folder-panel" aria-label="Mod Folders">
+            aria-label="Open Mod Library" aria-expanded="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-library"></use></svg></button>
+    <section id="mod-folder-panel" class="mod-folder-panel" aria-label="Mod Library">
       <div class="panel-hdr">
         <button id="mod-folder-close" class="mod-folder-close" type="button"
-              aria-label="Close Mod Folders">◀</button>
-        <h3>Mod Folders</h3>
+              aria-label="Close Mod Library"><svg class="ui-icon" aria-hidden="true"><use href="#icon-close"></use></svg></button>
+        <h3>Mod Library</h3>
         <button id="mod-folder-add" class="icon-btn" type="button"
-                title="Add Mod Folder">+</button>
+                title="Add Mod Folder"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
       </div>
       <div id="mod-folder-error" class="mod-folder-error" role="alert"></div>
       <div id="mod-folder-list" class="mod-folder-list"></div>
+      <div id="mod-folder-empty" class="mod-folder-empty" hidden>
+        <div class="empty-icon" aria-hidden="true"><svg class="ui-icon"><use href="#icon-library"></use></svg></div>
+        <strong>No mod folders yet</strong>
+        <span>Add frequently used mod folders here for quick access.</span>
+        <button id="mod-folder-empty-add" class="ui-button ui-button-primary" type="button">Add Mod Folder</button>
+      </div>
     </section>
   </div>
 
   <div id="sidebar">
     <div class="panel-hdr">
-      <span class="group-toggle">▼</span>
+      <button type="button" class="group-toggle" aria-expanded="true" aria-controls="mesh-list"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
       <h3>Meshes</h3>
-      <button id="reset-state-btn" class="icon-btn" title="Reset mesh visibility">⟲</button>
+      <button id="reset-state-btn" class="icon-btn" title="Reset mesh visibility" aria-label="Reset mesh visibility"><svg class="ui-icon" aria-hidden="true"><use href="#icon-reset"></use></svg></button>
     </div>
     <div id="mesh-list"></div>
   </div>
 
   <div id="camera-panel">
     <div class="panel-hdr">
-      <span class="group-toggle">▼</span>
+      <button type="button" class="group-toggle" aria-expanded="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
       <h3>Orientation</h3>
     </div>
     <div id="camera-buttons">
@@ -120,20 +158,21 @@
     </div>
   </div>
 
-  <div id="tool-panel">
+  <div id="tool-panel" class="viewport-toolbar">
+    <div id="viewport-camera-buttons" class="viewport-camera-buttons" aria-label="Viewport orientation"></div>
     <div class="panel-hdr">
-      <span class="group-toggle">▼</span>
+      <button type="button" class="group-toggle" aria-expanded="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
       <h3>Tools</h3>
     </div>
     <div id="tool-buttons">
-      <button id="wire-btn" class="tool-btn" title="Wireframe rendering">⬡</button>
-      <button id="outline-btn" class="tool-btn" title="Silhouette outlines" aria-label="Silhouette outlines">◉</button>
-      <button id="glossy-btn" class="tool-btn off" title="Glossy materials: off" aria-label="Glossy materials: off" aria-pressed="false">✦</button>
-      <button id="grid-btn" class="tool-btn" title="Grid visibility">⊞</button>
-      <button id="shading-btn" class="tool-btn" title="Smooth/flat shading">◐</button>
-      <button id="texture-btn" class="tool-btn" title="Textures: all maps" aria-label="Textures: all maps">▩</button>
-      <button id="light-btn" class="tool-btn double" title="Key light: double brightness and handle size" aria-label="Key light: double">☀</button>
-      <button id="trackball-btn" class="tool-btn active" title="Toggle navigation gizmo" aria-label="Toggle navigation gizmo">
+      <button id="wire-btn" class="tool-btn" title="Wireframe rendering: off" aria-label="Wireframe rendering: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-wireframe"></use></svg></button>
+      <button id="outline-btn" class="tool-btn" title="Silhouette outlines: off" aria-label="Silhouette outlines: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-outline"></use></svg></button>
+      <button id="glossy-btn" class="tool-btn off" title="Glossy materials: off" aria-label="Glossy materials: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-glossy"></use></svg></button>
+      <button id="grid-btn" class="tool-btn" title="Grid visibility: on" aria-label="Grid visibility: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-grid"></use></svg></button>
+      <button id="shading-btn" class="tool-btn" title="Smooth shading: on" aria-label="Smooth shading: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-shading"></use></svg></button>
+      <button id="texture-btn" class="tool-btn" title="Textures: all maps" aria-label="Textures: all maps"><svg class="ui-icon" aria-hidden="true"><use href="#icon-texture"></use></svg></button>
+      <button id="light-btn" class="tool-btn double" title="Key light: double brightness and handle size" aria-label="Key light: double" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-light"></use></svg></button>
+      <button id="trackball-btn" class="tool-btn active" title="Toggle navigation gizmo: on" aria-label="Toggle navigation gizmo: on" aria-pressed="true">
         <svg class="nav-gizmo-icon" viewBox="0 0 24 24" aria-hidden="true">
           <path class="nav-x" d="M12 12L20 15"/><path class="nav-y" d="M12 12V3"/><path class="nav-z" d="M12 12L5 18"/>
           <circle class="nav-x" cx="20" cy="15" r="2"/><circle class="nav-y" cx="12" cy="3" r="2"/><circle class="nav-z" cx="5" cy="18" r="2"/>
@@ -144,31 +183,49 @@
 </div>
 
 <div id="right-dock">
+  <div class="right-dock-tabs" role="tablist" aria-label="Details panels">
+    <button id="inspector-tab" class="right-dock-tab active" type="button" role="tab"
+            aria-selected="true" aria-controls="inspector-panel">Inspector</button>
+    <button id="controls-tab" class="right-dock-tab" type="button" role="tab"
+            aria-selected="false" aria-controls="controls-panel">Controls</button>
+  </div>
+  <section id="inspector-panel" class="right-dock-pane" role="tabpanel" aria-labelledby="inspector-tab">
+    <div class="inspector-empty" id="inspector-empty">
+      <div class="empty-icon" aria-hidden="true"><svg class="ui-icon"><use href="#icon-inspector"></use></svg></div>
+      <strong>Nothing selected</strong>
+      <span>Select a component or mesh to inspect its properties.</span>
+    </div>
+    <div id="inspector-content" hidden></div>
+  </section>
+  <div id="controls-panel" class="right-dock-pane" role="tabpanel" aria-labelledby="controls-tab" hidden>
   <div id="present-panel">
     <div class="panel-hdr">
-      <span class="group-toggle">&#9660;</span>
+      <button type="button" class="group-toggle" aria-expanded="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
       <h3>Present</h3>
-      <button id="present-action-btn" class="icon-btn" title="Add PRESENT">+</button>
+      <button id="present-action-btn" class="icon-btn" title="Add PRESENT" aria-label="Add PRESENT"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
     </div>
     <div id="present-list"></div>
   </div>
 
   <div id="toggle-panel">
     <div class="panel-hdr">
-      <span class="group-toggle">▼</span>
+      <button type="button" class="group-toggle" aria-expanded="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
       <h3>Key Toggle</h3>
-      <button id="toggle-add-btn" class="icon-btn" title="Add toggle">＋</button>
+      <button id="toggle-add-btn" class="icon-btn" title="Add toggle" aria-label="Add toggle"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
     </div>
     <div id="toggle-list"></div>
   </div>
 
   <div id="menu-panel">
     <div class="panel-hdr">
-      <span class="group-toggle">▼</span>
+      <button type="button" class="group-toggle" aria-expanded="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
       <h3>Menu Toggle</h3>
     </div>
     <div id="menu-list"></div>
   </div>
+  </div>
+  <div id="texture-popover" class="ui-popover tool-popover" role="menu" aria-label="Texture display options" hidden></div>
+  <div id="light-popover" class="ui-popover tool-popover" role="menu" aria-label="Light options" hidden></div>
 </div>
 
 <div id="mod-folder-modal-backdrop" class="modal-backdrop">
@@ -265,7 +322,7 @@
     <h4 id="texm-title">Manage Textures</h4>
     <div id="texm-list" class="texm-list"></div>
     <div class="modal-actions">
-      <button type="button" id="texm-add">＋ Add texture…</button>
+      <button type="button" id="texm-add"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg> Add texture…</button>
       <button type="button" id="texm-close">Close</button>
     </div>
   </div>
@@ -329,13 +386,20 @@
 </div>
 
 <div id="hint">
-  <div class="big">📦</div>
-  <div class="msg">Click <strong>Open Mod</strong> and select a mod folder</div>
+  <div class="big"><svg class="ui-icon" aria-hidden="true"><use href="#icon-library"></use></svg></div>
+  <div class="msg"><strong>No mod loaded</strong><span>Open a mod folder directly, or add a folder to your Mod Library.</span></div>
 </div>
 
-<div id="info">Drag to rotate &nbsp;·&nbsp; Scroll to zoom &nbsp;·&nbsp; Right-drag to pan</div>
+<div id="empty-actions" class="empty-actions">
+  <button id="empty-open-btn" class="ui-button ui-button-primary" type="button" disabled>Open Mod</button>
+  <button id="empty-add-folder-btn" class="ui-button" type="button" disabled>Add Mod Folder</button>
+</div>
 
 <div id="footer">
+  <div id="footer-status" class="footer-status">
+    <span id="interaction-help">LMB Orbit · RMB Pan · Wheel Zoom</span>
+    <span id="selected-mesh-status" aria-live="polite"></span>
+  </div>
   <span id="app-version">v__APP_VERSION__</span>
   <a id="github-link" href="__REPO_URL__" title="GitHub Repository" target="_blank" rel="noopener noreferrer">
     <svg viewBox="0 0 16 16" width="18" height="18" aria-hidden="true">

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -108,8 +108,6 @@
 
 <div id="left-dock">
   <div id="mod-folder-dock" class="mod-folder-dock">
-    <button id="mod-folder-toggle" class="mod-folder-handle" type="button"
-            aria-label="Open Mod Library" aria-expanded="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-library"></use></svg></button>
     <section id="mod-folder-panel" class="mod-folder-panel" aria-label="Mod Library">
       <div class="panel-hdr">
         <button id="mod-folder-close" class="mod-folder-close" type="button"
@@ -134,6 +132,8 @@
       <button type="button" class="group-toggle" aria-expanded="true" aria-controls="mesh-list"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
       <h3>Meshes</h3>
       <button id="reset-state-btn" class="icon-btn" title="Reset mesh visibility" aria-label="Reset mesh visibility"><svg class="ui-icon" aria-hidden="true"><use href="#icon-reset"></use></svg></button>
+      <button id="mod-folder-toggle" class="icon-btn mesh-library-btn" type="button"
+              title="Open Mod Library" aria-label="Open Mod Library" aria-expanded="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-library"></use></svg></button>
     </div>
     <div id="mesh-list"></div>
   </div>
@@ -404,7 +404,8 @@
 
 <div id="empty-actions" class="empty-actions">
   <button id="empty-open-btn" class="ui-button ui-button-primary" type="button" disabled>Open Mod</button>
-  <button id="empty-add-folder-btn" class="ui-button" type="button" disabled>Add Mod Folder</button>
+  <button id="empty-add-folder-btn" class="ui-button" type="button"
+          aria-label="Add Mod Folder" disabled>Add Mod Folder</button>
 </div>
 
 <div id="footer">

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -161,10 +161,6 @@
 
   <div id="tool-panel" class="viewport-toolbar">
     <div id="viewport-camera-buttons" class="viewport-camera-buttons" aria-label="Viewport orientation"></div>
-    <div class="panel-hdr">
-      <button type="button" class="group-toggle" aria-expanded="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
-      <h3>Tools</h3>
-    </div>
     <div id="tool-buttons">
       <button id="wire-btn" class="tool-btn" title="Wireframe rendering: off" aria-label="Wireframe rendering: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-wireframe"></use></svg></button>
       <button id="outline-btn" class="tool-btn" title="Silhouette outlines: off" aria-label="Silhouette outlines: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-outline"></use></svg></button>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -30,6 +30,7 @@
   <symbol id="icon-cycle" viewBox="0 0 24 24"><path d="M5 8h11l-3-3M19 16H8l3 3M16 8a6 6 0 0 1 3 5M8 16a6 6 0 0 1-3-5"/></symbol>
   <symbol id="icon-record" viewBox="0 0 24 24"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="3" fill="currentColor" stroke="none"/></symbol>
   <symbol id="icon-chevron-down" viewBox="0 0 24 24"><path d="m5 9 7 7 7-7"/></symbol>
+  <symbol id="icon-chevron-left" viewBox="0 0 24 24"><path d="m14 5-7 7 7 7"/></symbol>
   <symbol id="icon-chevron-right" viewBox="0 0 24 24"><path d="m9 5 7 7-7 7"/></symbol>
   <symbol id="icon-close" viewBox="0 0 24 24"><path d="m5 5 14 14M19 5 5 19"/></symbol>
 </svg>
@@ -112,7 +113,7 @@
     <section id="mod-folder-panel" class="mod-folder-panel" aria-label="Mod Library">
       <div class="panel-hdr">
         <button id="mod-folder-close" class="mod-folder-close" type="button"
-              aria-label="Close Mod Library"><svg class="ui-icon" aria-hidden="true"><use href="#icon-close"></use></svg></button>
+              aria-label="Close Mod Library"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-left"></use></svg></button>
         <h3>Mod Library</h3>
         <button id="mod-folder-add" class="icon-btn" type="button"
                 title="Add Mod Folder"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
@@ -202,7 +203,18 @@
     <div class="panel-hdr">
       <button type="button" class="group-toggle" aria-expanded="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
       <h3>Present</h3>
-      <button id="present-action-btn" class="icon-btn" title="Add PRESENT" aria-label="Add PRESENT"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
+      <span class="panel-actions present-key-actions">
+        <button id="present-action-btn" class="icon-btn" type="button"
+                title="More PRESENT actions" aria-label="More PRESENT actions"
+                aria-expanded="false" aria-haspopup="menu">
+          <svg class="ui-icon" aria-hidden="true"><use href="#icon-more"></use></svg>
+        </button>
+        <span id="present-key-menu" class="panel-action-menu" role="menu" hidden>
+          <button id="present-key-add" type="button" role="menuitem">Add PRESENT</button>
+          <button id="present-key-edit" type="button" role="menuitem">Edit key binding</button>
+          <button id="present-key-remove" type="button" role="menuitem">Remove PRESENT key</button>
+        </span>
+      </span>
     </div>
     <div id="present-list"></div>
   </div>

--- a/src/web/js/health-report.js
+++ b/src/web/js/health-report.js
@@ -120,6 +120,9 @@ export function setHealthReport(report) {
   button.title = !report ? (reportLoader ? 'Run INI diagnostics' : 'Open a mod to run INI diagnostics')
     : count ? `${count} INI diagnostic issue${count === 1 ? '' : 's'}`
       : 'No INI issues found';
+  button.setAttribute('aria-label', !report
+    ? (reportLoader ? 'Run INI diagnostics' : 'Open a mod to run INI diagnostics')
+    : `${count} INI diagnostic issue${count === 1 ? '' : 's'}. Open diagnostics`);
   if ($('health-modal-backdrop').classList.contains('show')) renderReport();
 }
 

--- a/src/web/js/inspector-panel.js
+++ b/src/web/js/inspector-panel.js
@@ -2,12 +2,23 @@
 // this module only presents the already-authoritative mesh/component state.
 
 import { setRightDockTab } from './right-dock.js';
+import { clearSelection } from './selection.js';
 
 const meshRecords = new WeakMap();
 let current = null;
 let selectionCount = 0;
 
 const $ = id => document.getElementById(id);
+
+const MATERIAL_KIND_OPTIONS = Object.freeze([
+  ['auto', 'Auto'],
+  ['body', 'Body'],
+  ['face', 'Face'],
+  ['hair', 'Hair'],
+  ['eye', 'Eye'],
+  ['weapon', 'Weapon'],
+  ['special', 'Special'],
+]);
 
 export function registerInspectorMesh(mesh, record) {
   if (mesh) meshRecords.set(mesh, record);
@@ -57,7 +68,7 @@ function buildHeader(content, title, subtitle) {
 }
 
 function buildTextureControls(content, record, mesh) {
-  const sourceList = record.textureList;
+  const component = record.component;
   const section = document.createElement('section');
   section.className = 'inspector-section';
   const title = document.createElement('div');
@@ -65,27 +76,66 @@ function buildTextureControls(content, record, mesh) {
   title.textContent = 'Texture override';
   section.appendChild(title);
 
-  const rows = sourceList?.querySelectorAll('.tex-item') || [];
-  if (!rows.length) {
-    addText(section, 'inspector-muted', 'No texture variants registered.');
-  } else {
-    const list = document.createElement('div');
-    list.className = 'inspector-texture-list';
-    rows.forEach(row => {
-      const clone = document.createElement('button');
-      clone.type = 'button';
-      clone.className = 'inspector-texture-option';
-      clone.textContent = row.textContent;
-      clone.classList.toggle('selected', row.classList.contains('selected'));
-      clone.addEventListener('click', () => row.click());
-      list.appendChild(clone);
+  const pool = component?.texturePool || [];
+  const override = component?.getTextureOverride?.(mesh) || {
+    value: undefined, automatic: true, resolved: null,
+  };
+  const list = document.createElement('div');
+  list.className = 'inspector-texture-list';
+  const addOption = (label, value, selected, choice) => {
+    const option = document.createElement('button');
+    option.type = 'button';
+    option.className = 'inspector-texture-option';
+    option.textContent = label;
+    option.dataset.textureChoice = choice;
+    option.dataset.textureValue = value == null ? '' : value;
+    option.classList.toggle('selected', selected);
+    option.addEventListener('click', () => {
+      component?.setTextureOverride?.(mesh, value);
     });
-    section.appendChild(list);
+    list.appendChild(option);
+  };
+  addOption(
+    override.resolved ? `Automatic (${override.resolved})` : 'Automatic',
+    undefined, override.automatic, 'automatic');
+  pool.forEach(option => addOption(
+    option.label || option.file || option.tex_key,
+    option.tex_key, !override.automatic && override.value === option.tex_key,
+    'texture'));
+  addOption('None', null, !override.automatic && override.value === null, 'none');
+  if (!pool.length) {
+    addText(section, 'inspector-muted', 'No texture variants registered.');
   }
+  section.appendChild(list);
   if (mesh?.userData?.resolvedTexKey) {
     addRow(section, 'Resolved', mesh.userData.resolvedTexKey);
   }
   content.appendChild(section);
+}
+
+function buildMaterialControl(record) {
+  const select = document.createElement('select');
+  select.className = 'inspector-material-kind-control material-kind-select';
+  select.setAttribute('aria-label', 'Material kind');
+  MATERIAL_KIND_OPTIONS.forEach(([value, label]) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    select.appendChild(option);
+  });
+  const getKind = record.getMaterialKind || (() => null);
+  const setKind = record.setMaterialKind;
+  select.value = getKind() || 'auto';
+  select.disabled = typeof setKind !== 'function';
+  select.addEventListener('change', async () => {
+    if (typeof setKind !== 'function') return;
+    const previous = getKind() || 'auto';
+    select.disabled = true;
+    const saved = await setKind(select.value);
+    if (!saved) select.value = previous;
+    select.disabled = false;
+  });
+  return select;
 }
 
 function buildComponent(record) {
@@ -106,22 +156,13 @@ function buildComponent(record) {
   title.className = 'inspector-section-title';
   title.textContent = 'Material';
   material.appendChild(title);
-  if (record.materialSelect) {
-    const select = record.materialSelect.cloneNode(true);
-    select.className = 'inspector-material-kind-control material-kind-select';
-    select.removeAttribute('id');
-    select.addEventListener('change', () => {
-      record.materialSelect.value = select.value;
-      record.materialSelect.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-    material.appendChild(select);
-  }
-  if (record.texBtn) {
+  if (record.setMaterialKind) material.appendChild(buildMaterialControl(record));
+  if (record.openTextureManager) {
     const manage = document.createElement('button');
     manage.type = 'button';
     manage.className = 'ui-button inspector-manage-textures';
     manage.textContent = 'Manage textures';
-    manage.addEventListener('click', () => record.texBtn.click());
+    manage.addEventListener('click', () => record.openTextureManager());
     material.appendChild(manage);
   }
   content.appendChild(material);
@@ -170,22 +211,13 @@ function buildMesh(mesh, record) {
   materialTitle.textContent = 'Material';
   material.appendChild(materialTitle);
   const component = record.component;
-  if (component?.materialSelect) {
-    const select = component.materialSelect.cloneNode(true);
-    select.className = 'inspector-material-kind-control material-kind-select';
-    select.removeAttribute('id');
-    select.addEventListener('change', () => {
-      component.materialSelect.value = select.value;
-      component.materialSelect.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-    material.appendChild(select);
-  }
-  if (component?.texBtn) {
+  if (component?.setMaterialKind) material.appendChild(buildMaterialControl(component));
+  if (component?.openTextureManager) {
     const manage = document.createElement('button');
     manage.type = 'button';
     manage.className = 'ui-button inspector-manage-textures';
     manage.textContent = 'Manage textures';
-    manage.addEventListener('click', () => component.texBtn.click());
+    manage.addEventListener('click', () => component.openTextureManager());
     material.appendChild(manage);
   }
   content.appendChild(material);
@@ -233,18 +265,44 @@ function updateInspectorState() {
       resolved.querySelector('.inspector-value').textContent =
         mesh.userData.resolvedTexKey || 'None';
     }
+    const material = content.querySelector('.inspector-material-kind-control');
+    if (material) material.value = current.record.component.getMaterialKind?.() || 'auto';
+    const override = current.record.component.getTextureOverride?.(mesh);
+    if (override) {
+      content.querySelectorAll('.inspector-texture-option').forEach(option => {
+        const selected = option.dataset.textureChoice === 'automatic'
+          ? override.automatic
+          : option.dataset.textureChoice === 'none'
+            ? !override.automatic && override.value === null
+            : !override.automatic && override.value === option.dataset.textureValue;
+        option.classList.toggle('selected', selected);
+      });
+    }
   } else if (current.type === 'component') {
     const meshes = current.record.meshes || [];
     if (values.has('Visible')) {
       values.get('Visible').textContent =
         `${meshes.filter(mesh => mesh.visible).length} of ${meshes.length}`;
     }
+    const material = content.querySelector('.inspector-material-kind-control');
+    if (material) material.value = current.record.getMaterialKind?.() || 'auto';
+    content.querySelectorAll('.inspector-row').forEach(row => {
+      const label = row.querySelector('.inspector-label')?.textContent;
+      if (!label || label === 'Visible' || label === 'Draw calls') return;
+      const mesh = meshes.find(item =>
+        (item.userData.displayName || 'Mesh') === label);
+      if (mesh) row.querySelector('.inspector-value').textContent =
+        mesh.visible ? 'Visible' : 'Hidden';
+    });
   }
 }
 
 function selectComponent(record) {
+  if (current?.type === 'component') current.record.header?.classList.remove('selected');
+  clearSelection();
   if (selectionCount++ === 0) setRightDockTab('inspector', { persist: false });
   current = { type: 'component', record };
+  record.header?.classList.add('selected');
   buildComponent(record);
   const status = $('selected-mesh-status');
   if (status) status.textContent = record.component || 'Component';
@@ -254,6 +312,7 @@ function selectMesh(mesh) {
   const record = meshRecords.get(mesh);
   if (!record) return;
   if (selectionCount++ === 0) setRightDockTab('inspector', { persist: false });
+  if (current?.type === 'component') current.record.header?.classList.remove('selected');
   current = { type: 'mesh', mesh, record };
   buildMesh(mesh, record);
   const status = $('selected-mesh-status');
@@ -271,6 +330,7 @@ export function initInspectorPanel() {
   window.addEventListener('mod-viewer-mesh-selected', event => {
     if (event.detail?.mesh) selectMesh(event.detail.mesh);
     else {
+      if (current?.type === 'component') current.record.header?.classList.remove('selected');
       current = null;
       $('selected-mesh-status').textContent = '';
       clearContent();
@@ -292,10 +352,19 @@ export function initInspectorPanel() {
       buildMesh(current.mesh, current.record);
     }
   });
+  window.addEventListener('mod-viewer-mesh-state-changed', event => {
+    const changed = event.detail?.meshes || [];
+    if (!current || !changed.length) return;
+    const affected = current.type === 'mesh'
+      ? changed.includes(current.mesh)
+      : (current.record.meshes || []).some(mesh => changed.includes(mesh));
+    if (affected) updateInspectorState();
+  });
   clearContent();
 }
 
 export function clearInspector() {
+  if (current?.type === 'component') current.record.header?.classList.remove('selected');
   current = null;
   selectionCount = 0;
   $('selected-mesh-status').textContent = '';

--- a/src/web/js/inspector-panel.js
+++ b/src/web/js/inspector-panel.js
@@ -1,0 +1,307 @@
+// Selection-aware details panel.  Mesh creation remains owned by mesh-panel;
+// this module only presents the already-authoritative mesh/component state.
+
+import { setRightDockTab } from './right-dock.js';
+
+const meshRecords = new WeakMap();
+let current = null;
+let selectionCount = 0;
+
+const $ = id => document.getElementById(id);
+
+export function registerInspectorMesh(mesh, record) {
+  if (mesh) meshRecords.set(mesh, record);
+}
+
+function clearContent() {
+  const empty = $('inspector-empty');
+  const content = $('inspector-content');
+  if (empty) empty.hidden = false;
+  if (content) {
+    content.hidden = true;
+    content.replaceChildren();
+  }
+}
+
+function showContent() {
+  $('inspector-empty')?.setAttribute('hidden', '');
+  const content = $('inspector-content');
+  if (content) content.hidden = false;
+  return content;
+}
+
+function addText(parent, className, text) {
+  const node = document.createElement('span');
+  node.className = className;
+  node.textContent = text;
+  parent.appendChild(node);
+  return node;
+}
+
+function addRow(parent, label, value) {
+  const row = document.createElement('div');
+  row.className = 'inspector-row';
+  addText(row, 'inspector-label', label);
+  addText(row, 'inspector-value', value || '—');
+  parent.appendChild(row);
+}
+
+function buildHeader(content, title, subtitle) {
+  const header = document.createElement('div');
+  header.className = 'inspector-header';
+  addText(header, 'inspector-kicker', subtitle);
+  const heading = document.createElement('h3');
+  heading.textContent = title;
+  header.appendChild(heading);
+  content.appendChild(header);
+}
+
+function buildTextureControls(content, record, mesh) {
+  const sourceList = record.textureList;
+  const section = document.createElement('section');
+  section.className = 'inspector-section';
+  const title = document.createElement('div');
+  title.className = 'inspector-section-title';
+  title.textContent = 'Texture override';
+  section.appendChild(title);
+
+  const rows = sourceList?.querySelectorAll('.tex-item') || [];
+  if (!rows.length) {
+    addText(section, 'inspector-muted', 'No texture variants registered.');
+  } else {
+    const list = document.createElement('div');
+    list.className = 'inspector-texture-list';
+    rows.forEach(row => {
+      const clone = document.createElement('button');
+      clone.type = 'button';
+      clone.className = 'inspector-texture-option';
+      clone.textContent = row.textContent;
+      clone.classList.toggle('selected', row.classList.contains('selected'));
+      clone.addEventListener('click', () => row.click());
+      list.appendChild(clone);
+    });
+    section.appendChild(list);
+  }
+  if (mesh?.userData?.resolvedTexKey) {
+    addRow(section, 'Resolved', mesh.userData.resolvedTexKey);
+  }
+  content.appendChild(section);
+}
+
+function buildComponent(record) {
+  const content = showContent();
+  content.replaceChildren();
+  const meshes = record.meshes || [];
+  buildHeader(content, record.component || 'Component', record.source || 'Component');
+
+  const summary = document.createElement('section');
+  summary.className = 'inspector-section inspector-summary';
+  addRow(summary, 'Draw calls', String(meshes.length));
+  addRow(summary, 'Visible', `${meshes.filter(mesh => mesh.visible).length} of ${meshes.length}`);
+  content.appendChild(summary);
+
+  const material = document.createElement('section');
+  material.className = 'inspector-section';
+  const title = document.createElement('div');
+  title.className = 'inspector-section-title';
+  title.textContent = 'Material';
+  material.appendChild(title);
+  if (record.materialSelect) {
+    const select = record.materialSelect.cloneNode(true);
+    select.className = 'inspector-material-kind-control material-kind-select';
+    select.removeAttribute('id');
+    select.addEventListener('change', () => {
+      record.materialSelect.value = select.value;
+      record.materialSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    material.appendChild(select);
+  }
+  if (record.texBtn) {
+    const manage = document.createElement('button');
+    manage.type = 'button';
+    manage.className = 'ui-button inspector-manage-textures';
+    manage.textContent = 'Manage textures';
+    manage.addEventListener('click', () => record.texBtn.click());
+    material.appendChild(manage);
+  }
+  content.appendChild(material);
+
+  const poolSection = document.createElement('section');
+  poolSection.className = 'inspector-section';
+  const poolTitle = document.createElement('div');
+  poolTitle.className = 'inspector-section-title';
+  poolTitle.textContent = 'Texture pool';
+  poolSection.appendChild(poolTitle);
+  const pool = record.texturePool || [];
+  if (!pool.length) addText(poolSection, 'inspector-muted', 'No texture variants registered.');
+  else pool.forEach(option => addRow(poolSection, option.label, option.file || option.tex_key));
+  content.appendChild(poolSection);
+
+  if (meshes.length) {
+    const meshList = document.createElement('section');
+    meshList.className = 'inspector-section';
+    const title = document.createElement('div');
+    title.className = 'inspector-section-title';
+    title.textContent = 'Meshes in component';
+    meshList.appendChild(title);
+    meshes.forEach(mesh => addRow(meshList, mesh.userData.displayName || 'Mesh',
+      mesh.visible ? 'Visible' : 'Hidden'));
+    content.appendChild(meshList);
+  }
+}
+
+function buildMesh(mesh, record) {
+  const content = showContent();
+  content.replaceChildren();
+  const name = mesh.userData.displayName || record.label || 'Mesh';
+  const componentName = record.component?.component || record.component || 'Mesh';
+  buildHeader(content, name, componentName);
+  const summary = document.createElement('section');
+  summary.className = 'inspector-section inspector-summary';
+  addRow(summary, 'State', mesh.visible ? 'Visible' : 'Hidden');
+  addRow(summary, 'Material kind', mesh.userData.materialKindOverride || mesh.userData.materialKind || 'Auto');
+  addRow(summary, 'Diffuse', mesh.userData.resolvedTexKey || mesh.userData.texKey || 'None');
+  content.appendChild(summary);
+
+  const material = document.createElement('section');
+  material.className = 'inspector-section';
+  const materialTitle = document.createElement('div');
+  materialTitle.className = 'inspector-section-title';
+  materialTitle.textContent = 'Material';
+  material.appendChild(materialTitle);
+  const component = record.component;
+  if (component?.materialSelect) {
+    const select = component.materialSelect.cloneNode(true);
+    select.className = 'inspector-material-kind-control material-kind-select';
+    select.removeAttribute('id');
+    select.addEventListener('change', () => {
+      component.materialSelect.value = select.value;
+      component.materialSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    material.appendChild(select);
+  }
+  if (component?.texBtn) {
+    const manage = document.createElement('button');
+    manage.type = 'button';
+    manage.className = 'ui-button inspector-manage-textures';
+    manage.textContent = 'Manage textures';
+    manage.addEventListener('click', () => component.texBtn.click());
+    material.appendChild(manage);
+  }
+  content.appendChild(material);
+
+  const draw = record.entry?.drawindexed;
+  if (draw?.length) {
+    const drawInfo = document.createElement('section');
+    drawInfo.className = 'inspector-section';
+    const title = document.createElement('div');
+    title.className = 'inspector-section-title';
+    title.textContent = 'Draw';
+    drawInfo.appendChild(title);
+    addRow(drawInfo, 'Count', String(draw[0] ?? '—'));
+    addRow(drawInfo, 'Start', String(draw[1] ?? '—'));
+    addRow(drawInfo, 'Base', String(draw[2] ?? '—'));
+    content.appendChild(drawInfo);
+  }
+  buildTextureControls(content, record, mesh);
+}
+
+function updateInspectorState() {
+  if (!current) return;
+  const content = $('inspector-content');
+  if (!content) return;
+  const values = new Map();
+  content.querySelectorAll('.inspector-row').forEach(row => {
+    const label = row.querySelector('.inspector-label')?.textContent;
+    const value = row.querySelector('.inspector-value');
+    if (label && value) values.set(label, value);
+  });
+  if (current.type === 'mesh') {
+    const mesh = current.mesh;
+    if (values.has('State')) values.get('State').textContent = mesh.visible ? 'Visible' : 'Hidden';
+    if (values.has('Material kind')) {
+      values.get('Material kind').textContent =
+        mesh.userData.materialKindOverride || mesh.userData.materialKind || 'Auto';
+    }
+    if (values.has('Diffuse')) {
+      values.get('Diffuse').textContent =
+        mesh.userData.resolvedTexKey || mesh.userData.texKey || 'None';
+    }
+    const resolved = [...content.querySelectorAll('.inspector-row')].find(row =>
+      row.querySelector('.inspector-label')?.textContent === 'Resolved');
+    if (resolved) {
+      resolved.querySelector('.inspector-value').textContent =
+        mesh.userData.resolvedTexKey || 'None';
+    }
+  } else if (current.type === 'component') {
+    const meshes = current.record.meshes || [];
+    if (values.has('Visible')) {
+      values.get('Visible').textContent =
+        `${meshes.filter(mesh => mesh.visible).length} of ${meshes.length}`;
+    }
+  }
+}
+
+function selectComponent(record) {
+  if (selectionCount++ === 0) setRightDockTab('inspector', { persist: false });
+  current = { type: 'component', record };
+  buildComponent(record);
+  const status = $('selected-mesh-status');
+  if (status) status.textContent = record.component || 'Component';
+}
+
+function selectMesh(mesh) {
+  const record = meshRecords.get(mesh);
+  if (!record) return;
+  if (selectionCount++ === 0) setRightDockTab('inspector', { persist: false });
+  current = { type: 'mesh', mesh, record };
+  buildMesh(mesh, record);
+  const status = $('selected-mesh-status');
+  if (status) {
+    const componentName = record.component?.component || record.component || 'Component';
+    const meshName = mesh.userData.displayName || record.label || 'Mesh';
+    status.textContent = `${componentName} > ${meshName}`;
+  }
+}
+
+export function initInspectorPanel() {
+  window.addEventListener('mod-viewer-component-selected', event => {
+    if (event.detail?.component) selectComponent(event.detail.component);
+  });
+  window.addEventListener('mod-viewer-mesh-selected', event => {
+    if (event.detail?.mesh) selectMesh(event.detail.mesh);
+    else {
+      current = null;
+      $('selected-mesh-status').textContent = '';
+      clearContent();
+    }
+  });
+  window.addEventListener('mod-viewer-inspector-refresh', event => {
+    const component = event.detail?.component;
+    const reason = event.detail?.reason || 'selection';
+    if (!component || !current) return;
+    if (reason === 'state') {
+      if ((current.type === 'component' && current.record === component)
+          || (current.type === 'mesh' && current.record.component === component)) {
+        updateInspectorState();
+      }
+      return;
+    }
+    if (current.type === 'component' && current.record === component) buildComponent(component);
+    if (current.type === 'mesh' && current.record.component === component) {
+      buildMesh(current.mesh, current.record);
+    }
+  });
+  clearContent();
+}
+
+export function clearInspector() {
+  current = null;
+  selectionCount = 0;
+  $('selected-mesh-status').textContent = '';
+  clearContent();
+}
+
+export function getInspectorSelection() {
+  return current;
+}

--- a/src/web/js/key-light-controller.js
+++ b/src/web/js/key-light-controller.js
@@ -131,8 +131,10 @@ export function createKeyLightController({
   renderer.domElement.addEventListener('pointerup', finishDrag);
   renderer.domElement.addEventListener('pointercancel', finishDrag);
 
-  function toggleMode() {
-    modeIndex = (modeIndex + 1) % modes.length;
+  function setMode(nextMode) {
+    const nextIndex = modes.indexOf(nextMode);
+    if (nextIndex < 0) return false;
+    modeIndex = nextIndex;
     const mode = modes[modeIndex];
     handle.visible = mode !== 'off';
     light.intensity = mode === 'double' ? 1 : (mode === 'current' ? 0.5 : 0);
@@ -150,6 +152,11 @@ export function createKeyLightController({
     button.setAttribute('aria-pressed', String(mode !== 'off'));
     updateCursor();
     onChange?.();
+    return true;
+  }
+
+  function toggleMode() {
+    return setMode(modes[(modeIndex + 1) % modes.length]);
   }
 
   function rebase(modelSize) {
@@ -170,5 +177,5 @@ export function createKeyLightController({
     handle.scale.set(size, size, 1);
   }
 
-  return { toggleMode, rebase, update };
+  return { toggleMode, setMode, getMode: () => modes[modeIndex], rebase, update };
 }

--- a/src/web/js/key-light-controller.js
+++ b/src/web/js/key-light-controller.js
@@ -147,6 +147,7 @@ export function createKeyLightController({
     };
     button.title = labels[mode];
     button.setAttribute('aria-label', labels[mode]);
+    button.setAttribute('aria-pressed', String(mode !== 'off'));
     updateCursor();
     onChange?.();
   }

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -1,9 +1,9 @@
 // Entry point: wires the toolbar and orchestrates loading a mod.
 
 import { fitTo, resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
-         toggleGrid, toggleLightHandle, toggleTrackballGizmo,
-         getEnvironmentPreset, isRendererAvailable, rendererReady,
-         setEnvironmentPreset, getRenderCount } from './scene.js';
+         toggleGrid, toggleTrackballGizmo,
+         getEnvironmentPreset, getLightMode, isRendererAvailable, rendererReady,
+         setEnvironmentPreset, setLightMode, getRenderCount } from './scene.js';
 import { ENVIRONMENT_PRESETS } from './environment.js';
 import { refreshMeshTexture, setTextures } from './mesh-factory.js';
 import { activeMeshes, reset, resetMeshState, setStateRules, toggleWireframe, toggleSmoothShading, toggleGlossy } from './visibility.js';
@@ -139,16 +139,19 @@ function initToolPopovers() {
     const wasOpen = !lightPopover.hidden;
     closeAll();
     if (wasOpen) return;
-    const option = document.createElement('button');
-    option.type = 'button';
-    option.className = 'ui-popover-option';
-    option.setAttribute('role', 'menuitem');
-    option.textContent = 'Toggle key light handle';
-    option.addEventListener('click', () => {
-      toggleLightHandle();
-      closeAll();
+    [['double', 'Bright'], ['current', 'Normal'], ['off', 'Off']].forEach(([mode, label]) => {
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'ui-popover-option';
+      option.setAttribute('role', 'menuitemradio');
+      option.setAttribute('aria-checked', String(getLightMode() === mode));
+      option.textContent = label;
+      option.addEventListener('click', () => {
+        setLightMode(mode);
+        closeAll();
+      });
+      lightPopover.appendChild(option);
     });
-    lightPopover.appendChild(option);
     lightPopover.hidden = false;
   }
 
@@ -498,12 +501,12 @@ function initPanelCollapse(panel, contentId) {
   chevron.setAttribute('aria-controls', contentId);
   setCollapsed(initiallyCollapsed, false);
   const toggle = (e) => {
-    if (e?.target?.closest?.('.icon-btn')) return;
+    if (e?.target?.closest?.('.icon-btn, .panel-actions, .panel-action-menu')) return;
     e?.stopPropagation?.();
     setCollapsed(!content.classList.contains('collapsed'));
   };
   hdr.addEventListener('click', e => {
-    if (e.target.closest('.icon-btn, .group-toggle')) return;
+    if (e.target.closest('.icon-btn, .group-toggle, .panel-actions, .panel-action-menu')) return;
     setCollapsed(!content.classList.contains('collapsed'));
   });
   chevron.addEventListener('click', toggle);

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -109,7 +109,12 @@ function initToolPopovers() {
     if (!popover) return;
     popover.hidden = true;
   };
-  const closeAll = () => { close(texturePopover); close(lightPopover); };
+  const closeAll = () => {
+    close(texturePopover);
+    close(lightPopover);
+    textureButton?.setAttribute('aria-expanded', 'false');
+    lightButton?.setAttribute('aria-expanded', 'false');
+  };
 
   function toggleTexturePopover() {
     if (!texturePopover) return;
@@ -132,6 +137,7 @@ function initToolPopovers() {
       texturePopover.appendChild(option);
     });
     texturePopover.hidden = false;
+    textureButton?.setAttribute('aria-expanded', 'true');
   }
 
   function toggleLightPopover() {
@@ -153,10 +159,13 @@ function initToolPopovers() {
       lightPopover.appendChild(option);
     });
     lightPopover.hidden = false;
+    lightButton?.setAttribute('aria-expanded', 'true');
   }
 
   textureButton?.setAttribute('aria-haspopup', 'menu');
   lightButton?.setAttribute('aria-haspopup', 'menu');
+  textureButton?.setAttribute('aria-expanded', 'false');
+  lightButton?.setAttribute('aria-expanded', 'false');
   textureButton?.addEventListener('click', toggleTexturePopover);
   lightButton?.addEventListener('click', toggleLightPopover);
   document.addEventListener('click', event => {
@@ -531,7 +540,10 @@ rendererReady.then(ready => {
   $('shading-btn').addEventListener('click', toggleSmoothShading);
   $('glossy-btn').addEventListener('click', toggleGlossy);
   initToolPopovers();
-  $('reset-state-btn').addEventListener('click', resetMeshState);
+  $('reset-state-btn').addEventListener('click', event => {
+    event.stopPropagation();
+    resetMeshState();
+  });
   $('trackball-btn').addEventListener('click', toggleTrackballGizmo);
   $('camera-reset-view-btn').addEventListener('click', () => resetView(activeMeshes));
   $('camera-flip-btn').addEventListener('click', () => rotateModelQuarterTurn(activeMeshes));
@@ -549,13 +561,25 @@ rendererReady.then(ready => {
   initPanelCollapse($('present-panel'), 'present-list');
   initPanelCollapse($('toggle-panel'), 'toggle-list');
   initPanelCollapse($('menu-panel'), 'menu-list');
-  const modFolderPanel = initModFolderPanel({ switchMod });
+  const emptyFolderAction = $('empty-add-folder-btn');
+  let hasModFolders = false;
+  const updateEmptyFolderAction = hasFolders => {
+    hasModFolders = !!hasFolders;
+    emptyFolderAction.textContent = hasModFolders
+      ? 'Open Mod Folder' : 'Add Mod Folder';
+    emptyFolderAction.setAttribute('aria-label', emptyFolderAction.textContent);
+  };
+  updateEmptyFolderAction(false);
+  const modFolderPanel = initModFolderPanel({
+    switchMod,
+    onRegistryChanged: updateEmptyFolderAction,
+  });
   $('empty-open-btn').disabled = false;
-  $('empty-add-folder-btn').disabled = false;
+  emptyFolderAction.disabled = false;
   $('empty-open-btn').addEventListener('click', openMod);
-  $('empty-add-folder-btn').addEventListener('click', () => {
+  emptyFolderAction.addEventListener('click', () => {
     modFolderPanel.setExpanded(true);
-    modFolderPanel.openAddDialog();
+    if (!hasModFolders) modFolderPanel.openAddDialog();
   });
   $('mod-folder-empty-add')?.addEventListener('click', modFolderPanel.openAddDialog);
 

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -34,7 +34,6 @@ function initEnvironmentControl() {
   const button = $('environment-btn');
   const icon = $('environment-icon');
   const label = $('environment-label');
-  const ids = Object.values(ENVIRONMENT_PRESETS).map(preset => preset.id);
   const labels = Object.fromEntries(
     Object.values(ENVIRONMENT_PRESETS).map(preset => [preset.id, preset.label]));
   const popover = $('environment-popover');
@@ -582,7 +581,6 @@ rendererReady.then(ready => {
   if (viewportCameraButtons && cameraButtons) viewportCameraButtons.append(cameraButtons);
   syncViewportControlPlacement();
   initPanelCollapse($('sidebar'), 'mesh-list');
-  initPanelCollapse($('tool-panel'), 'tool-buttons');
   initPanelCollapse($('present-panel'), 'present-list');
   initPanelCollapse($('toggle-panel'), 'toggle-list');
   initPanelCollapse($('menu-panel'), 'menu-list');

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -109,11 +109,26 @@ function initToolPopovers() {
     if (!popover) return;
     popover.hidden = true;
   };
+  let activeToolPopover = null;
+  const positionPopover = (popover, button) => {
+    if (!popover || !button) return;
+    const buttonRect = button.getBoundingClientRect();
+    const popoverRect = popover.getBoundingClientRect();
+    const gutter = 8;
+    const maxLeft = Math.max(gutter, window.innerWidth - popoverRect.width - gutter);
+    const desiredLeft = buttonRect.left
+      + (buttonRect.width - popoverRect.width) / 2;
+    const left = Math.min(maxLeft, Math.max(gutter, desiredLeft));
+    const top = Math.max(gutter, buttonRect.top - popoverRect.height - gutter);
+    popover.style.left = `${left}px`;
+    popover.style.top = `${top}px`;
+  };
   const closeAll = () => {
     close(texturePopover);
     close(lightPopover);
     textureButton?.setAttribute('aria-expanded', 'false');
     lightButton?.setAttribute('aria-expanded', 'false');
+    activeToolPopover = null;
   };
 
   function toggleTexturePopover() {
@@ -138,6 +153,8 @@ function initToolPopovers() {
     });
     texturePopover.hidden = false;
     textureButton?.setAttribute('aria-expanded', 'true');
+    activeToolPopover = { popover: texturePopover, button: textureButton };
+    positionPopover(texturePopover, textureButton);
   }
 
   function toggleLightPopover() {
@@ -145,6 +162,7 @@ function initToolPopovers() {
     const wasOpen = !lightPopover.hidden;
     closeAll();
     if (wasOpen) return;
+    lightPopover.replaceChildren();
     [['double', 'Bright'], ['current', 'Normal'], ['off', 'Off']].forEach(([mode, label]) => {
       const option = document.createElement('button');
       option.type = 'button';
@@ -160,6 +178,8 @@ function initToolPopovers() {
     });
     lightPopover.hidden = false;
     lightButton?.setAttribute('aria-expanded', 'true');
+    activeToolPopover = { popover: lightPopover, button: lightButton };
+    positionPopover(lightPopover, lightButton);
   }
 
   textureButton?.setAttribute('aria-haspopup', 'menu');
@@ -174,6 +194,11 @@ function initToolPopovers() {
   });
   document.addEventListener('keydown', event => {
     if (event.key === 'Escape') closeAll();
+  });
+  window.addEventListener('resize', () => {
+    if (activeToolPopover) {
+      positionPopover(activeToolPopover.popover, activeToolPopover.button);
+    }
   });
 }
 

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -6,7 +6,7 @@ import { fitTo, resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterT
          setEnvironmentPreset, getRenderCount } from './scene.js';
 import { ENVIRONMENT_PRESETS } from './environment.js';
 import { refreshMeshTexture, setTextures } from './mesh-factory.js';
-import { activeMeshes, reset, resetMeshState, setStateRules, toggleWireframe, toggleSmoothShading, toggleGlossy, toggleTextures } from './visibility.js';
+import { activeMeshes, reset, resetMeshState, setStateRules, toggleWireframe, toggleSmoothShading, toggleGlossy } from './visibility.js';
 import { initSelection, clearSelection } from './selection.js';
 import { buildMeshPanel } from './mesh-panel.js';
 import { buildTogglePanel } from './toggle-panel.js';
@@ -19,6 +19,9 @@ import { refreshHealthReport, setHealthLoader, setHealthReport } from './health-
 import { setIniEditorContext } from './ini-editor.js';
 import { getMaterialDebugMode, setMaterialDebugMode } from './material-profile.js';
 import { requestRender } from './render-scheduler.js';
+import { setTextureDisplayMode } from './render-modes.js';
+import { clearInspector, initInspectorPanel } from './inspector-panel.js';
+import { initRightDock, setRightDockVisible } from './right-dock.js';
 import {
   getOutlineState as getMeshOutlineState,
   setOutlineSuppressedByDebug,
@@ -34,6 +37,7 @@ function initEnvironmentControl() {
   const ids = Object.values(ENVIRONMENT_PRESETS).map(preset => preset.id);
   const labels = Object.fromEntries(
     Object.values(ENVIRONMENT_PRESETS).map(preset => [preset.id, preset.label]));
+  const popover = $('environment-popover');
   let currentId = getEnvironmentPreset().id;
 
   function updateControl(id) {
@@ -52,21 +56,152 @@ function initEnvironmentControl() {
     return true;
   }
 
+  function closePopover() {
+    if (!popover) return;
+    popover.hidden = true;
+    button.setAttribute('aria-expanded', 'false');
+  }
+
+  function openPopover() {
+    if (!popover) return;
+    popover.replaceChildren();
+    Object.values(ENVIRONMENT_PRESETS).forEach(preset => {
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'ui-popover-option';
+      option.setAttribute('role', 'menuitem');
+      option.textContent = preset.label;
+      option.classList.toggle('selected', preset.id === currentId);
+      option.addEventListener('click', () => {
+        applyEnvironmentPreset(preset.id);
+        closePopover();
+      });
+      popover.appendChild(option);
+    });
+    popover.hidden = false;
+    button.setAttribute('aria-expanded', 'true');
+  }
+
   updateControl(currentId);
+  button.setAttribute('aria-haspopup', 'menu');
+  button.setAttribute('aria-expanded', 'false');
   button.addEventListener('click', () => {
-    const currentIndex = Math.max(ids.indexOf(currentId), 0);
-    const nextId = ids[(currentIndex + 1) % ids.length];
-    applyEnvironmentPreset(nextId);
+    if (popover?.hidden === false) closePopover();
+    else openPopover();
+  });
+  document.addEventListener('click', event => {
+    if (!popover || popover.hidden || event.target.closest('#environment-control, #environment-popover')) return;
+    closePopover();
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') closePopover();
   });
 
   return applyEnvironmentPreset;
 }
 
+function initToolPopovers() {
+  const textureButton = $('texture-btn');
+  const lightButton = $('light-btn');
+  const texturePopover = $('texture-popover');
+  const lightPopover = $('light-popover');
+  const close = popover => {
+    if (!popover) return;
+    popover.hidden = true;
+  };
+  const closeAll = () => { close(texturePopover); close(lightPopover); };
+
+  function toggleTexturePopover() {
+    if (!texturePopover) return;
+    const wasOpen = !texturePopover.hidden;
+    closeAll();
+    if (wasOpen) return;
+    texturePopover.replaceChildren();
+    [
+      ['all', 'All maps'], ['diffuse', 'Diffuse only'], ['none', 'No textures'],
+    ].forEach(([mode, label]) => {
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'ui-popover-option';
+      option.setAttribute('role', 'menuitem');
+      option.textContent = label;
+      option.addEventListener('click', () => {
+        setTextureDisplayMode(mode, activeMeshes);
+        closeAll();
+      });
+      texturePopover.appendChild(option);
+    });
+    texturePopover.hidden = false;
+  }
+
+  function toggleLightPopover() {
+    if (!lightPopover) return;
+    const wasOpen = !lightPopover.hidden;
+    closeAll();
+    if (wasOpen) return;
+    const option = document.createElement('button');
+    option.type = 'button';
+    option.className = 'ui-popover-option';
+    option.setAttribute('role', 'menuitem');
+    option.textContent = 'Toggle key light handle';
+    option.addEventListener('click', () => {
+      toggleLightHandle();
+      closeAll();
+    });
+    lightPopover.appendChild(option);
+    lightPopover.hidden = false;
+  }
+
+  textureButton?.setAttribute('aria-haspopup', 'menu');
+  lightButton?.setAttribute('aria-haspopup', 'menu');
+  textureButton?.addEventListener('click', toggleTexturePopover);
+  lightButton?.addEventListener('click', toggleLightPopover);
+  document.addEventListener('click', event => {
+    if (event.target.closest('#texture-btn, #texture-popover, #light-btn, #light-popover')) return;
+    closeAll();
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') closeAll();
+  });
+}
+
 function syncViewportControlPlacement() {
   const rightDock = $('right-dock');
-  const hasVisiblePanel = [...(rightDock?.children || [])].some((panel) =>
-    getComputedStyle(panel).display !== 'none');
+  const panelIds = ['inspector-panel', 'present-panel', 'toggle-panel', 'menu-panel'];
+  const hasVisiblePanel = rightDockEnabled && panelIds.some(id => {
+    const panel = $(id);
+    return panel && !panel.hidden && getComputedStyle(panel).display !== 'none';
+  });
+  setRightDockVisible(hasVisiblePanel);
   document.body.classList.toggle('right-dock-visible', hasVisiblePanel);
+}
+
+function initToolbarOverflow() {
+  const button = $('toolbar-more');
+  const menu = $('toolbar-overflow');
+  if (!button || !menu) return;
+  const close = () => {
+    menu.hidden = true;
+    button.setAttribute('aria-expanded', 'false');
+  };
+  button.addEventListener('click', event => {
+    event.stopPropagation();
+    menu.hidden = !menu.hidden;
+    button.setAttribute('aria-expanded', String(!menu.hidden));
+  });
+  menu.addEventListener('click', event => {
+    const item = event.target.closest('[data-toolbar-target]');
+    if (!item) return;
+    const target = $(item.dataset.toolbarTarget);
+    if (target && !target.disabled) target.click();
+    close();
+  });
+  document.addEventListener('click', event => {
+    if (!event.target.closest('#toolbar-more, #toolbar-overflow')) close();
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') close();
+  });
 }
 
 // The currently open mod folder, so the Toggle panel's staged add/edit/delete
@@ -74,6 +209,7 @@ function syncViewportControlPlacement() {
 // refresh afterward.
 let currentModPath = null;
 let modTransitionInFlight = false;
+let rightDockEnabled = false;
 
 // The last-loaded payload's controls.toggles model, kept
 // around purely so refreshPendingState() can check for a still-unwired
@@ -116,6 +252,8 @@ async function refreshPendingState() {
 
 function clearScene() {
   clearSelection();
+  clearInspector();
+  rightDockEnabled = false;
   reset();
   // Debug mode is material-local and does not survive a reload; keep outline
   // suppression in the same lifecycle rather than carrying stale state onto
@@ -133,6 +271,7 @@ function clearScene() {
   $('present-panel').style.display = 'none';
   $('menu-list').innerHTML = '';
   $('menu-panel').style.display = 'none';
+  setRightDockVisible(false);
   syncViewportControlPlacement();
 }
 
@@ -154,7 +293,9 @@ function beginModLoad(path, message) {
     detail: { path },
   }));
   $('hint').style.display = 'none';
+  $('empty-actions').style.display = 'none';
   $('mod-path').textContent = path;
+  $('mod-path').title = path;
   setHealthReport(null);
   setHealthLoader(() => window.pywebview.api.get_diagnostics(path));
   setIniEditorContext(path, reloadCurrentMod);
@@ -189,6 +330,7 @@ async function displayMeshPayload(payload) {
   buildTogglePanel(controls.toggles, { modPath: currentModPath, onChange: reloadCurrentMod });
   buildMenuPanel(controls.menu);
   buildPresentPanel(controls.present, { modPath: currentModPath, onChange: reloadCurrentMod });
+  rightDockEnabled = true;
   syncViewportControlPlacement();
   fitTo(activeMeshes);
 
@@ -221,6 +363,8 @@ async function loadModAt(path) {
   // Lead with the folder name; the full path is long and rarely the useful part.
   const folderName = path.replace(/\\/g, '/').split('/').filter(Boolean).at(-1);
   $('mod-path').textContent = `${folderName}  —  ${path}`;
+  $('mod-path').textContent = folderName;
+  $('mod-path').title = path;
   window.dispatchEvent(new CustomEvent('mod-viewer-mod-loaded', {
     detail: { path },
   }));
@@ -339,12 +483,33 @@ function initPanelCollapse(panel, contentId) {
   const hdr = panel.querySelector('.panel-hdr');
   const chevron = hdr.querySelector('.group-toggle');
   const content = $(contentId);
-  hdr.addEventListener('click', (e) => {
-    if (e.target.closest('.icon-btn')) return;
-    chevron.classList.toggle('collapsed');
-    content.classList.toggle('collapsed');
+  const storageKey = `mod-viewer.panel.${panel.id}.collapsed`;
+  const setCollapsed = (collapsed, persist = true) => {
+    chevron.classList.toggle('collapsed', collapsed);
+    content.classList.toggle('collapsed', collapsed);
+    chevron.setAttribute('aria-expanded', String(!collapsed));
+    chevron.setAttribute('aria-label', `${collapsed ? 'Expand' : 'Collapse'} ${panel.querySelector('h3')?.textContent || 'panel'}`);
+    if (persist) {
+      try { localStorage.setItem(storageKey, String(collapsed)); } catch (_) { /* private mode */ }
+    }
+  };
+  let initiallyCollapsed = false;
+  try { initiallyCollapsed = localStorage.getItem(storageKey) === 'true'; } catch (_) { /* private mode */ }
+  chevron.setAttribute('aria-controls', contentId);
+  setCollapsed(initiallyCollapsed, false);
+  const toggle = (e) => {
+    if (e?.target?.closest?.('.icon-btn')) return;
+    e?.stopPropagation?.();
+    setCollapsed(!content.classList.contains('collapsed'));
+  };
+  hdr.addEventListener('click', e => {
+    if (e.target.closest('.icon-btn, .group-toggle')) return;
+    setCollapsed(!content.classList.contains('collapsed'));
   });
+  chevron.addEventListener('click', toggle);
 }
+
+initToolbarOverflow();
 
 rendererReady.then(ready => {
   if (!ready || !isRendererAvailable()) return;
@@ -354,28 +519,42 @@ rendererReady.then(ready => {
   $('wire-btn').addEventListener('click', toggleWireframe);
   $('outline-btn').addEventListener('click', () => {
     const enabled = setOutlinesEnabled();
-    $('outline-btn').classList.toggle('active', enabled);
+    const button = $('outline-btn');
+    button.classList.toggle('active', enabled);
+    button.setAttribute('aria-pressed', String(enabled));
+    button.setAttribute('aria-label', `Silhouette outlines: ${enabled ? 'on' : 'off'}`);
   });
   $('grid-btn').addEventListener('click', toggleGrid);
   $('shading-btn').addEventListener('click', toggleSmoothShading);
   $('glossy-btn').addEventListener('click', toggleGlossy);
-  $('texture-btn').addEventListener('click', toggleTextures);
-  $('light-btn').addEventListener('click', toggleLightHandle);
+  initToolPopovers();
   $('reset-state-btn').addEventListener('click', resetMeshState);
   $('trackball-btn').addEventListener('click', toggleTrackballGizmo);
   $('camera-reset-view-btn').addEventListener('click', () => resetView(activeMeshes));
   $('camera-flip-btn').addEventListener('click', () => rotateModelQuarterTurn(activeMeshes));
   $('camera-flip-horizontal-btn').addEventListener('click', () => rotateModelHorizontalQuarterTurn(activeMeshes));
   const applyEnvironmentPreset = initEnvironmentControl();
+  initRightDock();
+  initInspectorPanel();
   initSelection();
+  const viewportCameraButtons = $('viewport-camera-buttons');
+  const cameraButtons = $('camera-buttons');
+  if (viewportCameraButtons && cameraButtons) viewportCameraButtons.append(cameraButtons);
   syncViewportControlPlacement();
   initPanelCollapse($('sidebar'), 'mesh-list');
-  initPanelCollapse($('camera-panel'), 'camera-buttons');
   initPanelCollapse($('tool-panel'), 'tool-buttons');
   initPanelCollapse($('present-panel'), 'present-list');
   initPanelCollapse($('toggle-panel'), 'toggle-list');
   initPanelCollapse($('menu-panel'), 'menu-list');
-  initModFolderPanel({ switchMod });
+  const modFolderPanel = initModFolderPanel({ switchMod });
+  $('empty-open-btn').disabled = false;
+  $('empty-add-folder-btn').disabled = false;
+  $('empty-open-btn').addEventListener('click', openMod);
+  $('empty-add-folder-btn').addEventListener('click', () => {
+    modFolderPanel.setExpanded(true);
+    modFolderPanel.openAddDialog();
+  });
+  $('mod-folder-empty-add')?.addEventListener('click', modFolderPanel.openAddDialog);
 
   // Exposed for automated smoke tests and for poking at the app from the
   // devtools console; the UI itself always goes through the listeners above.
@@ -430,7 +609,10 @@ rendererReady.then(ready => {
     setMaterialDebugMode: setMaterialDebugModeForMeshes,
     setOutlineEnabled: value => {
       const enabled = setOutlinesEnabled(value);
-      $('outline-btn').classList.toggle('active', enabled);
+      const button = $('outline-btn');
+      button.classList.toggle('active', enabled);
+      button.setAttribute('aria-pressed', String(enabled));
+      button.setAttribute('aria-label', `Silhouette outlines: ${enabled ? 'on' : 'off'}`);
       return enabled;
     },
     getOutlineState: index => getMeshOutlineState(activeMeshes[index]),

--- a/src/web/js/menu-panel.js
+++ b/src/web/js/menu-panel.js
@@ -8,6 +8,7 @@
 import { refreshAll, setToggleValue, getToggleValue } from './visibility.js';
 import { registerViewSync, syncView } from './view-sync.js';
 import { buildSourceSection, groupKeysBySource, usesSourceSections } from './panel-utils.js';
+import { createIcon } from './ui-icons.js';
 
 /** Variable names carry a "source::" prefix in multi-ini folders. */
 function displayName(variable) {
@@ -37,11 +38,11 @@ function buildMenuItem(info) {
 
   const btn = document.createElement('button');
   btn.className = 'toggle-cycle-btn';
-  btn.textContent = '⟳';
+  btn.appendChild(createIcon('cycle'));
   btn.title = `Cycle $${displayName(info.var)} (menu slot ${info.slot})`;
   if (info.image_slot) {
     btn.classList.add('menu-image-btn');
-    btn.textContent = '';
+    btn.replaceChildren();
   }
   if (info.image) {
     const img = document.createElement('img');

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -4,7 +4,8 @@
 
 import { buildMesh, hasTexture } from './mesh-factory.js';
 import {
-  activeMeshes, addMesh, applyMeshVisibility, setManualTexOverride,
+  activeMeshes, addMesh, applyMeshVisibility, conditionsSatisfied,
+  setManualTexOverride,
 } from './mesh-state.js';
 import {
   meshMetadataKey, recomputeTextureRuns, saveTextureState,
@@ -129,9 +130,11 @@ function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
   cb.checked = true;
   cb.addEventListener('click', (e) => {
     e.stopPropagation();
-    cb.checked = !mesh.visible;
-    mesh.userData.manualVisible = cb.checked;
-    mesh.userData.manuallyToggled = true;
+    const nextVisible = !mesh.visible;
+    cb.checked = nextVisible;
+    mesh.userData.manualVisible = nextVisible;
+    const automaticVisible = conditionsSatisfied(mesh);
+    mesh.userData.manuallyToggled = nextVisible !== automaticVisible;
     applyMeshVisibility(mesh);
     updateStateIndicator(mesh);
     const any = itemCbs.some(c => c.checked);
@@ -154,11 +157,9 @@ function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
     cb.classList.toggle('state-manual', !!m.userData.manuallyToggled);
     cb.setAttribute('aria-pressed', String(m.visible));
     if (m.userData.manuallyToggled) {
-      cb.title = 'Manually toggled in the viewer';
-    } else if (m.visible === (m.userData.loadedVisible !== false)) {
-      cb.title = m.visible ? 'Visible by default' : 'Hidden by the mod default state';
+      cb.title = m.visible ? 'Visible (manual override)' : 'Hidden (manual override)';
     } else {
-      cb.title = m.visible ? 'Visible under the current mod state' : 'Hidden under the current mod state';
+      cb.title = m.visible ? 'Visible automatically' : 'Hidden automatically';
     }
   };
   updateStateIndicator(mesh);

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -16,19 +16,10 @@ import { selectMesh } from './selection.js';
 import { openTextureModal } from './texture-modal.js';
 import { registerInspectorMesh } from './inspector-panel.js';
 import { createIcon } from './ui-icons.js';
+import { notifyMeshStateChanged } from './mesh-state-events.js';
 
 let groupsUI = [];
 let meshSectionId = 0;
-
-const MATERIAL_KIND_OPTIONS = Object.freeze([
-  ['auto', 'Auto'],
-  ['body', 'Body'],
-  ['face', 'Face'],
-  ['hair', 'Hair'],
-  ['eye', 'Eye'],
-  ['weapon', 'Weapon'],
-  ['special', 'Special'],
-]);
 
 function saveComponentMaterialKind(modPath, source, component, kind) {
   if (!modPath || !window.pywebview?.api?.save_component_material_kind) {
@@ -75,10 +66,7 @@ function groupByComponent(names, meshes) {
   return grouped;
 }
 
-function buildGroupHeader(groupName, itemsWrap, texturePool, modPath,
-                          onPoolChange, componentKind,
-                          onMaterialKindChanged, componentIdentity = groupName,
-                          source = '', onComponentSelected = null) {
+function buildGroupHeader(groupName, itemsWrap, onComponentSelected = null) {
   const hdr = document.createElement('div');
   hdr.className = 'group-hdr';
 
@@ -105,51 +93,6 @@ function buildGroupHeader(groupName, itemsWrap, texturePool, modPath,
     onComponentSelected?.();
   });
 
-  const materialSelect = document.createElement('select');
-  materialSelect.className = 'material-kind-select component-material-kind-control';
-  materialSelect.title = 'Choose a viewer material kind for this component';
-  materialSelect.setAttribute('aria-label', 'Component material kind');
-  for (const [value, label] of MATERIAL_KIND_OPTIONS) {
-    const option = document.createElement('option');
-    option.value = value;
-    option.textContent = label;
-    materialSelect.appendChild(option);
-  }
-  materialSelect.value = componentKind || 'auto';
-  materialSelect.disabled = !componentIdentity;
-  materialSelect.addEventListener('click', event => event.stopPropagation());
-  materialSelect.addEventListener('change', async event => {
-    event.stopPropagation();
-    const previous = componentKind || 'auto';
-    const next = materialSelect.value;
-    materialSelect.disabled = true;
-    try {
-      const result = await saveComponentMaterialKind(
-        modPath, source, componentIdentity, next);
-      if (result?.error || result?.saved === false) {
-        throw new Error(result?.error || 'material kind was not saved');
-      }
-      componentKind = next === 'auto' ? null : next;
-      await onMaterialKindChanged?.();
-    } catch (error) {
-      materialSelect.value = previous;
-      console.error('Could not save component material kind', error);
-    } finally {
-      materialSelect.disabled = false;
-    }
-  });
-  // Always available to Inspector, even for a component with no diffuse
-  // loaded at all -- that is the only way to attach one via "Add".
-  const texBtn = document.createElement('button');
-  texBtn.type = 'button';
-  texBtn.className = 'group-tex-btn';
-  texBtn.appendChild(createIcon('texture'));
-  texBtn.title = 'Manage textures for this component';
-  texBtn.setAttribute('aria-label', 'Manage textures for this component');
-  texBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    openTextureModal(groupName, texturePool, modPath, onPoolChange);
-  });
   const toggleItems = () => {
     const collapsed = !itemsWrap.classList.contains('collapsed');
     chevron.classList.toggle('collapsed', collapsed);
@@ -162,125 +105,11 @@ function buildGroupHeader(groupName, itemsWrap, texturePool, modPath,
     toggleItems();
   });
   hdr.addEventListener('click', (e) => {
-    if (e.target === masterCb || e.target.closest('select')) return;
+    if (e.target === masterCb) return;
     onComponentSelected?.();
   });
 
-  return { hdr, masterCb, texBtn, materialSelect };
-}
-
-/** Collapsed-by-default child list of every diffuse this mesh's component
- * ever references (the shared `pool` array -- the application payload's
- * `texture_pools` entry, or the fresh empty array a component with none loaded
- * yet falls back to in buildMeshPanel) -- a radio-style single-select that
- * drives mesh.userData.manualTexOverride (see visibility.js).
- *
- * Returns a list element plus separate structural and selection sync calls.
- * `rebuild()` recreates rows from `pool`'s CURRENT contents and must be
- * re-invoked after the "manage textures" popup adds/removes an entry (see
- * buildMeshPanel's refreshers array), since `pool` starts empty for a
- * component with nothing loaded yet and is mutated in place afterward --
- * a one-time snapshot at build time would never see what gets added later.
- *
- * Clicking a row selects it (mesh.userData.manualTexOverride = that
- * tex_key, sticky until de-selected); clicking the already-selected row
- * de-selects it (clears back to undefined, mesh reverts to its ini
- * default). `groupMeshes` is the ordered list for this component; texture
- * inheritance is recomputed from top to bottom after every selection. */
-function buildTextureList(pool, mesh, groupMeshes, onActiveChanged) {
-  const wrap = document.createElement('div');
-  wrap.className = 'tex-list collapsed';
-  let rows = [];
-
-  function selectedKey() {
-    const current = mesh.userData.manualTexOverride;
-    const autoKey = mesh.userData.automaticTextureBoundary
-      ? mesh.userData.resolvedTexKey
-      : undefined;
-    const isAutomaticBoundary = current === undefined && !!autoKey;
-    return current === undefined && !mesh.userData.textureHighlightDisabled
-      ? (isAutomaticBoundary ? autoKey : undefined)
-      : current;
-  }
-
-  function syncSelection() {
-    const selected = selectedKey();
-    const current = mesh.userData.manualTexOverride;
-    rows.forEach(({ row, value }) => {
-      const kind = row.dataset.textureChoice;
-      row.classList.toggle('selected',
-        (kind === 'automatic' && current === undefined)
-        || (kind === 'none' && current === null)
-        || (kind === 'texture' && selected === value));
-    });
-  }
-
-  function rebuild() {
-    wrap.replaceChildren();
-    rows = [];
-    function addRow(label, value, kind = 'texture') {
-      const row = document.createElement('div');
-      row.className = 'tex-item';
-      row.dataset.textureChoice = kind;
-      row.textContent = label;
-      row.addEventListener('click', () => {
-        const current = mesh.userData.manualTexOverride;
-        if (kind === 'automatic') {
-          mesh.userData.textureHighlightDisabled = false;
-          setManualTexOverride(mesh, undefined);
-          recomputeTextureRuns(groupMeshes);
-          syncSelection();
-          onActiveChanged?.('selection');
-          saveTextureState(mesh.userData.modPath);
-          return;
-        }
-        if (kind === 'none') {
-          const newVal = current === null ? undefined : null;
-          mesh.userData.textureHighlightDisabled = false;
-          setManualTexOverride(mesh, newVal);
-          recomputeTextureRuns(groupMeshes);
-          syncSelection();
-          onActiveChanged?.('selection');
-          saveTextureState(mesh.userData.modPath);
-          return;
-        }
-        const autoHighlighted = current === undefined
-          && mesh.userData.automaticTextureBoundary
-          && mesh.userData.resolvedTexKey === value
-          && !mesh.userData.textureHighlightDisabled;
-        // Click the already-selected row -> de-select (revert to ini default).
-        const newVal = (current === value || autoHighlighted) ? undefined : value;
-        if (newVal !== undefined && !hasTexture(newVal)) {
-          console.warn('Texture pool entry missing registry source', newVal);
-          return;
-        }
-        if (newVal === undefined && autoHighlighted) {
-          // Clicking an automatic boundary disables that boundary. Clearing a
-          // manual pin is different: it must restore automatic propagation so
-          // INI texture toggles can take control again.
-          mesh.userData.textureHighlightDisabled = true;
-        } else {
-          mesh.userData.textureHighlightDisabled = false;
-        }
-        setManualTexOverride(mesh, newVal);
-        recomputeTextureRuns(groupMeshes);
-        syncSelection();
-        if (onActiveChanged) onActiveChanged('selection');
-        saveTextureState(mesh.userData.modPath);
-      });
-      wrap.appendChild(row);
-      rows.push({ row, value });
-    }
-
-    addRow('Automatic', undefined, 'automatic');
-    for (const opt of pool) addRow(opt.label, opt.tex_key);
-    addRow('None', null, 'none');
-    // A removed active option has no matching row, so all rows remain clear.
-    syncSelection();
-  }
-
-  rebuild();
-  return { wrap, rebuild, syncSelection };
+  return { hdr, masterCb };
 }
 
 /** "count, start, base" from the ini's own drawindexed line — falls back to
@@ -289,8 +118,7 @@ function buildTextureList(pool, mesh, groupMeshes, onActiveChanged) {
  * Returns `{wrap, rebuildTexList}` -- the caller collects `rebuildTexList`
  * alongside every other mesh in the component so the "manage textures"
  * popup can refresh them all after an add/remove (see buildMeshPanel). */
-function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
-                      groupMeshes, onActiveChanged) {
+function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
   const row = document.createElement('div');
   row.className = 'draw-item';
 
@@ -312,9 +140,6 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
     masterCb.checked = all;
   });
   itemCbs.push(cb);
-
-  const { wrap: texList, rebuild: rebuildTexList, syncSelection } = buildTextureList(
-    pool, mesh, groupMeshes, onActiveChanged);
 
   const label = entry.drawindexed
     ? entry.drawindexed.join(', ')
@@ -385,9 +210,6 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
     row,
     stateButton: cb,
     syncStateIndicator: () => updateStateIndicator(mesh),
-    syncTextureSelection: syncSelection,
-    rebuildTextureList: rebuildTexList,
-    onTextureChanged: () => onActiveChanged?.('state'),
   });
   row.addEventListener('click', (e) => {
     if (e.target === cb) return;
@@ -396,10 +218,8 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
 
   const wrap = document.createElement('div');
   wrap.className = 'draw-item-wrap';
-  // Texture choices are rendered by Inspector. Keep this detached list as
-  // the authoritative event/state surface for its buttons.
   wrap.append(row);
-  return { wrap, rebuildTexList, texList };
+  return { wrap };
 }
 
 /** Build the panel and add every mesh in the mesh map to the scene. `modPath`
@@ -442,35 +262,75 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
         .map(n => meshes[n].component)
         .find(Boolean) || null;
 
-      const itemCbs = [], itemObjs = [], texListRenderers = [];
+      const itemCbs = [], itemObjs = [];
       const highlightedDefaults = new Set();
       const componentDescriptor = {
         type: 'component', component: groupName, source: src,
         meshes: itemObjs, texturePool, modPath,
       };
-      const onActiveChanged = (reason = 'selection') => window.dispatchEvent(
-        new CustomEvent('mod-viewer-inspector-refresh', {
-          detail: { component: componentDescriptor, reason },
-        }));
-      // Re-renders every mesh's own texture list in this component after the
-      // "manage textures" popup adds/removes an entry from the shared pool
-      // -- a plain add/remove on `texturePool` doesn't itself touch the
-      // already-built DOM rows.
-      const onPoolChange = () => {
-        texListRenderers.forEach(r => r());
-        recomputeTextureRuns(itemObjs);
-        onActiveChanged('pool');
-        saveTextureState(modPath);
+      let materialKind = componentKind;
+      let materialKindInFlight = false;
+      const setMaterialKind = async kind => {
+        if (!componentIdentity || materialKindInFlight) return false;
+        materialKindInFlight = true;
+        try {
+          const result = await saveComponentMaterialKind(
+            modPath, src, componentIdentity, kind);
+          if (result?.error || result?.saved === false) {
+            throw new Error(result?.error || 'material kind was not saved');
+          }
+          materialKind = kind === 'auto' ? null : kind;
+          await options.onMaterialKindChanged?.();
+          return true;
+        } catch (error) {
+          console.error(`Could not save material kind for ${groupName}`, error);
+          return false;
+        } finally {
+          materialKindInFlight = false;
+        }
       };
 
-      const { hdr, masterCb, texBtn, materialSelect } = buildGroupHeader(
-        groupName, itemsWrap, texturePool, modPath, onPoolChange,
-        componentKind, options.onMaterialKindChanged, componentIdentity, src,
+      const setTextureOverride = (mesh, value) => {
+        if (value !== undefined && value !== null && !hasTexture(value)) {
+          console.warn('Texture pool entry missing registry source', value);
+          return false;
+        }
+        mesh.userData.textureHighlightDisabled = false;
+        setManualTexOverride(mesh, value, { notify: false });
+        recomputeTextureRuns(itemObjs);
+        notifyMeshStateChanged(itemObjs);
+        saveTextureState(modPath);
+        return true;
+      };
+      const getTextureOverride = mesh => ({
+        value: mesh.userData.manualTexOverride,
+        automatic: mesh.userData.manualTexOverride === undefined
+          && !mesh.userData.textureHighlightDisabled,
+        resolved: mesh.userData.resolvedTexKey || null,
+      });
+      const onPoolChange = () => {
+        recomputeTextureRuns(itemObjs);
+        notifyMeshStateChanged(itemObjs);
+        window.dispatchEvent(new CustomEvent('mod-viewer-inspector-refresh', {
+          detail: { component: componentDescriptor, reason: 'pool' },
+        }));
+        saveTextureState(modPath);
+      };
+      Object.assign(componentDescriptor, {
+        getMaterialKind: () => materialKind,
+        setMaterialKind,
+        openTextureManager: () => openTextureModal(
+          groupName, texturePool, modPath, onPoolChange),
+        getTextureOverride,
+        setTextureOverride,
+      });
+
+      const { hdr, masterCb } = buildGroupHeader(
+        groupName, itemsWrap,
         () => window.dispatchEvent(new CustomEvent('mod-viewer-component-selected', {
           detail: { component: componentDescriptor },
         })));
-      componentDescriptor.materialSelect = materialSelect;
-      componentDescriptor.texBtn = texBtn;
+      componentDescriptor.header = hdr;
       container.append(hdr, itemsWrap);
 
       for (const name of names) {
@@ -503,16 +363,13 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
           highlightedDefaults.add(defaultKey);
           mesh.userData.automaticTextureBoundary = true;
         }
-        const { wrap, rebuildTexList, texList } = buildDrawRow(
-          name, groupName, meshes[name], mesh, texturePool, itemCbs, masterCb,
-          itemObjs, onActiveChanged);
-        texListRenderers.push(rebuildTexList);
+        const { wrap } = buildDrawRow(
+          name, groupName, meshes[name], mesh, itemCbs, masterCb);
         itemsWrap.appendChild(wrap);
         registerInspectorMesh(mesh, {
           component: componentDescriptor,
           entry: meshes[name],
           label: mesh.userData.displayName || name,
-          textureList: texList,
         });
       }
       recomputeTextureRuns(itemObjs);
@@ -524,9 +381,10 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
           c.checked = v;
           itemObjs[i].userData.manualVisible = v;
           itemObjs[i].userData.manuallyToggled = true;
-          applyMeshVisibility(itemObjs[i]);
+          applyMeshVisibility(itemObjs[i], { notify: false });
           getMeshView(itemObjs[i])?.syncStateIndicator?.();
         });
+        notifyMeshStateChanged(itemObjs);
       });
 
       groupsUI.push({

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -3,7 +3,6 @@
 // per component, one checkbox per draw call within it.
 
 import { buildMesh, hasTexture } from './mesh-factory.js';
-import { isGameMaterialTextureBound } from './material-profile.js';
 import {
   activeMeshes, addMesh, applyMeshVisibility, setManualTexOverride,
 } from './mesh-state.js';
@@ -15,8 +14,11 @@ import { registerViewSync } from './view-sync.js';
 import { buildSourceSection, groupKeysBySource, usesSourceSections } from './panel-utils.js';
 import { selectMesh } from './selection.js';
 import { openTextureModal } from './texture-modal.js';
+import { registerInspectorMesh } from './inspector-panel.js';
+import { createIcon } from './ui-icons.js';
 
 let groupsUI = [];
+let meshSectionId = 0;
 
 const MATERIAL_KIND_OPTIONS = Object.freeze([
   ['auto', 'Auto'],
@@ -49,7 +51,6 @@ function syncMeshPanel() {
     const all = group.itemCbs.every(control => control.checked);
     group.masterCb.checked = all;
     group.masterCb.indeterminate = any && !all;
-    group.onTexChanged?.();
   }
 }
 
@@ -77,13 +78,17 @@ function groupByComponent(names, meshes) {
 function buildGroupHeader(groupName, itemsWrap, texturePool, modPath,
                           onPoolChange, componentKind,
                           onMaterialKindChanged, componentIdentity = groupName,
-                          source = '') {
+                          source = '', onComponentSelected = null) {
   const hdr = document.createElement('div');
   hdr.className = 'group-hdr';
 
-  const chevron = document.createElement('span');
+  const chevron = document.createElement('button');
+  chevron.type = 'button';
   chevron.className = 'group-toggle';
-  chevron.textContent = '▼';
+  chevron.setAttribute('aria-expanded', 'true');
+  chevron.setAttribute('aria-label', `Collapse ${groupName}`);
+  chevron.setAttribute('aria-controls', itemsWrap.id);
+  chevron.appendChild(createIcon('chevron-down'));
 
   const masterCb = document.createElement('input');
   masterCb.type = 'checkbox';
@@ -95,6 +100,10 @@ function buildGroupHeader(groupName, itemsWrap, texturePool, modPath,
   nameSpan.title = groupName;
 
   hdr.append(chevron, masterCb, nameSpan);
+  nameSpan.addEventListener('click', event => {
+    event.stopPropagation();
+    onComponentSelected?.();
+  });
 
   const materialSelect = document.createElement('select');
   materialSelect.className = 'material-kind-select component-material-kind-control';
@@ -129,32 +138,35 @@ function buildGroupHeader(groupName, itemsWrap, texturePool, modPath,
       materialSelect.disabled = false;
     }
   });
-  hdr.appendChild(materialSelect);
-
-  // Always shown, even for a component with no diffuse loaded at all --
-  // that's the only way to attach one via "Add". updateTexButtonState gives
-  // it the plain (non-.active) look automatically whenever nothing's
-  // actually applied, which already reads as "disabled" without a separate
-  // CSS state.
+  // Always available to Inspector, even for a component with no diffuse
+  // loaded at all -- that is the only way to attach one via "Add".
   const texBtn = document.createElement('button');
+  texBtn.type = 'button';
   texBtn.className = 'group-tex-btn';
-  texBtn.textContent = '🖼';
+  texBtn.appendChild(createIcon('texture'));
   texBtn.title = 'Manage textures for this component';
+  texBtn.setAttribute('aria-label', 'Manage textures for this component');
   texBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     openTextureModal(groupName, texturePool, modPath, onPoolChange);
   });
-  hdr.appendChild(texBtn);
-
-  // Expand/collapse the item list without touching mesh visibility.
+  const toggleItems = () => {
+    const collapsed = !itemsWrap.classList.contains('collapsed');
+    chevron.classList.toggle('collapsed', collapsed);
+    chevron.setAttribute('aria-expanded', String(!collapsed));
+    chevron.setAttribute('aria-label', `${collapsed ? 'Expand' : 'Collapse'} ${groupName}`);
+    itemsWrap.classList.toggle('collapsed', collapsed);
+  };
+  chevron.addEventListener('click', event => {
+    event.stopPropagation();
+    toggleItems();
+  });
   hdr.addEventListener('click', (e) => {
-    if (e.target === masterCb || e.target === texBtn
-        || e.target.closest('select')) return;
-    chevron.classList.toggle('collapsed');
-    itemsWrap.classList.toggle('collapsed');
+    if (e.target === masterCb || e.target.closest('select')) return;
+    onComponentSelected?.();
   });
 
-  return { hdr, masterCb, texBtn };
+  return { hdr, masterCb, texBtn, materialSelect };
 }
 
 /** Collapsed-by-default child list of every diffuse this mesh's component
@@ -193,20 +205,45 @@ function buildTextureList(pool, mesh, groupMeshes, onActiveChanged) {
 
   function syncSelection() {
     const selected = selectedKey();
+    const current = mesh.userData.manualTexOverride;
     rows.forEach(({ row, value }) => {
-      row.classList.toggle('selected', selected === value);
+      const kind = row.dataset.textureChoice;
+      row.classList.toggle('selected',
+        (kind === 'automatic' && current === undefined)
+        || (kind === 'none' && current === null)
+        || (kind === 'texture' && selected === value));
     });
   }
 
   function rebuild() {
     wrap.replaceChildren();
     rows = [];
-    function addRow(label, value) {
+    function addRow(label, value, kind = 'texture') {
       const row = document.createElement('div');
       row.className = 'tex-item';
+      row.dataset.textureChoice = kind;
       row.textContent = label;
       row.addEventListener('click', () => {
         const current = mesh.userData.manualTexOverride;
+        if (kind === 'automatic') {
+          mesh.userData.textureHighlightDisabled = false;
+          setManualTexOverride(mesh, undefined);
+          recomputeTextureRuns(groupMeshes);
+          syncSelection();
+          onActiveChanged?.('selection');
+          saveTextureState(mesh.userData.modPath);
+          return;
+        }
+        if (kind === 'none') {
+          const newVal = current === null ? undefined : null;
+          mesh.userData.textureHighlightDisabled = false;
+          setManualTexOverride(mesh, newVal);
+          recomputeTextureRuns(groupMeshes);
+          syncSelection();
+          onActiveChanged?.('selection');
+          saveTextureState(mesh.userData.modPath);
+          return;
+        }
         const autoHighlighted = current === undefined
           && mesh.userData.automaticTextureBoundary
           && mesh.userData.resolvedTexKey === value
@@ -228,16 +265,16 @@ function buildTextureList(pool, mesh, groupMeshes, onActiveChanged) {
         setManualTexOverride(mesh, newVal);
         recomputeTextureRuns(groupMeshes);
         syncSelection();
-        if (onActiveChanged) onActiveChanged();
+        if (onActiveChanged) onActiveChanged('selection');
         saveTextureState(mesh.userData.modPath);
       });
       wrap.appendChild(row);
       rows.push({ row, value });
     }
 
-    for (const opt of pool) {
-      addRow(opt.label, opt.tex_key);
-    }
+    addRow('Automatic', undefined, 'automatic');
+    for (const opt of pool) addRow(opt.label, opt.tex_key);
+    addRow('None', null, 'none');
     // A removed active option has no matching row, so all rows remain clear.
     syncSelection();
   }
@@ -260,6 +297,7 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
   const cb = document.createElement('button');
   cb.type = 'button';
   cb.className = 'mesh-state-btn';
+  cb.appendChild(createIcon('visibility'));
   cb.checked = true;
   cb.addEventListener('click', (e) => {
     e.stopPropagation();
@@ -278,20 +316,18 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
   const { wrap: texList, rebuild: rebuildTexList, syncSelection } = buildTextureList(
     pool, mesh, groupMeshes, onActiveChanged);
 
-  const chevron = document.createElement('span');
-  chevron.className = 'group-toggle collapsed';
-  chevron.textContent = '▼';
-
   const label = entry.drawindexed
     ? entry.drawindexed.join(', ')
     : '#' + name.slice(groupName.length + 1);
   const labelSpan = document.createElement('span');
   labelSpan.className = 'mesh-name';
   labelSpan.textContent = mesh.userData.displayName || label;
-  row.append(cb, chevron, labelSpan);
+  row.append(cb, labelSpan);
   const updateStateIndicator = (m) => {
     cb.checked = m.visible;
-    cb.textContent = m.userData.manuallyToggled ? (m.visible ? '✅' : '🟨') : (m.visible ? '✅' : '🟥');
+    cb.classList.toggle('state-hidden', !m.visible);
+    cb.classList.toggle('state-manual', !!m.userData.manuallyToggled);
+    cb.setAttribute('aria-pressed', String(m.visible));
     if (m.userData.manuallyToggled) {
       cb.title = 'Manually toggled in the viewer';
     } else if (m.visible === (m.userData.loadedVisible !== false)) {
@@ -351,31 +387,19 @@ function buildDrawRow(name, groupName, entry, mesh, pool, itemCbs, masterCb,
     syncStateIndicator: () => updateStateIndicator(mesh),
     syncTextureSelection: syncSelection,
     rebuildTextureList: rebuildTexList,
-    onTextureChanged: onActiveChanged,
+    onTextureChanged: () => onActiveChanged?.('state'),
   });
   row.addEventListener('click', (e) => {
     if (e.target === cb) return;
-    if (e.target === chevron) {
-      chevron.classList.toggle('collapsed');
-      texList.classList.toggle('collapsed');
-      return;
-    }
     selectMesh(mesh);
   });
 
   const wrap = document.createElement('div');
   wrap.className = 'draw-item-wrap';
-  wrap.append(row, texList);
-  return { wrap, rebuildTexList };
-}
-
-/** Reflects whether any mesh in the component currently has a texture
- * actually applied (post toggle/manual resolution) onto its header button --
- * same on/off visual language as #texture-btn/#wire-btn in app.css. */
-function updateTexButtonState(texBtn, itemObjs) {
-  if (!texBtn) return;
-  texBtn.classList.toggle('active', itemObjs.some(mesh =>
-    isGameMaterialTextureBound(mesh.material, 'diffuse')));
+  // Texture choices are rendered by Inspector. Keep this detached list as
+  // the authoritative event/state surface for its buttons.
+  wrap.append(row);
+  return { wrap, rebuildTexList, texList };
 }
 
 /** Build the panel and add every mesh in the mesh map to the scene. `modPath`
@@ -402,6 +426,7 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
     for (const [groupName, names] of Object.entries(groupByComponent(bySource[src], meshes))) {
       const itemsWrap = document.createElement('div');
       itemsWrap.className = 'group-items';
+      itemsWrap.id = `mesh-group-${++meshSectionId}`;
 
       const poolIds = new Set(names.map(name => meshes[name].texture_pool_id)
         .filter(Boolean));
@@ -419,7 +444,14 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
 
       const itemCbs = [], itemObjs = [], texListRenderers = [];
       const highlightedDefaults = new Set();
-      const onActiveChanged = () => updateTexButtonState(texBtn, itemObjs);
+      const componentDescriptor = {
+        type: 'component', component: groupName, source: src,
+        meshes: itemObjs, texturePool, modPath,
+      };
+      const onActiveChanged = (reason = 'selection') => window.dispatchEvent(
+        new CustomEvent('mod-viewer-inspector-refresh', {
+          detail: { component: componentDescriptor, reason },
+        }));
       // Re-renders every mesh's own texture list in this component after the
       // "manage textures" popup adds/removes an entry from the shared pool
       // -- a plain add/remove on `texturePool` doesn't itself touch the
@@ -427,13 +459,18 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
       const onPoolChange = () => {
         texListRenderers.forEach(r => r());
         recomputeTextureRuns(itemObjs);
-        onActiveChanged();
+        onActiveChanged('pool');
         saveTextureState(modPath);
       };
 
-      const { hdr, masterCb, texBtn } = buildGroupHeader(
+      const { hdr, masterCb, texBtn, materialSelect } = buildGroupHeader(
         groupName, itemsWrap, texturePool, modPath, onPoolChange,
-        componentKind, options.onMaterialKindChanged, componentIdentity, src);
+        componentKind, options.onMaterialKindChanged, componentIdentity, src,
+        () => window.dispatchEvent(new CustomEvent('mod-viewer-component-selected', {
+          detail: { component: componentDescriptor },
+        })));
+      componentDescriptor.materialSelect = materialSelect;
+      componentDescriptor.texBtn = texBtn;
       container.append(hdr, itemsWrap);
 
       for (const name of names) {
@@ -466,14 +503,19 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
           highlightedDefaults.add(defaultKey);
           mesh.userData.automaticTextureBoundary = true;
         }
-        const { wrap, rebuildTexList } = buildDrawRow(
+        const { wrap, rebuildTexList, texList } = buildDrawRow(
           name, groupName, meshes[name], mesh, texturePool, itemCbs, masterCb,
           itemObjs, onActiveChanged);
         texListRenderers.push(rebuildTexList);
         itemsWrap.appendChild(wrap);
+        registerInspectorMesh(mesh, {
+          component: componentDescriptor,
+          entry: meshes[name],
+          label: mesh.userData.displayName || name,
+          textureList: texList,
+        });
       }
       recomputeTextureRuns(itemObjs);
-      updateTexButtonState(texBtn, itemObjs);
 
       masterCb.addEventListener('change', () => {
         masterCb.indeterminate = false;
@@ -488,13 +530,13 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
       });
 
       groupsUI.push({
-        masterCb, itemCbs, itemObjs, onTexChanged: onActiveChanged,
+        masterCb, itemCbs, itemObjs,
         applyTextureRuns: () => recomputeTextureRuns(itemObjs),
       });
     }
   }
 
   document.getElementById('sidebar').style.display = 'block';
-  document.getElementById('camera-panel').style.display = 'block';
+  document.getElementById('camera-panel').style.display = 'none';
   return activeMeshes;
 }

--- a/src/web/js/mesh-state-events.js
+++ b/src/web/js/mesh-state-events.js
@@ -1,0 +1,7 @@
+// Shared notification for authoritative viewer mesh-state changes.
+
+export function notifyMeshStateChanged(meshes = []) {
+  window.dispatchEvent(new CustomEvent('mod-viewer-mesh-state-changed', {
+    detail: { meshes: Array.isArray(meshes) ? meshes : [meshes] },
+  }));
+}

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -7,6 +7,7 @@ import { setMeshTextureState } from './mesh-factory.js';
 import { attachOutline, detachOutline } from './outline-renderer.js';
 import { initializeMeshRenderModes } from './render-modes.js';
 import { requestRender } from './render-scheduler.js';
+import { notifyMeshStateChanged } from './mesh-state-events.js';
 
 export const activeMeshes = [];
 
@@ -53,8 +54,9 @@ export function resetMeshVisibility() {
   activeMeshes.forEach(mesh => {
     mesh.userData.manualVisible = mesh.userData.loadedVisible !== false;
     mesh.userData.manuallyToggled = false;
-    applyMeshVisibility(mesh);
+    applyMeshVisibility(mesh, { notify: false });
   });
+  notifyMeshStateChanged(activeMeshes);
   requestRender();
 }
 
@@ -63,6 +65,7 @@ export function resetMeshVisibility() {
 export function setManualTexOverride(mesh, value) {
   mesh.userData.manualTexOverride = value;
   applyTextureVariant(mesh);
+  notifyMeshStateChanged([mesh]);
   requestRender();
 }
 
@@ -102,8 +105,9 @@ export function applyTextureVariant(mesh) {
 // The MESHES control is the direct visibility source. Gating conditions only
 // re-baseline manualVisible during refreshMeshes(), so a manual click can
 // always reveal a currently gated mesh.
-export function applyMeshVisibility(mesh) {
+export function applyMeshVisibility(mesh, { notify = true } = {}) {
   mesh.visible = mesh.userData.manualVisible !== false;
+  if (notify) notifyMeshStateChanged([mesh]);
   requestRender();
 }
 
@@ -151,7 +155,7 @@ export function refreshMeshes() {
     if ((mesh.userData.conditions || []).length > 0) {
       mesh.userData.manualVisible = conditionsSatisfied(mesh);
     }
-    applyMeshVisibility(mesh);
+    applyMeshVisibility(mesh, { notify: false });
     if (!mesh.userData.defaultCaptured) {
       mesh.userData.loadedVisible = mesh.visible;
       mesh.userData.defaultCaptured = true;
@@ -159,5 +163,6 @@ export function refreshMeshes() {
     applyTextureVariant(mesh);
     applyShapeTargets(mesh);
   });
+  notifyMeshStateChanged(activeMeshes);
   requestRender();
 }

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -62,10 +62,10 @@ export function resetMeshVisibility() {
 
 /** Pin or clear one mesh's highlighted diffuse. Ordered component propagation
  * remains the texture-state module's responsibility. */
-export function setManualTexOverride(mesh, value) {
+export function setManualTexOverride(mesh, value, { notify = true } = {}) {
   mesh.userData.manualTexOverride = value;
   applyTextureVariant(mesh);
-  notifyMeshStateChanged([mesh]);
+  if (notify) notifyMeshStateChanged([mesh]);
   requestRender();
 }
 

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -102,9 +102,8 @@ export function applyTextureVariant(mesh) {
   });
 }
 
-// The MESHES control is the direct visibility source. Gating conditions only
-// re-baseline manualVisible during refreshMeshes(), so a manual click can
-// always reveal a currently gated mesh.
+// The MESHES control is the direct visibility source. Automatic refreshes
+// re-baseline visibility and clear any transient manual eye-click marker.
 export function applyMeshVisibility(mesh, { notify = true } = {}) {
   mesh.visible = mesh.userData.manualVisible !== false;
   if (notify) notifyMeshStateChanged([mesh]);
@@ -152,9 +151,8 @@ function applyShapeTargets(mesh) {
 
 export function refreshMeshes() {
   activeMeshes.forEach(mesh => {
-    if ((mesh.userData.conditions || []).length > 0) {
-      mesh.userData.manualVisible = conditionsSatisfied(mesh);
-    }
+    mesh.userData.manualVisible = conditionsSatisfied(mesh);
+    mesh.userData.manuallyToggled = false;
     applyMeshVisibility(mesh, { notify: false });
     if (!mesh.userData.defaultCaptured) {
       mesh.userData.loadedVisible = mesh.visible;

--- a/src/web/js/mod-folder-panel.js
+++ b/src/web/js/mod-folder-panel.js
@@ -54,7 +54,7 @@ export function initModFolderPanel({ switchMod }) {
     toggle.setAttribute('aria-expanded', String(expanded));
     toggle.setAttribute('aria-label', expanded
       ? 'Close Mod Library' : 'Open Mod Library');
-    toggle.replaceChildren(createIcon(expanded ? 'close' : 'library'));
+    toggle.replaceChildren(createIcon(expanded ? 'chevron-left' : 'library'));
     toggle.title = expanded ? 'Close Mod Library' : 'Open Mod Library';
     try { localStorage.setItem(layoutKey, String(expanded)); } catch (_) { /* private mode */ }
   }
@@ -74,8 +74,10 @@ export function initModFolderPanel({ switchMod }) {
   function setActivePath(path) {
     activePath = canonicalPath(path);
     list.querySelectorAll('[data-mod-folder-path]').forEach(row => {
-      row.classList.toggle('active',
-        canonicalPath(row.dataset.modFolderPath) === activePath);
+      const rowPath = canonicalPath(row.dataset.modFolderPath);
+      row.classList.toggle('active', rowPath === activePath);
+      row.classList.toggle('active-descendant', !!activePath && rowPath !== activePath
+        && activePath.startsWith(`${rowPath}/`));
     });
   }
 

--- a/src/web/js/mod-folder-panel.js
+++ b/src/web/js/mod-folder-panel.js
@@ -63,6 +63,8 @@ export function initModFolderPanel({ switchMod, onRegistryChanged }) {
     if (event.target.closest('.mod-folder-actions')) return;
     list.querySelectorAll('.mod-folder-action-menu').forEach(menu => {
       menu.hidden = true;
+      menu.parentElement?.querySelector(':scope > .mod-folder-more')
+        ?.setAttribute('aria-expanded', 'false');
     });
   });
 
@@ -199,31 +201,43 @@ export function initModFolderPanel({ switchMod, onRegistryChanged }) {
       more.appendChild(createIcon('more'));
       more.title = 'More folder actions';
       more.setAttribute('aria-label', `More actions for ${entry.name}`);
+      more.setAttribute('aria-haspopup', 'menu');
+      more.setAttribute('aria-expanded', 'false');
       const menu = document.createElement('span');
       menu.className = 'mod-folder-action-menu';
+      menu.setAttribute('role', 'menu');
       menu.hidden = true;
       const menuEdit = document.createElement('button');
       menuEdit.type = 'button';
+      menuEdit.setAttribute('role', 'menuitem');
       menuEdit.textContent = 'Edit';
       const menuRemove = document.createElement('button');
       menuRemove.type = 'button';
+      menuRemove.setAttribute('role', 'menuitem');
       menuRemove.textContent = 'Remove from Mod Library';
       menu.append(menuEdit, menuRemove);
       more.addEventListener('click', event => {
         event.stopPropagation();
         list.querySelectorAll('.mod-folder-action-menu').forEach(candidate => {
-          if (candidate !== menu) candidate.hidden = true;
+          if (candidate !== menu) {
+            candidate.hidden = true;
+            candidate.parentElement?.querySelector(':scope > .mod-folder-more')
+              ?.setAttribute('aria-expanded', 'false');
+          }
         });
         menu.hidden = !menu.hidden;
+        more.setAttribute('aria-expanded', String(!menu.hidden));
       });
       menuEdit.addEventListener('click', event => {
         event.stopPropagation();
         menu.hidden = true;
+        more.setAttribute('aria-expanded', 'false');
         edit.click();
       });
       menuRemove.addEventListener('click', event => {
         event.stopPropagation();
         menu.hidden = true;
+        more.setAttribute('aria-expanded', 'false');
         remove.click();
       });
       actions.append(edit, remove, more, menu);

--- a/src/web/js/mod-folder-panel.js
+++ b/src/web/js/mod-folder-panel.js
@@ -2,6 +2,7 @@
 
 import { confirmDialog } from './dialogs.js';
 import { requestRender } from './render-scheduler.js';
+import { createIcon } from './ui-icons.js';
 
 const $ = id => document.getElementById(id);
 
@@ -26,6 +27,7 @@ export function initModFolderPanel({ switchMod }) {
   const toggle = $('mod-folder-toggle');
   const close = $('mod-folder-close');
   const add = $('mod-folder-add');
+  const empty = $('mod-folder-empty');
   const backdrop = $('mod-folder-modal-backdrop');
   const title = $('mfm-title');
   const form = $('mfm-form');
@@ -42,14 +44,32 @@ export function initModFolderPanel({ switchMod }) {
   let editorMode = 'add';
   let originalPath = null;
   let selectedPath = null;
+  const layoutKey = 'mod-viewer.mod-library.expanded';
 
   function setExpanded(expanded) {
+    if (!expanded && panel.contains(document.activeElement)) toggle.focus();
+    panel.inert = !expanded;
+    panel.setAttribute('aria-hidden', String(!expanded));
     dock.classList.toggle('expanded', expanded);
     toggle.setAttribute('aria-expanded', String(expanded));
     toggle.setAttribute('aria-label', expanded
-      ? 'Close Mod Folders' : 'Open Mod Folders');
-    toggle.textContent = expanded ? '◀' : '▶';
+      ? 'Close Mod Library' : 'Open Mod Library');
+    toggle.replaceChildren(createIcon(expanded ? 'close' : 'library'));
+    toggle.title = expanded ? 'Close Mod Library' : 'Open Mod Library';
+    try { localStorage.setItem(layoutKey, String(expanded)); } catch (_) { /* private mode */ }
   }
+
+  document.addEventListener('click', event => {
+    if (event.target.closest('.mod-folder-actions')) return;
+    list.querySelectorAll('.mod-folder-action-menu').forEach(menu => {
+      menu.hidden = true;
+    });
+  });
+
+  panel.inert = true;
+  panel.setAttribute('aria-hidden', 'true');
+  try { if (localStorage.getItem(layoutKey) === 'true') setExpanded(true); }
+  catch (_) { /* private mode */ }
 
   function setActivePath(path) {
     activePath = canonicalPath(path);
@@ -153,7 +173,8 @@ export function initModFolderPanel({ switchMod }) {
       actions.className = 'mod-folder-actions';
       const edit = document.createElement('button');
       edit.type = 'button';
-      edit.textContent = '✎';
+      edit.className = 'mod-folder-edit';
+      edit.appendChild(createIcon('edit'));
       edit.title = 'Edit Mod Folder';
       edit.setAttribute('aria-label', `Edit ${entry.name}`);
       edit.addEventListener('click', event => {
@@ -162,14 +183,48 @@ export function initModFolderPanel({ switchMod }) {
       });
       const remove = document.createElement('button');
       remove.type = 'button';
-      remove.textContent = '🗑';
+      remove.className = 'mod-folder-remove';
+      remove.appendChild(createIcon('delete'));
       remove.title = 'Remove from Mod Folders';
       remove.setAttribute('aria-label', `Remove ${entry.name}`);
       remove.addEventListener('click', event => {
         event.stopPropagation();
         removeFolder(entry);
       });
-      actions.append(edit, remove);
+      const more = document.createElement('button');
+      more.type = 'button';
+      more.className = 'mod-folder-more';
+      more.appendChild(createIcon('more'));
+      more.title = 'More folder actions';
+      more.setAttribute('aria-label', `More actions for ${entry.name}`);
+      const menu = document.createElement('span');
+      menu.className = 'mod-folder-action-menu';
+      menu.hidden = true;
+      const menuEdit = document.createElement('button');
+      menuEdit.type = 'button';
+      menuEdit.textContent = 'Edit';
+      const menuRemove = document.createElement('button');
+      menuRemove.type = 'button';
+      menuRemove.textContent = 'Remove from Mod Library';
+      menu.append(menuEdit, menuRemove);
+      more.addEventListener('click', event => {
+        event.stopPropagation();
+        list.querySelectorAll('.mod-folder-action-menu').forEach(candidate => {
+          if (candidate !== menu) candidate.hidden = true;
+        });
+        menu.hidden = !menu.hidden;
+      });
+      menuEdit.addEventListener('click', event => {
+        event.stopPropagation();
+        menu.hidden = true;
+        edit.click();
+      });
+      menuRemove.addEventListener('click', event => {
+        event.stopPropagation();
+        menu.hidden = true;
+        remove.click();
+      });
+      actions.append(edit, remove, more, menu);
       row.appendChild(actions);
     }
 
@@ -180,7 +235,7 @@ export function initModFolderPanel({ switchMod }) {
     if (entry.exists === false && isRoot) {
       const missing = document.createElement('div');
       missing.className = 'mod-folder-missing';
-      missing.textContent = 'Folder not found';
+      missing.append(createIcon('diagnostics'), document.createTextNode('Folder not found'));
       node.appendChild(missing);
     }
     if (canonicalPath(entry.path) === activePath) row.classList.add('active');
@@ -191,6 +246,7 @@ export function initModFolderPanel({ switchMod }) {
     roots = entries || [];
     list.innerHTML = '';
     roots.forEach(entry => list.appendChild(createNode(entry, true)));
+    if (empty) empty.hidden = roots.length !== 0;
     setActivePath(activePath);
   }
 
@@ -224,6 +280,10 @@ export function initModFolderPanel({ switchMod }) {
     nameInput.focus();
   }
 
+  function openAddDialog() {
+    openEditor('add');
+  }
+
   async function removeFolder(entry) {
     const confirmed = await confirmDialog(
       `Remove "${entry.name}" from Mod Folders?\n\n` +
@@ -241,7 +301,7 @@ export function initModFolderPanel({ switchMod }) {
     setExpanded(false);
     requestRender();
   });
-  add.addEventListener('click', () => openEditor('add'));
+  add.addEventListener('click', openAddDialog);
   cancel.addEventListener('click', closeEditor);
   backdrop.addEventListener('click', event => {
     if (event.target === backdrop) closeEditor();
@@ -300,5 +360,6 @@ export function initModFolderPanel({ switchMod }) {
     refresh: () => window.pywebview.api.get_mod_folders().then(applyRegistryResponse),
     setActivePath,
     setExpanded,
+    openAddDialog,
   };
 }

--- a/src/web/js/mod-folder-panel.js
+++ b/src/web/js/mod-folder-panel.js
@@ -19,7 +19,7 @@ function setTextError(element, message) {
   element.classList.toggle('show', !!message);
 }
 
-export function initModFolderPanel({ switchMod }) {
+export function initModFolderPanel({ switchMod, onRegistryChanged }) {
   const dock = $('mod-folder-dock');
   const panel = $('mod-folder-panel');
   const list = $('mod-folder-list');
@@ -249,6 +249,7 @@ export function initModFolderPanel({ switchMod }) {
     list.innerHTML = '';
     roots.forEach(entry => list.appendChild(createNode(entry, true)));
     if (empty) empty.hidden = roots.length !== 0;
+    onRegistryChanged?.(roots.length > 0);
     setActivePath(activePath);
   }
 
@@ -295,7 +296,8 @@ export function initModFolderPanel({ switchMod }) {
     applyRegistryResponse(response);
   }
 
-  toggle.addEventListener('click', () => {
+  toggle.addEventListener('click', event => {
+    event.stopPropagation();
     setExpanded(!dock.classList.contains('expanded'));
     requestRender();
   });

--- a/src/web/js/panel-utils.js
+++ b/src/web/js/panel-utils.js
@@ -1,5 +1,9 @@
 // Exact shared source grouping/collapse behavior used by the three panels.
 
+import { createIcon } from './ui-icons.js';
+
+let sourceSectionId = 0;
+
 export function groupKeysBySource(records, keys = Object.keys(records || {})) {
   const grouped = {};
   for (const key of keys) {
@@ -20,9 +24,12 @@ export function buildSourceSection(source, container, {
 } = {}) {
   const header = document.createElement('div');
   header.className = headerClass;
-  const chevron = document.createElement('span');
+  const chevron = document.createElement('button');
+  chevron.type = 'button';
   chevron.className = 'group-toggle';
-  chevron.textContent = '▼';
+  chevron.setAttribute('aria-expanded', 'true');
+  chevron.setAttribute('aria-label', `Collapse ${source}`);
+  chevron.appendChild(createIcon('chevron-down'));
   const name = document.createElement('span');
   name.className = 'group-name';
   name.textContent = source;
@@ -30,9 +37,14 @@ export function buildSourceSection(source, container, {
 
   const items = document.createElement('div');
   items.className = itemsClass;
+  items.id = `source-section-${++sourceSectionId}`;
+  chevron.setAttribute('aria-controls', items.id);
   header.addEventListener('click', () => {
-    chevron.classList.toggle('collapsed');
-    items.classList.toggle('collapsed');
+    const collapsed = !items.classList.contains('collapsed');
+    chevron.classList.toggle('collapsed', collapsed);
+    chevron.setAttribute('aria-expanded', String(!collapsed));
+    chevron.setAttribute('aria-label', `${collapsed ? 'Expand' : 'Collapse'} ${source}`);
+    items.classList.toggle('collapsed', collapsed);
   });
   container.append(header, items);
   return items;

--- a/src/web/js/present-modal.js
+++ b/src/web/js/present-modal.js
@@ -60,7 +60,9 @@ async function submit(event) {
     const saved = context.onSaved;
     close();
     $('present-list').classList.remove('collapsed');
-    $('present-panel').querySelector('.group-toggle').classList.remove('collapsed');
+    const toggle = $('present-panel').querySelector('.group-toggle');
+    toggle.classList.remove('collapsed');
+    toggle.setAttribute('aria-expanded', 'true');
     if (saved) await saved();
   } catch (error) {
     setError(String(error));

--- a/src/web/js/present-panel.js
+++ b/src/web/js/present-panel.js
@@ -250,9 +250,9 @@ export function buildPresentPanel(present, context = {}) {
   if (!item) {
     const empty = document.createElement('div');
     empty.className = 'toggle-empty';
-    empty.textContent = action.disabled
-      ? 'No key or menu toggle is available for PRESENT.'
-      : 'No presents yet - click Add to create one.';
+    empty.textContent = canAdd
+      ? 'No presents yet - click Add to create one.'
+      : 'No key or menu toggle is available for PRESENT.';
     list.appendChild(empty);
     return;
   }

--- a/src/web/js/present-panel.js
+++ b/src/web/js/present-panel.js
@@ -4,6 +4,7 @@ import { getToggleValue, refreshAll, setToggleValue } from './visibility.js';
 import { alertDialog, confirmDialog, inputConfirmDialog } from './dialogs.js';
 import { openPresentModal, presentSnapshots } from './present-modal.js';
 import { registerViewSync } from './view-sync.js';
+import { createIcon } from './ui-icons.js';
 
 const $ = (id) => document.getElementById(id);
 const MAX_PRESENTS = 10;
@@ -90,8 +91,9 @@ function buildItem(item) {
   headerActions.className = 'toggle-actions present-author-actions';
   const editKey = document.createElement('button');
   editKey.className = 'toggle-icon-btn';
-  editKey.textContent = '\u270E';
+  editKey.appendChild(createIcon('edit'));
   editKey.title = 'Edit PRESENT key binding';
+  editKey.setAttribute('aria-label', 'Edit PRESENT key binding');
   editKey.addEventListener('click', () => openPresentModal({
     mode: 'edit', modPath: current.modPath, present: current.present, item,
     onSaved: current.onChange,
@@ -103,8 +105,9 @@ function buildItem(item) {
   row.className = 'toggle-row';
   const cycle = document.createElement('button');
   cycle.className = 'toggle-cycle-btn';
-  cycle.textContent = '\u27F3';
+  cycle.appendChild(createIcon('cycle'));
   cycle.title = 'Cycle present';
+  cycle.setAttribute('aria-label', 'Cycle PRESENT');
   cycle.disabled = !synchronized;
   const name = document.createElement('span');
   name.className = 'toggle-value';
@@ -212,10 +215,11 @@ export function buildPresentPanel(present, context = {}) {
   panel.style.display = 'block';
   const item = current.present.item;
   const incomplete = !!item && (item.missing_inis || []).length > 0;
-  action.textContent = item && !incomplete ? '\u{1F5D1}' : '+';
+  action.replaceChildren(createIcon(item && !incomplete ? 'delete' : 'plus'));
   action.title = item
     ? (incomplete ? 'Complete PRESENT in the remaining INI files' : 'Delete PRESENT')
     : 'Add PRESENT';
+  action.setAttribute('aria-label', action.title);
   action.disabled = !item && !(current.present.target_inis || []).length;
 
   if (!item) {
@@ -223,7 +227,7 @@ export function buildPresentPanel(present, context = {}) {
     empty.className = 'toggle-empty';
     empty.textContent = action.disabled
       ? 'No key or menu toggle is available for PRESENT.'
-      : 'No presents yet - click + to add one.';
+      : 'No presents yet - click Add to create one.';
     list.appendChild(empty);
     return;
   }

--- a/src/web/js/present-panel.js
+++ b/src/web/js/present-panel.js
@@ -22,22 +22,49 @@ async function removeKey() {
   if (current.onChange) await current.onChange();
 }
 
-$('present-action-btn').addEventListener('click', async (event) => {
+function closeKeyMenu() {
+  const menu = $('present-key-menu');
+  const action = $('present-action-btn');
+  if (!menu || !action) return;
+  menu.hidden = true;
+  action.setAttribute('aria-expanded', 'false');
+}
+
+function openKeyMenu() {
+  const menu = $('present-key-menu');
+  const action = $('present-action-btn');
+  if (!menu || !action) return;
+  menu.hidden = !menu.hidden;
+  action.setAttribute('aria-expanded', String(!menu.hidden));
+}
+
+$('present-action-btn').addEventListener('click', event => {
   event.stopPropagation();
-  if (!current.modPath) return;
-  if (current.present?.item) {
-    if ((current.present.item.missing_inis || []).length) {
-      openPresentModal({ mode: 'complete', modPath: current.modPath,
-        present: current.present, item: current.present.item,
-        onSaved: current.onChange });
-      return;
-    }
-    await removeKey();
-    return;
-  }
+  openKeyMenu();
+});
+$('present-key-add').addEventListener('click', () => {
+  closeKeyMenu();
   if (!(current.present?.target_inis || []).length) return;
   openPresentModal({ mode: 'add', modPath: current.modPath,
     present: current.present, onSaved: current.onChange });
+});
+$('present-key-edit').addEventListener('click', () => {
+  closeKeyMenu();
+  const item = current.present?.item;
+  if (!item) return;
+  const incomplete = (item.missing_inis || []).length > 0;
+  openPresentModal({ mode: incomplete ? 'complete' : 'edit', modPath: current.modPath,
+    present: current.present, item, onSaved: current.onChange });
+});
+$('present-key-remove').addEventListener('click', () => {
+  closeKeyMenu();
+  if (current.present?.item) void removeKey();
+});
+document.addEventListener('click', event => {
+  if (!event.target.closest('.present-key-actions')) closeKeyMenu();
+});
+document.addEventListener('keydown', event => {
+  if (event.key === 'Escape') closeKeyMenu();
 });
 
 async function capture(item, position, name, allowDuplicate = false) {
@@ -87,19 +114,7 @@ function buildItem(item) {
     badge.textContent = `${label}: ${value}`;
     fields.appendChild(badge);
   }
-  const headerActions = document.createElement('span');
-  headerActions.className = 'toggle-actions present-author-actions';
-  const editKey = document.createElement('button');
-  editKey.className = 'toggle-icon-btn';
-  editKey.appendChild(createIcon('edit'));
-  editKey.title = 'Edit PRESENT key binding';
-  editKey.setAttribute('aria-label', 'Edit PRESENT key binding');
-  editKey.addEventListener('click', () => openPresentModal({
-    mode: 'edit', modPath: current.modPath, present: current.present, item,
-    onSaved: current.onChange,
-  }));
-  headerActions.append(editKey);
-  header.append(fields, headerActions);
+  header.append(fields);
 
   const row = document.createElement('div');
   row.className = 'toggle-row';
@@ -165,9 +180,10 @@ function buildItem(item) {
     if (current.onChange) await current.onChange();
   });
   const replace = document.createElement('button');
-  replace.textContent = 'Edit';
+  replace.textContent = 'Update';
   replace.disabled = !(item.capture_vars || []).length;
-  replace.title = replace.disabled ? 'This mod has no key or menu toggle states to capture.' : '';
+  replace.title = replace.disabled ? 'This mod has no key or menu toggle states to capture.'
+    : 'Replace this present with the current key and menu toggle states.';
   replace.addEventListener('click', async () => {
     const chosen = await inputConfirmDialog(
       `Replace ${item.names[position] || `Present ${position + 1}`} with the current key and menu toggle states?`,
@@ -215,12 +231,21 @@ export function buildPresentPanel(present, context = {}) {
   panel.style.display = 'block';
   const item = current.present.item;
   const incomplete = !!item && (item.missing_inis || []).length > 0;
-  action.replaceChildren(createIcon(item && !incomplete ? 'delete' : 'plus'));
-  action.title = item
-    ? (incomplete ? 'Complete PRESENT in the remaining INI files' : 'Delete PRESENT')
-    : 'Add PRESENT';
+  const canAdd = !item && (current.present.target_inis || []).length > 0;
+  const addKey = $('present-key-add');
+  const editKey = $('present-key-edit');
+  const removeKeyButton = $('present-key-remove');
+  action.replaceChildren(createIcon('more'));
+  action.title = 'More PRESENT actions';
   action.setAttribute('aria-label', action.title);
-  action.disabled = !item && !(current.present.target_inis || []).length;
+  action.disabled = false;
+  addKey.hidden = !!item;
+  addKey.disabled = !canAdd;
+  editKey.hidden = !item;
+  editKey.disabled = !item;
+  editKey.textContent = incomplete ? 'Complete PRESENT' : 'Edit key binding';
+  removeKeyButton.hidden = !item;
+  removeKeyButton.disabled = !item;
 
   if (!item) {
     const empty = document.createElement('div');

--- a/src/web/js/record-session.js
+++ b/src/web/js/record-session.js
@@ -11,6 +11,7 @@ import {
   activeMeshes, conditionsSatisfied, getToggleValue, setToggleValue,
   applyMeshVisibility, syncCheckboxes, refreshAll,
 } from './visibility.js';
+import { notifyMeshStateChanged } from './mesh-state-events.js';
 import { alertDialog } from './dialogs.js';
 
 let active = null;    // non-null while a session is in progress
@@ -46,8 +47,9 @@ function snapshotVisibility() {
 function applySnapshot(snap) {
   for (const mesh of activeMeshes) {
     mesh.userData.manualVisible = snap.get(mesh) !== false;
-    applyMeshVisibility(mesh);
+    applyMeshVisibility(mesh, { notify: false });
   }
+  notifyMeshStateChanged(activeMeshes);
   syncCheckboxes();
 }
 

--- a/src/web/js/render-modes.js
+++ b/src/web/js/render-modes.js
@@ -28,7 +28,10 @@ export function initializeMeshRenderModes(mesh) {
 export function toggleWireframeMode(meshes) {
   wireframe = !wireframe;
   setOutlineSuppressedByWireframe(wireframe);
-  document.getElementById('wire-btn').classList.toggle('active', wireframe);
+  const button = document.getElementById('wire-btn');
+  button.classList.toggle('active', wireframe);
+  button.setAttribute('aria-pressed', String(wireframe));
+  button.setAttribute('aria-label', `Wireframe rendering: ${wireframe ? 'on' : 'off'}`);
   meshes.forEach(mesh => {
     const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
     materials.forEach(material => { material.wireframe = wireframe; });
@@ -38,7 +41,10 @@ export function toggleWireframeMode(meshes) {
 
 export function toggleSmoothShadingMode(meshes) {
   smoothShading = !smoothShading;
-  document.getElementById('shading-btn').classList.toggle('off', !smoothShading);
+  const button = document.getElementById('shading-btn');
+  button.classList.toggle('off', !smoothShading);
+  button.setAttribute('aria-pressed', String(smoothShading));
+  button.setAttribute('aria-label', `Smooth shading: ${smoothShading ? 'on' : 'off'}`);
   meshes.forEach(mesh => {
     const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
     materials.forEach(material => {
@@ -68,8 +74,14 @@ export function toggleGlossyMode(meshes) {
 }
 
 export function toggleTextureDisplayMode(meshes) {
-  textureModeIndex = (textureModeIndex + 1) % textureModes.length;
-  const mode = textureModes[textureModeIndex];
+  const mode = textureModes[(textureModeIndex + 1) % textureModes.length];
+  setTextureDisplayMode(mode, meshes);
+}
+
+export function setTextureDisplayMode(mode, meshes) {
+  const nextIndex = textureModes.indexOf(mode);
+  if (nextIndex < 0) return false;
+  textureModeIndex = nextIndex;
   const button = document.getElementById('texture-btn');
   button.classList.toggle('diffuse-only', mode === 'diffuse');
   button.classList.toggle('off', mode === 'none');
@@ -83,4 +95,5 @@ export function toggleTextureDisplayMode(meshes) {
   setTextureMode(mode);
   meshes.forEach(refreshMeshTexture);
   requestRender();
+  return true;
 }

--- a/src/web/js/right-dock.js
+++ b/src/web/js/right-dock.js
@@ -1,0 +1,58 @@
+// The right side of the viewer has two intentionally separate destinations:
+// selection details and mod controls.  Keeping the tab state here means the
+// panel modules do not need to know how they are presented.
+
+const STORAGE_KEY = 'mod-viewer.right-dock-tab';
+
+let activeTab = 'inspector';
+let ready = false;
+
+function elements() {
+  return {
+    inspectorTab: document.getElementById('inspector-tab'),
+    controlsTab: document.getElementById('controls-tab'),
+    inspector: document.getElementById('inspector-panel'),
+    controls: document.getElementById('controls-panel'),
+    dock: document.getElementById('right-dock'),
+  };
+}
+
+export function setRightDockTab(tab, { persist = true } = {}) {
+  if (tab !== 'controls' && tab !== 'inspector') return;
+  activeTab = tab;
+  const { inspectorTab, controlsTab, inspector, controls } = elements();
+  const inspectorActive = tab === 'inspector';
+  inspectorTab?.classList.toggle('active', inspectorActive);
+  controlsTab?.classList.toggle('active', !inspectorActive);
+  inspectorTab?.setAttribute('aria-selected', String(inspectorActive));
+  controlsTab?.setAttribute('aria-selected', String(!inspectorActive));
+  if (inspector) inspector.hidden = !inspectorActive;
+  if (controls) controls.hidden = inspectorActive;
+  if (persist) {
+    try { localStorage.setItem(STORAGE_KEY, tab); } catch (_) { /* private mode */ }
+  }
+}
+
+export function getRightDockTab() {
+  return activeTab;
+}
+
+export function setRightDockVisible(visible) {
+  elements().dock?.classList.toggle('ui-visible', !!visible);
+}
+
+export function initRightDock() {
+  const { inspectorTab, controlsTab } = elements();
+  if (!inspectorTab || !controlsTab) return;
+  inspectorTab.addEventListener('click', () => setRightDockTab('inspector'));
+  controlsTab.addEventListener('click', () => setRightDockTab('controls'));
+  if (!ready) {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored === 'controls' || stored === 'inspector') activeTab = stored;
+    } catch (_) { /* private mode */ }
+    ready = true;
+  }
+  setRightDockTab(activeTab, { persist: false });
+  setRightDockVisible(false);
+}

--- a/src/web/js/scene.js
+++ b/src/web/js/scene.js
@@ -213,6 +213,16 @@ export function toggleLightHandle() {
   requestRender();
 }
 
+export function setLightMode(mode) {
+  const changed = keyLightController.setMode(mode);
+  if (changed) requestRender();
+  return changed;
+}
+
+export function getLightMode() {
+  return keyLightController.getMode();
+}
+
 export function frameView(meshes = [], direction = null, targetYOffset = 0) {
   cameraFrame.frameView(meshes, direction, targetYOffset);
   requestRender();

--- a/src/web/js/scene.js
+++ b/src/web/js/scene.js
@@ -197,7 +197,10 @@ export function getEnvironmentPreset() {
 
 export function toggleGrid() {
   grid.visible = !grid.visible;
-  document.getElementById('grid-btn').classList.toggle('off', !grid.visible);
+  const button = document.getElementById('grid-btn');
+  button.classList.toggle('off', !grid.visible);
+  button.setAttribute('aria-pressed', String(grid.visible));
+  button.setAttribute('aria-label', `Grid visibility: ${grid.visible ? 'on' : 'off'}`);
   requestRender();
 }
 

--- a/src/web/js/selection.js
+++ b/src/web/js/selection.js
@@ -36,7 +36,9 @@ function expandAncestorsAndScrollTo(row) {
   while (el && !el.id) {
     if (el.classList && el.classList.contains('collapsed')) {
       el.classList.remove('collapsed');
-      el.previousElementSibling?.querySelector?.('.group-toggle')?.classList.remove('collapsed');
+      const toggle = el.previousElementSibling?.querySelector?.('.group-toggle');
+      toggle?.classList.remove('collapsed');
+      toggle?.setAttribute('aria-expanded', 'true');
     }
     el = el.parentElement;
   }
@@ -54,6 +56,9 @@ export function selectMesh(mesh) {
     setHighlight(mesh, true);
     setRowSelected(mesh, true);
   }
+  window.dispatchEvent(new CustomEvent('mod-viewer-mesh-selected', {
+    detail: { mesh },
+  }));
   requestRender();
 }
 

--- a/src/web/js/texture-modal.js
+++ b/src/web/js/texture-modal.js
@@ -6,6 +6,7 @@
 import { addTexture } from './mesh-factory.js';
 import { bindModalDismiss } from './modal-shell.js';
 import { textureFile } from './texture-key.js';
+import { createIcon } from './ui-icons.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -96,7 +97,7 @@ function render() {
       if (displayKey) {
         const clear = document.createElement('span');
         clear.className = 'texm-map-clear';
-        clear.textContent = '×';
+        clear.appendChild(createIcon('close'));
         clear.title = `Remove ${title}`;
         clear.addEventListener('click', (evt) => {
           evt.stopPropagation();
@@ -123,8 +124,9 @@ function render() {
     }
     const del = document.createElement('button');
     del.className = 'toggle-icon-btn';
-    del.textContent = '🗑';
+    del.appendChild(createIcon('delete'));
     del.title = 'Remove from this component\'s texture list';
+    del.setAttribute('aria-label', 'Remove texture from this component');
     del.addEventListener('click', () => {
       const idx = currentPool.indexOf(opt);
       if (idx !== -1) currentPool.splice(idx, 1);

--- a/src/web/js/toggle-panel.js
+++ b/src/web/js/toggle-panel.js
@@ -12,6 +12,7 @@ import { startRecordSession } from './record-session.js';
 import { alertDialog, confirmDialog } from './dialogs.js';
 import { registerViewSync, syncView } from './view-sync.js';
 import { buildSourceSection, groupKeysBySource, usesSourceSections } from './panel-utils.js';
+import { createIcon } from './ui-icons.js';
 
 /** Variable names carry a "source::" prefix in multi-ini folders. */
 function displayName(variable) {
@@ -110,7 +111,7 @@ function buildToggleItem(info, ctx) {
   if (info.wired === false) {
     const warnBadge = document.createElement('span');
     warnBadge.className = 'toggle-unwired-badge';
-    warnBadge.textContent = '⚠';
+    warnBadge.appendChild(createIcon('diagnostics'));
     warnBadge.title = 'Not wired to any mesh yet — click ⏺ Record below and check/uncheck ' +
       'meshes at each position to assign what this toggle shows. Export is disabled until ' +
       'this toggle is wired (or deleted).';
@@ -120,22 +121,25 @@ function buildToggleItem(info, ctx) {
 
   const editBtn = document.createElement('button');
   editBtn.className = 'toggle-icon-btn';
-  editBtn.textContent = '✎';
+  editBtn.appendChild(createIcon('edit'));
   editBtn.title = 'Edit toggle';
+  editBtn.setAttribute('aria-label', 'Edit toggle');
   editBtn.addEventListener('click', () => {
     openToggleModal({ mode: 'edit', modPath: ctx.modPath, info, onSaved: ctx.onChange });
   });
 
   const deleteBtn = document.createElement('button');
   deleteBtn.className = 'toggle-icon-btn';
-  deleteBtn.textContent = '🗑';
+  deleteBtn.appendChild(createIcon('delete'));
   deleteBtn.title = 'Delete toggle';
+  deleteBtn.setAttribute('aria-label', 'Delete toggle');
   deleteBtn.addEventListener('click', () => handleDelete(info, ctx));
 
   const recordBtn = document.createElement('button');
   recordBtn.className = 'toggle-icon-btn';
-  recordBtn.textContent = '⏺';
+  recordBtn.appendChild(createIcon('record'));
   recordBtn.title = 'Record which meshes show at each position';
+  recordBtn.setAttribute('aria-label', 'Record toggle mesh visibility');
 
   const actions = document.createElement('span');
   actions.className = 'toggle-actions';
@@ -155,8 +159,9 @@ function buildToggleItem(info, ctx) {
 
   const btn = document.createElement('button');
   btn.className = 'toggle-cycle-btn';
-  btn.textContent = '⟳';
+  btn.appendChild(createIcon('cycle'));
   btn.title = 'Cycle value';
+  btn.setAttribute('aria-label', 'Cycle toggle value');
 
   const valSpan = document.createElement('span');
   valSpan.className = 'toggle-value';
@@ -242,7 +247,7 @@ export function buildTogglePanel(toggles, ctx = {}) {
   if (!sections.length) {
     const empty = document.createElement('div');
     empty.className = 'toggle-empty';
-    empty.textContent = 'No toggles yet — click ＋ to add one.';
+    empty.textContent = 'No toggles yet — click Add to create one.';
     list.appendChild(empty);
     return;
   }

--- a/src/web/js/ui-icons.js
+++ b/src/web/js/ui-icons.js
@@ -1,0 +1,15 @@
+// Small inline SVG icon factory shared by the vanilla frontend.
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+export function createIcon(name, label = '') {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.classList.add('ui-icon');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('aria-hidden', label ? 'false' : 'true');
+  if (label) svg.setAttribute('aria-label', label);
+  const use = document.createElementNS(SVG_NS, 'use');
+  use.setAttribute('href', `#icon-${name}`);
+  svg.appendChild(use);
+  return svg;
+}

--- a/src/web/js/view-gizmo-controller.js
+++ b/src/web/js/view-gizmo-controller.js
@@ -165,6 +165,8 @@ export function createViewGizmoController({ camera, controls, element, onChange 
     const button = document.getElementById('trackball-btn');
     button.classList.toggle('active', visible);
     button.classList.toggle('off', !visible);
+    button.setAttribute('aria-pressed', String(visible));
+    button.setAttribute('aria-label', `Toggle navigation gizmo: ${visible ? 'on' : 'off'}`);
   }
 
   function cancelSnap() {


### PR DESCRIPTION
## Summary
- modernize the viewer chrome with reusable SVG icons, clearer empty states, and responsive toolbar overflow
- add Inspector/Controls dock organization and move camera tools into the viewport toolbar
- improve Mod Library actions, collapse accessibility, selection breadcrumbs, and popover positioning
- preserve render-on-demand behavior with explicit UI regression coverage

## Validation
- `pytest -q src/tests/test_frontend.py` — 37 passed
- `pytest -q` — 228 passed
- `git diff --check` — clean
