### PR TITLE
Introduce typed DrawCall IR

### DIFF
--- a/context.md
+++ b/context.md
@@ -117,6 +117,9 @@ machine-specific paths or facts that are obvious from the source.
 - Geometry detection is conservative and format-specific. Do not infer a game
   or material meaning from a filename alone. Unknown, malformed or too-small
   buffers must be rejected or dropped safely rather than read beyond bounds.
+- Draw deduplication uses normalized effective buffer and material state.
+  Classify each new draw field explicitly as render identity, visibility or
+  provenance; never derive identity reflectively from every dictionary field.
 - An `ib` section without `drawindexed` may produce one synthetic whole-buffer
   draw. A `handling=skip` section without an explicit draw produces nothing.
   Real draw rows retain authored `count,start,base`; synthetic rows are the

--- a/context.md
+++ b/context.md
@@ -120,6 +120,10 @@ machine-specific paths or facts that are obvious from the source.
 - Draw deduplication uses normalized effective buffer and material state.
   Classify each new draw field explicitly as render identity, visibility or
   provenance; never derive identity reflectively from every dictionary field.
+- Authored draw state preserves vertex-buffer bindings by numeric slot and
+  distinguishes an untouched slot from an explicit `null`. Resolve effective
+  files per draw before deduplication; an IB change must not be required for a
+  VB change to take effect.
 - An `ib` section without `drawindexed` may produce one synthetic whole-buffer
   draw. A `handling=skip` section without an explicit draw produces nothing.
   Real draw rows retain authored `count,start,base`; synthetic rows are the

--- a/src/core/draw_call.py
+++ b/src/core/draw_call.py
@@ -9,7 +9,7 @@ rendered output instead of silently changing deduplication behavior.
 """
 
 from collections.abc import Iterator, Mapping, MutableMapping
-from dataclasses import dataclass, field, fields, replace
+from dataclasses import dataclass, field, fields
 from typing import ClassVar
 
 
@@ -23,7 +23,7 @@ def _freeze(value):
     return value
 
 
-@dataclass
+@dataclass(slots=True)
 class AuthoredDrawCall:
     """One parsed ``drawindexed`` row before resource-name resolution."""
 
@@ -35,19 +35,19 @@ class AuthoredDrawCall:
     index_resource: str | None = None
     diffuse_variants: list = field(default_factory=list)
     diffuse_history: list = field(default_factory=list)
-    vertex_resources: tuple[str | None, str | None, str | None] = (
-        None, None, None)
+    # Missing slot = no authored state in this execution path; None = an
+    # explicit `vbN = null`; a string = the resource bound at this draw.
+    vertex_resources: dict[int, str | None] = field(default_factory=dict)
     auxiliary_maps: dict = field(default_factory=dict)
 
 
-@dataclass
+@dataclass(slots=True)
 class DrawCall(MutableMapping):
     """Resolved draw geometry, material state, visibility and provenance.
 
-    Buffer fields may initially be ``None`` to inherit their draw group's
-    binding.  :meth:`resolved` applies those defaults before geometry packing
-    and deduplication, so :meth:`render_identity` describes effective state,
-    not the incidental difference between explicit and inherited bindings.
+    Buffer fields are effective resolved state. ``None`` means that slot is
+    unbound or unsupported, never "inherit from the group". Legacy dictionary
+    fixtures receive inheritance only in :meth:`from_mapping`.
     """
 
     label: str = ""
@@ -102,7 +102,7 @@ class DrawCall(MutableMapping):
         return tuple(item.name for item in fields(cls))
 
     @classmethod
-    def from_mapping(cls, value):
+    def from_mapping(cls, value, group=None):
         if isinstance(value, cls):
             return value
         if not isinstance(value, Mapping):
@@ -112,24 +112,16 @@ class DrawCall(MutableMapping):
         if unknown:
             names = ", ".join(sorted(unknown))
             raise TypeError(f"unsupported DrawCall field(s): {names}")
-        return cls(**dict(value))
+        values = dict(value)
+        for name in ("ib_file", "index_size", "position_file",
+                     "position_stride", "texcoord_file", "texcoord_stride"):
+            if name not in values and group is not None:
+                values[name] = group.get(name)
+        return cls(**values)
 
-    def resolved(self, group):
-        """Return a copy with effective group-level buffer state applied."""
-        def inherited(value, key):
-            return group.get(key) if value is None else value
-
-        return replace(
-            self,
-            ib_file=inherited(self.ib_file, "ib_file"),
-            index_size=inherited(self.index_size, "index_size"),
-            position_file=inherited(self.position_file, "position_file"),
-            texcoord_file=inherited(self.texcoord_file, "texcoord_file"),
-            position_stride=inherited(
-                self.position_stride, "position_stride"),
-            texcoord_stride=inherited(
-                self.texcoord_stride, "texcoord_stride"),
-        )
+    def to_dict(self):
+        """Return the legacy sparse mapping projection for external callers."""
+        return {name: self[name] for name in self}
 
     def render_identity(self):
         """Stable identity for geometry/material deduplication.

