### PR TITLE
Harden mesh geometry and toggle discovery

### DIFF
--- a/src/app/mod_loader.py
+++ b/src/app/mod_loader.py
@@ -342,6 +342,17 @@ def build_toggle_panel(toggle_keys, toggle_defaults, gating_vars, mod_dir=None,
                 }
                 for var, values in shown_vars.items()
             ],
+            # Keep the normal Toggle UI focused on variables that visibly
+            # affect the model, but retain the Key section's complete aligned
+            # tuple for Record-mode position evaluation.
+            "cycle_vars": [
+                {
+                    "var": var,
+                    "values": values,
+                    "default": toggle_defaults.get(var, values[0]),
+                }
+                for var, values in info["vars"].items()
+            ],
         }
     return panel
 

--- a/src/app/toggle_api.py
+++ b/src/app/toggle_api.py
@@ -190,8 +190,10 @@ def get_record_positions(mod_dir, ini_rel, section_name):
     """{"ok": True, "positions": N, "vars": [var, ...]}: how many cycle
     positions a Record-mode session for this section must supply, and which
     of its variables are actually writable (namespaced/master vars are
-    read-only and excluded). Call this before starting a session rather
-    than reusing the toggle panel's own cycle length, which can disagree.
+    read-only and excluded from ``vars``). The position count still includes
+    every co-driven variable so Record can preview the complete tuple. Call
+    this before starting a session rather than reusing the toggle panel's own
+    cycle length, which can disagree.
     Reads the pending in-memory edit if one is staged this session.
     """
     try:

--- a/src/core/ini_health.py
+++ b/src/core/ini_health.py
@@ -21,6 +21,8 @@ _LOCAL_RUN_TARGET_RE = re.compile(
     r"^(?:CommandList|CustomShader)[A-Za-z0-9_.-]+$", re.I)
 _RESOURCE_REFERENCE_RE = re.compile(
     r"^(?P<prefix>\S+)\s+(?P<resource>Resource[A-Za-z0-9_.\\-]+)\s*$", re.I)
+_VIEWER_DRAWINDEXED_RE = re.compile(
+    r"^\d+\s*,\s*\d+\s*,\s*-?\d+$")
 _ASSET_EXTENSIONS = {
     ".buf", ".ib", ".vb", ".dds", ".png", ".jpg", ".jpeg", ".tga", ".bmp",
 }
@@ -127,6 +129,20 @@ def _analyze_statements(doc, ini_rel, issues):
                     f"Unexpected statement in [{section.name}]: {line.text}",
                     ini_rel, section.name, line.no + 1, line.raw.strip(),
                 ))
+
+            if "=" in line.text:
+                draw_lhs, draw_rhs = (
+                    part.strip() for part in line.text.split("=", 1))
+                if (draw_lhs.lower() == "drawindexed"
+                        and not _VIEWER_DRAWINDEXED_RE.fullmatch(
+                            draw_rhs.split(";", 1)[0].strip())):
+                    issues.append(_issue(
+                        "unsupported_drawindexed_arguments", "warning", "ini",
+                        "The viewer cannot build this drawindexed statement: "
+                        "expected numeric count, start index and signed base vertex.",
+                        ini_rel, section.name, line.no + 1, line.raw.strip(),
+                        arguments=draw_rhs,
+                    ))
 
             if line.kind != "assign" or "=" not in line.text:
                 continue

--- a/src/core/ini_parser.py
+++ b/src/core/ini_parser.py
@@ -42,8 +42,8 @@ find_inis = discover_ini_paths
 
 
 def _ib_res_to_component(ib_res):
-    s = ib_res[8:] if ib_res.startswith("Resource") else ib_res
-    if s.endswith("IB"): s = s[:-2]
+    s = re.sub(r"^Resource", "", ib_res or "", flags=re.I)
+    s = re.sub(r"IB$", "", s, flags=re.I)
     return re.sub(r"[A-Z]$", "", s)
 
 
@@ -191,7 +191,9 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 info["_cur_ib"] = m.group(1)
             if re.match(r"handling\s*=\s*skip\b", line, re.I):
                 info["handling_skip"] = True
-            m = re.match(r"drawindexed\s*=\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)", line, re.I)
+            m = re.fullmatch(
+                r"drawindexed\s*=\s*(\d+)\s*,\s*(\d+)\s*,\s*(-?\d+)\s*",
+                line, re.I)
             if m:
                 combined = DNF_TRUE
                 for frame in cond_stack:
@@ -308,7 +310,9 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
     # scan BOTH TextureOverride AND CommandList sections.
     sec_info: dict = {}
     for name, lines in sections.items():
