### PR TITLE
Add typed geometry layouts and safer draw detection

### DIFF
--- a/context.md
+++ b/context.md
@@ -126,8 +126,8 @@ machine-specific paths or facts that are obvious from the source.
   distinguishes an untouched slot from an explicit `null`. Resolve effective
   files per draw before deduplication; an IB change must not be required for a
   VB change to take effect. At a conditional join, retain VB and IB state only
-  when every path agrees; divergent state is unsupported rather than inherited
-  from an arbitrary branch.
+  when every path agrees; divergent state that can affect a consumed geometry
+  semantic is unsupported rather than inherited from an arbitrary branch.
 - Geometry decoding uses explicit position, texcoord and index layout
   descriptors. Numeric non-indexed draws and safely derived whole-IB
   `drawindexed = auto` are supported; variable, instanced and indirect calls

--- a/context.md
+++ b/context.md
@@ -124,6 +124,12 @@ machine-specific paths or facts that are obvious from the source.
   distinguishes an untouched slot from an explicit `null`. Resolve effective
   files per draw before deduplication; an IB change must not be required for a
   VB change to take effect.
+- Geometry decoding uses explicit position, texcoord and index layout
+  descriptors. Numeric non-indexed draws and safely derived whole-IB
+  `drawindexed = auto` are supported; variable, instanced and indirect calls
+  remain diagnostic-only. Reject a whole draw when its layout, stride, index
+  range or effective vertex range is invalid rather than truncating it or
+  manufacturing zero-valued vertices.
 - An `ib` section without `drawindexed` may produce one synthetic whole-buffer
   draw. A `handling=skip` section without an explicit draw produces nothing.
   Real draw rows retain authored `count,start,base`; synthetic rows are the

--- a/context.md
+++ b/context.md
@@ -117,6 +117,8 @@ machine-specific paths or facts that are obvious from the source.
 - Geometry detection is conservative and format-specific. Do not infer a game
   or material meaning from a filename alone. Unknown, malformed or too-small
   buffers must be rejected or dropped safely rather than read beyond bounds.
+  A broader auto-detected UV offset must not displace a credible established
+  layout unless its evidence is materially stronger.
 - Draw deduplication uses normalized effective buffer and material state.
   Classify each new draw field explicitly as render identity, visibility or
   provenance; never derive identity reflectively from every dictionary field.
@@ -127,9 +129,12 @@ machine-specific paths or facts that are obvious from the source.
 - Geometry decoding uses explicit position, texcoord and index layout
   descriptors. Numeric non-indexed draws and safely derived whole-IB
   `drawindexed = auto` are supported; variable, instanced and indirect calls
-  remain diagnostic-only. Reject a whole draw when its layout, stride, index
-  range or effective vertex range is invalid rather than truncating it or
-  manufacturing zero-valued vertices.
+  remain diagnostic-only. A non-indexed draw is geometry only when its own
+  execution path binds complete, resolvable position and texcoord streams;
+  never borrow sibling component buffers for an incomplete setup/replay pass.
+  Reject a whole draw when its layout, stride, index range or effective vertex
+  range is invalid rather than truncating it or manufacturing zero-valued
+  vertices.
 - An `ib` section without `drawindexed` may produce one synthetic whole-buffer
   draw. A `handling=skip` section without an explicit draw produces nothing.
   Real draw rows retain authored `count,start,base`; synthetic rows are the

--- a/context.md
+++ b/context.md
@@ -128,6 +128,8 @@ machine-specific paths or facts that are obvious from the source.
   VB change to take effect. At a conditional join, retain VB and IB state only
   when every path agrees; divergent state that can affect a consumed geometry
   semantic is unsupported rather than inherited from an arbitrary branch.
+  Group fallbacks require the same concrete binding at every authored draw;
+  a first-seen resource from one sibling branch must never resolve another.
 - Geometry decoding uses explicit position, texcoord and index layout
   descriptors. Numeric non-indexed draws and safely derived whole-IB
   `drawindexed = auto` are supported; variable, instanced and indirect calls

--- a/context.md
+++ b/context.md
@@ -130,6 +130,8 @@ machine-specific paths or facts that are obvious from the source.
   semantic is unsupported rather than inherited from an arbitrary branch.
   Group fallbacks require the same concrete binding at every authored draw;
   a first-seen resource from one sibling branch must never resolve another.
+  Candidate-less null-versus-untouched ambiguity in an established geometry
+  slot must not be rebound through a component, hash or global fallback.
   A runtime-only binding without backing bytes must not shadow the next
   structurally validated, file-backed fallback.
 - Geometry decoding uses explicit position, texcoord and index layout

--- a/context.md
+++ b/context.md
@@ -125,16 +125,22 @@ machine-specific paths or facts that are obvious from the source.
 - Authored draw state preserves vertex-buffer bindings by numeric slot and
   distinguishes an untouched slot from an explicit `null`. Resolve effective
   files per draw before deduplication; an IB change must not be required for a
-  VB change to take effect.
+  VB change to take effect. At a conditional join, retain VB and IB state only
+  when every path agrees; divergent state is unsupported rather than inherited
+  from an arbitrary branch.
 - Geometry decoding uses explicit position, texcoord and index layout
   descriptors. Numeric non-indexed draws and safely derived whole-IB
   `drawindexed = auto` are supported; variable, instanced and indirect calls
   remain diagnostic-only. A non-indexed draw is geometry only when its own
   execution path binds complete, resolvable position and texcoord streams;
   never borrow sibling component buffers for an incomplete setup/replay pass.
+  Validate its vertex range before materializing sequential indices. Only
+  explicit unsigned `R16_UINT` and `R32_UINT` index formats are supported.
   Reject a whole draw when its layout, stride, index range or effective vertex
   range is invalid rather than truncating it or manufacturing zero-valued
-  vertices.
+  vertices. Higher vertex slots require a compatible declared format; resource
+  and filename labels may rank credible bindings but never establish a
+  position or texcoord semantic by themselves.
 - An `ib` section without `drawindexed` may produce one synthetic whole-buffer
   draw. A `handling=skip` section without an explicit draw produces nothing.
   Real draw rows retain authored `count,start,base`; synthetic rows are the

--- a/context.md
+++ b/context.md
@@ -130,6 +130,8 @@ machine-specific paths or facts that are obvious from the source.
   semantic is unsupported rather than inherited from an arbitrary branch.
   Group fallbacks require the same concrete binding at every authored draw;
   a first-seen resource from one sibling branch must never resolve another.
+  A runtime-only binding without backing bytes must not shadow the next
+  structurally validated, file-backed fallback.
 - Geometry decoding uses explicit position, texcoord and index layout
   descriptors. Numeric non-indexed draws and safely derived whole-IB
   `drawindexed = auto` are supported; variable, instanced and indirect calls

--- a/src/core/buffer_layout.py
+++ b/src/core/buffer_layout.py
@@ -117,12 +117,44 @@ class IndexLayout:
             f"<{count}{code}", data, start * self.size))
 
 
+def index_layout(resource_format):
+    """Return the explicitly supported unsigned index layout, if any."""
+    normalized = _normalize_dxgi_format(resource_format)
+    if normalized == "R16_UINT":
+        return IndexLayout(2)
+    if normalized == "R32_UINT":
+        return IndexLayout(4)
+    return None
+
+
 @dataclass(frozen=True, slots=True)
 class GeometryLayout:
     """The supported semantic layout for one effective draw."""
 
     position: VertexAttributeLayout
     texcoord: VertexAttributeLayout | None = None
+
+    def validate_vertex_range(self, start, count, position_data,
+                              texcoord_data=None):
+        """Validate a non-indexed range before callers materialize it."""
+        if start < 0:
+            raise LayoutError(f"vertex start {start} is negative")
+        if count <= 0:
+            raise LayoutError(f"vertex count {count} is not positive")
+        end = start + count
+        position_count = self.position.vertex_count(position_data)
+        if end > position_count:
+            raise LayoutError(
+                f"vertex range {start}..{end} exceeds {position_count} "
+                "positions")
+        if self.texcoord is not None:
+            if texcoord_data is None:
+                raise LayoutError("draw has a texcoord layout but no buffer")
+            texcoord_count = self.texcoord.vertex_count(texcoord_data)
+            if end > texcoord_count:
+                raise LayoutError(
+                    f"vertex range {start}..{end} exceeds {texcoord_count} "
+                    "texcoords")
 
     def validate_indices(self, indices, position_data, texcoord_data=None):
         if not indices:

--- a/src/core/buffer_layout.py
+++ b/src/core/buffer_layout.py
@@ -1,0 +1,224 @@
+"""Typed, bounded decoders for the geometry layouts the viewer understands.
+
+The INI parser identifies semantic position/texcoord resources.  This module
+owns the smaller question of how bytes in those resources are decoded.  Keep
+the supported format table explicit: an unknown layout is not an invitation to
+read past a stride or manufacture zero-valued vertices.
+"""
+
+from dataclasses import dataclass
+import struct
+
+
+class LayoutError(ValueError):
+    """A buffer or draw range does not satisfy its declared layout."""
+
+
+_FORMATS = {
+    "float16x2": ("<ee", 2),
+    "float16x4": ("<eeee", 4),
+    "float32x2": ("<ff", 2),
+    "float32x3": ("<fff", 3),
+    "float32x4": ("<ffff", 4),
+}
+
+_DXGI_FORMATS = {
+    "R16G16_FLOAT": "float16x2",
+    "R16G16B16A16_FLOAT": "float16x4",
+    "R32G32_FLOAT": "float32x2",
+    "R32G32B32_FLOAT": "float32x3",
+    "R32G32B32A32_FLOAT": "float32x4",
+}
+
+
+def _normalize_dxgi_format(value):
+    normalized = (value or "").strip().upper()
+    if normalized.startswith("DXGI_FORMAT_"):
+        normalized = normalized[len("DXGI_FORMAT_"):]
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class VertexAttributeLayout:
+    """One semantic attribute within a strided vertex-buffer binding."""
+
+    semantic: str
+    stride: int
+    offset: int
+    format: str
+    slot: int | None = None
+
+    def __post_init__(self):
+        if self.format not in _FORMATS:
+            raise LayoutError(f"unsupported {self.semantic} format: {self.format}")
+        if self.stride <= 0:
+            raise LayoutError(f"invalid {self.semantic} stride: {self.stride}")
+        if self.offset < 0 or self.offset + self.byte_width > self.stride:
+            raise LayoutError(
+                f"{self.semantic} attribute does not fit its stride")
+
+    @property
+    def struct_format(self):
+        return _FORMATS[self.format][0]
+
+    @property
+    def component_count(self):
+        return _FORMATS[self.format][1]
+
+    @property
+    def byte_width(self):
+        return struct.calcsize(self.struct_format)
+
+    def vertex_count(self, data):
+        if len(data) % self.stride:
+            raise LayoutError(
+                f"{self.semantic} buffer size is not aligned to stride "
+                f"{self.stride}")
+        return len(data) // self.stride
+
+    def read(self, data, vertex_index):
+        count = self.vertex_count(data)
+        if vertex_index < 0 or vertex_index >= count:
+            raise LayoutError(
+                f"{self.semantic} vertex {vertex_index} is outside 0..{count - 1}")
+        offset = vertex_index * self.stride + self.offset
+        return struct.unpack_from(self.struct_format, data, offset)
+
+
+@dataclass(frozen=True, slots=True)
+class IndexLayout:
+    """A bounded R16/R32 index-buffer decoder."""
+
+    size: int
+
+    def __post_init__(self):
+        if self.size not in (2, 4):
+            raise LayoutError(f"unsupported index size: {self.size}")
+
+    def index_count(self, data):
+        if len(data) % self.size:
+            raise LayoutError(
+                f"index buffer size is not aligned to {self.size}-byte indices")
+        return len(data) // self.size
+
+    def read(self, data, start=0, count=None):
+        total = self.index_count(data)
+        if start < 0 or start > total:
+            raise LayoutError(f"index start {start} is outside 0..{total}")
+        if count is None:
+            count = total - start
+        if count < 0 or start + count > total:
+            raise LayoutError(
+                f"index range {start}..{start + count} exceeds {total} indices")
+        if not count:
+            return []
+        code = "H" if self.size == 2 else "I"
+        return list(struct.unpack_from(
+            f"<{count}{code}", data, start * self.size))
+
+
+@dataclass(frozen=True, slots=True)
+class GeometryLayout:
+    """The supported semantic layout for one effective draw."""
+
+    position: VertexAttributeLayout
+    texcoord: VertexAttributeLayout | None = None
+
+    def validate_indices(self, indices, position_data, texcoord_data=None):
+        if not indices:
+            raise LayoutError("draw references no vertices")
+        highest = max(indices)
+        position_count = self.position.vertex_count(position_data)
+        if highest >= position_count:
+            raise LayoutError(
+                f"draw references position vertex {highest}, but the buffer "
+                f"contains {position_count}")
+        if self.texcoord is not None:
+            if texcoord_data is None:
+                raise LayoutError("draw has a texcoord layout but no buffer")
+            texcoord_count = self.texcoord.vertex_count(texcoord_data)
+            if highest >= texcoord_count:
+                raise LayoutError(
+                    f"draw references texcoord vertex {highest}, but the buffer "
+                    f"contains {texcoord_count}")
+
+
+def position_layout(stride, resource_format=None, slot=None, offset=0):
+    """Return a conservative position descriptor, or ``None`` if unsupported."""
+    normalized = _normalize_dxgi_format(resource_format)
+    if normalized:
+        value_format = _DXGI_FORMATS.get(normalized)
+        if value_format not in {"float16x4", "float32x3", "float32x4"}:
+            return None
+    else:
+        # Existing XXMI buffer dumps omit `format` and store float32 XYZ at 0.
+        value_format = "float32x3"
+    try:
+        return VertexAttributeLayout(
+            "position", int(stride), int(offset or 0), value_format, slot)
+    except (LayoutError, TypeError, ValueError):
+        return None
+
+
+def texcoord_layout(data, stride, resource_format=None, slot=None, offset=None,
+                    sample_limit=4096):
+    """Resolve an explicit UV descriptor or conservatively detect one.
+
+    Legacy layouts search offsets 0/4.  Additional four-byte-aligned offsets
+    are considered only when both UV axes have real spread, keeping broader
+    layout support from turning arbitrary blend data into plausible UVs.
+    """
+    try:
+        stride = int(stride)
+    except (TypeError, ValueError):
+        return None
+    normalized = _normalize_dxgi_format(resource_format)
+    if normalized:
+        value_format = _DXGI_FORMATS.get(normalized)
+        if value_format not in {
+                "float16x2", "float16x4", "float32x2", "float32x4"}:
+            return None
+        try:
+            return VertexAttributeLayout(
+                "texcoord", stride, int(offset or 0), value_format, slot)
+        except (LayoutError, TypeError, ValueError):
+            return None
+
+    if stride <= 0 or len(data) % stride:
+        return None
+    total = len(data) // stride
+    if not total:
+        return None
+    step = max(1, total // sample_limit)
+    offsets = list(range(0, stride, 4))
+    scored = []
+    for candidate_offset in offsets:
+        for value_format in ("float16x2", "float32x2"):
+            try:
+                layout = VertexAttributeLayout(
+                    "texcoord", stride, candidate_offset, value_format, slot)
+            except LayoutError:
+                continue
+            us, vs, sampled = [], [], 0
+            for vertex_index in range(0, total, step):
+                values = layout.read(data, vertex_index)
+                sampled += 1
+                u, v = values[:2]
+                if -0.01 <= u <= 2.0 and -0.01 <= v <= 2.0:
+                    us.append(u)
+                    vs.append(v)
+            if not sampled or not us or len(us) / sampled < 0.95:
+                continue
+            du, dv = max(us) - min(us), max(vs) - min(vs)
+            both_live = du >= 1e-4 and dv >= 1e-4
+            if candidate_offset not in (0, 4) and not both_live:
+                continue
+            scored.append((
+                both_live, round(len(us) / sampled, 3),
+                round(du + dv, 3), candidate_offset,
+                value_format == "float32x2", layout,
+            ))
+    if not scored:
+        return None
+    scored.sort(key=lambda item: item[:-1], reverse=True)
+    return scored[0][-1]

--- a/src/core/buffer_layout.py
+++ b/src/core/buffer_layout.py
@@ -220,5 +220,22 @@ def texcoord_layout(data, stride, resource_format=None, slot=None, offset=None,
             ))
     if not scored:
         return None