--- a/src/core/draw_call.py
+++ b/src/core/draw_call.py
@@ -1,0 +1,208 @@
+"""Typed draw-call records shared by INI discovery and mesh construction.
+
+The parser first captures an :class:`AuthoredDrawCall`, whose resources still
+use INI names. Resource resolution then produces :class:`DrawCall`. The latter
+retains a small mapping compatibility surface because ``build_draw_groups`` is
+also used by low-level fixtures and external scripts, but its schema and render
+identity are explicit: adding a field requires deciding whether it changes
+rendered output instead of silently changing deduplication behavior.
+"""
+
+from collections.abc import Iterator, Mapping, MutableMapping
+from dataclasses import dataclass, field, fields, replace
+from typing import ClassVar
+
+
+def _freeze(value):
+    """Return a deterministic, hashable projection of nested IR state."""
+    if isinstance(value, Mapping):
+        return tuple(sorted((key, _freeze(item))
+                            for key, item in value.items()))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+@dataclass
+class AuthoredDrawCall:
+    """One parsed ``drawindexed`` row before resource-name resolution."""
+
+    count: int | None
+    start: int
+    base: int
+    conditions: list = field(default_factory=list)
+    source: dict | None = None
+    index_resource: str | None = None
+    diffuse_variants: list = field(default_factory=list)
+    diffuse_history: list = field(default_factory=list)
+    vertex_resources: tuple[str | None, str | None, str | None] = (
+        None, None, None)
+    auxiliary_maps: dict = field(default_factory=dict)
+
+
+@dataclass
+class DrawCall(MutableMapping):
+    """Resolved draw geometry, material state, visibility and provenance.
+
+    Buffer fields may initially be ``None`` to inherit their draw group's
+    binding.  :meth:`resolved` applies those defaults before geometry packing
+    and deduplication, so :meth:`render_identity` describes effective state,
+    not the incidental difference between explicit and inherited bindings.
+    """
+
+    label: str = ""
+    count: int | None = None
+    start: int = 0
+    base: int = 0
+    conditions: list = field(default_factory=list)
+    sources: list = field(default_factory=list)
+
+    ib_file: str | None = None
+    index_size: int | None = None
+    position_file: str | None = None
+    texcoord_file: str | None = None
+    position_stride: int | None = None
+    texcoord_stride: int | None = None
+
+    texture_default_file: str | None = None
+    texture_variants: list = field(default_factory=list)
+    texture_assignments: list = field(default_factory=list)
+    normal_map_default_file: str | None = None
+    normal_map_variants: list = field(default_factory=list)
+    light_map_default_file: str | None = None
+    light_map_variants: list = field(default_factory=list)
+    material_map_default_file: str | None = None
+    material_map_variants: list = field(default_factory=list)
+
+    _ALWAYS_PRESENT: ClassVar[frozenset[str]] = frozenset({
+        "count", "start", "base", "conditions", "sources",
+    })
+    _TEXTURE_PREFIX: ClassVar[dict[str, str]] = {
+        "diffuse": "texture",
+        "normal_map": "normal_map",
+        "light_map": "light_map",
+        "material_map": "material_map",
+    }
+    _NON_RENDER_FIELDS: ClassVar[frozenset[str]] = frozenset({
+        "label", "conditions", "sources",
+    })
+    _RENDER_IDENTITY_FIELDS: ClassVar[tuple[str, ...]] = (
+        "count", "start", "base",
+        "ib_file", "index_size",
+        "position_file", "position_stride",
+        "texcoord_file", "texcoord_stride",
+        "texture_default_file", "texture_variants", "texture_assignments",
+        "normal_map_default_file", "normal_map_variants",
+        "light_map_default_file", "light_map_variants",
+        "material_map_default_file", "material_map_variants",
+    )
+
+    @classmethod
+    def field_names(cls):
+        return tuple(item.name for item in fields(cls))
+
+    @classmethod
+    def from_mapping(cls, value):
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, Mapping):
+            raise TypeError(
+                f"draw call must be a mapping, got {type(value).__name__}")
+        unknown = set(value) - set(cls.field_names())
+        if unknown:
+            names = ", ".join(sorted(unknown))
+            raise TypeError(f"unsupported DrawCall field(s): {names}")
+        return cls(**dict(value))
+
+    def resolved(self, group):
+        """Return a copy with effective group-level buffer state applied."""
+        def inherited(value, key):
+            return group.get(key) if value is None else value
+
+        return replace(
+            self,
+            ib_file=inherited(self.ib_file, "ib_file"),
+            index_size=inherited(self.index_size, "index_size"),
+            position_file=inherited(self.position_file, "position_file"),
+            texcoord_file=inherited(self.texcoord_file, "texcoord_file"),
+            position_stride=inherited(
+                self.position_stride, "position_stride"),
+            texcoord_stride=inherited(
+                self.texcoord_stride, "texcoord_stride"),
+        )
+
+    def render_identity(self):
+        """Stable identity for geometry/material deduplication.
+
+        Visibility alternatives, provenance and the generated label are
+        deliberately excluded.  Every field below has been reviewed as state
+        that can change the rendered result.
+        """
+        classified = (set(self._RENDER_IDENTITY_FIELDS)
+                      | set(self._NON_RENDER_FIELDS))
+        schema = set(self.field_names())
+        if classified != schema:
+            missing = ", ".join(sorted(schema - classified)) or "none"
+            stale = ", ".join(sorted(classified - schema)) or "none"
+            raise TypeError(
+                "DrawCall identity classification is incomplete "
+                f"(unclassified: {missing}; stale: {stale})")
+        return _freeze(tuple(
+            getattr(self, name) for name in self._RENDER_IDENTITY_FIELDS))
+
+    def set_texture_default(self, role, path):
+        prefix = self._TEXTURE_PREFIX[role]
+        setattr(self, f"{prefix}_default_file", path)
+
+    def texture_default(self, role):
+        prefix = self._TEXTURE_PREFIX[role]
+        return getattr(self, f"{prefix}_default_file")
+
+    def set_texture_variants(self, role, variants):
+        prefix = self._TEXTURE_PREFIX[role]
+        setattr(self, f"{prefix}_variants", variants)
+
+    def texture_rules(self, role):
+        if role == "diffuse" and self.texture_assignments:
+            return self.texture_assignments
+        prefix = self._TEXTURE_PREFIX[role]
+        return getattr(self, f"{prefix}_variants")
+
+    # MutableMapping compatibility for existing low-level consumers.
+    def _present(self, key):
+        value = getattr(self, key)
+        if key in self._ALWAYS_PRESENT:
+            return True
+        if isinstance(value, (list, dict)):
+            return bool(value)
+        return value is not None and value != ""
+
+    def __getitem__(self, key):
+        if key not in self.field_names() or not self._present(key):
+            raise KeyError(key)
+        return getattr(self, key)
+
+    def __setitem__(self, key, value):
+        if key not in self.field_names():
+            raise KeyError(f"unsupported DrawCall field: {key}")
+        setattr(self, key, value)
+
+    def __delitem__(self, key):
+        if key not in self.field_names():
+            raise KeyError(key)
+        if key in self._ALWAYS_PRESENT:
+            raise KeyError(f"cannot delete required DrawCall field: {key}")
+        if key in {"texture_variants", "texture_assignments",
+                   "normal_map_variants", "light_map_variants",
+                   "material_map_variants"}:
+            setattr(self, key, [])
+        elif key == "label":
+            setattr(self, key, "")
+        else:
+            setattr(self, key, None)
+
+    def __iter__(self) -> Iterator[str]:
+        return (name for name in self.field_names() if self._present(name))
+
+    def __len__(self):
+        return sum(1 for _ in self)