-        if not (name.startswith("TextureOverride") or name.startswith("CommandList")):
+        name_low = name.lower()
+        if not (name_low.startswith("textureoverride")
+                or name_low.startswith("commandlist")):
             continue
         info: dict = dict(vb0=None, vb1=None, vb2=None, ib=None, draws=[],
                           diffuse=None, diffuse_pool=[], src=None, handling_skip=False,
@@ -394,7 +398,7 @@ def _collect_resource_copy_sources(sections, resources):
 def _select_draw_sections(sec_info, global_ib):
     """Select TextureOverride sections that can produce viewer geometry."""
     return [(name, info) for name, info in sec_info.items()
-            if name.startswith("TextureOverride")
+            if name.lower().startswith("textureoverride")
             and (info["ib"] or global_ib)
             and (info["draws"] or (info["ib"] and not info["handling_skip"]))]
 
@@ -450,32 +454,34 @@ def _resolve_component_buffers(sec_info, resources, resource_copy_sources):
     # Texcoord sections set comp_tc first (highest priority -- must win over
     # Blend).
     for name, info in sec_info.items():
-        if not name.startswith("TextureOverride"):
+        if not name.lower().startswith("textureoverride"):
             continue
         base = name[len("TextureOverride"):]
-        if base.endswith("Texcoord"):
+        if base.lower().endswith("texcoord"):
             comp = base[:-len("Texcoord")]
             if info["vb1"]:
-                comp_tc[comp] = info["vb1"]
+                comp_tc[comp.lower()] = info["vb1"]
 
     # Blend and Position sections (lower priority for tc).
     for name, info in sec_info.items():
-        if not name.startswith("TextureOverride"):
+        if not name.lower().startswith("textureoverride"):
             continue
         base = name[len("TextureOverride"):]
-        if base.endswith("Blend"):
+        if base.lower().endswith("blend"):
             comp = base[:-len("Blend")]
-            if info["vb0"] and comp not in comp_pos:
-                comp_pos[comp] = info["vb0"]
+            comp_key = comp.lower()
+            if info["vb0"] and comp_key not in comp_pos:
+                comp_pos[comp_key] = info["vb0"]
             # GIMI: *Blend sets vb1 to the blend buffer (stride 32), not tc.
-            if info["vb1"] and comp not in comp_tc:
+            if info["vb1"] and comp_key not in comp_tc:
                 if _res_get(resources, info["vb1"]).get("stride", 0) != 32:
-                    comp_tc[comp] = info["vb1"]
-        elif base.endswith("Position"):
+                    comp_tc[comp_key] = info["vb1"]
+        elif base.lower().endswith("position"):
             # GIMI: vb0 is in a *Position section, not *Blend.
             comp = base[:-len("Position")]
-            if info["vb0"] and comp not in comp_pos:
-                comp_pos[comp] = info["vb0"]
+            comp_key = comp.lower()
+            if info["vb0"] and comp_key not in comp_pos:
+                comp_pos[comp_key] = info["vb0"]
 
         # Skip vb2 if it's a blend buffer (stride 32, ZZMI format) so it does
         # not shadow the real texcoord in vb1. WWMI uses vb2=TexCoord.
@@ -497,7 +503,7 @@ def _resolve_component_buffers(sec_info, resources, resource_copy_sources):
     # Discover global IB/position/texcoord from CommandList sections (WWMI).
     global_ib, global_pos, global_tc = None, None, None
     for name, info in sec_info.items():
-        if not name.startswith("CommandList"):
+        if not name.lower().startswith("commandlist"):
             continue
         if info["ib"] and not global_ib:
             global_ib = info["ib"]
@@ -601,15 +607,24 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         return ri.get("filename"), ri.get("stride")
 
     def _lookup_comp_value(mapping, comp):
-        value = mapping.get(comp)
-        if not value:
-            c2 = re.sub(r"[A-Za-z]+$", "", comp)
-            if c2 and c2 != comp: value = mapping.get(c2)
-        if not value:
-            # Strip last CamelCase word.
-            c2 = re.sub(r"(?<=.)[A-Z][a-z]+$", "", comp)
-            if c2 and c2 != comp: value = mapping.get(c2)
-        return value
+        candidates = [
+            comp,
+            re.sub(r"[A-Za-z]+$", "", comp),
+            re.sub(r"(?<=.)[A-Z][a-z]+$", "", comp),
+        ]
+        for candidate in candidates:
+            if candidate:
+                value = mapping.get(candidate.lower())
+                if value:
+                    return value
+        # All-lowercase templates lose the CamelCase boundary used above.
+        # Prefer the longest declared component that prefixes the IB-derived
+        # name, avoiding encounter-order dependence.
+        comp_low = comp.lower()
+        prefix = max(
+            (key for key in mapping if comp_low.startswith(key)),
+            key=len, default=None)
+        return mapping.get(prefix) if prefix else None
 
     def _lookup_comp_buf(comp):
         return _lookup_comp_value(comp_bufs, comp)

--- a/src/core/ini_sections.py
+++ b/src/core/ini_sections.py
@@ -175,10 +175,11 @@ def sections_from_document(document):
 
 def extract_resources(sections):
     """Return {resource_name: {filename, stride, format}} from Resource sections."""
-    SKIP = ("TextureOverride", "CommandList", "ShaderOverride", "Present", "Key", "Constants")
+    skip = ("textureoverride", "commandlist", "shaderoverride", "present",
+            "key", "constants")
     resources = {}
     for name, lines in sections.items():
-        if any(name.startswith(p) for p in SKIP): continue
+        if name.lower().startswith(skip): continue
         res = {}
         for line in lines:
             if "=" not in line: continue

--- a/src/core/ini_toggles.py
+++ b/src/core/ini_toggles.py
@@ -35,7 +35,7 @@ def extract_toggle_keys(sections, var_prefix=None, source=None,
     canon = (canonical_vars if canonical_vars is not None
              else canonical_var_names(sections))
     for name, lines in sections.items():
-        if not name.startswith("Key"): continue
+        if not name.lower().startswith("key"): continue
         key_combo, back_combo, ktype, cvars = None, None, None, {}
         src = None
         for line in lines:

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -240,6 +240,8 @@ def _deduplicate_draws(group, max_draws=0):
     merged = {}
     order = []
     for draw in group["draws"]:
+        # TODO(DrawCall IR): replace this reflective key with an explicit,
+        # normalized render_identity once draw parsing has a typed IR.
         # Only provenance, visibility alternatives and the generated label may
         # differ between rows that are safe to merge. In particular, base
         # vertex, index size and material/texture state are part of identity.
@@ -519,6 +521,11 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
             base = draw.get("base") or 0
             if base:
                 raw = [v + base for v in raw]
+            # A negative effective DirectX vertex index is invalid.  Reject it
+            # before buffer decoding, where negative offsets can be interpreted
+            # as end-relative instead of failing safely.
+            if any(index < 0 for index in raw):
+                continue
 
             # Compact: only export vertices actually referenced
             used  = sorted(set(raw))

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -228,11 +228,23 @@ def _deduplicate_draws(group, max_draws=0):
     This is a distinct pipeline stage: geometry packing receives one
     deterministic draw list and does not own the condition-merging rules.
     """
+    def freeze(value):
+        """Turn nested draw metadata into a stable, hashable identity."""
+        if isinstance(value, dict):
+            return tuple(sorted((key, freeze(item))
+                                for key, item in value.items()))
+        if isinstance(value, (list, tuple)):
+            return tuple(freeze(item) for item in value)
+        return value
+
     merged = {}
     order = []
     for draw in group["draws"]:
-        key = (draw.get("ib_file"), draw.get("position_file"),
-               draw.get("texcoord_file"), draw["start"], draw["count"])
+        # Only provenance, visibility alternatives and the generated label may
+        # differ between rows that are safe to merge. In particular, base
+        # vertex, index size and material/texture state are part of identity.
+        key = freeze({name: value for name, value in draw.items()
+                      if name not in {"label", "conditions", "sources"}})
         if key not in merged:
             merged[key] = {"draw": draw, "alts": [], "sources": []}
             order.append(key)

--- a/src/core/record_editor.py
+++ b/src/core/record_editor.py
@@ -330,24 +330,20 @@ def writable_cycle_vars(doc, section_name):
     supply data for.
 
     Namespaced/master vars are cross-ini and read-only, so they're excluded
-    here even though `cycle_vars` still reports them — and since a section's
-    own namespaced var can carry a *different-length* values list than its
-    writable var(s), `max_positions` must come from the writable ones alone.
-    The existing Toggle-panel cycle button instead advances by its *lead*
-    var's length (which can be namespaced) — so callers preparing a Record
-    session must ask here rather than reuse that count, or they can end up
-    supplying data for the wrong number of positions.
+    from the returned write set. They still participate in the section's
+    cycle, however, so `max_positions` covers every co-driven variable. The
+    recorder must preview that complete tuple while only rewriting locals.
 
     Raises ToggleEditError if the section isn't a cycle toggle with at least
     one writable variable.
     """
     sec = te.find_cycle_section(doc, section_name)
-    cvars = te.cycle_vars(sec)
+    cvars = te.cycle_vars(sec, include_read_only=True)
     writable = {v: vals for v, vals in cvars.items() if not ic.is_namespaced(v)}
     if not writable:
         raise te.ToggleEditError(
             f"{section_name!r} is not a cycle toggle with any writable variable")
-    return writable, max(len(v) for v in writable.values())
+    return writable, max(len(v) for v in cvars.values())
 
 
 def record_toggle(doc, section_name, position_lines):

--- a/src/core/record_editor.py
+++ b/src/core/record_editor.py
@@ -2,8 +2,9 @@
 `[Key...]` toggle, and rewrite the ini's `if`/`elif`/`endif` gates to match.
 
 A cycle toggle steps through positions 0..N-1; at each position every var the
-section cycles takes its own `values[position % len(values)]` (same
-wraparound rule the Toggle panel's cycle button already uses). The caller
+section cycles uses its value at that row. If its list is shorter than the
+section's longest list, 3Dmigoto keeps its final value for the remaining rows.
+The caller
 (the frontend, which already has the mesh payload's `conditions`) decides,
 per position, which drawindexed *lines* should be visible -- this module
 only has to make the ini agree.
@@ -169,10 +170,26 @@ def _chain_content(doc, var, branches, endif_line, desired):
     return content
 
 
-def _or_expr(var, values, pos_set):
+def _cycle_value(values, position):
+    return values[min(max(position, 0), len(values) - 1)]
+
+
+def _or_expr(var, values, pos_set, all_positions):
     if not pos_set:
         return "0"   # permanently false — mirrors toggle_editor's own convention
-    return " || ".join(f"${var} == {values[p % len(values)]}" for p in sorted(pos_set))
+    by_value = {}
+    for position in all_positions:
+        by_value.setdefault(_cycle_value(values, position), set()).add(position)
+    selected = set(pos_set)
+    partial = [positions for positions in by_value.values()
+               if positions & selected and not positions <= selected]
+    if partial:
+        raise _Unsupported(
+            f"this visibility differs between cycle positions where ${var} "
+            "has the same value")
+    selected_values = [value for value, positions in by_value.items()
+                       if positions <= selected]
+    return " || ".join(f"${var} == {value}" for value in selected_values)
 
 
 def _regenerate_chain(doc, var, values, branches, endif_line, desired, all_positions):
@@ -197,7 +214,8 @@ def _regenerate_chain(doc, var, values, branches, endif_line, desired, all_posit
         if pos_set == all_positions:
             new_lines.extend(l.raw for l in lines)
         else:
-            new_lines.append(f"if {_or_expr(var, values, pos_set)}")
+            new_lines.append(
+                f"if {_or_expr(var, values, pos_set, all_positions)}")
             new_lines.extend(l.raw for l in lines)
             new_lines.append("endif")
 
@@ -208,7 +226,8 @@ def _regenerate_chain(doc, var, values, branches, endif_line, desired, all_posit
     return start, end, new_lines
 
 
-def _analyze_var(doc, var, values, desired, report, unsafe_sections):
+def _analyze_var(doc, var, values, desired, report, unsafe_sections,
+                 max_positions):
     """Everything this var's recorded data implies, without mutating `doc`.
 
     Returns (chain_edits, bare_edits, verified):
@@ -227,7 +246,7 @@ def _analyze_var(doc, var, values, desired, report, unsafe_sections):
 
     Anything refused is appended to `report["skipped"]`.
     """
-    all_positions = frozenset(range(len(values)))
+    all_positions = frozenset(range(max_positions))
     chain_leaders = {}     # leader.no -> Line
     leader_lines = {}      # leader.no -> [desired line_no, ...]
     bare_targets = []      # Lines with no ancestor referencing var
@@ -294,7 +313,13 @@ def _analyze_var(doc, var, values, desired, report, unsafe_sections):
         if line.no not in nested_bare:
             verified[line.no] = sorted(pos_set)
         if pos_set != all_positions:
-            bare_edits[line.no] = _or_expr(var, values, pos_set)
+            try:
+                bare_edits[line.no] = _or_expr(
+                    var, values, pos_set, all_positions)
+            except _Unsupported as exc:
+                verified.pop(line.no, None)
+                report["skipped"].append({
+                    "var": var, "line": line.no + 1, "reason": str(exc)})
 
     return chain_edits, bare_edits, verified
 
@@ -372,7 +397,8 @@ def record_toggle(doc, section_name, position_lines):
     all_bare_claims = {}   # line_no -> [(var, expr), ...]
     per_var_verify = {}    # var -> (values, {line_no: [position, ...]})
     for var, values in writable.items():
-        chain_edits, bare_edits, verified = _analyze_var(doc, var, values, desired, report, unsafe_sections)
+        chain_edits, bare_edits, verified = _analyze_var(
+            doc, var, values, desired, report, unsafe_sections, max_positions)
         all_chain_edits.extend(chain_edits)
         for line_no, expr in bare_edits.items():
             all_bare_claims.setdefault(line_no, []).append((var, expr))
@@ -457,7 +483,8 @@ def record_toggle(doc, section_name, position_lines):
 # positions. The caller (app/toggle_api.record_toggle) restores the
 # just-made backup if not.
 
-_DRAW_RE = re.compile(r"drawindexed\s*=\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)", re.I)
+_DRAW_RE = re.compile(
+    r"drawindexed\s*=\s*(\d+)\s*,\s*(\d+)\s*,\s*(-?\d+)", re.I)
 
 
 def _draw_key(doc, line_no):
@@ -527,7 +554,8 @@ def verify_recording(path, report, text=None, document=None):
                 continue
             expected = set(d["positions"])
             for p in range(len(values)):
-                actual = _dnf_satisfied(conds, {var: values[p % len(values)]})
+                actual = _dnf_satisfied(
+                    conds, {var: _cycle_value(values, p)})
                 if (p in expected) != actual:
                     mismatches.append({
                         "var": var, "section": d["section"],

--- a/src/core/toggle_editor.py
+++ b/src/core/toggle_editor.py
@@ -32,6 +32,7 @@ from . import ini_condition as ic
 from .ini_document import IF, ELIF, ELSE, ENDIF, ASSIGN, BLANK
 
 _VAR_ASSIGN_RE = re.compile(r"^\$(\w+)\s*=\s*(.+)$")
+_ALL_VAR_ASSIGN_RE = re.compile(r"^\$([\\\w]+)\s*=\s*(.+)$")
 _CONST_VAR_RE = re.compile(r"^(?:global\s+)?(?:persist\s+)?\$(\w+)\s*=\s*([^,]+)$", re.I)
 _COND_LINE_RE = re.compile(r"^(if|else\s+if|elif)\s+(.*)$", re.I)
 
@@ -67,18 +68,21 @@ def is_cycle_section(sec):
     return any(re.match(r"^type\s*=\s*cycle$", line.text, re.I) for line in sec.lines)
 
 
-def cycle_vars(sec):
-    """{var: [values]} declared by `$var = v0,v1,...` lines in this section."""
+def cycle_vars(sec, include_read_only=False):
+    """Return cycle values, optionally including cross-file variables."""
     out = {}
     for line in sec.lines:
         if line.kind != ASSIGN:
             continue
-        m = _VAR_ASSIGN_RE.match(line.text)
+        m = _ALL_VAR_ASSIGN_RE.match(line.text)
         if not m:
+            continue
+        variable = m.group(1)
+        if ic.is_namespaced(variable) and not include_read_only:
             continue
         values = [p.strip() for p in m.group(2).split(",") if p.strip()]
         if values:
-            out[m.group(1)] = values
+            out[variable] = values
     return out
 
 

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -2350,6 +2350,44 @@ def test_mismatched_toggle_lists_hold_the_last_short_value(
         context.close()
 
 
+def test_record_advances_read_only_vars_across_complete_cycle(
+        edge_browser, frontend_url):
+    payload = _payload("RecordCycle")
+    payload["controls"]["toggles"]["KeyRecordCycle"]["vars"] = [
+        {"var": "local", "default": "0", "values": ["0", "1"]},
+        {"var": r"\Other\Master\Mode", "default": "0",
+         "values": ["0", "1", "2"]},
+    ]
+    payload["state"]["defaults"].update(
+        {"local": "0", r"\Other\Master\Mode": "0"})
+    context, page = _page(
+        edge_browser, frontend_url, {"RecordCycle": payload})
+    try:
+        _open(page, "RecordCycle")
+        page.evaluate("""
+          () => {
+            window.pywebview.api.get_record_positions = async () => ({
+              positions: 3, vars: ['local'],
+            });
+          }
+        """)
+        page.locator("#toggle-list [title^='Record']").click()
+        row = page.locator("#toggle-list .toggle-row.recording")
+        row.wait_for()
+        value = page.locator("#toggle-list .toggle-value")
+        assert "local=0" in value.inner_text()
+        assert r"\Other\Master\Mode=0" in value.inner_text()
+
+        cycle = page.locator("#toggle-list .toggle-cycle-btn")
+        cycle.click()
+        cycle.click()
+        assert "Position 3 of 3" in value.inner_text()
+        assert "local=1" in value.inner_text()
+        assert r"\Other\Master\Mode=2" in value.inner_text()
+    finally:
+        context.close()
+
+
 def test_reload_preserves_camera_but_switching_mod_resets_it(
         edge_browser, frontend_url):
     context, page = _page(

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -2325,6 +2325,31 @@ def test_mod_folder_name_selection_preserves_dock_state_across_reload(
         context.close()
 
 
+def test_mismatched_toggle_lists_hold_the_last_short_value(
+        edge_browser, frontend_url):
+    payload = _payload("Cycle")
+    payload["controls"]["toggles"]["KeyCycle"]["vars"] = [
+        {"var": "short", "default": "0", "values": ["0", "1"]},
+        {"var": "long", "default": "0", "values": ["0", "1", "2"]},
+    ]
+    payload["state"]["defaults"].update({"short": "0", "long": "0"})
+    context, page = _page(edge_browser, frontend_url, {"Cycle": payload})
+    try:
+        _open(page, "Cycle")
+        button = page.locator("#toggle-list .toggle-cycle-btn")
+        value = page.locator("#toggle-list .toggle-value")
+        button.wait_for()
+        assert value.inner_text() == "short=0, long=0"
+        button.click()
+        assert value.inner_text() == "short=1, long=1"
+        button.click()
+        assert value.inner_text() == "short=1, long=2"
+        button.click()
+        assert value.inner_text() == "short=0, long=0"
+    finally:
+        context.close()
+
+
 def test_reload_preserves_camera_but_switching_mod_resets_it(
         edge_browser, frontend_url):
     context, page = _page(

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -2355,6 +2355,9 @@ def test_record_advances_read_only_vars_across_complete_cycle(
     payload = _payload("RecordCycle")
     payload["controls"]["toggles"]["KeyRecordCycle"]["vars"] = [
         {"var": "local", "default": "0", "values": ["0", "1"]},
+    ]
+    payload["controls"]["toggles"]["KeyRecordCycle"]["cycle_vars"] = [
+        {"var": "local", "default": "0", "values": ["0", "1"]},
         {"var": r"\Other\Master\Mode", "default": "0",
          "values": ["0", "1", "2"]},
     ]

--- a/src/tests/test_ini_health.py
+++ b/src/tests/test_ini_health.py
@@ -196,6 +196,22 @@ def test_statement_run_target_and_key_binding_findings():
             by_code["missing_local_run_target"]] == ["CommandListMissing"]
 
 
+def test_unsupported_drawindexed_arguments_are_structured_diagnostics():
+    with tempfile.TemporaryDirectory() as tmp:
+        _write(os.path.join(tmp, "mod.ini"), (
+            "[TextureOverrideBody]\n"
+            "drawindexed = 3, 0, -4\n"
+            "drawindexed = auto\n"
+            "drawindexed = $count, $start, 0\n"))
+        report = analyze_mod(tmp)
+
+    issues = [item for item in report["issues"]
+              if item["code"] == "unsupported_drawindexed_arguments"]
+    assert [item["line"] for item in issues] == [3, 4]
+    assert [item["arguments"] for item in issues] == [
+        "auto", "$count, $start, 0"]
+
+
 
 
 def test_health_survives_geometry_failure():

--- a/src/tests/test_mesh_builder.py
+++ b/src/tests/test_mesh_builder.py
@@ -4,7 +4,8 @@ import os
 import struct
 import tempfile
 
-from core.ini_parser import build_draw_groups, extract_resources, merge_sections
+from core.ini_parser import (build_draw_groups, extract_resources,
+                             extract_toggle_keys, merge_sections)
 from _provenance_support import IB_R16_INI, build_mesh_fixture, geometry_values, write
 
 IB_REASSIGN_INI = """[TextureOverrideBodyBlend]
@@ -294,3 +295,85 @@ def test_r16_index_buffer():
         pos = geometry_values(geometry, entry["pos"])
         verts = sorted(round(pos[i]) for i in range(0, len(pos), 3))
         assert (verts == [5, 6, 7]), (f"16-bit indices are decoded as 16-bit, not 32-bit (got {verts})")
+
+
+SIGNED_BASE_INI = """[TextureOverrideBodyBlend]
+ib = ResourceBodyIB
+vb0 = ResourcePos
+vb1 = ResourceTc
+drawindexed = 3, 0, -3
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePos]
+filename = pos.buf
+stride = 40
+
+[ResourceTc]
+filename = tc.buf
+stride = 20
+"""
+
+
+def test_negative_base_vertex_is_parsed_and_applied():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", SIGNED_BASE_INI)
+        open(os.path.join(tmp, "body.ib"), "wb").write(
+            struct.pack("<3I", 3, 4, 5))
+        with open(os.path.join(tmp, "pos.buf"), "wb") as file:
+            for i in range(6):
+                file.write(struct.pack("<3f", float(i), float(i), float(i))
+                           + b"\0" * 28)
+        open(os.path.join(tmp, "tc.buf"), "wb").write(b"\0" * 20 * 6)
+
+        secs = merge_sections([path])
+        groups = build_draw_groups(secs, extract_resources(secs))
+        assert groups[0]["draws"][0]["base"] == -3
+        meshes, geometry = build_mesh_fixture(groups, tmp)
+        entry = next(iter(meshes.values()))
+        positions = geometry_values(geometry, entry["pos"])
+        vertices = sorted(round(positions[i])
+                          for i in range(0, len(positions), 3))
+        assert vertices == [0, 1, 2]
+
+
+LOWERCASE_SECTIONS_INI = """[constants]
+global persist $swap = 0
+
+[keyswap]
+key = x
+type = cycle
+$swap = 0,1
+
+[textureoverridebodyblend]
+ib = resourcebodyib
+vb0 = resourcepos
+vb1 = resourcetc
+drawindexed = 3, 0, 0
+
+[resourcebodyib]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[resourcepos]
+filename = pos.buf
+stride = 40
+
+[resourcetc]
+filename = tc.buf
+stride = 20
+"""
+
+
+def test_section_classification_is_case_insensitive():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", LOWERCASE_SECTIONS_INI)
+        secs = merge_sections([path])
+        groups = build_draw_groups(secs, extract_resources(secs))
+        toggles = extract_toggle_keys(secs)
+        assert len(groups) == 1
+        assert groups[0]["position_file"] == "pos.buf"
+        assert groups[0]["texcoord_file"] == "tc.buf"
+        assert list(toggles) == ["keyswap"]

--- a/src/tests/test_mesh_builder.py
+++ b/src/tests/test_mesh_builder.py
@@ -339,6 +339,25 @@ def test_negative_base_vertex_is_parsed_and_applied():
         assert vertices == [0, 1, 2]
 
 
+def test_negative_effective_vertex_index_skips_invalid_draw():
+    with tempfile.TemporaryDirectory() as tmp:
+        ini = SIGNED_BASE_INI.replace(
+            "drawindexed = 3, 0, -3", "drawindexed = 3, 0, -1")
+        path = write(tmp, "mod.ini", ini)
+        open(os.path.join(tmp, "body.ib"), "wb").write(
+            struct.pack("<3I", 0, 1, 2))
+        with open(os.path.join(tmp, "pos.buf"), "wb") as file:
+            for i in range(3):
+                file.write(struct.pack("<3f", float(i), float(i), float(i))
+                           + b"\0" * 28)
+        open(os.path.join(tmp, "tc.buf"), "wb").write(b"\0" * 20 * 3)
+
+        secs = merge_sections([path])
+        groups = build_draw_groups(secs, extract_resources(secs))
+        meshes, _geometry = build_mesh_fixture(groups, tmp)
+        assert meshes == {}
+
+
 LOWERCASE_SECTIONS_INI = """[constants]
 global persist $swap = 0
 

--- a/src/tests/test_mod_loader.py
+++ b/src/tests/test_mod_loader.py
@@ -34,13 +34,20 @@ def test_wired_toggle_shows_only_its_gating_vars():
     """Long-standing behaviour, unchanged: when a section has one var that
     gates something and a sibling var that doesn't, only the gating var is
     shown — and the whole section counts as wired."""
-    toggle_keys = {"KeyUpper": _key("Upper", {"Upper": ["0", "1"], "TT": ["0", "1"]})}
+    master = "\\Some\\Master\\State"
+    toggle_keys = {"KeyUpper": _key("Upper", {
+        "Upper": ["0", "1"], master: ["0", "1", "2"],
+    })}
     panel = build_toggle_panel(toggle_keys, {}, gating_vars={"Upper"}, mod_dir=None)
     assert ("KeyUpper" in panel), ("the section appears")
     entry = panel["KeyUpper"]
     assert (entry["wired"] is True), (f"marked wired (got {entry['wired']})")
     names = [v["var"] for v in entry["vars"]]
     assert (names == ["Upper"]), (f"only the gating var is listed (got {names})")
+    cycle_names = [v["var"] for v in entry["cycle_vars"]]
+    assert (cycle_names == ["Upper", master]), (
+        f"Record receives the complete co-driven tuple (got {cycle_names})")
+    assert entry["cycle_vars"][1]["values"] == ["0", "1", "2"]
 
 
 def test_unwired_pending_toggle_shown_with_writable_vars():

--- a/src/tests/test_provenance.py
+++ b/src/tests/test_provenance.py
@@ -155,6 +155,26 @@ def test_deduplicate_preserves_buffer_identity():
     assert (len(merged) == 2), (f"different buffer bindings do not collapse by range alone (got {len(merged)})")
 
 
+def test_deduplicate_preserves_base_index_and_material_identity():
+    common = {
+        "start": 0, "count": 100, "ib_file": "body.ib",
+        "position_file": "body.pos", "texcoord_file": "body.tc",
+        "conditions": [], "sources": [],
+    }
+    draws = [
+        {**common, "label": "base-0", "base": 0, "index_size": 4,
+         "texture_default_file": "red.dds"},
+        {**common, "label": "base-1", "base": 1, "index_size": 4,
+         "texture_default_file": "red.dds"},
+        {**common, "label": "r16", "base": 0, "index_size": 2,
+         "texture_default_file": "red.dds"},
+        {**common, "label": "blue", "base": 0, "index_size": 4,
+         "texture_default_file": "blue.dds"},
+    ]
+    merged = _deduplicate_draws({"draws": draws})
+    assert len(merged) == 4
+
+
 COMPONENT0_INI = """[CommandListShared]
 ib = ResourceBodyIB
 vb0 = ResourcePos

--- a/src/tests/test_record_editor.py
+++ b/src/tests/test_record_editor.py
@@ -237,6 +237,20 @@ $tt = 0,1
 drawindexed = 999,0,0
 """
 
+MISMATCHED_LENGTHS = """[Constants]
+global persist $short = 0
+global persist $long = 0
+
+[KeyMulti]
+key = 1
+type = cycle
+$short = 0,1
+$long = 0,1,2
+
+[TextureOverrideBody]
+drawindexed = 999,0,-4
+"""
+
 OVERLAP = """[Constants]
 global persist $upper = 0
 global persist $tt = 0
@@ -306,6 +320,24 @@ def test_two_variables_claiming_same_bare_line_refused():
     assert (len(report["skipped"]) == 1
           and "more than one variable" in report["skipped"][0]["reason"]), (f"the ambiguity is reported ({report['skipped']})")
     assert (d.to_string() == before), ("document left completely untouched")
+
+
+def test_mismatched_cycle_lengths_hold_last_value_and_refuse_ambiguity():
+    d = doc(MISMATCHED_LENGTHS)
+    before = d.to_string()
+    line = dline(d, "999,0,-4")
+    report = re_.record_toggle(d, "KeyMulti", {
+        0: [], 1: [], 2: [line.no + 1],
+    })
+    # $short is 1 at both positions 1 and 2, so it cannot encode visibility
+    # at position 2 alone. $long can, and should own the safe wrapper.
+    assert any(item["var"] == "short" and "same value" in item["reason"]
+               for item in report["skipped"])
+    assert report["wraps_added"] == 1
+    assert "if $long == 2" in d.to_string()
+    assert "if $short" not in d.to_string()
+    assert d.to_string() != before
+    assert re_.verify_recording("<mem>", report, document=d) == []
 
 
 # â”€â”€ chain regeneration â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€

--- a/src/tests/test_toggle_api.py
+++ b/src/tests/test_toggle_api.py
@@ -31,14 +31,10 @@ record_editor.py itself is exercised in-memory (no disk I/O, no session) by
 test_record_editor.py; this file instead checks the app layer on top of it:
 resolving ini_rel to a path, staging via edit_session, and turning
 ToggleEditError into a plain {"error": ...} rather than raising across the JS
-bridge. It's also the only place that exercises get_record_positions, which
-exists specifically because a [Key...] section's writable variables can have
-a *different* (typically shorter) values list than a namespaced variable
-declared alongside them in the same section â€” ini_parser.extract_toggle_keys
-(the read path feeding the existing Toggle-panel cycle button) reports both,
-but toggle_editor.cycle_vars (the write path) can't even parse a namespaced
-declaration, so record_toggle's position count must come from
-get_record_positions rather than the panel's own lead-variable cycle length.
+bridge. It's also the only place that exercises get_record_positions. A
+[Key...] section's writable variables can have a shorter values list than a
+co-driven namespaced variable. Record therefore previews the complete cycle
+while reporting only the variables it may safely rewrite.
 """
 
 import glob, os
@@ -132,13 +128,13 @@ def wirable_mod(api_root):
     yield root, ini_path
 
 
-def test_get_record_positions_uses_writable_vars_only(toggle_mod):
+def test_get_record_positions_uses_complete_cycle_but_reports_writable_vars(toggle_mod):
     tmp, _ini_path = toggle_mod
     ini_rel = "mod.ini"
     result = toggle_api.get_record_positions(tmp, ini_rel, "KeyUpper")
     assert (result.get("ok") is True), ("get_record_positions succeeds on a real toggle")
-    assert (result.get("positions") == 2), (f"position count comes from the 2-value writable var, not the "
-          f"4-value namespaced one (got {result.get('positions')})")
+    assert (result.get("positions") == 4), (f"position count includes the 4-value co-driven namespaced var "
+          f"(got {result.get('positions')})")
     assert (result.get("vars") == ["Upper"]), (f"only the writable variable is reported (got {result.get('vars')})")
 
 
@@ -155,7 +151,9 @@ def _swap_positions(tmp, ini_rel):
     line_100 = next(i for i, l in enumerate(FIXTURE.splitlines(), 1) if "100,0,0" in l)
     line_200 = next(i for i, l in enumerate(FIXTURE.splitlines(), 1) if "200,0,0" in l)
     ini_path = os.path.join(tmp, ini_rel)
-    result = toggle_api.record_toggle(tmp, ini_rel, "KeyUpper", {0: [line_200], 1: [line_100]})
+    result = toggle_api.record_toggle(
+        tmp, ini_rel, "KeyUpper",
+        {0: [line_200], 1: [line_100], 2: [line_100], 3: [line_100]})
     return ini_path, result
 
 

--- a/src/web/js/cycle-values.js
+++ b/src/web/js/cycle-values.js
@@ -1,0 +1,11 @@
+/** 3Dmigoto cycle sections form aligned preset rows. Once one variable's
+ * value list is exhausted, its final value remains active for later rows. */
+export function cycleValueAt(variable, position) {
+  const values = variable?.values || [];
+  if (!values.length) return undefined;
+  return values[Math.min(Math.max(position, 0), values.length - 1)];
+}
+
+export function cyclePositionCount(variables) {
+  return Math.max(0, ...variables.map(variable => variable.values.length));
+}

--- a/src/web/js/record-session.js
+++ b/src/web/js/record-session.js
@@ -22,11 +22,9 @@ export function isRecording() {
   return active !== null;
 }
 
-/** This section's own writable vars (a subset of info.vars). Record mode
- * requires at least one, even though every co-driven var participates in its
- * preview and each uses its own position -> value mapping. */
-function writableVars(info, rawNames) {
-  return info.vars.filter((v) => rawNames.includes(v.var.split('::').pop()));
+/** Match the API's writable raw names to the source-scoped panel variables. */
+function writableVars(vars, rawNames) {
+  return vars.filter((v) => rawNames.includes(v.var.split('::').pop()));
 }
 
 /** {mesh -> visible} exactly as currently shown — the pre-population for
@@ -75,8 +73,8 @@ export async function startRecordSession(info, ctx, ui) {
       await alertDialog('Could not start recording:\n\n' + posInfo.error);
       return;
     }
-    const writable = writableVars(info, posInfo.vars || []);
-    const vars = info.vars;
+    const vars = info.cycle_vars || info.vars;
+    const writable = writableVars(vars, posInfo.vars || []);
     if (!writable.length || !vars.length || !posInfo.positions) {
       await alertDialog('This toggle has no variable this app can record automatically.');
       return;
@@ -85,7 +83,7 @@ export async function startRecordSession(info, ctx, ui) {
     // Undo target for Cancel: every var this section drives, at whatever value
     // it had when recording started (not just the writable ones — a namespaced
     // var in the same section is read-only but still affects visibility).
-    const before = info.vars.map((v) => ({ var: v.var, value: getToggleValue(v.var) }));
+    const before = vars.map((v) => ({ var: v.var, value: getToggleValue(v.var) }));
 
     // Pre-populate every position up front from the file's own current
     // combined visibility, never a partial map — an unvisited position must

--- a/src/web/js/record-session.js
+++ b/src/web/js/record-session.js
@@ -22,11 +22,9 @@ export function isRecording() {
   return active !== null;
 }
 
-/** This section's own vars that get recorded (a subset of info.vars — a
- * namespaced var declared alongside them never comes back from
- * get_record_positions, since it's cross-ini and read-only), each still
- * carrying its own values list so its own position -> value mapping is used
- * rather than assuming every var in the section cycles in lockstep. */
+/** This section's own writable vars (a subset of info.vars). Record mode
+ * requires at least one, even though every co-driven var participates in its
+ * preview and each uses its own position -> value mapping. */
 function writableVars(info, rawNames) {
   return info.vars.filter((v) => rawNames.includes(v.var.split('::').pop()));
 }
@@ -77,8 +75,9 @@ export async function startRecordSession(info, ctx, ui) {
       await alertDialog('Could not start recording:\n\n' + posInfo.error);
       return;
     }
-    const vars = writableVars(info, posInfo.vars || []);
-    if (!vars.length || !posInfo.positions) {
+    const writable = writableVars(info, posInfo.vars || []);
+    const vars = info.vars;
+    if (!writable.length || !vars.length || !posInfo.positions) {
       await alertDialog('This toggle has no variable this app can record automatically.');
       return;
     }
@@ -97,7 +96,10 @@ export async function startRecordSession(info, ctx, ui) {
       snapshots.push(snapshotVisibility());
     }
 
-    active = { info, ctx, ui, vars, positions: posInfo.positions, current: 0, snapshots, before };
+    active = {
+      info, ctx, ui, vars,
+      positions: posInfo.positions, current: 0, snapshots, before,
+    };
 
     for (const v of vars) setToggleValue(v.var, v.values[0]);
     applySnapshot(snapshots[0]);

--- a/src/web/js/record-session.js
+++ b/src/web/js/record-session.js
@@ -13,6 +13,7 @@ import {
 } from './visibility.js';
 import { notifyMeshStateChanged } from './mesh-state-events.js';
 import { alertDialog } from './dialogs.js';
+import { cycleValueAt } from './cycle-values.js';
 
 let active = null;    // non-null while a session is in progress
 let starting = false; // true from the first click until active is set (or the attempt is abandoned)
@@ -55,7 +56,7 @@ function applySnapshot(snap) {
 
 function positionLabel() {
   const { current, positions, vars } = active;
-  const values = vars.map((v) => `${v.var.split('::').pop()}=${v.values[current % v.values.length]}`).join(', ');
+  const values = vars.map((v) => `${v.var.split('::').pop()}=${cycleValueAt(v, current)}`).join(', ');
   return `Position ${current + 1} of ${positions} — ${values}`;
 }
 
@@ -92,7 +93,7 @@ export async function startRecordSession(info, ctx, ui) {
     // still default to matching what's already on disk.
     const snapshots = [];
     for (let p = 0; p < posInfo.positions; p++) {
-      for (const v of vars) setToggleValue(v.var, v.values[p % v.values.length]);
+      for (const v of vars) setToggleValue(v.var, cycleValueAt(v, p));
       snapshots.push(snapshotVisibility());
     }
 
@@ -156,7 +157,7 @@ function captureCurrent() {
 function advance() {
   captureCurrent();
   active.current = (active.current + 1) % active.positions;
-  for (const v of active.vars) setToggleValue(v.var, v.values[active.current % v.values.length]);
+  for (const v of active.vars) setToggleValue(v.var, cycleValueAt(v, active.current));
   applySnapshot(active.snapshots[active.current]);
   active.ui.valSpan.textContent = positionLabel();
 }

--- a/src/web/js/toggle-panel.js
+++ b/src/web/js/toggle-panel.js
@@ -13,6 +13,7 @@ import { alertDialog, confirmDialog } from './dialogs.js';
 import { registerViewSync, syncView } from './view-sync.js';
 import { buildSourceSection, groupKeysBySource, usesSourceSections } from './panel-utils.js';
 import { createIcon } from './ui-icons.js';
+import { cyclePositionCount, cycleValueAt } from './cycle-values.js';
 
 /** Variable names carry a "source::" prefix in multi-ini folders. */
 function displayName(variable) {
@@ -26,9 +27,11 @@ function displayName(variable) {
  * applied when the complete tuple itself is duplicated. */
 function findCyclePosition(vars, positions, preferred = -1) {
   const matches = (position) => vars.every(v =>
-    v.values[position % v.values.length] === getToggleValue(v.var));
+    cycleValueAt(v, position) === getToggleValue(v.var));
   if (preferred >= 0 && preferred < positions && matches(preferred)) return preferred;
-  for (let position = 0; position < positions; position++) {
+  // Duplicate complete tuples use the last position, matching the app's
+  // toggle identity invariant and Record/PRESENT tie-breaking.
+  for (let position = positions - 1; position >= 0; position--) {
     if (matches(position)) return position;
   }
   return -1;
@@ -87,7 +90,7 @@ async function handleDelete(info, ctx) {
 function buildToggleItem(info, ctx) {
   for (const v of info.vars) setToggleValue(v.var, v.default);
 
-  const positions = Math.max(...info.vars.map(v => v.values.length));
+  const positions = cyclePositionCount(info.vars);
   let cyclePosition = findCyclePosition(info.vars, positions);
 
   const item = document.createElement('div');
@@ -174,7 +177,7 @@ function buildToggleItem(info, ctx) {
     cyclePosition = findCyclePosition(info.vars, positions, cyclePosition);
     const next = (cyclePosition + 1) % positions;
     for (const v of info.vars) {
-      setToggleValue(v.var, v.values[next % v.values.length]);
+      setToggleValue(v.var, cycleValueAt(v, next));
     }
     cyclePosition = next;
     refreshAll();


### PR DESCRIPTION
## Summary

- parse and apply signed `BaseVertexLocation` values, reject invalid negative effective indices, and classify geometry/control sections case-insensitively
- preserve full geometry and material identity when deduplicating draws
- match 3Dmigoto's aligned multi-variable cycle semantics in preview and Record
- keep normal Toggle controls focused on gating variables while publishing the complete authored cycle tuple for Record, including read-only co-driven variables
- rewrite only local variables and refuse Record states they cannot represent
- report unsupported `drawindexed` argument forms through the lazy health diagnostics
- add backend and frontend regressions for the new behavior

## Testing

- `.venv-test\Scripts\python.exe -m pytest -q` — 277 passed, 3 warnings
- focused backend suite — 45 passed
- focused frontend cycle/Record suite — 3 passed