-    scored.sort(key=lambda item: item[:-1], reverse=True)
-    return scored[0][-1]
+    # Offsets 0/4 cover the established XXMI layouts. Wider layouts can hold
+    # several later float pairs (secondary UVs, tangents or other attributes)
+    # that are just as clean and live as the primary UVs. In that ambiguous
+    # case, preferring the greatest offset silently remaps an otherwise-correct
+    # texture. A broader offset may override a credible legacy candidate only
+    # when it has materially better in-range evidence, or when the legacy pair
+    # is degenerate.
+    legacy = [item for item in scored if item[3] in (0, 4)]
+    broader = [item for item in scored if item[3] not in (0, 4)]
+    best_legacy = max(legacy, key=lambda item: item[:-1], default=None)
+    best_broader = max(broader, key=lambda item: item[:-1], default=None)
+    if best_legacy is None:
+        return best_broader[-1]
+    if best_broader is None:
+        return best_legacy[-1]
+    materially_cleaner = best_broader[1] >= best_legacy[1] + 0.02
+    if best_broader[0] and (not best_legacy[0] or materially_cleaner):
+        return best_broader[-1]
+    return best_legacy[-1]

--- a/src/core/draw_call.py
+++ b/src/core/draw_call.py
@@ -25,11 +25,13 @@ def _freeze(value):
 
 @dataclass(slots=True)
 class AuthoredDrawCall:
-    """One parsed ``drawindexed`` row before resource-name resolution."""
+    """One parsed draw operation before resource-name resolution."""
 
     count: int | None
     start: int
     base: int
+    operation: str = "drawindexed"
+    auto_count: bool = False
     conditions: list = field(default_factory=list)
     source: dict | None = None
     index_resource: str | None = None
@@ -51,9 +53,11 @@ class DrawCall(MutableMapping):
     """
 
     label: str = ""
+    operation: str = "drawindexed"
     count: int | None = None
     start: int = 0
     base: int = 0
+    auto_count: bool = False
     conditions: list = field(default_factory=list)
     sources: list = field(default_factory=list)
 
@@ -63,6 +67,12 @@ class DrawCall(MutableMapping):
     texcoord_file: str | None = None
     position_stride: int | None = None
     texcoord_stride: int | None = None
+    position_slot: int | None = None
+    texcoord_slot: int | None = None
+    position_format: str | None = None
+    texcoord_format: str | None = None
+    position_offset: int = 0
+    texcoord_offset: int | None = None
 
     texture_default_file: str | None = None
     texture_variants: list = field(default_factory=list)
@@ -75,7 +85,8 @@ class DrawCall(MutableMapping):
     material_map_variants: list = field(default_factory=list)
 
     _ALWAYS_PRESENT: ClassVar[frozenset[str]] = frozenset({
-        "count", "start", "base", "conditions", "sources",
+        "operation", "count", "start", "base", "auto_count",
+        "conditions", "sources", "position_offset",
     })
     _TEXTURE_PREFIX: ClassVar[dict[str, str]] = {
         "diffuse": "texture",
@@ -84,13 +95,15 @@ class DrawCall(MutableMapping):
         "material_map": "material_map",
     }
     _NON_RENDER_FIELDS: ClassVar[frozenset[str]] = frozenset({
-        "label", "conditions", "sources",
+        "label", "conditions", "sources", "position_slot", "texcoord_slot",
     })
     _RENDER_IDENTITY_FIELDS: ClassVar[tuple[str, ...]] = (
-        "count", "start", "base",
+        "operation", "count", "start", "base", "auto_count",
         "ib_file", "index_size",
-        "position_file", "position_stride",
-        "texcoord_file", "texcoord_stride",
+        "position_file", "position_stride", "position_format",
+        "position_offset",
+        "texcoord_file", "texcoord_stride", "texcoord_format",
+        "texcoord_offset",
         "texture_default_file", "texture_variants", "texture_assignments",
         "normal_map_default_file", "normal_map_variants",
         "light_map_default_file", "light_map_variants",
@@ -114,7 +127,9 @@ class DrawCall(MutableMapping):
             raise TypeError(f"unsupported DrawCall field(s): {names}")
         values = dict(value)
         for name in ("ib_file", "index_size", "position_file",
-                     "position_stride", "texcoord_file", "texcoord_stride"):
+                     "position_stride", "position_slot", "position_format",
+                     "position_offset", "texcoord_file", "texcoord_stride",
+                     "texcoord_slot", "texcoord_format", "texcoord_offset"):
             if name not in values and group is not None:
                 values[name] = group.get(name)
         return cls(**values)

--- a/src/core/draw_call.py
+++ b/src/core/draw_call.py
@@ -35,11 +35,15 @@ class AuthoredDrawCall:
     conditions: list = field(default_factory=list)
     source: dict | None = None
     index_resource: str | None = None
+    index_resource_bound: bool = False
+    ambiguous_index_resource: bool = False
+    unsupported_reason: str | None = None
     diffuse_variants: list = field(default_factory=list)
     diffuse_history: list = field(default_factory=list)
     # Missing slot = no authored state in this execution path; None = an
     # explicit `vbN = null`; a string = the resource bound at this draw.
     vertex_resources: dict[int, str | None] = field(default_factory=dict)
+    ambiguous_vertex_slots: tuple[int, ...] = ()
     auxiliary_maps: dict = field(default_factory=dict)
 
 

--- a/src/core/draw_call.py
+++ b/src/core/draw_call.py
@@ -44,6 +44,8 @@ class AuthoredDrawCall:
     # explicit `vbN = null`; a string = the resource bound at this draw.
     vertex_resources: dict[int, str | None] = field(default_factory=dict)
     ambiguous_vertex_slots: tuple[int, ...] = ()
+    ambiguous_vertex_resources: dict[int, tuple[str, ...]] = field(
+        default_factory=dict)
     auxiliary_maps: dict = field(default_factory=dict)
 
 

--- a/src/core/ini_health.py
+++ b/src/core/ini_health.py
@@ -22,7 +22,10 @@ _LOCAL_RUN_TARGET_RE = re.compile(
 _RESOURCE_REFERENCE_RE = re.compile(
     r"^(?P<prefix>\S+)\s+(?P<resource>Resource[A-Za-z0-9_.\\-]+)\s*$", re.I)
 _VIEWER_DRAWINDEXED_RE = re.compile(
-    r"^\d+\s*,\s*\d+\s*,\s*-?\d+$")
+    r"^(?:auto|\d+\s*,\s*\d+\s*,\s*-?\d+)$", re.I)
+_VIEWER_DRAW_RE = re.compile(r"^\d+\s*,\s*\d+$")
+_UNSUPPORTED_DRAW_OPERATION_RE = re.compile(
+    r"^draw(?:indexed)?instanced(?:indirect)?$", re.I)
 _ASSET_EXTENSIONS = {
     ".buf", ".ib", ".vb", ".dds", ".png", ".jpg", ".jpeg", ".tga", ".bmp",
 }
@@ -133,15 +136,34 @@ def _analyze_statements(doc, ini_rel, issues):
             if "=" in line.text:
                 draw_lhs, draw_rhs = (
                     part.strip() for part in line.text.split("=", 1))
-                if (draw_lhs.lower() == "drawindexed"
-                        and not _VIEWER_DRAWINDEXED_RE.fullmatch(
-                            draw_rhs.split(";", 1)[0].strip())):
+                draw_name = draw_lhs.lower()
+                draw_arguments = draw_rhs.split(";", 1)[0].strip()
+                if (draw_name == "drawindexed"
+                        and not _VIEWER_DRAWINDEXED_RE.fullmatch(draw_arguments)):
                     issues.append(_issue(
                         "unsupported_drawindexed_arguments", "warning", "ini",
                         "The viewer cannot build this drawindexed statement: "
-                        "expected numeric count, start index and signed base vertex.",
+                        "expected auto or numeric count, start index and signed "
+                        "base vertex.",
                         ini_rel, section.name, line.no + 1, line.raw.strip(),
                         arguments=draw_rhs,
+                    ))
+                elif (draw_name == "draw"
+                      and draw_arguments.lower() != "from_caller"
+                      and not _VIEWER_DRAW_RE.fullmatch(draw_arguments)):
+                    issues.append(_issue(
+                        "unsupported_draw_arguments", "warning", "ini",
+                        "The viewer cannot build this draw statement: expected "
+                        "numeric vertex count and start vertex.",
+                        ini_rel, section.name, line.no + 1, line.raw.strip(),
+                        operation=draw_lhs, arguments=draw_rhs,
+                    ))
+                elif _UNSUPPORTED_DRAW_OPERATION_RE.fullmatch(draw_name):
+                    issues.append(_issue(
+                        "unsupported_draw_operation", "warning", "ini",
+                        f"The viewer does not build {draw_lhs} statements yet.",
+                        ini_rel, section.name, line.no + 1, line.raw.strip(),
+                        operation=draw_lhs, arguments=draw_rhs,
                     ))
 
             if line.kind != "assign" or "=" not in line.text:

--- a/src/core/ini_parser.py
+++ b/src/core/ini_parser.py
@@ -12,6 +12,7 @@ existing `from core.ini_parser import ...` callers keep working:
 
 import re
 
+from .buffer_layout import index_layout
 from .draw_call import AuthoredDrawCall, DrawCall
 from .mesh_builder import POSITION_STRIDE, DEFAULT_UV_OFFSET, _res_get
 from .ini_sections import (SrcLine, extract_resources, first_source,
@@ -46,11 +47,6 @@ def _ib_res_to_component(ib_res):
     s = re.sub(r"^Resource", "", ib_res or "", flags=re.I)
     s = re.sub(r"IB$", "", s, flags=re.I)
     return re.sub(r"[A-Z]$", "", s)
-
-
-def _ib_index_size(fmt):
-    """Bytes per index -- 3DMigoto index buffers are R16_UINT or R32_UINT."""
-    return 2 if "R16" in (fmt or "").upper() else 4
 
 
 def _extract_hash(name):
@@ -126,6 +122,61 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
     bare_counter = [0]  # unique id per diffuse line reached with an empty cond_stack
     aux_bare_counters = {channel: 0 for channel in _AUX_MAP_CHANNELS.values()}
 
+    def _new_resource_state():
+        return {
+            "vertex_resources": {},
+            "ambiguous_vertex_slots": set(),
+            "index_resource": None,
+            "index_resource_bound": False,
+            "ambiguous_index_resource": False,
+        }
+
+    def _copy_resource_state(state):
+        return {
+            "vertex_resources": dict(state["vertex_resources"]),
+            "ambiguous_vertex_slots": set(
+                state["ambiguous_vertex_slots"]),
+            "index_resource": state["index_resource"],
+            "index_resource_bound": state["index_resource_bound"],
+            "ambiguous_index_resource": state["ambiguous_index_resource"],
+        }
+
+    unset = object()
+
+    def _all_same(values):
+        first = values[0]
+        if first is unset:
+            return all(value is unset for value in values)
+        return all(value is not unset and value == first for value in values)
+
+    def _merge_resource_states(states):
+        """Join branch exits, retaining only state common to every path."""
+        merged = _new_resource_state()
+        slots = set().union(*(
+            set(state["vertex_resources"])
+            | state["ambiguous_vertex_slots"] for state in states))
+        for slot in slots:
+            values = [state["vertex_resources"].get(slot, unset)
+                      for state in states]
+            if (any(slot in state["ambiguous_vertex_slots"]
+                    for state in states) or not _all_same(values)):
+                merged["ambiguous_vertex_slots"].add(slot)
+            elif values[0] is not unset:
+                merged["vertex_resources"][slot] = values[0]
+
+        index_values = [
+            state["index_resource"]
+            if state["index_resource_bound"] else unset
+            for state in states
+        ]
+        if (any(state["ambiguous_index_resource"] for state in states)
+                or not _all_same(index_values)):
+            merged["ambiguous_index_resource"] = True
+        elif index_values[0] is not unset:
+            merged["index_resource"] = index_values[0]
+            merged["index_resource_bound"] = True
+        return merged
+
     def _aux_snapshot(info):
         return {
             channel: {
@@ -139,10 +190,12 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
     def _record_draw(raw, info, cond_stack, operation, count, start, base,
                      auto_count=False):
         combined = DNF_TRUE
-        vertex_resources = dict(info["_root_vertex_resources"])
         for frame in cond_stack:
             combined = dnf_and(combined, frame["cur"])
-            vertex_resources.update(frame["vertex_resources"])
+        resource_state = info["_resource_state"]
+        ambiguous_slots = tuple(sorted(
+            resource_state["ambiguous_vertex_slots"]))
+        ambiguous_index = resource_state["ambiguous_index_resource"]
         info["draws"].append(AuthoredDrawCall(
             count=count,
             start=start,
@@ -151,11 +204,17 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             auto_count=auto_count,
             conditions=normalize_dnf(combined, toggle_vars, var_prefix),
             source=line_source(raw),
-            index_resource=info.get("_cur_ib"),
+            index_resource=resource_state["index_resource"],
+            index_resource_bound=resource_state["index_resource_bound"],
+            ambiguous_index_resource=ambiguous_index,
+            unsupported_reason=(
+                "ambiguous_resource_state"
+                if ambiguous_index or ambiguous_slots else None),
             diffuse_variants=list(
                 info.get("_cur_diffuse_variants") or []),
             diffuse_history=list(info.get("_diffuse_history") or []),
-            vertex_resources=vertex_resources,
+            vertex_resources=dict(resource_state["vertex_resources"]),
+            ambiguous_vertex_slots=ambiguous_slots,
             auxiliary_maps=_aux_snapshot(info),
         ))
 
@@ -183,12 +242,15 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             if m_elif:
                 if cond_stack:
                     frame = cond_stack[-1]
+                    frame["resource_states"].append(_copy_resource_state(
+                        info["_resource_state"]))
+                    info["_resource_state"] = _copy_resource_state(
+                        frame["entry_resource_state"])
                     branch = parse_condition_dnf(
                         m_elif.group(1).strip(), alias_map)
                     not_seen = dnf_not(frame["seen"])
                     frame["cur"] = dnf_and(not_seen, branch)
                     frame["seen"] = dnf_or(frame["seen"], branch)
-                    frame["vertex_resources"] = {}
                 continue
             if low.startswith("if "):
                 branch = parse_condition_dnf(line[3:].strip(), alias_map)
@@ -197,17 +259,32 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                     "cur": branch,
                     "seen": branch,
                     "seq": seq_counter[0],
-                    "vertex_resources": {},
+                    "entry_resource_state": _copy_resource_state(
+                        info["_resource_state"]),
+                    "resource_states": [],
+                    "has_else": False,
                 })
                 continue
             if low == "else":
                 if cond_stack:
                     frame = cond_stack[-1]
+                    frame["resource_states"].append(_copy_resource_state(
+                        info["_resource_state"]))
+                    info["_resource_state"] = _copy_resource_state(
+                        frame["entry_resource_state"])
                     frame["cur"] = dnf_not(frame["seen"])
-                    frame["vertex_resources"] = {}
+                    frame["has_else"] = True
                 continue
             if low == "endif":
-                if cond_stack: cond_stack.pop()
+                if cond_stack:
+                    frame = cond_stack.pop()
+                    frame["resource_states"].append(_copy_resource_state(
+                        info["_resource_state"]))
+                    if not frame["has_else"]:
+                        frame["resource_states"].append(
+                            frame["entry_resource_state"])
+                    info["_resource_state"] = _merge_resource_states(
+                        frame["resource_states"])
                 continue
             m = re.match(r"vb(\d+)\s*=\s*(?:ref\s+)?(\S+)", line, re.I)
             if m:
@@ -216,13 +293,19 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 value = None if resource.lower() == "null" else resource
                 if slot <= 2 and value and not info[f"vb{slot}"]:
                     info[f"vb{slot}"] = value
-                target = (cond_stack[-1]["vertex_resources"]
-                          if cond_stack else info["_root_vertex_resources"])
-                target[slot] = value
+                state = info["_resource_state"]
+                state["vertex_resources"][slot] = value
+                state["ambiguous_vertex_slots"].discard(slot)
             m = re.match(r"ib\s*=\s*(\S+)", line, re.I)
             if m:
-                if not info["ib"]: info["ib"] = m.group(1)
-                info["_cur_ib"] = m.group(1)
+                resource = m.group(1)
+                value = None if resource.lower() == "null" else resource
+                if value and not info["ib"]:
+                    info["ib"] = value
+                state = info["_resource_state"]
+                state["index_resource"] = value
+                state["index_resource_bound"] = True
+                state["ambiguous_index_resource"] = False
             if re.match(r"handling\s*=\s*skip\b", line, re.I):
                 info["handling_skip"] = True
             m = re.fullmatch(
@@ -359,10 +442,9 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                           diffuse=None, diffuse_pool=[], src=None, handling_skip=False,
                           _cur_diffuse_variants=[], _diffuse_chain_key=None,
                           _diffuse_history=[], _aux_maps={},
-                          _root_vertex_resources={})
+                          _resource_state=_new_resource_state())
         _scan(lines, info, [], {name}, {"steps": 0})
-        info.pop("_cur_ib", None)
-        info.pop("_root_vertex_resources", None)
+        info.pop("_resource_state", None)
         # Whatever diffuse was active at the end of the scan -- needed for a
         # section with NO drawindexed line at all (the game's original,
         # whole-buffer draw proceeds unmodified against this section's own
@@ -672,6 +754,37 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             if (binding := _resolve_vertex_binding(slot, resource)) is not None
         ]
 
+        def _format(binding):
+            value = (binding.get("format") or "").strip().upper()
+            return (value[len("DXGI_FORMAT_"):]
+                    if value.startswith("DXGI_FORMAT_") else value)
+
+        position_formats = {
+            "R16G16B16A16_FLOAT",
+            "R32G32B32_FLOAT",
+            "R32G32B32A32_FLOAT",
+        }
+        texcoord_formats = {
+            "R16G16_FLOAT",
+            "R16G16B16A16_FLOAT",
+            "R32G32_FLOAT",
+            "R32G32B32A32_FLOAT",
+        }
+
+        # Names rank candidates only after structural admission. Established
+        # slots may use the format-less XXMI dump layouts; higher slots must
+        # declare a decoder-compatible format.
+        position_bindings = [
+            binding for binding in bindings
+            if (_format(binding) in position_formats
+                if _format(binding) else binding["slot"] == 0)
+        ]
+        texcoord_bindings = [
+            binding for binding in bindings
+            if (_format(binding) in texcoord_formats
+                if _format(binding) else binding["slot"] in (1, 2))
+        ]
+
         def _label(binding):
             return (binding["resource"] + " " + binding["filename"]).lower()
 
@@ -689,7 +802,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                 score -= 150
             return score
 
-        position = max(bindings, key=_position_score, default=None)
+        position = max(position_bindings, key=_position_score, default=None)
         if position is not None and _position_score(position) <= 0:
             position = None
 
@@ -711,7 +824,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                 score -= 100
             return score
 
-        texcoord = max(bindings, key=_texcoord_score, default=None)
+        texcoord = max(texcoord_bindings, key=_texcoord_score, default=None)
         if texcoord is not None and _texcoord_score(texcoord) <= 0:
             texcoord = None
         return position, texcoord
@@ -748,6 +861,8 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         # sequential triangle list after borrowing unrelated fallback buffers.
         render_draws = []
         for authored in info["draws"]:
+            if authored.unsupported_reason:
+                continue
             if authored.operation != "draw":
                 render_draws.append(authored)
                 continue
@@ -755,7 +870,9 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                 authored.vertex_resources)
             if position and texcoord:
                 render_draws.append(authored)
-        if (not render_draws
+        if info["draws"] and not render_draws:
+            continue
+        if (not info["draws"]
                 and (not info["ib"] or info["handling_skip"])):
             continue
 
@@ -807,9 +924,6 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         ib_file  = ib_ri.get("filename")
         requires_ib = (not render_draws or any(
             draw.operation != "draw" for draw in render_draws))
-        if not (pos_file and tc_file) or (requires_ib and not ib_file):
-            continue
-
         tc_stride  = tc_ri.get("stride", 20)
         pos_stride = pos_ri.get("stride", POSITION_STRIDE)
         position_slot = (authored_position["slot"] if authored_position
@@ -818,8 +932,13 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         texcoord_slot = (authored_texcoord["slot"] if authored_texcoord
                          and authored_texcoord["resource"] == buf["texcoord"]
                          else None)
-        index_size = (_ib_index_size(ib_ri.get("format"))
-                      if ib_file else None)
+        resolved_index_layout = (
+            index_layout(ib_ri.get("format")) if ib_file else None)
+        index_size = (resolved_index_layout.size
+                      if resolved_index_layout else None)
+        if (not (pos_file and tc_file)
+                or (requires_ib and (not ib_file or index_size is None))):
+            continue
         uv_off     = DEFAULT_UV_OFFSET
 
         draws_list = list(render_draws) or [AuthoredDrawCall(
@@ -859,16 +978,21 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             # per-draw VB bindings win; runtime-only resources retain the
             # existing IB/component heuristic, while an authored null stays
             # unbound instead of inheriting the group's first binding.
-            effective_ib = authored.index_resource or ib_res
+            effective_ib = (authored.index_resource
+                            if authored.index_resource_bound else ib_res)
             if authored.operation == "draw":
                 d.ib_file = None
                 d.index_size = None
             elif effective_ib != ib_res:
                 resolved_ib = _resolve_ib_file(effective_ib)
-                if resolved_ib:
+                resolved_layout = index_layout(
+                    _res_get(resources, effective_ib).get("format"))
+                if resolved_ib and resolved_layout:
                     d.ib_file = resolved_ib
-                    d.index_size = _ib_index_size(
-                        _res_get(resources, effective_ib).get("format"))
+                    d.index_size = resolved_layout.size
+                else:
+                    d.ib_file = None
+                    d.index_size = None
 
             draw_buf = (_lookup_comp_buf(_ib_res_to_component(effective_ib))
                         if effective_ib else None)

--- a/src/core/ini_parser.py
+++ b/src/core/ini_parser.py
@@ -126,6 +126,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
         return {
             "vertex_resources": {},
             "ambiguous_vertex_slots": set(),
+            "ambiguous_vertex_resources": {},
             "index_resource": None,
             "index_resource_bound": False,
             "ambiguous_index_resource": False,
@@ -136,6 +137,8 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             "vertex_resources": dict(state["vertex_resources"]),
             "ambiguous_vertex_slots": set(
                 state["ambiguous_vertex_slots"]),
+            "ambiguous_vertex_resources": dict(
+                state["ambiguous_vertex_resources"]),
             "index_resource": state["index_resource"],
             "index_resource_bound": state["index_resource_bound"],
             "ambiguous_index_resource": state["ambiguous_index_resource"],
@@ -154,13 +157,28 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
         merged = _new_resource_state()
         slots = set().union(*(
             set(state["vertex_resources"])
-            | state["ambiguous_vertex_slots"] for state in states))
+            | state["ambiguous_vertex_slots"]
+            | set(state["ambiguous_vertex_resources"])
+            for state in states))
         for slot in slots:
             values = [state["vertex_resources"].get(slot, unset)
                       for state in states]
             if (any(slot in state["ambiguous_vertex_slots"]
                     for state in states) or not _all_same(values)):
                 merged["ambiguous_vertex_slots"].add(slot)
+                candidates = []
+                for state, value in zip(states, values):
+                    candidates.extend(
+                        state["ambiguous_vertex_resources"].get(slot, ()))
+                    if isinstance(value, str):
+                        candidates.append(value)
+                unique = []
+                for candidate in candidates:
+                    if all(existing.lower() != candidate.lower()
+                           for existing in unique):
+                        unique.append(candidate)
+                if unique:
+                    merged["ambiguous_vertex_resources"][slot] = tuple(unique)
             elif values[0] is not unset:
                 merged["vertex_resources"][slot] = values[0]
 
@@ -215,6 +233,8 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             diffuse_history=list(info.get("_diffuse_history") or []),
             vertex_resources=dict(resource_state["vertex_resources"]),
             ambiguous_vertex_slots=ambiguous_slots,
+            ambiguous_vertex_resources=dict(
+                resource_state["ambiguous_vertex_resources"]),
             auxiliary_maps=_aux_snapshot(info),
         ))
 
@@ -296,6 +316,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 state = info["_resource_state"]
                 state["vertex_resources"][slot] = value
                 state["ambiguous_vertex_slots"].discard(slot)
+                state["ambiguous_vertex_resources"].pop(slot, None)
             m = re.match(r"ib\s*=\s*(\S+)", line, re.I)
             if m:
                 resource = m.group(1)
@@ -829,6 +850,18 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             texcoord = None
         return position, texcoord
 
+    def _has_ambiguous_geometry_state(authored):
+        if (authored.operation != "draw"
+                and authored.ambiguous_index_resource):
+            return True
+        for slot, candidates in authored.ambiguous_vertex_resources.items():
+            for candidate in candidates:
+                position, texcoord = _semantic_vertex_bindings(
+                    {slot: candidate})
+                if position or texcoord:
+                    return True
+        return False
+
     def _lookup_comp_value(mapping, comp):
         candidates = [
             comp,
@@ -861,7 +894,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         # sequential triangle list after borrowing unrelated fallback buffers.
         render_draws = []
         for authored in info["draws"]:
-            if authored.unsupported_reason:
+            if _has_ambiguous_geometry_state(authored):
                 continue
             if authored.operation != "draw":
                 render_draws.append(authored)

--- a/src/core/ini_parser.py
+++ b/src/core/ini_parser.py
@@ -62,6 +62,9 @@ def _extract_hash(name):
 
 
 _RUN_SKIP_PREFIXES = ("TextureOverride", "ShaderOverride", "Resource", "Present", "Key", "Constants")
+_MAX_RUN_DEPTH = 64
+_MAX_EXECUTION_STEPS = 200_000
+_MAX_EXECUTION_DRAWS = 20_000
 _AUX_MAP_CHANNELS = {
     "normalmap": "normal_map",
     "lightmap": "light_map",
@@ -109,9 +112,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
     Returns {section_name: {vb0, vb1, vb2, ib, draws, diffuse, src}} — the
     same per-section shape build_draw_groups uses internally as `sec_info`.
     `draws` entries are typed AuthoredDrawCall records. Their vertex_resources
-    snapshot is kept for provenance only; build_draw_groups re-derives the
-    actual position/texcoord buffers for a reassigned `ib` from its component
-    instead of trusting those literal values.
+    snapshot is resolved per draw before geometry deduplication.
     """
     toggle_vars = (gating_vars if gating_vars is not None else
                    gating_var_names(sections))