--- a/src/core/ini_parser.py
+++ b/src/core/ini_parser.py
@@ -12,6 +12,7 @@ existing `from core.ini_parser import ...` callers keep working:
 
 import re
 
+from .draw_call import AuthoredDrawCall, DrawCall
 from .mesh_builder import POSITION_STRIDE, DEFAULT_UV_OFFSET, _res_get
 from .ini_sections import (SrcLine, extract_resources, first_source,
                            line_source, merge_sections, parse_sections,
@@ -107,11 +108,10 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
 
     Returns {section_name: {vb0, vb1, vb2, ib, draws, diffuse, src}} — the
     same per-section shape build_draw_groups uses internally as `sec_info`.
-    `draws` entries are (count, start, base, conds, source, ib, diffuse_variants,
-    vb_snapshot) tuples, where vb_snapshot is the (vb0, vb1, vb2) most recently
-    assigned before that line -- kept for provenance only; build_draw_groups
-    re-derives the actual position/texcoord buffers for a reassigned `ib`
-    from its component instead of trusting these literal values.
+    `draws` entries are typed AuthoredDrawCall records. Their vertex_resources
+    snapshot is kept for provenance only; build_draw_groups re-derives the
+    actual position/texcoord buffers for a reassigned `ib` from its component
+    instead of trusting those literal values.
     """
     toggle_vars = (gating_vars if gating_vars is not None else
                    gating_var_names(sections))
@@ -199,14 +199,21 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 for frame in cond_stack:
                     combined = dnf_and(combined, frame["cur"])
                 conds = normalize_dnf(combined, toggle_vars, var_prefix)
-                info["draws"].append((int(m.group(1)), int(m.group(2)),
-                                      int(m.group(3)), conds, line_source(raw),
-                                      info.get("_cur_ib"),
-                                      list(info.get("_cur_diffuse_variants") or []),
-                                      list(info.get("_diffuse_history") or []),
-                                      (info.get("_cur_vb0"), info.get("_cur_vb1"),
-                                       info.get("_cur_vb2"))))
-                info["aux_draw_states"].append(_aux_snapshot(info))
+                info["draws"].append(AuthoredDrawCall(
+                    count=int(m.group(1)),
+                    start=int(m.group(2)),
+                    base=int(m.group(3)),
+                    conditions=conds,
+                    source=line_source(raw),
+                    index_resource=info.get("_cur_ib"),
+                    diffuse_variants=list(
+                        info.get("_cur_diffuse_variants") or []),
+                    diffuse_history=list(info.get("_diffuse_history") or []),
+                    vertex_resources=(
+                        info.get("_cur_vb0"), info.get("_cur_vb1"),
+                        info.get("_cur_vb2")),
+                    auxiliary_maps=_aux_snapshot(info),
+                ))
             # "ref" is optional -- XXMI-generated mods omit it (e.g. "Resource\GIMI\Diffuse = X").
             m_diff = re.match(r"Resource\\[^\\]+\\Diffuse\s*=\s*(?:ref\s+)?(\S+)", line, re.I)
             if not m_diff:
@@ -317,7 +324,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
         info: dict = dict(vb0=None, vb1=None, vb2=None, ib=None, draws=[],
                           diffuse=None, diffuse_pool=[], src=None, handling_skip=False,
                           _cur_diffuse_variants=[], _diffuse_chain_key=None,
-                          _diffuse_history=[], _aux_maps={}, aux_draw_states=[])
+                          _diffuse_history=[], _aux_maps={})
         _scan(lines, info, [], {name})
         info.pop("_cur_ib", None)
         info.pop("_cur_vb0", None)
@@ -673,32 +680,43 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         pos_stride = pos_ri.get("stride", POSITION_STRIDE)
         uv_off     = DEFAULT_UV_OFFSET
 
-        draws_list = list(info["draws"]) or [
-            (None, 0, 0, [], info["src"], None,
-             info.get("diffuse_variants_at_end") or [],
-             info.get("diffuse_history_at_end") or [], (None, None, None))]
-        aux_draw_states = (info.get("aux_draw_states") or
-                           [info.get("aux_maps_at_end") or {}])
+        draws_list = list(info["draws"]) or [AuthoredDrawCall(
+            count=None,
+            start=0,
+            base=0,
+            source=info["src"],
+            diffuse_variants=info.get("diffuse_variants_at_end") or [],
+            diffuse_history=info.get("diffuse_history_at_end") or [],
+            auxiliary_maps=info.get("aux_maps_at_end") or {},
+        )]
         draws = []
-        for i, (c, s, b, cd, src, draw_ib, diff_variants,
-                diff_history, _vb_ov) in enumerate(draws_list, 1):
-            d = dict(label=f"{label}-{i}", count=c, start=s, base=b,
-                     conditions=cd, sources=[src] if src else [])
+        for i, authored in enumerate(draws_list, 1):
+            d = DrawCall(
+                label=f"{label}-{i}",
+                count=authored.count,
+                start=authored.start,
+                base=authored.base,
+                conditions=authored.conditions,
+                sources=[authored.source] if authored.source else [],
+            )
             # A mid-section `ib = ...` reassignment.
-            if draw_ib and draw_ib != ib_res:
-                resolved = _resolve_ib_file(draw_ib)
+            if (authored.index_resource
+                    and authored.index_resource != ib_res):
+                resolved = _resolve_ib_file(authored.index_resource)
                 if resolved:
-                    d["ib_file"] = resolved
-                    d["index_size"] = _ib_index_size(_res_get(resources, draw_ib).get("format"))
-                draw_buf = _lookup_comp_buf(_ib_res_to_component(draw_ib))
+                    d.ib_file = resolved
+                    d.index_size = _ib_index_size(
+                        _res_get(resources, authored.index_resource).get("format"))
+                draw_buf = _lookup_comp_buf(
+                    _ib_res_to_component(authored.index_resource))
                 if draw_buf and draw_buf != buf:
                     pfile, pstride = _resolve_vertex_res(draw_buf["position"])
                     tfile, tstride = _resolve_vertex_res(draw_buf["texcoord"])
                     if pfile and tfile:
-                        d["position_file"] = pfile
-                        d["texcoord_file"] = tfile
-                        d["position_stride"] = pstride or POSITION_STRIDE
-                        d["texcoord_stride"] = tstride or 20
+                        d.position_file = pfile
+                        d.texcoord_file = tfile
+                        d.position_stride = pstride or POSITION_STRIDE
+                        d.texcoord_stride = tstride or 20
             # Whichever Resource\...\Diffuse line most recently ran before
             # this draw, in execution order -- the draw's own default
             # texture (see core.mesh_builder.build_mesh_payload). The first
@@ -706,17 +724,17 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             # bound (matches the `if` branch of an elif chain); a toggle
             # press picks a different entry via texture_variants below.
             variants = []
-            for v in diff_variants:
+            for v in authored.diffuse_variants:
                 file = _resolve_diffuse_file(v["res"])
                 if file:
                     variants.append({"conditions": v["cond"], "file": file})
             if variants:
-                d["texture_default_file"] = variants[0]["file"]
+                d.set_texture_default("diffuse", variants[0]["file"])
             # A toggle that swaps the diffuse texture rather than gating a draw.
             if len(variants) > 1:
-                d["texture_variants"] = variants
+                d.set_texture_variants("diffuse", variants)
             history = []
-            for v in diff_history:
+            for v in authored.diffuse_history:
                 file = _resolve_diffuse_file(v["res"])
                 if file:
                     history.append({"conditions": v["cond"], "file": file})
@@ -732,18 +750,17 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             if (len(history) > 1 and
                     (history_vars - legacy_vars or
                      len(history) > len(variants))):
-                d["texture_assignments"] = history
+                d.texture_assignments = history
 
             # Authored PBR companions follow the same execution-order model
             # as diffuse assignments, but remain INI-only (no manual pool).
             # A conditional single assignment has no unconditional default;
             # the frontend must be able to fall back to no map when it fails.
-            aux_state = aux_draw_states[min(i - 1, len(aux_draw_states) - 1)]
-            for channel, state in aux_state.items():
-                authored = state.get("history") or state.get("variants") or []
+            for channel, state in authored.auxiliary_maps.items():
+                assignments = state.get("history") or state.get("variants") or []
                 resolved = []
                 default_file = None
-                for assignment in authored:
+                for assignment in assignments:
                     file = _resolve_diffuse_file(assignment["res"])
                     if not file:
                         continue
@@ -752,10 +769,10 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                     if not conditions:
                         default_file = file
                 if default_file:
-                    d[f"{channel}_default_file"] = default_file
+                    d.set_texture_default(channel, default_file)
                 if (len(resolved) > 1 or
                         (resolved and resolved[0]["conditions"])):
-                    d[f"{channel}_variants"] = resolved
+                    d.set_texture_variants(channel, resolved)
             draws.append(d)
         pool_files, seen_pool_files = [], set()
         for res in info["diffuse_pool"]:

--- a/src/core/ini_parser.py
+++ b/src/core/ini_parser.py
@@ -170,21 +170,14 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             if low == "endif":
                 if cond_stack: cond_stack.pop()
                 continue
-            m = re.match(r"vb0\s*=\s*(?:ref\s+)?(\S+)", line, re.I)
+            m = re.match(r"vb(\d+)\s*=\s*(?:ref\s+)?(\S+)", line, re.I)
             if m:
-                value = None if m.group(1).lower() == "null" else m.group(1)
-                if value and not info["vb0"]: info["vb0"] = value
-                info["_cur_vb0"] = value
-            m = re.match(r"vb1\s*=\s*(?:ref\s+)?(\S+)", line, re.I)
-            if m:
-                value = None if m.group(1).lower() == "null" else m.group(1)
-                if value and not info["vb1"]: info["vb1"] = value
-                info["_cur_vb1"] = value
-            m = re.match(r"vb2\s*=\s*(?:ref\s+)?(\S+)", line, re.I)
-            if m:
-                value = None if m.group(1).lower() == "null" else m.group(1)
-                if value and not info["vb2"]: info["vb2"] = value
-                info["_cur_vb2"] = value
+                slot = int(m.group(1))
+                resource = m.group(2)
+                value = None if resource.lower() == "null" else resource
+                if slot <= 2 and value and not info[f"vb{slot}"]:
+                    info[f"vb{slot}"] = value
+                info["_cur_vertex_resources"][slot] = value
             m = re.match(r"ib\s*=\s*(\S+)", line, re.I)
             if m:
                 if not info["ib"]: info["ib"] = m.group(1)
@@ -209,9 +202,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                     diffuse_variants=list(
                         info.get("_cur_diffuse_variants") or []),
                     diffuse_history=list(info.get("_diffuse_history") or []),
-                    vertex_resources=(
-                        info.get("_cur_vb0"), info.get("_cur_vb1"),
-                        info.get("_cur_vb2")),
+                    vertex_resources=dict(info["_cur_vertex_resources"]),
                     auxiliary_maps=_aux_snapshot(info),
                 ))
             # "ref" is optional -- XXMI-generated mods omit it (e.g. "Resource\GIMI\Diffuse = X").
@@ -324,12 +315,11 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
         info: dict = dict(vb0=None, vb1=None, vb2=None, ib=None, draws=[],
                           diffuse=None, diffuse_pool=[], src=None, handling_skip=False,
                           _cur_diffuse_variants=[], _diffuse_chain_key=None,
-                          _diffuse_history=[], _aux_maps={})
+                          _diffuse_history=[], _aux_maps={},
+                          _cur_vertex_resources={})
         _scan(lines, info, [], {name})
         info.pop("_cur_ib", None)
-        info.pop("_cur_vb0", None)
-        info.pop("_cur_vb1", None)
-        info.pop("_cur_vb2", None)
+        info.pop("_cur_vertex_resources", None)
         # Whatever diffuse was active at the end of the scan -- needed for a
         # section with NO drawindexed line at all (the game's original,
         # whole-buffer draw proceeds unmodified against this section's own
@@ -678,6 +668,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
 
         tc_stride  = tc_ri.get("stride", 20)
         pos_stride = pos_ri.get("stride", POSITION_STRIDE)
+        index_size = _ib_index_size(ib_ri.get("format"))
         uv_off     = DEFAULT_UV_OFFSET
 
         draws_list = list(info["draws"]) or [AuthoredDrawCall(
@@ -698,25 +689,68 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                 base=authored.base,
                 conditions=authored.conditions,
                 sources=[authored.source] if authored.source else [],
+                ib_file=ib_file,
+                index_size=index_size,
+                position_file=pos_file,
+                position_stride=pos_stride,
+                texcoord_file=tc_file,
+                texcoord_stride=tc_stride,
             )
-            # A mid-section `ib = ...` reassignment.
-            if (authored.index_resource
-                    and authored.index_resource != ib_res):
-                resolved = _resolve_ib_file(authored.index_resource)
-                if resolved:
-                    d.ib_file = resolved
+            # Resolve the effective buffers before deduplication. Concrete
+            # per-draw VB bindings win; runtime-only resources retain the
+            # existing IB/component heuristic, while an authored null stays
+            # unbound instead of inheriting the group's first binding.
+            effective_ib = authored.index_resource or ib_res
+            if effective_ib != ib_res:
+                resolved_ib = _resolve_ib_file(effective_ib)
+                if resolved_ib:
+                    d.ib_file = resolved_ib
                     d.index_size = _ib_index_size(
-                        _res_get(resources, authored.index_resource).get("format"))
-                draw_buf = _lookup_comp_buf(
-                    _ib_res_to_component(authored.index_resource))
-                if draw_buf and draw_buf != buf:
-                    pfile, pstride = _resolve_vertex_res(draw_buf["position"])
-                    tfile, tstride = _resolve_vertex_res(draw_buf["texcoord"])
-                    if pfile and tfile:
+                        _res_get(resources, effective_ib).get("format"))
+
+            draw_buf = _lookup_comp_buf(_ib_res_to_component(effective_ib))
+            if draw_buf and draw_buf != buf:
+                pfile, pstride = _resolve_vertex_res(draw_buf["position"])
+                tfile, tstride = _resolve_vertex_res(draw_buf["texcoord"])
+                if pfile:
+                    d.position_file = pfile
+                    d.position_stride = pstride or POSITION_STRIDE
+                if tfile:
+                    d.texcoord_file = tfile
+                    d.texcoord_stride = tstride or 20
+
+            vertex_resources = authored.vertex_resources
+            if 0 in vertex_resources:
+                position_resource = vertex_resources[0]
+                if position_resource is None:
+                    d.position_file = None
+                    d.position_stride = None
+                else:
+                    pfile, pstride = _resolve_vertex_res(position_resource)
+                    if pfile:
                         d.position_file = pfile
-                        d.texcoord_file = tfile
                         d.position_stride = pstride or POSITION_STRIDE
-                        d.texcoord_stride = tstride or 20
+
+            authored_tc = {
+                slot: vertex_resources[slot]
+                for slot in (1, 2) if slot in vertex_resources
+            }
+            resolved_tc = None
+            for slot in (2, 1):
+                resource_name = authored_tc.get(slot)
+                if not resource_name:
+                    continue
+                tfile, tstride = _resolve_vertex_res(resource_name)
+                if tfile and (tstride or 0) != 32:
+                    resolved_tc = (tfile, tstride or 20)
+                    break
+            if resolved_tc:
+                d.texcoord_file, d.texcoord_stride = resolved_tc
+            elif authored_tc and any(
+                    resource_name is None
+                    for resource_name in authored_tc.values()):
+                d.texcoord_file = None
+                d.texcoord_stride = None
             # Whichever Resource\...\Diffuse line most recently ran before
             # this draw, in execution order -- the draw's own default
             # texture (see core.mesh_builder.build_mesh_payload). The first
@@ -789,7 +823,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             texcoord_stride=tc_stride, texcoord_uv_off=uv_off,
             ib_file=ib_file, diffuse_file=diff_ri.get("filename"),
             diffuse_pool_files=pool_files,
-            index_size=_ib_index_size(ib_ri.get("format")),
+            index_size=index_size,
             draws=draws,
         ))
 

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -3,6 +3,7 @@
 import re, struct, os, base64
 from dataclasses import dataclass
 
+from .draw_call import DrawCall
 from .resource_paths import safe_resource_path
 from .textures import (_texture_source_uri, _begin_texture_cache,
                        encode_texture_data_uri, normalize_texture_role,
@@ -228,33 +229,19 @@ def _deduplicate_draws(group, max_draws=0):
     This is a distinct pipeline stage: geometry packing receives one
     deterministic draw list and does not own the condition-merging rules.
     """
-    def freeze(value):
-        """Turn nested draw metadata into a stable, hashable identity."""
-        if isinstance(value, dict):
-            return tuple(sorted((key, freeze(item))
-                                for key, item in value.items()))
-        if isinstance(value, (list, tuple)):
-            return tuple(freeze(item) for item in value)
-        return value
-
     merged = {}
     order = []
-    for draw in group["draws"]:
-        # TODO(DrawCall IR): replace this reflective key with an explicit,
-        # normalized render_identity once draw parsing has a typed IR.
-        # Only provenance, visibility alternatives and the generated label may
-        # differ between rows that are safe to merge. In particular, base
-        # vertex, index size and material/texture state are part of identity.
-        key = freeze({name: value for name, value in draw.items()
-                      if name not in {"label", "conditions", "sources"}})
+    for raw_draw in group["draws"]:
+        draw = DrawCall.from_mapping(raw_draw).resolved(group)
+        key = draw.render_identity()
         if key not in merged:
             merged[key] = {"draw": draw, "alts": [], "sources": []}
             order.append(key)
         entry = merged[key]
-        for src in draw.get("sources") or []:
+        for src in draw.sources:
             if src not in entry["sources"]:
                 entry["sources"].append(src)
-        cond_groups = draw.get("conditions") or []
+        cond_groups = draw.conditions
         if not cond_groups:
             if [] not in entry["alts"]:
                 entry["alts"].append([])
@@ -267,9 +254,9 @@ def _deduplicate_draws(group, max_draws=0):
     for key in order:
         entry = merged[key]
         draw, alternatives = entry["draw"], entry["alts"]
-        draw["conditions"] = (
+        draw.conditions = (
             [] if any(not group for group in alternatives) else alternatives)
-        draw["sources"] = entry["sources"]
+        draw.sources = entry["sources"]
         unique.append(draw)
     return unique[:max_draws] if max_draws else unique
 
@@ -503,22 +490,21 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                                         "label": label})
 
         for draw in unique:
-            lbl = draw["label"]
-            draw_ib_path = ib_path
-            if draw.get("ib_file"):
-                draw_ib_path = safe_resource_path(mod_dir, draw["ib_file"])
-                if not draw_ib_path or not os.path.exists(draw_ib_path):
-                    continue
-                if draw_ib_path not in ib_cache:
-                    ib_cache[draw_ib_path] = _read_buffer(draw_ib_path)
-            raw = read_indices(ib_cache[draw_ib_path], draw["start"], draw["count"],
-                               draw.get("index_size", index_size))
+            lbl = draw.label
+            draw_ib_path = safe_resource_path(mod_dir, draw.ib_file)
+            if not draw_ib_path or not os.path.exists(draw_ib_path):
+                continue
+            if draw_ib_path not in ib_cache:
+                ib_cache[draw_ib_path] = _read_buffer(draw_ib_path)
+            raw = read_indices(
+                ib_cache[draw_ib_path], draw.start, draw.count,
+                draw.index_size if draw.index_size is not None else index_size)
             if not raw:
                 continue
             # DirectX resolves each index as index_buffer_value + BaseVertexLocation
             # against the vertex buffer -- shared/merged buffers rely on this offset
             # to pick out this draw's own vertex range.
-            base = draw.get("base") or 0
+            base = draw.base
             if base:
                 raw = [v + base for v in raw]
             # A negative effective DirectX vertex index is invalid.  Reject it