@@ -135,14 +136,42 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             if state.get("variants") or state.get("history")
         }
 
-    def _scan(lines, info, cond_stack, visiting):
+    def _record_draw(raw, info, cond_stack, operation, count, start, base,
+                     auto_count=False):
+        combined = DNF_TRUE
+        for frame in cond_stack:
+            combined = dnf_and(combined, frame["cur"])
+        info["draws"].append(AuthoredDrawCall(
+            count=count,
+            start=start,
+            base=base,
+            operation=operation,
+            auto_count=auto_count,
+            conditions=normalize_dnf(combined, toggle_vars, var_prefix),
+            source=line_source(raw),
+            index_resource=info.get("_cur_ib"),
+            diffuse_variants=list(
+                info.get("_cur_diffuse_variants") or []),
+            diffuse_history=list(info.get("_diffuse_history") or []),
+            vertex_resources=dict(info["_cur_vertex_resources"]),
+            auxiliary_maps=_aux_snapshot(info),
+        ))
+
+    def _scan(lines, info, cond_stack, visiting, budget, depth=0):
         # cond_stack tracks the stack of active gate branches. Each frame is
         # {"cur": <DNF active for the current branch>,
         #  "seen": <DNF of "some earlier branch at this level already matched">}
         # so `else if` / `else` correctly exclude every preceding branch. It's
         # threaded through run= recursion unchanged, so a called section's own
         # if/elif nests correctly under whichever branch called it.
+        if depth > _MAX_RUN_DEPTH:
+            raise ValueError(
+                f"INI run chain exceeds {_MAX_RUN_DEPTH} nested sections")
         for raw in lines:
+            budget["steps"] += 1
+            if budget["steps"] > _MAX_EXECUTION_STEPS:
+                raise ValueError(
+                    "INI command expansion exceeds the viewer safety limit")
             line = raw.split(";")[0].strip()
             if not line: continue
             if info["src"] is None:
@@ -188,23 +217,23 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 r"drawindexed\s*=\s*(\d+)\s*,\s*(\d+)\s*,\s*(-?\d+)\s*",
                 line, re.I)
             if m:
-                combined = DNF_TRUE
-                for frame in cond_stack:
-                    combined = dnf_and(combined, frame["cur"])
-                conds = normalize_dnf(combined, toggle_vars, var_prefix)
-                info["draws"].append(AuthoredDrawCall(
-                    count=int(m.group(1)),
-                    start=int(m.group(2)),
-                    base=int(m.group(3)),
-                    conditions=conds,
-                    source=line_source(raw),
-                    index_resource=info.get("_cur_ib"),
-                    diffuse_variants=list(
-                        info.get("_cur_diffuse_variants") or []),
-                    diffuse_history=list(info.get("_diffuse_history") or []),
-                    vertex_resources=dict(info["_cur_vertex_resources"]),
-                    auxiliary_maps=_aux_snapshot(info),
-                ))
+                _record_draw(
+                    raw, info, cond_stack, "drawindexed",
+                    int(m.group(1)), int(m.group(2)), int(m.group(3)))
+            elif re.fullmatch(r"drawindexed\s*=\s*auto\s*", line, re.I):
+                _record_draw(
+                    raw, info, cond_stack, "drawindexed", None, 0, 0,
+                    auto_count=True)
+            else:
+                m_draw = re.fullmatch(
+                    r"draw\s*=\s*(\d+)\s*,\s*(\d+)\s*", line, re.I)
+                if m_draw:
+                    _record_draw(
+                        raw, info, cond_stack, "draw",
+                        int(m_draw.group(1)), int(m_draw.group(2)), 0)
+            if len(info["draws"]) > _MAX_EXECUTION_DRAWS:
+                raise ValueError(
+                    "INI command expansion produces too many draw calls")
             # "ref" is optional -- XXMI-generated mods omit it (e.g. "Resource\GIMI\Diffuse = X").
             m_diff = re.match(r"Resource\\[^\\]+\\Diffuse\s*=\s*(?:ref\s+)?(\S+)", line, re.I)
             if not m_diff:
@@ -302,7 +331,9 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                         and not any(target_low.startswith(p.lower())
                                    for p in _RUN_SKIP_PREFIXES)):
                     visiting.add(target_name)
-                    _scan(sections[target_name], info, cond_stack, visiting)
+                    _scan(
+                        sections[target_name], info, cond_stack, visiting,
+                        budget, depth + 1)
                     visiting.discard(target_name)
 
     # scan BOTH TextureOverride AND CommandList sections.
@@ -317,7 +348,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                           _cur_diffuse_variants=[], _diffuse_chain_key=None,
                           _diffuse_history=[], _aux_maps={},
                           _cur_vertex_resources={})
-        _scan(lines, info, [], {name})
+        _scan(lines, info, [], {name}, {"steps": 0})
         info.pop("_cur_ib", None)
         info.pop("_cur_vertex_resources", None)
         # Whatever diffuse was active at the end of the scan -- needed for a
@@ -396,7 +427,8 @@ def _select_draw_sections(sec_info, global_ib):
     """Select TextureOverride sections that can produce viewer geometry."""
     return [(name, info) for name, info in sec_info.items()
             if name.lower().startswith("textureoverride")
-            and (info["ib"] or global_ib)
+            and (info["ib"] or global_ib or any(
+                draw.operation == "draw" for draw in info["draws"]))
             and (info["draws"] or (info["ib"] and not info["handling_skip"]))]
 
 
@@ -599,9 +631,78 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             diffuse_file_cache[res_name] = _res_get(resources, res_name).get("filename")
         return diffuse_file_cache[res_name]
 
-    def _resolve_vertex_res(res_name):
-        ri = resolve_vertex_info(res_name)
-        return ri.get("filename"), ri.get("stride")
+    def _resolve_vertex_binding(slot, res_name):
+        if not res_name:
+            return None
+        info = resolve_vertex_info(res_name)
+        filename = info.get("filename")
+        stride = info.get("stride")
+        if not filename or not stride:
+            return None
+        return {
+            "slot": slot,
+            "resource": res_name,
+            "filename": filename,
+            "stride": stride,
+            "format": info.get("format"),
+        }
+
+    def _semantic_vertex_bindings(vertex_resources):
+        """Choose supported position/UV bindings from concrete active slots.
+
+        Slot conventions remain useful fallback evidence, but explicit
+        resource/filename roles and declared formats allow newer templates to
+        place those semantics in higher slots without teaching the renderer a
+        new game-specific section shape.
+        """
+        bindings = [
+            binding for slot, resource in vertex_resources.items()
+            if (binding := _resolve_vertex_binding(slot, resource)) is not None
+        ]
+
+        def _label(binding):
+            return (binding["resource"] + " " + binding["filename"]).lower()
+
+        def _position_score(binding):
+            label = _label(binding)
+            fmt = (binding.get("format") or "").upper()
+            score = 30 if binding["slot"] == 0 else 0
+            if "position" in label:
+                score += 120
+            elif "pos" in label:
+                score += 45
+            if "R32G32B32" in fmt or "R16G16B16A16_FLOAT" in fmt:
+                score += 80
+            if "texcoord" in label or "blend" in label:
+                score -= 150
+            return score
+
+        position = max(bindings, key=_position_score, default=None)
+        if position is not None and _position_score(position) <= 0:
+            position = None
+
+        def _texcoord_score(binding):
+            if binding is position:
+                return -1000
+            label = _label(binding)
+            fmt = (binding.get("format") or "").upper()
+            score = 25 if binding["slot"] in (1, 2) else 0
+            if "texcoord" in label:
+                score += 120
+            elif "uv" in label or "tc" in label:
+                score += 45
+            if ("R16G16_FLOAT" in fmt or "R32G32_FLOAT" in fmt):
+                score += 80
+            if "blend" in label or "position" in label:
+                score -= 150
+            if binding["stride"] == 32 and "texcoord" not in label:
+                score -= 100
+            return score
+
+        texcoord = max(bindings, key=_texcoord_score, default=None)
+        if texcoord is not None and _texcoord_score(texcoord) <= 0:
+            texcoord = None
+        return position, texcoord
 
     def _lookup_comp_value(mapping, comp):
         candidates = [
@@ -634,8 +735,18 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         if seen[display_name] > 1: label = f"{display_name}_{seen[display_name]}"
 
         ib_res = info["ib"] or global_ib
-        comp   = _ib_res_to_component(ib_res)
+        comp   = (_ib_res_to_component(ib_res) if ib_res else display_name)
         buf    = _lookup_comp_buf(comp)
+        authored_position = authored_texcoord = None
+        if info["draws"]:
+            authored_position, authored_texcoord = _semantic_vertex_bindings(
+                info["draws"][0].vertex_resources)
+        if not buf and info["draws"]:
+            if authored_position and authored_texcoord:
+                buf = {
+                    "position": authored_position["resource"],
+                    "texcoord": authored_texcoord["resource"],
+                }
         if not buf:
             # Some compute-skinned ZZMI components bind their runtime vb0 only
             # inside the draw CommandList, while the sibling *Texcoord section
@@ -664,17 +775,29 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         pos_file = pos_ri.get("filename")
         tc_file  = tc_ri.get("filename")
         ib_file  = ib_ri.get("filename")
-        if not (pos_file and tc_file and ib_file): continue
+        requires_ib = (not info["draws"] or any(
+            draw.operation != "draw" for draw in info["draws"]))
+        if not (pos_file and tc_file) or (requires_ib and not ib_file):
+            continue
 
         tc_stride  = tc_ri.get("stride", 20)
         pos_stride = pos_ri.get("stride", POSITION_STRIDE)
-        index_size = _ib_index_size(ib_ri.get("format"))
+        position_slot = (authored_position["slot"] if authored_position
+                         and authored_position["resource"] == buf["position"]
+                         else None)
+        texcoord_slot = (authored_texcoord["slot"] if authored_texcoord
+                         and authored_texcoord["resource"] == buf["texcoord"]
+                         else None)
+        index_size = (_ib_index_size(ib_ri.get("format"))
+                      if ib_file else None)
         uv_off     = DEFAULT_UV_OFFSET
 
         draws_list = list(info["draws"]) or [AuthoredDrawCall(
             count=None,
             start=0,
             base=0,
+            operation="implicit_indexed",
+            auto_count=True,
             source=info["src"],
             diffuse_variants=info.get("diffuse_variants_at_end") or [],
             diffuse_history=info.get("diffuse_history_at_end") or [],
@@ -684,73 +807,79 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         for i, authored in enumerate(draws_list, 1):
             d = DrawCall(
                 label=f"{label}-{i}",
+                operation=authored.operation,
                 count=authored.count,
                 start=authored.start,
                 base=authored.base,
+                auto_count=authored.auto_count,
                 conditions=authored.conditions,
                 sources=[authored.source] if authored.source else [],
                 ib_file=ib_file,
                 index_size=index_size,
                 position_file=pos_file,
                 position_stride=pos_stride,
+                position_slot=position_slot,
+                position_format=pos_ri.get("format"),
                 texcoord_file=tc_file,
                 texcoord_stride=tc_stride,
+                texcoord_slot=texcoord_slot,
+                texcoord_format=tc_ri.get("format"),
             )
             # Resolve the effective buffers before deduplication. Concrete
             # per-draw VB bindings win; runtime-only resources retain the
             # existing IB/component heuristic, while an authored null stays
             # unbound instead of inheriting the group's first binding.
             effective_ib = authored.index_resource or ib_res
-            if effective_ib != ib_res:
+            if authored.operation == "draw":
+                d.ib_file = None
+                d.index_size = None
+            elif effective_ib != ib_res:
                 resolved_ib = _resolve_ib_file(effective_ib)
                 if resolved_ib:
                     d.ib_file = resolved_ib
                     d.index_size = _ib_index_size(
                         _res_get(resources, effective_ib).get("format"))
 
-            draw_buf = _lookup_comp_buf(_ib_res_to_component(effective_ib))
+            draw_buf = (_lookup_comp_buf(_ib_res_to_component(effective_ib))
+                        if effective_ib else None)
             if draw_buf and draw_buf != buf:
-                pfile, pstride = _resolve_vertex_res(draw_buf["position"])
-                tfile, tstride = _resolve_vertex_res(draw_buf["texcoord"])
-                if pfile:
-                    d.position_file = pfile
-                    d.position_stride = pstride or POSITION_STRIDE
-                if tfile:
-                    d.texcoord_file = tfile
-                    d.texcoord_stride = tstride or 20
+                position_binding = _resolve_vertex_binding(
+                    None, draw_buf["position"])
+                texcoord_binding = _resolve_vertex_binding(
+                    None, draw_buf["texcoord"])
+                if position_binding:
+                    d.position_file = position_binding["filename"]
+                    d.position_stride = position_binding["stride"]
+                    d.position_format = position_binding["format"]
+                if texcoord_binding:
+                    d.texcoord_file = texcoord_binding["filename"]
+                    d.texcoord_stride = texcoord_binding["stride"]
+                    d.texcoord_format = texcoord_binding["format"]
 
             vertex_resources = authored.vertex_resources
-            if 0 in vertex_resources:
-                position_resource = vertex_resources[0]
-                if position_resource is None:
-                    d.position_file = None
-                    d.position_stride = None
-                else:
-                    pfile, pstride = _resolve_vertex_res(position_resource)
-                    if pfile:
-                        d.position_file = pfile
-                        d.position_stride = pstride or POSITION_STRIDE
-
-            authored_tc = {
-                slot: vertex_resources[slot]
-                for slot in (1, 2) if slot in vertex_resources
-            }
-            resolved_tc = None
-            for slot in (2, 1):
-                resource_name = authored_tc.get(slot)
-                if not resource_name:
-                    continue
-                tfile, tstride = _resolve_vertex_res(resource_name)
-                if tfile and (tstride or 0) != 32:
-                    resolved_tc = (tfile, tstride or 20)
-                    break
-            if resolved_tc:
-                d.texcoord_file, d.texcoord_stride = resolved_tc
-            elif authored_tc and any(
-                    resource_name is None
-                    for resource_name in authored_tc.values()):
+            position_binding, texcoord_binding = _semantic_vertex_bindings(
+                vertex_resources)
+            if position_binding:
+                d.position_file = position_binding["filename"]
+                d.position_stride = position_binding["stride"]
+                d.position_slot = position_binding["slot"]
+                d.position_format = position_binding["format"]
+            elif (0 in vertex_resources and vertex_resources[0] is None) or (
+                    d.position_slot in vertex_resources
+                    and vertex_resources[d.position_slot] is None):
+                d.position_file = None
+                d.position_stride = None
+                d.position_format = None
+            if texcoord_binding:
+                d.texcoord_file = texcoord_binding["filename"]
+                d.texcoord_stride = texcoord_binding["stride"]
+                d.texcoord_slot = texcoord_binding["slot"]
+                d.texcoord_format = texcoord_binding["format"]
+            elif any(vertex_resources.get(slot, "bound") is None
+                     for slot in {1, 2, d.texcoord_slot} if slot is not None):
                 d.texcoord_file = None
                 d.texcoord_stride = None
+                d.texcoord_format = None
             # Whichever Resource\...\Diffuse line most recently ran before
             # this draw, in execution order -- the draw's own default
             # texture (see core.mesh_builder.build_mesh_payload). The first
@@ -820,7 +949,11 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             source=source,
             position_file=pos_file, texcoord_file=tc_file,
             position_stride=pos_stride,
+            position_slot=position_slot, position_format=pos_ri.get("format"),
+            position_offset=0,
             texcoord_stride=tc_stride, texcoord_uv_off=uv_off,
+            texcoord_slot=texcoord_slot, texcoord_format=tc_ri.get("format"),
+            texcoord_offset=None,
             ib_file=ib_file, diffuse_file=diff_ri.get("filename"),
             diffuse_pool_files=pool_files,
             index_size=index_size,

--- a/src/core/ini_parser.py
+++ b/src/core/ini_parser.py
@@ -465,7 +465,56 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                           _diffuse_history=[], _aux_maps={},
                           _resource_state=_new_resource_state())
         _scan(lines, info, [], {name}, {"steps": 0})
-        info.pop("_resource_state", None)
+        resource_state = info.pop("_resource_state")
+        # Keep textual discovery separate from an execution-safe fallback.
+        # For an explicit-draw section, a binding is stable only when every
+        # authored draw sees the same concrete resource.  For an implicit-draw
+        # section, terminal state is the only execution point available.
+        # Per-draw snapshots remain authoritative for branch-local bindings.
+        info["discovered_vertex_resources"] = {
+            slot: info[f"vb{slot}"] for slot in range(3)
+            if info[f"vb{slot}"]
+        }
+        info["discovered_index_resource"] = info["ib"]
+
+        def _stable_draw_vertex(slot):
+            if not info["draws"]:
+                if slot in resource_state["ambiguous_vertex_slots"]:
+                    return None
+                return resource_state["vertex_resources"].get(slot)
+            values = []
+            for draw in info["draws"]:
+                if (slot in draw.ambiguous_vertex_slots
+                        or slot not in draw.vertex_resources):
+                    return None
+                values.append(draw.vertex_resources[slot])
+            first = values[0]
+            if not first or any(value != first for value in values[1:]):
+                return None
+            return first
+
+        for slot in range(3):
+            info[f"vb{slot}"] = _stable_draw_vertex(slot)
+        if info["draws"]:
+            index_values = []
+            for draw in info["draws"]:
+                if (draw.ambiguous_index_resource
+                        or not draw.index_resource_bound):
+                    index_values = []
+                    break
+                index_values.append(draw.index_resource)
+            info["ib"] = (
+                index_values[0]
+                if (index_values and index_values[0]
+                    and all(value == index_values[0]
+                            for value in index_values[1:]))
+                else None)
+        else:
+            info["ib"] = (
+                resource_state["index_resource"]
+                if (resource_state["index_resource_bound"]
+                    and not resource_state["ambiguous_index_resource"])
+                else None)
         # Whatever diffuse was active at the end of the scan -- needed for a
         # section with NO drawindexed line at all (the game's original,
         # whole-buffer draw proceeds unmodified against this section's own
@@ -543,7 +592,9 @@ def _select_draw_sections(sec_info, global_ib):
     return [(name, info) for name, info in sec_info.items()
             if name.lower().startswith("textureoverride")
             and (info["ib"] or global_ib or any(
-                draw.operation == "draw" for draw in info["draws"]))
+                draw.operation == "draw"
+                or (draw.index_resource_bound and draw.index_resource)
+                for draw in info["draws"]))
             and (info["draws"] or (info["ib"] and not info["handling_skip"]))]
 
 
@@ -914,49 +965,97 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         label = display_name
         if seen[display_name] > 1: label = f"{display_name}_{seen[display_name]}"
 