@@ -533,17 +519,25 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
 
             # A mid-section `vb0/vb1/vb2 = ...` reassignment (paired with `ib`).
             draw_buffers = buffers
-            effective_pos_path = pos_path
-            if draw.get("position_file") and draw.get("texcoord_file"):
-                draw_pos_path = safe_resource_path(mod_dir, draw["position_file"])
-                draw_tc_path  = safe_resource_path(mod_dir, draw["texcoord_file"])
-                if not (draw_pos_path and draw_tc_path
-                        and os.path.exists(draw_pos_path) and os.path.exists(draw_tc_path)):
-                    continue
+            draw_pos_path = safe_resource_path(mod_dir, draw.position_file)
+            draw_tc_path = safe_resource_path(mod_dir, draw.texcoord_file)
+            if not (draw_pos_path and draw_tc_path
+                    and os.path.exists(draw_pos_path)
+                    and os.path.exists(draw_tc_path)):
+                continue
+            effective_pos_path = draw_pos_path
+            draw_position_stride = (
+                draw.position_stride
+                if draw.position_stride is not None else pos_stride)
+            draw_texcoord_stride = (
+                draw.texcoord_stride
+                if draw.texcoord_stride is not None else tc_stride)
+            if (draw_pos_path != pos_path or draw_tc_path != tc_path
+                    or draw_position_stride != pos_stride
+                    or draw_texcoord_stride != tc_stride):
                 draw_buffers = _load_buf(
-                    draw_pos_path, draw.get("position_stride", pos_stride),
-                    draw_tc_path, draw.get("texcoord_stride", tc_stride))
-                effective_pos_path = draw_pos_path
+                    draw_pos_path, draw_position_stride,
+                    draw_tc_path, draw_texcoord_stride)
 
             pos_data, draw_pos_stride, tc_data, draw_tc_stride, uv_off, uv_fmt = draw_buffers
             uv_size = struct.calcsize(uv_fmt)
@@ -593,7 +587,7 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 struct.pack_into("<I", idx_bytes, out_i * 4, remap[value])
 
             default_key = _ensure_texture(
-                safe_resource_path(mod_dir, draw.get("texture_default_file")))
+                safe_resource_path(mod_dir, draw.texture_default("diffuse")))
             entry: dict = {
                 "pos": _geometry_ref(pos_bytes, geometry),
                 "idx": _geometry_ref(idx_bytes, geometry),
@@ -605,14 +599,14 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
             # profile-owned.  WuWa publishes the intact packed source as
             # normal_data; Genshin/ZZZ retain the derived normal_map path.
             normal_path = safe_resource_path(
-                mod_dir, draw.get("normal_map_default_file"))
+                mod_dir, draw.texture_default("normal_map"))
             normal_role = texture_profile.normal_transport_role
             normal_key = _ensure_texture(normal_path, normal_role)
             if normal_key:
                 entry[f"{normal_role}_key"] = normal_key
             for channel in ("light_map", "material_map"):
                 key = _ensure_texture(safe_resource_path(
-                    mod_dir, draw.get(f"{channel}_default_file")), channel)
+                    mod_dir, draw.texture_default(channel)), channel)
                 if key:
                     entry[f"{channel}_key"] = key
             # The manager presents one row per diffuse. Seed that row with the