-        ib_res = info["ib"] or global_ib
-        comp   = (_ib_res_to_component(ib_res) if ib_res else display_name)
-        buf    = _lookup_comp_buf(comp)
-        authored_position = authored_texcoord = None
-        if render_draws:
-            authored_position, authored_texcoord = _semantic_vertex_bindings(
-                render_draws[0].vertex_resources)
-        if not buf and render_draws:
-            if authored_position and authored_texcoord:
-                buf = {
-                    "position": authored_position["resource"],
-                    "texcoord": authored_texcoord["resource"],
-                }
-        if not buf:
-            # Some compute-skinned ZZMI components bind their runtime vb0 only
-            # inside the draw CommandList, while the sibling *Texcoord section
-            # still owns the UV buffer.  Combine those two authored bindings.
-            position = info["vb0"] or _lookup_comp_value(comp_pos, comp)
-            vb2_stride = (_res_get(resources, info["vb2"]).get("stride", 0)
-                          if info["vb2"] else 0)
-            texcoord = ((info["vb2"] if info["vb2"] and vb2_stride != 32 else None)
-                        or info["vb1"] or _lookup_comp_value(comp_tc, comp))
-            if (position and texcoord
-                    and resolve_vertex_info(position).get("filename")):
-                buf = {"position": position, "texcoord": texcoord}
-        if not buf:
-            h = _extract_hash(sec_name) or _extract_hash(ib_res)
-            if h and h in hash_pos and h in hash_tc:
-                buf = {"position": hash_pos[h], "texcoord": hash_tc[h]}
-        if not buf and global_pos and global_tc:
-            buf = {"position": global_pos, "texcoord": global_tc}  # WWMI fallback
-        if not buf: continue
+        fallback_ib = info["ib"] or global_ib
+        seed_ib = fallback_ib or next((
+            draw.index_resource for draw in render_draws
+            if (draw.operation != "draw" and draw.index_resource_bound
+                and draw.index_resource)), None)
+        comp = (_ib_res_to_component(seed_ib) if seed_ib else display_name)
 
-        pos_ri  = resolve_vertex_info(buf["position"])
-        tc_ri   = _res_get(resources, buf["texcoord"])
-        ib_ri   = _res_get(resources, ib_res)
+        # These component fallbacks are execution-safe: _scan_sections_for_draws
+        # replaces the old first-seen fields with state agreed at every draw,
+        # and _resolve_component_buffers consumes only those stable values.
+        component_buf = _lookup_comp_buf(comp)
+        fallback_position = (component_buf or {}).get("position")
+        fallback_texcoord = (component_buf or {}).get("texcoord")
+        fallback_position = (
+            fallback_position or info["vb0"]
+            or _lookup_comp_value(comp_pos, comp))
+        vb2_stride = (_res_get(resources, info["vb2"]).get("stride", 0)
+                      if info["vb2"] else 0)
+        fallback_texcoord = (
+            fallback_texcoord
+            or (info["vb2"] if info["vb2"] and vb2_stride != 32 else None)
+            or info["vb1"] or _lookup_comp_value(comp_tc, comp))
+        h = _extract_hash(sec_name) or (
+            _extract_hash(seed_ib) if seed_ib else None)
+        if h:
+            fallback_position = fallback_position or hash_pos.get(h)
+            fallback_texcoord = fallback_texcoord or hash_tc.get(h)
+        fallback_position = fallback_position or global_pos
+        fallback_texcoord = fallback_texcoord or global_tc
+
+        # Pick one complete draw only to seed the group's compatibility fields.
+        # Every output draw is resolved again below from its own execution
+        # snapshot, so this seed can never become a sibling-branch fallback.
+        seed = None
+        for authored in render_draws:
+            effective_ib = (authored.index_resource
+                            if authored.index_resource_bound else fallback_ib)
+            draw_component = (
+                _lookup_comp_buf(_ib_res_to_component(effective_ib))
+                if effective_ib else None)
+            authored_position, authored_texcoord = _semantic_vertex_bindings(
+                authored.vertex_resources)
+            if authored.operation == "draw":
+                position_res = (authored_position or {}).get("resource")
+                texcoord_res = (authored_texcoord or {}).get("resource")
+            else:
+                position_res = ((authored_position or {}).get("resource")
+                                or (draw_component or {}).get("position")
+                                or fallback_position)
+                texcoord_res = ((authored_texcoord or {}).get("resource")
+                                or (draw_component or {}).get("texcoord")
+                                or fallback_texcoord)
+            position_binding = _resolve_vertex_binding(None, position_res)
+            texcoord_binding = _resolve_vertex_binding(None, texcoord_res)
+            indexed_ok = True
+            if authored.operation != "draw":
+                ib_info = _res_get(resources, effective_ib)
+                indexed_ok = bool(
+                    ib_info.get("filename")
+                    and index_layout(ib_info.get("format")))
+            if position_binding and texcoord_binding and indexed_ok:
+                seed = (effective_ib, position_binding, texcoord_binding,
+                        authored_position, authored_texcoord)
+                break
+        if seed is None and not render_draws:
+            position_binding = _resolve_vertex_binding(
+                None, fallback_position)
+            texcoord_binding = _resolve_vertex_binding(None, fallback_texcoord)
+            ib_info = _res_get(resources, fallback_ib)
+            if (position_binding and texcoord_binding
+                    and ib_info.get("filename")
+                    and index_layout(ib_info.get("format"))):
+                seed = (fallback_ib, position_binding, texcoord_binding,
+                        None, None)
+        if seed is None:
+            continue
+
+        (ib_res, position_binding, texcoord_binding,
+         authored_position, authored_texcoord) = seed
+        buf = {
+            "position": position_binding["resource"],
+            "texcoord": texcoord_binding["resource"],
+        }
+        pos_ri = resolve_vertex_info(buf["position"])
+        tc_ri = _res_get(resources, buf["texcoord"])
+        ib_ri = _res_get(resources, ib_res)
         diff_ri = _res_get(resources, info["diffuse"]) if info["diffuse"] else {}
 
         pos_file = pos_ri.get("filename")
         tc_file  = tc_ri.get("filename")
         ib_file  = ib_ri.get("filename")
-        requires_ib = (not render_draws or any(
-            draw.operation != "draw" for draw in render_draws))
         tc_stride  = tc_ri.get("stride", 20)
         pos_stride = pos_ri.get("stride", POSITION_STRIDE)
         position_slot = (authored_position["slot"] if authored_position
@@ -969,8 +1068,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             index_layout(ib_ri.get("format")) if ib_file else None)
         index_size = (resolved_index_layout.size
                       if resolved_index_layout else None)
-        if (not (pos_file and tc_file)
-                or (requires_ib and (not ib_file or index_size is None))):
+        if not (pos_file and tc_file):
             continue
         uv_off     = DEFAULT_UV_OFFSET
 
@@ -1007,16 +1105,15 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                 texcoord_slot=texcoord_slot,
                 texcoord_format=tc_ri.get("format"),
             )
-            # Resolve the effective buffers before deduplication. Concrete
-            # per-draw VB bindings win; runtime-only resources retain the
-            # existing IB/component heuristic, while an authored null stays
-            # unbound instead of inheriting the group's first binding.
+            # Resolve the effective buffers before deduplication.  The safe
+            # fallback is state that dominates every path, never the resource
+            # chosen above merely to seed the group compatibility fields.
             effective_ib = (authored.index_resource
-                            if authored.index_resource_bound else ib_res)
+                            if authored.index_resource_bound else fallback_ib)
             if authored.operation == "draw":
                 d.ib_file = None
                 d.index_size = None
-            elif effective_ib != ib_res:
+            else:
                 resolved_ib = _resolve_ib_file(effective_ib)
                 resolved_layout = index_layout(
                     _res_get(resources, effective_ib).get("format"))
@@ -1029,19 +1126,30 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
 
             draw_buf = (_lookup_comp_buf(_ib_res_to_component(effective_ib))
                         if effective_ib else None)
-            if draw_buf and draw_buf != buf:
-                position_binding = _resolve_vertex_binding(
-                    None, draw_buf["position"])
-                texcoord_binding = _resolve_vertex_binding(
-                    None, draw_buf["texcoord"])
-                if position_binding:
-                    d.position_file = position_binding["filename"]
-                    d.position_stride = position_binding["stride"]
-                    d.position_format = position_binding["format"]
-                if texcoord_binding:
-                    d.texcoord_file = texcoord_binding["filename"]
-                    d.texcoord_stride = texcoord_binding["stride"]
-                    d.texcoord_format = texcoord_binding["format"]
+            fallback_position_binding = _resolve_vertex_binding(
+                None, (draw_buf or {}).get("position") or fallback_position)
+            fallback_texcoord_binding = _resolve_vertex_binding(
+                None, (draw_buf or {}).get("texcoord") or fallback_texcoord)
+            if fallback_position_binding:
+                d.position_file = fallback_position_binding["filename"]
+                d.position_stride = fallback_position_binding["stride"]
+                d.position_slot = None
+                d.position_format = fallback_position_binding["format"]
+            else:
+                d.position_file = None
+                d.position_stride = None
+                d.position_slot = None
+                d.position_format = None
+            if fallback_texcoord_binding:
+                d.texcoord_file = fallback_texcoord_binding["filename"]
+                d.texcoord_stride = fallback_texcoord_binding["stride"]
+                d.texcoord_slot = None
+                d.texcoord_format = fallback_texcoord_binding["format"]
+            else:
+                d.texcoord_file = None
+                d.texcoord_stride = None
+                d.texcoord_slot = None
+                d.texcoord_format = None
 
             vertex_resources = authored.vertex_resources
             position_binding, texcoord_binding = _semantic_vertex_bindings(

--- a/src/core/ini_parser.py
+++ b/src/core/ini_parser.py
@@ -911,11 +911,25 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         if (authored.operation != "draw"
                 and authored.ambiguous_index_resource):
             return True
-        for slot, candidates in authored.ambiguous_vertex_resources.items():
+        position, texcoord = _semantic_vertex_bindings(
+            authored.vertex_resources)
+        for slot in authored.ambiguous_vertex_slots:
+            candidates = authored.ambiguous_vertex_resources.get(slot, ())
             for candidate in candidates:
-                position, texcoord = _semantic_vertex_bindings(
-                    {slot: candidate})
-                if position or texcoord:
+                (candidate_position,
+                 candidate_texcoord) = _semantic_vertex_bindings({
+                     slot: candidate,
+                 })
+                if candidate_position or candidate_texcoord:
+                    return True
+            # A null-vs-untouched join has no concrete candidate to classify.
+            # Treat established slots conservatively unless another authored
+            # binding already supplies that geometry semantic.  Higher slots
+            # such as WWMI's conditional vb4 blend stream remain harmless.
+            if not candidates:
+                if slot == 0 and position is None:
+                    return True
+                if slot in (1, 2) and texcoord is None:
                     return True
         return False
 

--- a/src/core/ini_parser.py
+++ b/src/core/ini_parser.py
@@ -813,6 +813,12 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             "format": info.get("format"),
         }
 