@@ -643,13 +637,13 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                     if len(item) > 5 and item[5] is not None:
                         target["low_pos"] = _geometry_ref(item[5], geometry)
                     entry["shape_targets"].append(target)
-            if draw.get("conditions"):
-                entry["conditions"] = draw["conditions"]
-            if draw.get("sources"):
-                entry["sources"] = [_rel_source(s, mod_dir) for s in draw["sources"]]
+            if draw.conditions:
+                entry["conditions"] = draw.conditions
+            if draw.sources:
+                entry["sources"] = [_rel_source(s, mod_dir)
+                                    for s in draw.sources]
             # A toggle can swap the diffuse texture.
-            texture_rules = (draw.get("texture_assignments")
-                             or draw.get("texture_variants"))
+            texture_rules = draw.texture_rules("diffuse")
             if texture_rules:
                 variants = []
                 for v in texture_rules:
@@ -663,7 +657,7 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 if len(variants) > 1:
                     entry["texture_variants"] = variants
             for channel in ("light_map", "material_map"):
-                rules = draw.get(f"{channel}_variants") or []
+                rules = draw.texture_rules(channel)
                 variants = []
                 for variant in rules:
                     key = _ensure_texture(
@@ -675,7 +669,7 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                         })
                 if variants:
                     entry[f"{channel}_variants"] = variants
-            normal_rules = draw.get("normal_map_variants") or []
+            normal_rules = draw.texture_rules("normal_map")
             normal_variants = []
             for variant in normal_rules:
                 key = _ensure_texture(
@@ -696,9 +690,9 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
             # The literal `drawindexed = count, start, base` values, so the UI can
             # show a meaningful per-draw label instead of a bare "#1"/"#2" index.
             # Absent for the rare section with no drawindexed line at all (the
-            # whole index buffer is read unconditionally) — draw["count"] is None.
-            if draw.get("count") is not None:
-                entry["drawindexed"] = [draw["count"], draw["start"], draw["base"]]
+            # whole index buffer is read unconditionally) — count is None.
+            if draw.count is not None:
+                entry["drawindexed"] = [draw.count, draw.start, draw.base]
             if source:
                 entry["source"] = source
             if component:

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -232,7 +232,7 @@ def _deduplicate_draws(group, max_draws=0):
     merged = {}
     order = []
     for raw_draw in group["draws"]:
-        draw = DrawCall.from_mapping(raw_draw).resolved(group)
+        draw = DrawCall.from_mapping(raw_draw, group)
         key = draw.render_identity()
         if key not in merged:
             merged[key] = {"draw": draw, "alts": [], "sources": []}

--- a/src/core/record_editor.py
+++ b/src/core/record_editor.py
@@ -532,9 +532,9 @@ def verify_recording(path, report, text=None, document=None):
 
     conds_by_draw = {}
     for section_name, info in draw_info.items():
-        for (count, start, base, conds, _src, _ib, _dv,
-             _diffuse_history, _vb) in info["draws"]:
-            conds_by_draw[(section_name, count, start, base)] = conds
+        for draw in info["draws"]:
+            key = (section_name, draw.count, draw.start, draw.base)
+            conds_by_draw[key] = draw.conditions
 
     mismatches = []
     for var, spec in verify.items():

--- a/src/tests/test_provenance.py
+++ b/src/tests/test_provenance.py
@@ -7,7 +7,10 @@ and line after parsing and deduplication.
 import os
 import tempfile
 
+import pytest
+
 from app import mod_loader
+from core.draw_call import DrawCall
 from core.ini_parser import (SrcLine, build_draw_groups, extract_resources,
                              extract_toggle_keys, line_source, merge_sections,
                              parse_sections)
@@ -173,6 +176,41 @@ def test_deduplicate_preserves_base_index_and_material_identity():
     ]
     merged = _deduplicate_draws({"draws": draws})
     assert len(merged) == 4
+
+
+def test_draw_call_ir_normalizes_inherited_state_before_deduplication():
+    group = {
+        "ib_file": "body.ib", "index_size": 4,
+        "position_file": "body.pos", "position_stride": 40,
+        "texcoord_file": "body.tc", "texcoord_stride": 20,
+        "draws": [
+            {"label": "implicit", "count": 100, "start": 0, "base": 0,
+             "conditions": [[{"var": "swap", "value": "0"}]],
+             "sources": [{"line_no": 10}]},
+            {"label": "explicit", "count": 100, "start": 0, "base": 0,
+             "ib_file": "body.ib", "index_size": 4,
+             "position_file": "body.pos", "position_stride": 40,
+             "texcoord_file": "body.tc", "texcoord_stride": 20,
+             "conditions": [[{"var": "swap", "value": "1"}]],
+             "sources": [{"line_no": 20}]},
+        ],
+    }
+
+    merged = _deduplicate_draws(group)
+
+    assert len(merged) == 1
+    assert isinstance(merged[0], DrawCall)
+    assert [source["line_no"] for source in merged[0].sources] == [10, 20]
+    assert len(merged[0].conditions) == 2
+
+
+def test_draw_call_ir_rejects_unreviewed_fields():
+    with pytest.raises(TypeError, match="unsupported DrawCall field"):
+        _deduplicate_draws({
+            "draws": [{"count": 3, "start": 0, "base": 0,
+                       "conditions": [], "sources": [],
+                       "future_render_state": "unclassified"}],
+        })
 
 
 COMPONENT0_INI = """[CommandListShared]

--- a/src/tests/test_provenance.py
+++ b/src/tests/test_provenance.py
@@ -211,6 +211,10 @@ def test_draw_call_ir_rejects_unreviewed_fields():
                        "conditions": [], "sources": [],
                        "future_render_state": "unclassified"}],
         })
+    draw = DrawCall(count=3, start=0, base=0)
+    with pytest.raises(AttributeError):
+        draw.future_render_state = "unclassified"
+    assert draw.to_dict()["count"] == 3
 
 
 COMPONENT0_INI = """[CommandListShared]

--- a/src/tests/test_resource_resolution.py
+++ b/src/tests/test_resource_resolution.py
@@ -6,9 +6,11 @@ import tempfile
 
 from _corpus import sample_mods
 from app import mod_loader
-from core.ini_parser import build_draw_groups, extract_resources, merge_sections, parse_sections
+from core.ini_parser import (_scan_sections_for_draws, build_draw_groups,
+                             extract_resources, merge_sections, parse_sections)
 from core.textures import encode_texture_file
-from _provenance_support import build_mesh_fixture, visible, write
+from _provenance_support import (build_mesh_fixture, geometry_values, visible,
+                                 write)
 
 def _traversal_mod(tmp, pos_filename):
     """A minimal one-draw mod whose vb0 filename is `pos_filename`."""
@@ -40,6 +42,71 @@ stride = 20
     groups = build_draw_groups(secs, extract_resources(secs))
     meshes, _geometry = build_mesh_fixture(groups, tmp)
     return meshes
+
+
+SAME_IB_VB_STATE_INI = """[TextureOverrideBody]
+ib = ResourceBodyIB
+vb0 = ResourcePosA
+vb1 = ResourceTcA
+vb6 = ResourceUnsupported
+drawindexed = 3, 0, 0
+vb0 = ResourcePosB
+vb1 = ResourceTcB
+drawindexed = 3, 0, 0
+vb0 = null
+drawindexed = 3, 0, 0
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosA]
+filename = pos-a.buf
+stride = 12
+
+[ResourcePosB]
+filename = pos-b.buf
+stride = 12
+
+[ResourceTcA]
+filename = tc-a.buf
+stride = 8
+
+[ResourceTcB]
+filename = tc-b.buf
+stride = 8
+"""
+
+
+def test_same_ib_draws_keep_vb_snapshots_and_null_does_not_inherit():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", SAME_IB_VB_STATE_INI)
+        open(os.path.join(tmp, "body.ib"), "wb").write(
+            struct.pack("<3I", 0, 1, 2))
+        open(os.path.join(tmp, "pos-a.buf"), "wb").write(
+            struct.pack("<9f", 0, 0, 0, 1, 0, 0, 0, 1, 0))
+        open(os.path.join(tmp, "pos-b.buf"), "wb").write(
+            struct.pack("<9f", 10, 0, 0, 11, 0, 0, 10, 1, 0))
+        texcoords = struct.pack("<6f", 0, 0, 1, 0, 0, 1)
+        open(os.path.join(tmp, "tc-a.buf"), "wb").write(texcoords)
+        open(os.path.join(tmp, "tc-b.buf"), "wb").write(texcoords)
+
+        sections = merge_sections([path])
+        scanned = _scan_sections_for_draws(sections)["TextureOverrideBody"]
+        assert scanned["draws"][0].vertex_resources[6] == (
+            "ResourceUnsupported")
+        assert scanned["draws"][2].vertex_resources[0] is None
+
+        groups = build_draw_groups(sections, extract_resources(sections))
+        assert [draw.position_file for draw in groups[0]["draws"]] == [
+            "pos-a.buf", "pos-b.buf", None]
+        meshes, geometry = build_mesh_fixture(groups, tmp)
+
+        assert list(meshes) == ["Body-1", "Body-2"]
+        first = geometry_values(geometry, meshes["Body-1"]["pos"])
+        second = geometry_values(geometry, meshes["Body-2"]["pos"])
+        assert sorted(first[::3]) == [0, 0, 1]
+        assert sorted(second[::3]) == [10, 10, 11]
 
 
 def test_root_texture_picker_accepts_windows_case_variation():


### PR DESCRIPTION
## Summary

- replace positional scanned-draw tuples with typed `AuthoredDrawCall` records that preserve per-draw buffer, texture, condition, provenance, and auxiliary-map execution state
- preserve arbitrary numeric vertex-buffer slots and distinguish untouched slots from explicit `vbN = null`
- resolve each draw's effective IB/VB files and strides before geometry packing and deduplication, independent of whether its IB changed
- introduce a fully resolved, slotted `DrawCall` IR with an explicit `to_dict()` compatibility boundary for existing low-level callers
- replace reflective draw-dictionary deduplication with an explicit `render_identity()` contract that requires every future field to be classified
- migrate mesh building and Record verification to named IR fields while preserving the public mesh payload
- add an end-to-end same-IB/different-VB regression that verifies both meshes survive dedupe with their own geometry

## Testing

- `.venv-test\Scripts\python.exe -m pytest -q` — 280 passed, 3 warnings
- focused resource-resolution/provenance/geometry/material suite — 41 passed
- `python -m py_compile` for changed Python modules — passed