+    def _first_resolvable_vertex_resource(*candidates):
+        for candidate in candidates:
+            if _resolve_vertex_binding(None, candidate):
+                return candidate
+        return None
+
     def _semantic_vertex_bindings(vertex_resources):
         """Choose supported position/UV bindings from concrete active slots.
 
@@ -976,24 +982,23 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         # replaces the old first-seen fields with state agreed at every draw,
         # and _resolve_component_buffers consumes only those stable values.
         component_buf = _lookup_comp_buf(comp)
-        fallback_position = (component_buf or {}).get("position")
-        fallback_texcoord = (component_buf or {}).get("texcoord")
-        fallback_position = (
-            fallback_position or info["vb0"]
-            or _lookup_comp_value(comp_pos, comp))
         vb2_stride = (_res_get(resources, info["vb2"]).get("stride", 0)
                       if info["vb2"] else 0)
-        fallback_texcoord = (
-            fallback_texcoord
-            or (info["vb2"] if info["vb2"] and vb2_stride != 32 else None)
-            or info["vb1"] or _lookup_comp_value(comp_tc, comp))
         h = _extract_hash(sec_name) or (
             _extract_hash(seed_ib) if seed_ib else None)
-        if h:
-            fallback_position = fallback_position or hash_pos.get(h)
-            fallback_texcoord = fallback_texcoord or hash_tc.get(h)
-        fallback_position = fallback_position or global_pos
-        fallback_texcoord = fallback_texcoord or global_tc
+        fallback_position = _first_resolvable_vertex_resource(
+            (component_buf or {}).get("position"),
+            info["vb0"],
+            _lookup_comp_value(comp_pos, comp),
+            hash_pos.get(h) if h else None,
+            global_pos)
+        fallback_texcoord = _first_resolvable_vertex_resource(
+            (component_buf or {}).get("texcoord"),
+            info["vb2"] if info["vb2"] and vb2_stride != 32 else None,
+            info["vb1"],
+            _lookup_comp_value(comp_tc, comp),
+            hash_tc.get(h) if h else None,
+            global_tc)
 
         # Pick one complete draw only to seed the group's compatibility fields.
         # Every output draw is resolved again below from its own execution

--- a/src/core/ini_parser.py
+++ b/src/core/ini_parser.py
@@ -139,8 +139,10 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
     def _record_draw(raw, info, cond_stack, operation, count, start, base,
                      auto_count=False):
         combined = DNF_TRUE
+        vertex_resources = dict(info["_root_vertex_resources"])
         for frame in cond_stack:
             combined = dnf_and(combined, frame["cur"])
+            vertex_resources.update(frame["vertex_resources"])
         info["draws"].append(AuthoredDrawCall(
             count=count,
             start=start,
@@ -153,7 +155,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             diffuse_variants=list(
                 info.get("_cur_diffuse_variants") or []),
             diffuse_history=list(info.get("_diffuse_history") or []),
-            vertex_resources=dict(info["_cur_vertex_resources"]),
+            vertex_resources=vertex_resources,
             auxiliary_maps=_aux_snapshot(info),
         ))
 
@@ -181,20 +183,28 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             if m_elif:
                 if cond_stack:
                     frame = cond_stack[-1]
-                    branch = parse_condition_dnf(m_elif.group(1).strip(), alias_map)
+                    branch = parse_condition_dnf(
+                        m_elif.group(1).strip(), alias_map)
                     not_seen = dnf_not(frame["seen"])
                     frame["cur"] = dnf_and(not_seen, branch)
                     frame["seen"] = dnf_or(frame["seen"], branch)
+                    frame["vertex_resources"] = {}
                 continue
             if low.startswith("if "):
                 branch = parse_condition_dnf(line[3:].strip(), alias_map)
                 seq_counter[0] += 1
-                cond_stack.append({"cur": branch, "seen": branch, "seq": seq_counter[0]})
+                cond_stack.append({
+                    "cur": branch,
+                    "seen": branch,
+                    "seq": seq_counter[0],
+                    "vertex_resources": {},
+                })
                 continue
             if low == "else":
                 if cond_stack:
                     frame = cond_stack[-1]
                     frame["cur"] = dnf_not(frame["seen"])
+                    frame["vertex_resources"] = {}
                 continue
             if low == "endif":
                 if cond_stack: cond_stack.pop()
@@ -206,7 +216,9 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 value = None if resource.lower() == "null" else resource
                 if slot <= 2 and value and not info[f"vb{slot}"]:
                     info[f"vb{slot}"] = value
-                info["_cur_vertex_resources"][slot] = value
+                target = (cond_stack[-1]["vertex_resources"]
+                          if cond_stack else info["_root_vertex_resources"])
+                target[slot] = value
             m = re.match(r"ib\s*=\s*(\S+)", line, re.I)
             if m:
                 if not info["ib"]: info["ib"] = m.group(1)
@@ -347,10 +359,10 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                           diffuse=None, diffuse_pool=[], src=None, handling_skip=False,
                           _cur_diffuse_variants=[], _diffuse_chain_key=None,
                           _diffuse_history=[], _aux_maps={},
-                          _cur_vertex_resources={})
+                          _root_vertex_resources={})
         _scan(lines, info, [], {name}, {"steps": 0})
         info.pop("_cur_ib", None)
-        info.pop("_cur_vertex_resources", None)
+        info.pop("_root_vertex_resources", None)
         # Whatever diffuse was active at the end of the scan -- needed for a
         # section with NO drawindexed line at all (the game's original,
         # whole-buffer draw proceeds unmodified against this section's own
@@ -729,6 +741,24 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
 
     groups: list = []
     for sec_name, info in draw_secs:
+        # Indexed components can resolve missing streams through their IB and
+        # sibling override structure. A non-indexed draw has no such identity:
+        # require its own execution path to bind both supported vertex
+        # semantics, otherwise a Blend/upload/UI pass can be mistaken for a
+        # sequential triangle list after borrowing unrelated fallback buffers.
+        render_draws = []
+        for authored in info["draws"]:
+            if authored.operation != "draw":
+                render_draws.append(authored)
+                continue
+            position, texcoord = _semantic_vertex_bindings(
+                authored.vertex_resources)
+            if position and texcoord:
+                render_draws.append(authored)
+        if (not render_draws
+                and (not info["ib"] or info["handling_skip"])):
+            continue
+
         display_name = sec_name[len("TextureOverride"):] or sec_name
         seen[display_name] = seen.get(display_name, 0) + 1
         label = display_name
@@ -738,10 +768,10 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         comp   = (_ib_res_to_component(ib_res) if ib_res else display_name)
         buf    = _lookup_comp_buf(comp)
         authored_position = authored_texcoord = None
-        if info["draws"]:
+        if render_draws:
             authored_position, authored_texcoord = _semantic_vertex_bindings(
-                info["draws"][0].vertex_resources)
-        if not buf and info["draws"]:
+                render_draws[0].vertex_resources)
+        if not buf and render_draws:
             if authored_position and authored_texcoord:
                 buf = {
                     "position": authored_position["resource"],
@@ -775,8 +805,8 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         pos_file = pos_ri.get("filename")
         tc_file  = tc_ri.get("filename")
         ib_file  = ib_ri.get("filename")
-        requires_ib = (not info["draws"] or any(
-            draw.operation != "draw" for draw in info["draws"]))
+        requires_ib = (not render_draws or any(
+            draw.operation != "draw" for draw in render_draws))
         if not (pos_file and tc_file) or (requires_ib and not ib_file):
             continue
 
@@ -792,7 +822,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                       if ib_file else None)
         uv_off     = DEFAULT_UV_OFFSET
 
-        draws_list = list(info["draws"]) or [AuthoredDrawCall(
+        draws_list = list(render_draws) or [AuthoredDrawCall(
             count=None,
             start=0,
             base=0,

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -470,42 +470,6 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
 
         for draw in unique:
             lbl = draw.label
-            if draw.operation == "draw":
-                if draw.count is None:
-                    continue
-                raw = list(range(draw.start, draw.start + draw.count))
-            else:
-                draw_ib_path = safe_resource_path(mod_dir, draw.ib_file)
-                if not draw_ib_path or not os.path.exists(draw_ib_path):
-                    continue
-                if draw_ib_path not in ib_cache:
-                    ib_cache[draw_ib_path] = _read_buffer(draw_ib_path)
-                try:
-                    raw = read_indices(
-                        ib_cache[draw_ib_path], draw.start,
-                        None if draw.auto_count else draw.count,
-                        draw.index_size if draw.index_size is not None
-                        else index_size)
-                except LayoutError:
-                    continue
-            if not raw:
-                continue
-            # DirectX resolves each index as index_buffer_value + BaseVertexLocation
-            # against the vertex buffer -- shared/merged buffers rely on this offset
-            # to pick out this draw's own vertex range.
-            base = draw.base if draw.operation != "draw" else 0
-            if base:
-                raw = [v + base for v in raw]
-            # A negative effective DirectX vertex index is invalid.  Reject it
-            # before buffer decoding, where negative offsets can be interpreted
-            # as end-relative instead of failing safely.
-            if any(index < 0 for index in raw):
-                continue
-
-            # Compact: only export vertices actually referenced
-            used  = sorted(set(raw))
-            remap = {old: new for new, old in enumerate(used)}
-
             # A mid-section `vb0/vb1/vb2 = ...` reassignment (paired with `ib`).
             draw_buffers = buffers
             draw_pos_path = safe_resource_path(mod_dir, draw.position_file)
@@ -550,10 +514,50 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 continue
 
             pos_data, tc_data, layout = draw_buffers
+            if draw.operation == "draw":
+                if draw.count is None:
+                    continue
+                try:
+                    layout.validate_vertex_range(
+                        draw.start, draw.count, pos_data, tc_data)
+                except LayoutError:
+                    continue
+                raw = list(range(draw.start, draw.start + draw.count))
+            else:
+                draw_ib_path = safe_resource_path(mod_dir, draw.ib_file)
+                if not draw_ib_path or not os.path.exists(draw_ib_path):
+                    continue
+                if draw_ib_path not in ib_cache:
+                    ib_cache[draw_ib_path] = _read_buffer(draw_ib_path)
+                try:
+                    raw = read_indices(
+                        ib_cache[draw_ib_path], draw.start,
+                        None if draw.auto_count else draw.count,
+                        draw.index_size if draw.index_size is not None
+                        else index_size)
+                except LayoutError:
+                    continue
+            if not raw:
+                continue
+            # DirectX resolves each index as index_buffer_value + BaseVertexLocation
+            # against the vertex buffer -- shared/merged buffers rely on this offset
+            # to pick out this draw's own vertex range.
+            base = draw.base if draw.operation != "draw" else 0
+            if base:
+                raw = [v + base for v in raw]
+            # A negative effective DirectX vertex index is invalid.  Reject it
+            # before buffer decoding, where negative offsets can be interpreted
+            # as end-relative instead of failing safely.
+            if any(index < 0 for index in raw):
+                continue
             try:
                 layout.validate_indices(raw, pos_data, tc_data)
             except LayoutError:
                 continue
+
+            # Compact: only export vertices actually referenced
+            used  = sorted(set(raw))
+            remap = {old: new for new, old in enumerate(used)}
             pos_bytes = bytearray(len(used) * 12)
             shape_buffers = (
                 _build_shape_buffers(

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -3,6 +3,8 @@
 import re, struct, os, base64
 from dataclasses import dataclass
 
+from .buffer_layout import (GeometryLayout, IndexLayout, LayoutError,
+                            position_layout, texcoord_layout)
 from .draw_call import DrawCall
 from .resource_paths import safe_resource_path
 from .textures import (_texture_source_uri, _begin_texture_cache,
@@ -43,13 +45,8 @@ def read_positions(buf_path, stride=POSITION_STRIDE):
     return positions
 
 
-_MIN_AXIS_SPREAD = 1e-4   # below this an axis is constant, i.e. not a real UV set
-_MIN_IN_RANGE    = 0.95   # fraction of sampled UVs that must land in [0, 2]
-
-
 def _detect_uv_best(tc_path, stride, n=4096, data=None):
-    """Try (offset 0 or 4) x (float16 or float32) and return the (uv_off, fmt)
-    with the largest UV spread where all values are within [0, 2].
+    """Compatibility projection of the typed texcoord layout detector.
 
     Candidates are sampled EVENLY ACROSS THE WHOLE BUFFER, not from the first
     n vertices: consecutive vertices are spatially adjacent, so a head-only
@@ -84,54 +81,17 @@ def _detect_uv_best(tc_path, stride, n=4096, data=None):
     merely useless (flat zero UVs) instead of misaligned.
     """
     if data is None:
-        with open(tc_path, 'rb') as f:
-            data = f.read()
-    size = len(data)
-    total = size // stride if stride else 0
-    if not total:
-        return (DEFAULT_UV_OFFSET, '<ee')
-    step = max(1, total // n)   # stride the sample across the entire buffer
-    # Rank every in-range candidate; prefer two live axes over a bigger total.
-    scored = []
-    for uv_off in (0, 4):
-        for fmt in ('<ee', '<ff'):
-            fmtsize = struct.calcsize(fmt)
-            if uv_off + fmtsize > stride:
-                continue
-            us, vs, sampled = [], [], 0
-            for i in range(0, total, step):
-                off = i * stride + uv_off
-                if off + fmtsize > size:
-                    break
-                u, v = struct.unpack_from(fmt, data, off)
-                sampled += 1
-                # NaN fails every comparison, so test for validity positively:
-                # a misread buffer routinely decodes to NaN/inf, which would
-                # otherwise slip through a `u < lo or u > hi` style check.
-                if -0.01 <= u <= 2.0 and -0.01 <= v <= 2.0:
-                    us.append(u); vs.append(v)
-            if not sampled or not us:
-                continue
-            in_range = len(us) / sampled
-            if in_range < _MIN_IN_RANGE:
-                continue
-            du, dv = max(us) - min(us), max(vs) - min(vs)
-            both_live = du >= _MIN_AXIS_SPREAD and dv >= _MIN_AXIS_SPREAD
-            scored.append((both_live, round(in_range, 3), round(du + dv, 3),
-                           uv_off, fmt))
-    if scored:
-        # Rank: both axes live, then cleanliness, then total spread. Cleanliness
-        # must outrank spread -- a misread float32 can post a huge spread (up to
-        # the full 0..2 window) while being 12% garbage, and swept across the
-        # corpus spread-first regressed 27 buffers where clean-first regressed
-        # none.
-        scored.sort(reverse=True)
-        return (scored[0][3], scored[0][4])
-    # Nothing decoded in range: fall back to the first offset that at least fits.
+        with open(tc_path, "rb") as stream:
+            data = stream.read()
+    layout = texcoord_layout(data, stride, sample_limit=n)
+    if layout:
+        return layout.offset, layout.struct_format
+    # Compatibility callers of this legacy helper still receive a fitting
+    # tuple. The production builder requires a real typed descriptor instead.
     for uv_off in (DEFAULT_UV_OFFSET, 0):
         if uv_off + 4 <= stride:
-            return (uv_off, '<ee')
-    return (0, '<ee')
+            return uv_off, "<ee"
+    return 0, "<ee"
 
 
 def read_texcoords(buf_path, stride, uv_off=DEFAULT_UV_OFFSET, uv_fmt='<ee',
@@ -150,13 +110,13 @@ def read_texcoords(buf_path, stride, uv_off=DEFAULT_UV_OFFSET, uv_fmt='<ee',
 
 
 def read_indices(ib_data, start_index=0, count=None, index_size=INDEX_SIZE):
-    total = len(ib_data) // index_size
-    if count is None: count = total - start_index
-    end = min(start_index + count, total)
-    if end <= start_index: return []
-    fmt = "H" if index_size == 2 else "I"
-    return list(struct.unpack_from(f"<{end - start_index}{fmt}", ib_data,
-                                   start_index * index_size))
+    """Decode one complete bounded index range.
+
+    Older code silently truncated a draw that extended beyond the IB.  That
+    changed authored geometry and could leave a non-triangle tail; callers now
+    receive ``LayoutError`` and can reject the draw as one unit.
+    """
+    return IndexLayout(index_size).read(ib_data, start_index, count)
 
 
 # ── Encoding helpers ───────────────────────────────────────────────────────────
@@ -409,15 +369,26 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
         ib_path   = safe_resource_path(mod_dir, grp["ib_file"])
         tc_stride = grp["texcoord_stride"]
         pos_stride = grp.get("position_stride", POSITION_STRIDE)
+        position_slot = grp.get("position_slot")
+        texcoord_slot = grp.get("texcoord_slot")
+        position_format = grp.get("position_format")
+        texcoord_format = grp.get("texcoord_format")
+        position_offset = grp.get("position_offset", 0)
+        texcoord_offset = grp.get("texcoord_offset")
         index_size = grp.get("index_size", INDEX_SIZE)
         component = grp.get("display_name") or grp.get("name")
         source    = grp.get("source")
 
-        if not all(p and os.path.exists(p) for p in [pos_path, tc_path, ib_path]):
+        if not all(p and os.path.exists(p) for p in [pos_path, tc_path]):
+            continue
+        if ib_path and not os.path.exists(ib_path):
             continue
 
-        def _load_buf(pos_path, pos_stride, tc_path, tc_stride):
-            key = (pos_path, pos_stride, tc_path, tc_stride)
+        def _load_buf(pos_path, pos_stride, tc_path, tc_stride,
+                      pos_format=None, tc_format=None, pos_slot=None,
+                      tc_slot=None, pos_offset=0, tc_offset=None):
+            key = (pos_path, pos_stride, pos_format, pos_slot, pos_offset,
+                   tc_path, tc_stride, tc_format, tc_slot, tc_offset)
             if key not in buf_cache:
                 if pos_path not in raw_buf_cache:
                     raw_buf_cache[pos_path] = _read_buffer(pos_path)
@@ -425,14 +396,22 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                     raw_buf_cache[tc_path] = _read_buffer(tc_path)
                 pos_data = raw_buf_cache[pos_path]
                 tc_data = raw_buf_cache[tc_path]
-                uv_off, uv_fmt = _detect_uv_best(
-                    tc_path, tc_stride, data=tc_data)
-                buf_cache[key] = (pos_data, pos_stride, tc_data, tc_stride,
-                                  uv_off, uv_fmt)
+                pos_layout = position_layout(
+                    pos_stride, pos_format, pos_slot, pos_offset)
+                tc_layout = texcoord_layout(
+                    tc_data, tc_stride, tc_format, tc_slot, tc_offset)
+                buf_cache[key] = (
+                    (pos_data, tc_data, GeometryLayout(pos_layout, tc_layout))
+                    if pos_layout and tc_layout else None)
             return buf_cache[key]
 
-        buffers = _load_buf(pos_path, pos_stride, tc_path, tc_stride)
-        if ib_path not in ib_cache:
+        buffers = _load_buf(
+            pos_path, pos_stride, tc_path, tc_stride,
+            position_format, texcoord_format, position_slot, texcoord_slot,
+            position_offset, texcoord_offset)
+        if buffers is None:
+            continue
+        if ib_path and ib_path not in ib_cache:
             ib_cache[ib_path] = _read_buffer(ib_path)
 
         unique = _deduplicate_draws(grp, max_draws=max_draws)
@@ -491,20 +470,30 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
 
         for draw in unique:
             lbl = draw.label
-            draw_ib_path = safe_resource_path(mod_dir, draw.ib_file)
-            if not draw_ib_path or not os.path.exists(draw_ib_path):
-                continue
-            if draw_ib_path not in ib_cache:
-                ib_cache[draw_ib_path] = _read_buffer(draw_ib_path)
-            raw = read_indices(
-                ib_cache[draw_ib_path], draw.start, draw.count,
-                draw.index_size if draw.index_size is not None else index_size)
+            if draw.operation == "draw":
+                if draw.count is None:
+                    continue
+                raw = list(range(draw.start, draw.start + draw.count))
+            else:
+                draw_ib_path = safe_resource_path(mod_dir, draw.ib_file)
+                if not draw_ib_path or not os.path.exists(draw_ib_path):
+                    continue
+                if draw_ib_path not in ib_cache:
+                    ib_cache[draw_ib_path] = _read_buffer(draw_ib_path)
+                try:
+                    raw = read_indices(
+                        ib_cache[draw_ib_path], draw.start,
+                        None if draw.auto_count else draw.count,
+                        draw.index_size if draw.index_size is not None
+                        else index_size)
+                except LayoutError:
+                    continue
             if not raw:
                 continue
             # DirectX resolves each index as index_buffer_value + BaseVertexLocation
             # against the vertex buffer -- shared/merged buffers rely on this offset
             # to pick out this draw's own vertex range.
-            base = draw.base
+            base = draw.base if draw.operation != "draw" else 0
             if base:
                 raw = [v + base for v in raw]
             # A negative effective DirectX vertex index is invalid.  Reject it
@@ -532,26 +521,50 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
             draw_texcoord_stride = (
                 draw.texcoord_stride
                 if draw.texcoord_stride is not None else tc_stride)
+            draw_position_format = draw.position_format or position_format
+            draw_texcoord_format = draw.texcoord_format or texcoord_format
+            draw_position_slot = (draw.position_slot
+                                  if draw.position_slot is not None
+                                  else position_slot)
+            draw_texcoord_slot = (draw.texcoord_slot
+                                  if draw.texcoord_slot is not None
+                                  else texcoord_slot)
+            draw_position_offset = draw.position_offset
+            draw_texcoord_offset = draw.texcoord_offset
             if (draw_pos_path != pos_path or draw_tc_path != tc_path
                     or draw_position_stride != pos_stride
-                    or draw_texcoord_stride != tc_stride):
+                    or draw_texcoord_stride != tc_stride
+                    or draw_position_format != position_format
+                    or draw_texcoord_format != texcoord_format
+                    or draw_position_slot != position_slot
+                    or draw_texcoord_slot != texcoord_slot
+                    or draw_position_offset != position_offset
+                    or draw_texcoord_offset != texcoord_offset):
                 draw_buffers = _load_buf(
                     draw_pos_path, draw_position_stride,
-                    draw_tc_path, draw_texcoord_stride)
+                    draw_tc_path, draw_texcoord_stride,
+                    draw_position_format, draw_texcoord_format,
+                    draw_position_slot, draw_texcoord_slot,
+                    draw_position_offset, draw_texcoord_offset)
+            if draw_buffers is None:
+                continue
 
-            pos_data, draw_pos_stride, tc_data, draw_tc_stride, uv_off, uv_fmt = draw_buffers
-            uv_size = struct.calcsize(uv_fmt)
+            pos_data, tc_data, layout = draw_buffers
+            try:
+                layout.validate_indices(raw, pos_data, tc_data)
+            except LayoutError:
+                continue
             pos_bytes = bytearray(len(used) * 12)
-            shape_buffers = _build_shape_buffers(
-                grp.get("shape_sliders"), mod_dir, effective_pos_path, used,
-                raw_buf_cache, sparse_shape_cache, _read_buffer)
+            shape_buffers = (
+                _build_shape_buffers(
+                    grp.get("shape_sliders"), mod_dir, effective_pos_path, used,
+                    raw_buf_cache, sparse_shape_cache, _read_buffer)
+                if (layout.position.format == "float32x3"
+                    and layout.position.offset == POSITION_OFFSET)
+                else [])
             uv_bytes = bytearray(len(used) * 8) if tc_data else None
             for out_i, vi in enumerate(used):
-                pos_off = vi * draw_pos_stride + POSITION_OFFSET
-                if pos_off + 12 <= len(pos_data):
-                    x, y, z = struct.unpack_from("<fff", pos_data, pos_off)
-                else:
-                    x, y, z = 0., 0., 0.
+                x, y, z = layout.position.read(pos_data, vi)[:3]
                 struct.pack_into("<fff", pos_bytes, out_i * 12, x, y, z)
                 for item in shape_buffers:
                     shape, target_data, target_bytes, sparse = item[:4]
@@ -574,11 +587,7 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                             lx, ly, lz = x, y, z
                         struct.pack_into("<fff", low_bytes, out_i * 12, lx, ly, lz)
                 if tc_data:
-                    tc_off = vi * draw_tc_stride + uv_off
-                    if tc_off + uv_size <= len(tc_data):
-                        u, v = struct.unpack_from(uv_fmt, tc_data, tc_off)
-                    else:
-                        u, v = 0., 0.
+                    u, v = layout.texcoord.read(tc_data, vi)[:2]
                     struct.pack_into("<ff", uv_bytes, out_i * 8,
                                      u, 1.0 - v)  # flip V for Three.js
 
@@ -691,7 +700,11 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
             # show a meaningful per-draw label instead of a bare "#1"/"#2" index.
             # Absent for the rare section with no drawindexed line at all (the
             # whole index buffer is read unconditionally) — count is None.
-            if draw.count is not None:
+            if draw.operation == "draw":
+                entry["draw"] = [draw.count, draw.start]
+            elif draw.operation == "drawindexed" and draw.auto_count:
+                entry["drawindexed"] = ["auto"]
+            elif draw.operation == "drawindexed" and draw.count is not None:
                 entry["drawindexed"] = [draw.count, draw.start, draw.base]
             if source:
                 entry["source"] = source

--- a/src/tests/test_ini_health.py
+++ b/src/tests/test_ini_health.py
@@ -207,9 +207,27 @@ def test_unsupported_drawindexed_arguments_are_structured_diagnostics():
 
     issues = [item for item in report["issues"]
               if item["code"] == "unsupported_drawindexed_arguments"]
-    assert [item["line"] for item in issues] == [3, 4]
+    assert [item["line"] for item in issues] == [4]
     assert [item["arguments"] for item in issues] == [
-        "auto", "$count, $start, 0"]
+        "$count, $start, 0"]
+
+
+def test_unsupported_draw_capabilities_are_structured_diagnostics():
+    with tempfile.TemporaryDirectory() as tmp:
+        _write(os.path.join(tmp, "mod.ini"), (
+            "[TextureOverrideBody]\n"
+            "draw = 3, 0\n"
+            "draw = auto\n"
+            "drawindexedinstanced = 3, 2, 0, 0, 0\n"))
+        report = analyze_mod(tmp)
+
+    by_code = {}
+    for issue in report["issues"]:
+        by_code.setdefault(issue["code"], []).append(issue)
+    assert "unsupported_draw_arguments" in by_code
+    assert by_code["unsupported_draw_arguments"][0]["line"] == 3
+    assert "unsupported_draw_operation" in by_code
+    assert by_code["unsupported_draw_operation"][0]["line"] == 4
 
 
 

--- a/src/tests/test_material_maps.py
+++ b/src/tests/test_material_maps.py
@@ -244,6 +244,7 @@ drawindexed = 3, 0, 0
 
 [ResourceBodyIB]
 filename = body.ib
+format = DXGI_FORMAT_R32_UINT
 [ResourceBodyPosition]
 filename = pos.buf
 stride = 40

--- a/src/tests/test_mesh_builder.py
+++ b/src/tests/test_mesh_builder.py
@@ -4,7 +4,10 @@ import os
 import struct
 import tempfile
 
-from core.ini_parser import (build_draw_groups, extract_resources,
+import pytest
+
+from core.ini_parser import (_scan_sections_for_draws, build_draw_groups,
+                             extract_resources,
                              extract_toggle_keys, merge_sections)
 from _provenance_support import IB_R16_INI, build_mesh_fixture, geometry_values, write
 
@@ -396,3 +399,122 @@ def test_section_classification_is_case_insensitive():
         assert groups[0]["position_file"] == "pos.buf"
         assert groups[0]["texcoord_file"] == "tc.buf"
         assert list(toggles) == ["keyswap"]
+
+
+DRAW_CAPABILITIES_INI = """[TextureOverrideBody]
+vb3 = ResourceBodyPosition
+vb4 = ResourceBodyTexcoord
+draw = 3, 1
+
+[ResourceBodyPosition]
+filename = position.buf
+stride = 8
+format = DXGI_FORMAT_R16G16B16A16_FLOAT
+
+[ResourceBodyTexcoord]
+filename = texcoord.buf
+stride = 8
+format = DXGI_FORMAT_R32G32_FLOAT
+"""
+
+
+def test_nonindexed_draw_uses_typed_layouts_and_higher_vb_slots():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", DRAW_CAPABILITIES_INI)
+        with open(os.path.join(tmp, "position.buf"), "wb") as stream:
+            for values in ((-1, -1, -1, 1), (1, 2, 3, 1),
+                           (4, 5, 6, 1), (7, 8, 9, 1)):
+                stream.write(struct.pack("<4e", *values))
+        with open(os.path.join(tmp, "texcoord.buf"), "wb") as stream:
+            for values in ((0, 0), (.1, .2), (.3, .4), (.5, .6)):
+                stream.write(struct.pack("<2f", *values))
+
+        sections = merge_sections([path])
+        groups = build_draw_groups(sections, extract_resources(sections))
+        assert groups[0]["draws"][0].operation == "draw"
+        assert groups[0]["draws"][0].position_slot == 3
+        assert groups[0]["draws"][0].texcoord_slot == 4
+
+        meshes, geometry = build_mesh_fixture(groups, tmp)
+        assert len(meshes) == 1
+        entry = next(iter(meshes.values()))
+        assert entry["draw"] == [3, 1]
+        positions = geometry_values(geometry, entry["pos"])
+        assert positions == (1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+
+AUTO_INDEXED_INI = """[TextureOverrideBody]
+ib = ResourceBodyIB
+vb0 = ResourceBodyPosition
+vb1 = ResourceBodyTexcoord
+drawindexed = auto
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R16_UINT
+
+[ResourceBodyPosition]
+filename = position.buf
+stride = 12
+format = DXGI_FORMAT_R32G32B32_FLOAT
+
+[ResourceBodyTexcoord]
+filename = texcoord.buf
+stride = 8
+format = DXGI_FORMAT_R32G32_FLOAT
+"""
+
+
+def _write_auto_geometry(tmp, indices=(0, 1, 2, 2, 1, 3)):
+    open(os.path.join(tmp, "body.ib"), "wb").write(
+        struct.pack(f"<{len(indices)}H", *indices))
+    open(os.path.join(tmp, "position.buf"), "wb").write(
+        struct.pack("<12f", 0, 0, 0, 1, 0, 0,
+                    0, 1, 0, 1, 1, 0))
+    open(os.path.join(tmp, "texcoord.buf"), "wb").write(
+        struct.pack("<8f", 0, 0, 1, 0, 0, 1, 1, 1))
+
+
+def test_drawindexed_auto_uses_the_complete_aligned_index_buffer():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", AUTO_INDEXED_INI)
+        _write_auto_geometry(tmp)
+        sections = merge_sections([path])
+        groups = build_draw_groups(sections, extract_resources(sections))
+        draw = groups[0]["draws"][0]
+        assert draw.auto_count and draw.count is None
+
+        meshes, _geometry = build_mesh_fixture(groups, tmp)
+        entry = next(iter(meshes.values()))
+        assert entry["drawindexed"] == ["auto"]
+        assert entry["idx"]["length"] == 6 * 4
+
+
+def test_out_of_range_vertex_or_index_range_rejects_whole_draw():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", AUTO_INDEXED_INI.replace(
+            "drawindexed = auto", "drawindexed = 4, 4, 0"))
+        _write_auto_geometry(tmp)
+        sections = merge_sections([path])
+        groups = build_draw_groups(sections, extract_resources(sections))
+        meshes, _geometry = build_mesh_fixture(groups, tmp)
+        assert meshes == {}
+
+        open(os.path.join(tmp, "body.ib"), "wb").write(
+            struct.pack("<3H", 0, 1, 8))
+        path = write(tmp, "mod.ini", AUTO_INDEXED_INI.replace(
+            "drawindexed = auto", "drawindexed = 3, 0, 0"))
+        sections = merge_sections([path])
+        groups = build_draw_groups(sections, extract_resources(sections))
+        meshes, _geometry = build_mesh_fixture(groups, tmp)
+        assert meshes == {}
+
+
+def test_run_expansion_has_a_depth_limit():
+    sections = {"TextureOverrideBody": ["run = CommandList0"]}
+    for index in range(66):
+        sections[f"CommandList{index}"] = [
+            f"run = CommandList{index + 1}"]
+    sections["CommandList66"] = ["draw = 3, 0"]
+    with pytest.raises(ValueError, match="run chain exceeds"):
+        _scan_sections_for_draws(sections)

--- a/src/tests/test_mesh_builder.py
+++ b/src/tests/test_mesh_builder.py
@@ -444,6 +444,38 @@ def test_nonindexed_draw_uses_typed_layouts_and_higher_vb_slots():
         assert positions == (1, 2, 3, 4, 5, 6, 7, 8, 9)
 
 
+def test_nonindexed_range_is_bounded_before_materializing_indices():
+    ini = DRAW_CAPABILITIES_INI.replace(
+        "draw = 3, 1", "draw = 4000000000, 0")
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        open(os.path.join(tmp, "position.buf"), "wb").write(
+            struct.pack("<4e", 0, 0, 0, 1))
+        open(os.path.join(tmp, "texcoord.buf"), "wb").write(
+            struct.pack("<2f", 0, 0))
+
+        sections = merge_sections([path])
+        groups = build_draw_groups(sections, extract_resources(sections))
+        meshes, _geometry = build_mesh_fixture(groups, tmp)
+
+        assert meshes == {}
+
+
+def test_higher_slots_are_not_admitted_by_resource_names_alone():
+    ini = DRAW_CAPABILITIES_INI.replace(
+        "stride = 8\nformat = DXGI_FORMAT_R16G16B16A16_FLOAT",
+        "stride = 12", 1).replace(
+        "stride = 8\nformat = DXGI_FORMAT_R32G32_FLOAT",
+        "stride = 8", 1)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        sections = merge_sections([path])
+
+        groups = build_draw_groups(sections, extract_resources(sections))
+
+        assert groups == []
+
+
 def test_credible_legacy_uv_offset_wins_over_ambiguous_later_float_pairs():
     data = bytearray()
     for uv, later_pair in (
@@ -614,6 +646,23 @@ def test_drawindexed_auto_uses_the_complete_aligned_index_buffer():
         entry = next(iter(meshes.values()))
         assert entry["drawindexed"] == ["auto"]
         assert entry["idx"]["length"] == 6 * 4
+
+
+@pytest.mark.parametrize("format_line", [
+    "format = DXGI_FORMAT_R8_UINT",
+    "",
+])
+def test_unsupported_index_format_is_not_coerced_to_r32(format_line):
+    ini = AUTO_INDEXED_INI.replace(
+        "format = DXGI_FORMAT_R16_UINT", format_line)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        _write_auto_geometry(tmp, indices=(0, 1, 2, 2))
+        sections = merge_sections([path])
+
+        groups = build_draw_groups(sections, extract_resources(sections))
+
+        assert groups == []
 
 
 def test_out_of_range_vertex_or_index_range_rejects_whole_draw():

--- a/src/tests/test_mesh_builder.py
+++ b/src/tests/test_mesh_builder.py
@@ -6,6 +6,7 @@ import tempfile
 
 import pytest
 
+from core.buffer_layout import texcoord_layout
 from core.ini_parser import (_scan_sections_for_draws, build_draw_groups,
                              extract_resources,
                              extract_toggle_keys, merge_sections)
@@ -441,6 +442,131 @@ def test_nonindexed_draw_uses_typed_layouts_and_higher_vb_slots():
         assert entry["draw"] == [3, 1]
         positions = geometry_values(geometry, entry["pos"])
         assert positions == (1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+
+def test_credible_legacy_uv_offset_wins_over_ambiguous_later_float_pairs():
+    data = bytearray()
+    for uv, later_pair in (
+            ((0.1, 0.2), (0.0, 0.0)),
+            ((0.9, 0.2), (1.0, 0.0)),
+            ((0.1, 0.8), (0.0, 1.0)),
+            ((0.9, 0.8), (1.0, 1.0))):
+        vertex = bytearray(28)
+        struct.pack_into("<2f", vertex, 4, *uv)
+        struct.pack_into("<2f", vertex, 20, *later_pair)
+        data.extend(vertex)
+
+    layout = texcoord_layout(data, 28)
+
+    assert (layout.offset, layout.format) == (4, "float32x2")
+
+
+def test_broader_uv_offset_remains_supported_when_legacy_offsets_are_invalid():
+    data = bytearray()
+    for uv in ((0.1, 0.2), (0.9, 0.2), (0.1, 0.8), (0.9, 0.8)):
+        vertex = bytearray(16)
+        struct.pack_into("<2I", vertex, 0, 0x7FC00000, 0x7FC00000)
+        struct.pack_into("<2f", vertex, 8, *uv)
+        data.extend(vertex)
+
+    layout = texcoord_layout(data, 16)
+
+    assert (layout.offset, layout.format) == (8, "float32x2")
+
+
+@pytest.mark.parametrize("runtime_name", ["DRAW_TYPE", "$DRAW_TYPE"])
+def test_branch_local_incomplete_draw_is_not_built_as_triangle_geometry(
+        runtime_name):
+    ini = f"""[TextureOverrideBodyBlend]
+handling = skip
+if {runtime_name} == 2 || {runtime_name} == 4
+vb1 = ResourceBodyTexcoord
+vb2 = ResourceBodyBlend
+checktextureoverride = ib
+elif {runtime_name} == 1
+vb0 = ResourceBodyPosition
+vb2 = ResourceBodyBlend
+draw = 3, 0
+endif
+
+[TextureOverrideBodyTexcoord]
+vb1 = ResourceBodyTexcoord
+
+[TextureOverrideBodyA]
+handling = skip
+ib = ResourceBodyIB
+drawindexed = 3, 0, 0
+
+[ResourceBodyPosition]
+filename = position.buf
+stride = 40
+
+[ResourceBodyTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceBodyBlend]
+filename = blend.buf
+stride = 32
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        sections = merge_sections([path])
+        scanned = _scan_sections_for_draws(sections)
+        replay = scanned["TextureOverrideBodyBlend"]["draws"][0]
+        assert replay.vertex_resources == {
+            0: "ResourceBodyPosition",
+            2: "ResourceBodyBlend",
+        }
+
+        groups = build_draw_groups(sections, extract_resources(sections))
+        assert [group["display_name"] for group in groups] == ["BodyA"]
+        assert groups[0]["draws"][0].operation == "drawindexed"
+
+
+def test_unconditional_incomplete_draw_does_not_borrow_sibling_buffers():
+    ini = """[TextureOverrideBodyPosition]
+vb0 = ResourceBodyPosition
+
+[TextureOverrideBodyBlend]
+handling = skip
+vb1 = ResourceBodyBlend
+draw = 3, 0
+
+[TextureOverrideBodyTexcoord]
+vb1 = ResourceBodyTexcoord
+
+[TextureOverrideBodyA]
+handling = skip
+ib = ResourceBodyIB
+drawindexed = 3, 0, 0
+
+[ResourceBodyPosition]
+filename = position.buf
+stride = 40
+
+[ResourceBodyTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceBodyBlend]
+filename = blend.buf
+stride = 32
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        sections = merge_sections([path])
+        groups = build_draw_groups(sections, extract_resources(sections))
+
+        assert [group["display_name"] for group in groups] == ["BodyA"]
 
 
 AUTO_INDEXED_INI = """[TextureOverrideBody]

--- a/src/tests/test_provenance.py
+++ b/src/tests/test_provenance.py
@@ -57,10 +57,12 @@ stride = 20
 def _fixture(tmp, name, text):
     """Write an ini plus the buffer files its Resource sections name."""
     path = write(tmp, name, text)
-    for buf in ("body.ib", "pos.buf", "tc.buf"):
+    sizes = {"body.ib": 4 * 1024, "pos.buf": 40 * 1024,
+             "tc.buf": 20 * 1024}
+    for buf, size in sizes.items():
         p = os.path.join(tmp, buf)
         if not os.path.exists(p):
-            open(p, "wb").write(b"\0" * 4096)
+            open(p, "wb").write(b"\0" * size)
     return path
 
 

--- a/src/tests/test_resource_resolution.py
+++ b/src/tests/test_resource_resolution.py
@@ -377,6 +377,43 @@ def test_runtime_position_copy_resolution():
               f"(got {group['draws'][1].get('position_file')})")
 
 
+def test_runtime_position_does_not_shadow_resolvable_global_fallback():
+    ini = """[TextureOverrideComponent0]
+run = CommandListSharedResources
+drawindexed = 3, 0, 0
+
+[CommandListSharedResources]
+ib = ResourceIndexBuffer
+vb0 = ResourceShapeKeyedPosition
+vb2 = ResourceTexcoordBuffer
+
+[ResourceShapeKeyedPosition]
+
+[ResourceIndexBuffer]
+filename = index.buf
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePositionBuffer]
+filename = position.buf
+stride = 12
+format = DXGI_FORMAT_R32G32B32_FLOAT
+
+[ResourceTexcoordBuffer]
+filename = texcoord.buf
+stride = 16
+format = DXGI_FORMAT_R16G16_FLOAT
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        sections = merge_sections([path])
+
+        groups = build_draw_groups(sections, extract_resources(sections))
+
+        assert len(groups) == 1
+        assert groups[0]["position_file"] == "position.buf"
+        assert groups[0]["texcoord_file"] == "texcoord.buf"
+
+
 LL_SKELETON_OUTPUT_INI = """[TextureOverrideBodyBlend]
 vb2 = ResourceBodyBlend
 

--- a/src/tests/test_resource_resolution.py
+++ b/src/tests/test_resource_resolution.py
@@ -170,6 +170,45 @@ stride = 8
             sections, extract_resources(sections)) == []
 
 
+@pytest.mark.parametrize("slot", [0, 1])
+def test_null_vs_untouched_geometry_slot_cannot_borrow_component_fallback(slot):
+    ini = f"""[TextureOverrideBodyPosition]
+vb0 = ResourcePosition
+
+[TextureOverrideBodyTexcoord]
+vb1 = ResourceTexcoord
+
+[TextureOverrideBodyA]
+ib = ResourceBodyIB
+if $swap == 1
+vb{slot} = null
+endif
+drawindexed = 3, 0, 0
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 12
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 8
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        sections = merge_sections([path])
+        draw = _scan_sections_for_draws(
+            sections)["TextureOverrideBodyA"]["draws"][0]
+
+        assert draw.ambiguous_vertex_slots == (slot,)
+        assert draw.ambiguous_vertex_resources == {}
+        assert build_draw_groups(
+            sections, extract_resources(sections)) == []
+
+
 def test_sibling_branch_does_not_inherit_first_seen_index_buffer():
     ini = """[TextureOverrideBody]
 vb0 = ResourcePosition

--- a/src/tests/test_resource_resolution.py
+++ b/src/tests/test_resource_resolution.py
@@ -170,6 +170,76 @@ stride = 8
             sections, extract_resources(sections)) == []
 
 
+def test_sibling_branch_does_not_inherit_first_seen_index_buffer():
+    ini = """[TextureOverrideBody]
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+if $swap == 0
+ib = ResourceBodyIB
+drawindexed = 3, 0, 0
+else
+drawindexed = 3, 0, 0
+endif
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 12
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 8
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        sections = merge_sections([path])
+
+        groups = build_draw_groups(sections, extract_resources(sections))
+
+        assert len(groups) == 1
+        assert [draw.ib_file for draw in groups[0]["draws"]] == [
+            "body.ib", None,
+        ]
+
+
+def test_sibling_branch_does_not_inherit_first_seen_position_buffer():
+    ini = """[TextureOverrideBodyBlend]
+vb1 = ResourceTexcoord
+ib = ResourceBodyIB
+if $swap == 0
+vb0 = ResourcePosition
+drawindexed = 3, 0, 0
+else
+drawindexed = 3, 0, 0
+endif
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 12
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 8
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        sections = merge_sections([path])
+
+        groups = build_draw_groups(sections, extract_resources(sections))
+
+        assert len(groups) == 1
+        assert [draw.position_file for draw in groups[0]["draws"]] == [
+            "position.buf", None,
+        ]
+
+
 def test_divergent_unused_vertex_stream_does_not_hide_geometry():
     ini = """[Constants]
 global persist $swap = 0

--- a/src/tests/test_resource_resolution.py
+++ b/src/tests/test_resource_resolution.py
@@ -170,6 +170,54 @@ stride = 8
             sections, extract_resources(sections)) == []
 
 
+def test_divergent_unused_vertex_stream_does_not_hide_geometry():
+    ini = """[Constants]
+global persist $swap = 0
+
+[TextureOverrideBody]
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+vb4 = ResourceBlend
+ib = ResourceBodyIB
+if $swap == 1
+vb4 = ResourceBlendOverride
+endif
+drawindexed = 3, 0, 0
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 12
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 8
+
+[ResourceBlend]
+filename = blend.buf
+stride = 16
+format = DXGI_FORMAT_R8_UINT
+
+[ResourceBlendOverride]
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        sections = merge_sections([path])
+        draw = _scan_sections_for_draws(
+            sections)["TextureOverrideBody"]["draws"][0]
+
+        assert draw.ambiguous_vertex_slots == (4,)
+        assert set(draw.ambiguous_vertex_resources[4]) == {
+            "ResourceBlend", "ResourceBlendOverride",
+        }
+        groups = build_draw_groups(sections, extract_resources(sections))
+        assert len(groups) == 1
+        assert len(groups[0]["draws"]) == 1
+
+
 def test_root_texture_picker_accepts_windows_case_variation():
     """The two native dialogs may spell the same Windows folder differently."""
     if os.name != "nt":

--- a/src/tests/test_resource_resolution.py
+++ b/src/tests/test_resource_resolution.py
@@ -4,6 +4,8 @@ import os
 import struct
 import tempfile
 
+import pytest
+
 from _corpus import sample_mods
 from app import mod_loader
 from core.ini_parser import (_scan_sections_for_draws, build_draw_groups,
@@ -107,6 +109,65 @@ def test_same_ib_draws_keep_vb_snapshots_and_null_does_not_inherit():
         second = geometry_values(geometry, meshes["Body-2"]["pos"])
         assert sorted(first[::3]) == [0, 0, 1]
         assert sorted(second[::3]) == [10, 10, 11]
+
+
+@pytest.mark.parametrize(
+    ("conditional_assignment", "ambiguous_slots", "ambiguous_index"),
+    [
+        ("vb0 = ResourcePosB", (0,), False),
+        ("ib = ResourceBodyIBB", (), True),
+    ],
+)
+def test_divergent_conditional_resource_state_is_unsupported_after_join(
+        conditional_assignment, ambiguous_slots, ambiguous_index):
+    ini = f"""[Constants]
+global persist $swap = 0
+
+[KeySwap]
+key = x
+type = cycle
+$swap = 0, 1
+
+[TextureOverrideBody]
+vb0 = ResourcePosA
+vb1 = ResourceTc
+ib = ResourceBodyIBA
+if $swap == 1
+{conditional_assignment}
+endif
+drawindexed = 3, 0, 0
+
+[ResourceBodyIBA]
+filename = body-a.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourceBodyIBB]
+filename = body-b.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosA]
+filename = pos-a.buf
+stride = 12
+
+[ResourcePosB]
+filename = pos-b.buf
+stride = 12
+
+[ResourceTc]
+filename = tc.buf
+stride = 8
+"""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(tmp, "mod.ini", ini)
+        sections = merge_sections([path])
+        draw = _scan_sections_for_draws(
+            sections)["TextureOverrideBody"]["draws"][0]
+
+        assert draw.ambiguous_vertex_slots == ambiguous_slots
+        assert draw.ambiguous_index_resource is ambiguous_index
+        assert draw.unsupported_reason == "ambiguous_resource_state"
+        assert build_draw_groups(
+            sections, extract_resources(sections)) == []
 
 
 def test_root_texture_picker_accepts_windows_case_variation():

--- a/src/web/js/inspector-panel.js
+++ b/src/web/js/inspector-panel.js
@@ -222,7 +222,9 @@ function buildMesh(mesh, record) {
   }
   content.appendChild(material);
 
-  const draw = record.entry?.drawindexed;
+  const indexed = record.entry?.drawindexed;
+  const vertices = record.entry?.draw;
+  const draw = indexed || vertices;
   if (draw?.length) {
     const drawInfo = document.createElement('section');
     drawInfo.className = 'inspector-section';
@@ -230,9 +232,10 @@ function buildMesh(mesh, record) {
     title.className = 'inspector-section-title';
     title.textContent = 'Draw';
     drawInfo.appendChild(title);
+    addRow(drawInfo, 'Operation', indexed ? 'DrawIndexed' : 'Draw');
     addRow(drawInfo, 'Count', String(draw[0] ?? '—'));
     addRow(drawInfo, 'Start', String(draw[1] ?? '—'));
-    addRow(drawInfo, 'Base', String(draw[2] ?? '—'));
+    if (indexed) addRow(drawInfo, 'Base', String(draw[2] ?? '—'));
     content.appendChild(drawInfo);
   }
   buildTextureControls(content, record, mesh);

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -146,6 +146,8 @@ function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
 
   const label = entry.drawindexed
     ? entry.drawindexed.join(', ')
+    : entry.draw
+      ? `draw ${entry.draw.join(', ')}`
     : '#' + name.slice(groupName.length + 1);
   const labelSpan = document.createElement('span');
   labelSpan.className = 'mesh-name';

--- a/src/web/js/mesh-texture-state.js
+++ b/src/web/js/mesh-texture-state.js
@@ -73,7 +73,11 @@ export function recomputeTextureRuns(groupMeshes) {
 
 export function meshMetadataKey(name, entry) {
   const component = entry.component || name.replace(/-\d+$/, '');
-  const draw = entry.drawindexed ? entry.drawindexed.join(',') : 'whole';
+  const draw = entry.drawindexed
+    ? entry.drawindexed.join(',')
+    : entry.draw
+      ? `draw:${entry.draw.join(',')}`
+      : 'whole';
   return `${component}::${draw}`;
 }
 


### PR DESCRIPTION
## Summary

- introduce typed position, texcoord, index, geometry, and draw capability models
- support bounded numeric non-indexed draws and `drawindexed = auto`
- validate non-indexed ranges before materializing sequential indices
- preserve per-draw VB/IB execution state across conditional branches and joins
- allow ambiguity in unused streams while rejecting geometry-relevant ambiguity
- reject null-versus-untouched ambiguity in established geometry slots before fallback
- prevent first-seen sibling-branch resources from becoming draw fallbacks
- skip runtime-only vertex resources when selecting a file-backed fallback
- accept only explicit unsigned `R16_UINT` and `R32_UINT` index layouts
- require declared compatible formats for higher-slot position/UV semantics
- reject incomplete setup/replay draws instead of borrowing sibling buffers
- preserve credible primary UV layouts when wider buffers contain ambiguous later float pairs

## Validation

- `302 passed`
- real-mod checks: BellyDancer and Chisa (WuWa), Remielle (ZZZ), Sandrone and Odette (Genshin)