### PR TITLE
Avoid model reloads for staged Toggle and PRESENT edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ concurrency:
 
 jobs:
   test:
-    name: Windows / Python 3.12
+    name: Python tests
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
 
     steps:
       - name: Check out repository
@@ -29,29 +29,12 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
+          cache-dependency-path: requirements.txt
 
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements-dev.txt
-
-      - name: Prepare vendored Three.js assets
-        run: |
-          python -c "import sys; sys.path.insert(0, 'src'); import build; build.fetch_assets(); build.verify_assets()"
-
-      - name: Verify Microsoft Edge for frontend tests
-        shell: pwsh
-        run: |
-          @'
-          from playwright.sync_api import sync_playwright
-
-          with sync_playwright() as playwright:
-              browser = playwright.chromium.launch(channel="msedge", headless=True)
-              browser.close()
-          '@ | python -
+          python -m pip install -r requirements.txt "pytest>=8.0"
 
       - name: Run test suite
-        run: python -m pytest -q
+        run: python -m pytest -q --ignore=src/tests/test_frontend.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
 
+      - name: Prepare vendored Three.js assets
+        run: |
+          python -c "import sys; sys.path.insert(0, 'src'); import build; build.fetch_assets(); build.verify_assets()"
+
       - name: Verify Microsoft Edge for frontend tests
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Windows / Python 3.12
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Verify Microsoft Edge for frontend tests
+        shell: pwsh
+        run: |
+          @'
+          from playwright.sync_api import sync_playwright
+
+          with sync_playwright() as playwright:
+              browser = playwright.chromium.launch(channel="msedge", headless=True)
+              browser.close()
+          '@ | python -
+
+      - name: Run test suite
+        run: python -m pytest -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@ Keep deterministic formatting, lint, and other mechanical checks in CI. Code rev
 
 - Run the repository test suite with `.venv-test\Scripts\python.exe -m pytest -q`. This project venv includes `mcp.server.fastmcp`; the system Python may not.
 
+## Pull requests
+
+- Push the feature branch first, then check for an existing open PR targeting `main` before creating another one. If `gh` is unavailable, use the existing Git credential helper with GitHub's REST API through an approved elevated command; keep credentials in memory and never print them.
+- PR titles and descriptions must contain only information that is available from the repository or CI. Do not include machine-specific paths, local-only test results, private environment details, or claims that reviewers cannot reproduce from the branch or CI.
+
 ## Code Review Rules
 
 ### Preserve lossless, staged INI editing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ The durable project invariants live in `context.md`. Read that file before subst
 
 Keep deterministic formatting, lint, and other mechanical checks in CI. Code review should focus on consequential regressions and repository-specific behavior.
 
+## Test environment
+
+- Run the repository test suite with `.venv-test\Scripts\python.exe -m pytest -q`. This project venv includes `mcp.server.fastmcp`; the system Python may not.
+
 ## Code Review Rules
 
 ### Preserve lossless, staged INI editing

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -30,6 +30,7 @@ class ModViewerAPI:
         self._authorized_folders = set()
         self._picker_authorized_folders = set()
         self._authorized_roots = set()
+        self._active_mesh_keys = {}
         try:
             self._authorized_roots = mod_folders.registered_paths(
                 mod_folders.load_registry())
@@ -219,6 +220,7 @@ class ModViewerAPI:
                 texture_source=publication.register)
             if not isinstance(result, dict) or result.get("error"):
                 publication.discard()
+                self._active_mesh_keys.pop(folder_path, None)
                 return result
 
             saved_metadata = context.metadata
@@ -235,9 +237,11 @@ class ModViewerAPI:
                                       saved_metadata)
             server.publish_payload_geometry(result, geometry)
             publication.commit()
+            self._active_mesh_keys[folder_path] = set(result.get("meshes", {}))
             return result
         except Exception:
             publication.discard()
+            self._active_mesh_keys.pop(folder_path, None)
             raise
 
     def get_present_state(self, folder_path):
@@ -257,7 +261,8 @@ class ModViewerAPI:
             folder_path, overrides, pending, context = \
                 self._authoritative_context(folder_path)
             result = mod_loader.load_control_state(
-                context, overrides, pending)
+                context, overrides, pending,
+                active_mesh_keys=self._active_mesh_keys.get(folder_path))
             metadata.hydrate_present(
                 folder_path, result["controls"]["present"], context.metadata)
             return result
@@ -269,7 +274,8 @@ class ModViewerAPI:
         try:
             _folder_path, overrides, _pending, context = \
                 self._authoritative_context(folder_path)
-            return {"meshes": mod_loader.load_mesh_semantics(context, overrides)}
+            return {"meshes": mod_loader.load_mesh_semantics(
+                context, overrides, self._active_mesh_keys.get(_folder_path))}
         except Exception:
             return self._semantic_read_error()
 

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -6,6 +6,7 @@ belongs in mod_loader instead.
 """
 
 import os
+import traceback
 
 import webview
 
@@ -187,22 +188,28 @@ class ModViewerAPI:
             texture_source=texture_source, texture_profile=profile)
         return encoded
 
-    def load_mod(self, folder_path):
+    def _authoritative_context(self, folder_path):
+        """Load active INI documents while preserving the current session."""
         folder_path = self._folder(folder_path)
-        # Reopen the same mod from its already-owned path set.  This keeps a
-        # staged edit that changes root geometry from triggering a new disk
-        # discovery and leaves only the first open responsible for selection.
         ini_paths = (edit_session.document_paths(folder_path)
                      or discover_ini_paths(folder_path))
-        # Every active INI is loaded once into the authoritative in-memory
-        # session. Reloads, text edits and toggle edits all read these docs;
-        # only Export copies dirty versions back to physical files.
         edit_session.load_documents(folder_path, ini_paths)
         overrides = edit_session.overrides_for(folder_path)
         pending_new_sections = edit_session.new_sections_for(folder_path)
         context = mod_loader.ModLoadContext(
             folder_path, ini_paths, edit_session.documents_for(folder_path),
             metadata.load(folder_path))
+        return folder_path, overrides, pending_new_sections, context
+
+    @staticmethod
+    def _semantic_read_error():
+        traceback.print_exc()
+        return {"error": "Unexpected backend error. See the application log for details."}
+
+    def load_mod(self, folder_path):
+        folder_path, overrides, pending_new_sections, context = \
+            self._authoritative_context(folder_path)
+        ini_paths = context.ini_paths
         geometry = GeometryBlob()
         publication = server.begin_texture_publication(folder_path)
         try:
@@ -232,6 +239,39 @@ class ModViewerAPI:
         except Exception:
             publication.discard()
             raise
+
+    def get_present_state(self, folder_path):
+        """Return staged PRESENT state without loading geometry or textures."""
+        try:
+            folder_path, overrides, _pending, context = \
+                self._authoritative_context(folder_path)
+            present = mod_loader.load_present_state(context, overrides)
+            metadata.hydrate_present(folder_path, present, context.metadata)
+            return {"present": present}
+        except Exception:
+            return self._semantic_read_error()
+
+    def get_control_state(self, folder_path):
+        """Return staged control semantics without rebuilding the model."""
+        try:
+            folder_path, overrides, pending, context = \
+                self._authoritative_context(folder_path)
+            result = mod_loader.load_control_state(
+                context, overrides, pending)
+            metadata.hydrate_present(
+                folder_path, result["controls"]["present"], context.metadata)
+            return result
+        except Exception:
+            return self._semantic_read_error()
+
+    def get_mesh_semantics(self, folder_path):
+        """Return staged draw visibility semantics without rebuilding meshes."""
+        try:
+            _folder_path, overrides, _pending, context = \
+                self._authoritative_context(folder_path)
+            return {"meshes": mod_loader.load_mesh_semantics(context, overrides)}
+        except Exception:
+            return self._semantic_read_error()
 
     def get_diagnostics(self, folder_path):
         """Return the read-only health scan for the current edit revision."""

--- a/src/app/mod_loader.py
+++ b/src/app/mod_loader.py
@@ -17,7 +17,7 @@ from core.ini_condition import is_namespaced
 from core.ini_sections import extract_resources, merge_sections
 from core.ini_analysis import analyze_ini
 from core.mod_discovery import discover_ini_paths
-from core.mesh_builder import build_mesh_result
+from core.mesh_builder import build_mesh_result, build_mesh_semantics
 from core.resource_paths import safe_resource_path
 from core.textures import encode_texture_data_uri
 from core.ini_menu import attach_menu_images
@@ -434,6 +434,40 @@ def _gating_vars_from_groups(groups):
                         for cond in cond_group:
                             found.add(cond["var"])
     return found
+
+
+def load_present_state(context, overrides=None):
+    """Read only the logical PRESENT projection from authoritative INIs."""
+    return _parse_inis(
+        context.ini_paths, context.mod_dir, overrides, context.docs).present
+
+
+def load_control_state(context, overrides=None, pending_new_sections=None):
+    """Read control semantics without constructing mesh or texture payloads."""
+    parsed = _parse_inis(
+        context.ini_paths, context.mod_dir, overrides, context.docs)
+    gating_vars = _gating_vars_from_groups(parsed.groups)
+    return {
+        "controls": {
+            "toggles": build_toggle_panel(
+                parsed.toggles, parsed.defaults, gating_vars,
+                context.mod_dir, pending_new_sections),
+            "menu": build_menu_panel(
+                parsed.menu, parsed.defaults, context.mod_dir),
+            "present": parsed.present,
+        },
+        "state": {
+            "rules": parsed.state_rules,
+            "defaults": parsed.defaults,
+        },
+    }
+
+
+def load_mesh_semantics(context, overrides=None):
+    """Read draw visibility semantics without building geometry."""
+    parsed = _parse_inis(
+        context.ini_paths, context.mod_dir, overrides, context.docs)
+    return build_mesh_semantics(parsed.groups, context.mod_dir)
 
 
 def _register_material_profile(table, profile):

--- a/src/app/mod_loader.py
+++ b/src/app/mod_loader.py
@@ -413,13 +413,33 @@ def build_menu_panel(menu_slots, toggle_defaults, mod_dir=None):
     return panel
 
 
-def _gating_vars_from_groups(groups):
+def _gating_vars_from_groups(groups, mod_dir=None, game_profile=None,
+                             active_mesh_keys=None):
     """Same notion as _gating_vars, computed directly from build_draw_groups'
     draws instead of the (buffer-file-dependent) mesh payload — matches
     _gating_vars(payload) but never needs buffer files to exist on disk.
     Used by unwired_pending_sections, which must stay cheap and reliable
     even when mesh geometry can't be resolved.
     """
+    if active_mesh_keys is not None:
+        semantics = build_mesh_semantics(
+            groups, mod_dir, game_profile=game_profile)
+        draws = (entry for label, entry in semantics.items()
+                 if label in active_mesh_keys)
+        found = set()
+        for draw in draws:
+            for cond_group in draw.get("conditions", []):
+                for cond in cond_group:
+                    found.add(cond["var"])
+            for field in ("texture_variants", "normal_map_variants",
+                          "normal_data_variants", "light_map_variants",
+                          "material_map_variants"):
+                for variant in draw.get(field, []):
+                    for cond_group in variant.get("conditions", []):
+                        for cond in cond_group:
+                            found.add(cond["var"])
+        return found
+
     found = set()
     for group in groups:
         for draw in group.get("draws", []):
@@ -442,11 +462,13 @@ def load_present_state(context, overrides=None):
         context.ini_paths, context.mod_dir, overrides, context.docs).present
 
 
-def load_control_state(context, overrides=None, pending_new_sections=None):
+def load_control_state(context, overrides=None, pending_new_sections=None,
+                       active_mesh_keys=None):
     """Read control semantics without constructing mesh or texture payloads."""
     parsed = _parse_inis(
         context.ini_paths, context.mod_dir, overrides, context.docs)
-    gating_vars = _gating_vars_from_groups(parsed.groups)
+    gating_vars = _gating_vars_from_groups(
+        parsed.groups, context.mod_dir, parsed.game.game, active_mesh_keys)
     return {
         "controls": {
             "toggles": build_toggle_panel(
@@ -463,11 +485,13 @@ def load_control_state(context, overrides=None, pending_new_sections=None):
     }
 
 
-def load_mesh_semantics(context, overrides=None):
+def load_mesh_semantics(context, overrides=None, active_mesh_keys=None):
     """Read draw visibility semantics without building geometry."""
     parsed = _parse_inis(
         context.ini_paths, context.mod_dir, overrides, context.docs)
-    return build_mesh_semantics(parsed.groups, context.mod_dir)
+    return build_mesh_semantics(
+        parsed.groups, context.mod_dir, game_profile=parsed.game.game,
+        active_mesh_keys=active_mesh_keys)
 
 
 def _register_material_profile(table, profile):

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -262,7 +262,27 @@ def _deduplicate_draws(group, max_draws=0):
     return unique[:max_draws] if max_draws else unique
 
 
-def build_mesh_semantics(groups, mod_dir, max_draws=0):
+def _semantic_texture_key(mod_dir, authored_path, role):
+    """Resolve a texture identity without opening or decoding the source."""
+    path = safe_resource_path(mod_dir, authored_path)
+    if not path or not os.path.exists(path):
+        return None
+    relative_path = os.path.relpath(path, mod_dir).replace(os.sep, "/")
+    return texture_key(relative_path, normalize_texture_role(role))
+
+
+def _semantic_texture_variants(draw, mod_dir, authored_role, transport_role=None):
+    role = transport_role or authored_role
+    variants = []
+    for variant in draw.texture_rules(authored_role):
+        key = _semantic_texture_key(mod_dir, variant.get("file"), role)
+        if key:
+            variants.append({"conditions": variant["conditions"], "tex_key": key})
+    return variants
+
+
+def build_mesh_semantics(groups, mod_dir, max_draws=0, game_profile=None,
+                         active_mesh_keys=None):
     """Return draw visibility semantics without resolving any geometry.
 
     This is used after Record changes a draw's conditions.  Keep it separate
@@ -274,13 +294,45 @@ def build_mesh_semantics(groups, mod_dir, max_draws=0):
         raise ValueError(
             f"Mod has too many draws ({draw_total:,}; limit {_MAX_DRAWS:,}).")
 
+    from .texture_profiles import texture_profile_for
+
+    texture_profile = texture_profile_for(game_profile)
+    normal_role = texture_profile.normal_transport_role
     result = {}
     for group in groups:
         for draw in _deduplicate_draws(group, max_draws=max_draws):
-            entry = {"conditions": draw.conditions or []}
+            if active_mesh_keys is not None and draw.label not in active_mesh_keys:
+                continue
+            entry = {
+                "conditions": draw.conditions or [],
+                "tex_key": _semantic_texture_key(
+                    mod_dir, draw.texture_default("diffuse"), "diffuse"),
+                "normal_map_key": None,
+                "normal_data_key": None,
+                "light_map_key": _semantic_texture_key(
+                    mod_dir, draw.texture_default("light_map"), "light_map"),
+                "material_map_key": _semantic_texture_key(
+                    mod_dir, draw.texture_default("material_map"), "material_map"),
+            }
+            normal_key = _semantic_texture_key(
+                mod_dir, draw.texture_default("normal_map"), normal_role)
+            entry[f"{normal_role}_key"] = normal_key
             if draw.sources:
                 entry["sources"] = [_rel_source(source, mod_dir)
                                      for source in draw.sources]
+
+            texture_variants = _semantic_texture_variants(
+                draw, mod_dir, "diffuse")
+            if len(texture_variants) > 1:
+                entry["texture_variants"] = texture_variants
+            for channel in ("light_map", "material_map"):
+                variants = _semantic_texture_variants(draw, mod_dir, channel)
+                if variants:
+                    entry[f"{channel}_variants"] = variants
+            normal_variants = _semantic_texture_variants(
+                draw, mod_dir, "normal_map", normal_role)
+            if normal_variants:
+                entry[f"{normal_role}_variants"] = normal_variants
             result[draw.label] = entry
     return result
 

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -262,6 +262,29 @@ def _deduplicate_draws(group, max_draws=0):
     return unique[:max_draws] if max_draws else unique
 
 
+def build_mesh_semantics(groups, mod_dir, max_draws=0):
+    """Return draw visibility semantics without resolving any geometry.
+
+    This is used after Record changes a draw's conditions.  Keep it separate
+    from :func:`build_mesh_result`: the incremental authoring path must not
+    read vertex/index buffers, publish textures, or allocate geometry storage.
+    """
+    draw_total = sum(len(group.get("draws", [])) for group in groups)
+    if draw_total > _MAX_DRAWS:
+        raise ValueError(
+            f"Mod has too many draws ({draw_total:,}; limit {_MAX_DRAWS:,}).")
+
+    result = {}
+    for group in groups:
+        for draw in _deduplicate_draws(group, max_draws=max_draws):
+            entry = {"conditions": draw.conditions or []}
+            if draw.sources:
+                entry["sources"] = [_rel_source(source, mod_dir)
+                                     for source in draw.sources]
+            result[draw.label] = entry
+    return result
+
+
 def _geometry_ref(raw, geometry):
     """Serialize one binary field into the caller-owned geometry store."""
     if geometry is not None:

--- a/src/core/resource_paths.py
+++ b/src/core/resource_paths.py
@@ -22,7 +22,13 @@ def _within(target, root):
 
 
 def safe_resource_path(mod_dir, relative_path):
-    """Resolve a mod-authored resource while allowing one parent level."""
+    """Resolve a mod-authored resource while allowing one parent level.
+
+    Canonical paths are used only for the sandbox containment check.  Return
+    the candidate path in the caller's original root namespace so downstream
+    relative-path identities stay stable when Windows exposes the same folder
+    through aliases/junctions with different spellings.
+    """
     if not relative_path:
         return None
     try:
@@ -36,10 +42,9 @@ def safe_resource_path(mod_dir, relative_path):
             or os.path.splitdrive(relative_path)[0]
             or ntpath.splitdrive(relative_path)[0]):
         return None
-    root_path = os.path.realpath(os.path.abspath(mod_dir))
+    root_path = os.path.abspath(mod_dir)
     root = _canonical(root_path)
-    target_path = os.path.realpath(os.path.abspath(
-        os.path.join(root_path, relative_path)))
+    target_path = os.path.abspath(os.path.join(root_path, relative_path))
     target = _canonical(target_path)
     if not _within(target, root):
         ceiling = root

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -129,6 +129,26 @@ def _payload(label="A"):
     }
 
 
+def _present_payload(label="Present"):
+    payload = _payload(label)
+    payload["controls"]["present"] = {
+        "target_inis": [{
+            "value": f"{label}.ini", "label": f"{label}.ini",
+            "vars": ["toggle"], "has_present": True,
+        }],
+        "item": {
+            "inis": [f"{label}.ini"], "target_inis": [],
+            "key": "ctrl p", "key_raw": "ctrl p", "back": "",
+            "vars": [{"var": "toggle", "values": ["0", "1"],
+                      "default": "0"}],
+            "capture_vars": ["toggle"], "count": 2, "aligned": True,
+            "missing_inis": [], "sync_error": None,
+            "names": ["Present 1", "Present 2"],
+        },
+    }
+    return payload
+
+
 def _dxt1_vertical_gradient():
     """One DXT1 block with red top rows and blue bottom rows."""
     data = bytearray(136)
@@ -299,7 +319,8 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
         "panelOpacityApi": panel_opacity_api,
         "calls": {"loadMod": [], "listSubfolders": [],
                    "discardChanges": [], "switches": [], "diagnostics": [],
-                   "panelOpacity": []},
+                   "panelOpacity": [], "presentState": [],
+                   "controlState": [], "meshSemantics": []},
     }
     encoded_state = json.dumps(json.dumps(state))
     context.add_init_script(
@@ -327,6 +348,31 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                 });
               }
               return copy(state.responses[path]);
+            },
+            get_present_state: async path => {
+              state.calls.presentState.push(path);
+              return copy({present: state.responses[path]?.controls?.present || {
+                target_inis: [], item: null,
+              }});
+            },
+            get_control_state: async path => {
+              state.calls.controlState.push(path);
+              const payload = state.responses[path] || {};
+              return copy({
+                controls: payload.controls || {},
+                state: payload.state || {rules: [], defaults: {}},
+              });
+            },
+            get_mesh_semantics: async path => {
+              state.calls.meshSemantics.push(path);
+              const payload = state.responses[path] || {};
+              const meshes = payload.meshSemantics || Object.fromEntries(
+                Object.entries(payload.meshes || {}).map(([name, entry]) => [name, {
+                  conditions: entry.conditions || [],
+                  sources: entry.sources || [],
+                }])
+              );
+              return copy({meshes});
             },
             has_pending_changes: async path => !!state.pending[path],
             discard_changes: async path => {
@@ -2555,6 +2601,84 @@ def test_wuwa_models_start_with_a_180_degree_base_turn(
           return window.modViewer.activeMeshes[0].quaternion.toArray();
         }""")
         assert reloaded == pytest.approx([0, 1, 0, 0])
+    finally:
+        context.close()
+
+
+def test_present_refresh_keeps_model_identity_and_selection(
+        edge_browser, frontend_url):
+    payload = _present_payload()
+    context, page = _page(edge_browser, frontend_url, {"Present": payload})
+    try:
+        _open(page, "Present")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""async () => {
+          const {setToggleValue, refreshAll} = await import('./js/visibility.js');
+          setToggleValue('toggle', '1');
+          refreshAll();
+          window.__presentMesh = window.modViewer.activeMeshes[0];
+        }""")
+        page.evaluate("""() => {
+          window.__fakeApi.responses.Present.controls.present.item.names = ['Zero', 'One'];
+        }""")
+
+        assert page.evaluate("window.modViewer.refreshPresentState()") is True
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["Present"]
+        assert page.evaluate("window.__fakeApi.calls.presentState") == ["Present"]
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0] === window.__presentMesh")
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].userData.conditions") == []
+        assert page.locator("#present-list .toggle-value").inner_text() == "One"
+        assert page.evaluate("window.modViewer.refreshPresentState({"
+                            "selectedPosition: 0, applySelection: true})") is True
+        assert page.evaluate("window.modViewer.activeMeshes[0] === window.__presentMesh")
+        assert page.evaluate("window.modViewer.activeMeshes[0] && "
+                            "window.__fakeApi.calls.loadMod.length") == 1
+        assert page.locator("#present-list .toggle-value").inner_text() == "Zero"
+    finally:
+        context.close()
+
+
+def test_control_and_mesh_semantic_refreshes_preserve_existing_meshes(
+        edge_browser, frontend_url):
+    payload = _payload("Semantic")
+    mesh_name = next(iter(payload["meshes"]))
+    payload["meshSemantics"] = {
+        mesh_name: {"conditions": [[{
+            "var": "toggle", "value": "1", "negate": False,
+        }]], "sources": payload["meshes"][mesh_name]["sources"]},
+    }
+    context, page = _page(edge_browser, frontend_url, {"Semantic": payload})
+    try:
+        _open(page, "Semantic")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""async () => {
+          const {setToggleValue, refreshAll} = await import('./js/visibility.js');
+          setToggleValue('toggle', '1');
+          refreshAll();
+          window.__semanticMesh = window.modViewer.activeMeshes[0];
+          window.__fakeApi.responses.Semantic.controls.toggles.KeySemantic.name = 'Renamed';
+        }""")
+
+        assert page.evaluate("window.modViewer.refreshControlSemantics()") is True
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["Semantic"]
+        assert page.evaluate("window.__fakeApi.calls.controlState") == ["Semantic"]
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0] === window.__semanticMesh")
+        assert page.locator("#toggle-list .toggle-name").inner_text() == "Renamed"
+        assert page.evaluate("""async () => {
+          await window.modViewer.refreshMeshSemantics();
+          return {
+            same: window.modViewer.activeMeshes[0] === window.__semanticMesh,
+            conditions: window.modViewer.activeMeshes[0].userData.conditions,
+          };
+        }""") == {
+            "same": True,
+            "conditions": [[{"var": "toggle", "value": "1", "negate": False}]],
+        }
+        assert page.evaluate("window.__fakeApi.calls.loadMod.length") == 1
+        assert page.evaluate("window.__fakeApi.calls.meshSemantics") == ["Semantic"]
     finally:
         context.close()
 

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -320,7 +320,8 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
         "calls": {"loadMod": [], "listSubfolders": [],
                    "discardChanges": [], "switches": [], "diagnostics": [],
                    "panelOpacity": [], "presentState": [],
-                   "controlState": [], "meshSemantics": []},
+                   "controlState": [], "meshSemantics": [],
+                   "deleteToggle": [], "exportChanges": []},
     }
     encoded_state = json.dumps(json.dumps(state))
     context.add_init_script(
@@ -373,6 +374,15 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                 }])
               );
               return copy({meshes});
+            },
+            delete_toggle: async (path, ini, section) => {
+              state.calls.deleteToggle.push([path, ini, section]);
+              return copy({ok: true, result: {}});
+            },
+            export_changes: async path => {
+              state.calls.exportChanges.push(path);
+              state.pending[path] = false;
+              return copy({saved: [], failed: []});
             },
             has_pending_changes: async path => !!state.pending[path],
             discard_changes: async path => {
@@ -2424,6 +2434,68 @@ def test_mismatched_toggle_lists_hold_the_last_short_value(
         assert value.inner_text() == "short=1, long=2"
         button.click()
         assert value.inner_text() == "short=0, long=0"
+    finally:
+        context.close()
+
+
+def test_shared_control_values_reconcile_as_a_union(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Shared": _payload("Shared")})
+    try:
+        _open(page, "Shared")
+        result = page.evaluate("""async () => {
+          const controls = await import('./js/control-state.js');
+          controls.setControlValue('shared', '2');
+          controls.setControlStateRules([], {shared: '0'}, {
+            toggles: {
+              KeyA: {vars: [{var: 'shared', values: ['0', '1']}]},
+              KeyB: {vars: [{var: 'shared', values: ['0', '2']}]},
+            },
+            menu: {},
+          });
+          return controls.getControlState().shared;
+        }""")
+        assert result == "2"
+    finally:
+        context.close()
+
+
+def test_delete_reloads_model_for_geometry_safety(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"Delete": _payload("Delete")},
+        pending={"Delete": True})
+    try:
+        _open(page, "Delete")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("window.__deleteMesh = window.modViewer.activeMeshes[0]")
+        page.locator("#toggle-list [title='Delete toggle']").click()
+        page.locator("#dialog-backdrop.show").wait_for()
+        page.locator("#dialog-ok").click()
+        page.wait_for_function("window.__fakeApi.calls.loadMod.length === 2")
+
+        assert page.evaluate("window.__fakeApi.calls.meshSemantics") == []
+        assert page.evaluate("window.modViewer.activeMeshes[0] !== window.__deleteMesh")
+    finally:
+        context.close()
+
+
+def test_export_refreshes_status_without_reloading_model(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"Export": _payload("Export")},
+        pending={"Export": True})
+    try:
+        _open(page, "Export")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("window.__exportMesh = window.modViewer.activeMeshes[0]")
+        page.locator("#export-btn").click()
+        page.wait_for_function("window.__fakeApi.calls.exportChanges.length === 1")
+        page.wait_for_function("!window.__fakeApi.pending.Export")
+
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["Export"]
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0] === window.__exportMesh")
     finally:
         context.close()
 

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -2647,7 +2647,22 @@ def test_control_and_mesh_semantic_refreshes_preserve_existing_meshes(
     payload["meshSemantics"] = {
         mesh_name: {"conditions": [[{
             "var": "toggle", "value": "1", "negate": False,
-        }]], "sources": payload["meshes"][mesh_name]["sources"]},
+        }]], "sources": payload["meshes"][mesh_name]["sources"],
+        "tex_key": "diffuse::Semantic-one.png",
+        "texture_variants": [{
+            "conditions": [[{
+                "var": "toggle", "value": "1", "negate": False,
+            }]], "tex_key": "diffuse::Semantic-two.png",
+        }],
+        "normal_map_key": "normal_map::Semantic-normal.png",
+        "normal_map_variants": [{
+            "conditions": [[{
+                "var": "toggle", "value": "1", "negate": False,
+            }]], "tex_key": "normal_map::Semantic-normal-alt.png",
+        }],
+        "normal_data_key": "normal_data::Semantic-packed.png",
+        "light_map_key": "light_map::Semantic-light.png",
+        "material_map_key": "material_map::Semantic-material.png"},
     }
     context, page = _page(edge_browser, frontend_url, {"Semantic": payload})
     try:
@@ -2672,13 +2687,144 @@ def test_control_and_mesh_semantic_refreshes_preserve_existing_meshes(
           return {
             same: window.modViewer.activeMeshes[0] === window.__semanticMesh,
             conditions: window.modViewer.activeMeshes[0].userData.conditions,
+            diffuse: window.modViewer.activeMeshes[0].userData.resolvedTexKey,
+            normal: window.modViewer.activeMeshes[0].userData.resolvedNormalMapKey,
           };
         }""") == {
             "same": True,
             "conditions": [[{"var": "toggle", "value": "1", "negate": False}]],
+            "diffuse": "diffuse::Semantic-two.png",
+            "normal": "normal_map::Semantic-normal-alt.png",
         }
         assert page.evaluate("window.__fakeApi.calls.loadMod.length") == 1
         assert page.evaluate("window.__fakeApi.calls.meshSemantics") == ["Semantic"]
+    finally:
+        context.close()
+
+
+def test_record_refreshes_controls_and_meshes_without_reloading_model(
+        edge_browser, frontend_url):
+    payload = _payload("Record")
+    payload["controls"]["toggles"]["KeyRecord"]["wired"] = False
+    context, page = _page(
+        edge_browser, frontend_url, {"Record": payload},
+        pending={"Record": True})
+    try:
+        _open(page, "Record")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""() => {
+          window.pywebview.api.record_toggle = async () => {
+            window.__fakeApi.responses.Record.controls.toggles.KeyRecord.wired = true;
+            return {ok: true, result: {}};
+          };
+          window.__recordMesh = window.modViewer.activeMeshes[0];
+        }""")
+        assert page.locator("#toggle-list .toggle-unwired-badge").count() == 1
+        assert page.locator("#export-btn").is_disabled()
+
+        page.locator("#toggle-list [title^='Record']").click()
+        page.locator("#toggle-list .toggle-row.recording").wait_for()
+        page.locator("#toggle-list .toggle-record-save").click()
+        page.wait_for_function("window.__fakeApi.calls.controlState.length === 1")
+
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["Record"]
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0] === window.__recordMesh")
+        assert page.locator("#toggle-list .toggle-unwired-badge").count() == 0
+        assert not page.locator("#export-btn").is_disabled()
+    finally:
+        context.close()
+
+
+def test_stale_semantic_response_cannot_modify_new_mod(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"A": _payload("A"), "B": _payload("B")})
+    try:
+        _open(page, "A")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""() => {
+          const original = window.pywebview.api.get_control_state;
+          window.__releaseAControls = null;
+          window.pywebview.api.get_control_state = async path => {
+            if (path === 'A') {
+              await new Promise(resolve => window.__releaseAControls = resolve);
+            }
+            return original(path);
+          };
+          window.__staleControls = window.modViewer.refreshControlSemantics();
+        }""")
+        page.wait_for_function("window.__releaseAControls !== null")
+
+        _open(page, "B")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("window.__releaseAControls()")
+        page.evaluate("async () => await window.__staleControls")
+
+        assert page.locator("#toggle-list .toggle-name").inner_text() == "Toggle B"
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["A", "B"]
+    finally:
+        context.close()
+
+
+def test_newer_same_mod_semantic_response_wins(
+        edge_browser, frontend_url):
+    payload = _payload("Race")
+    context, page = _page(edge_browser, frontend_url, {"Race": payload})
+    try:
+        _open(page, "Race")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""() => {
+          const original = window.pywebview.api.get_control_state;
+          let calls = 0;
+          window.__releaseOldControls = null;
+          window.pywebview.api.get_control_state = async path => {
+            calls += 1;
+            if (calls === 1) {
+              const stale = await original(path);
+              await new Promise(resolve => window.__releaseOldControls = resolve);
+              stale.controls.toggles.KeyRace.name = 'Old';
+              return stale;
+            }
+            return original(path);
+          };
+          window.__oldControls = window.modViewer.refreshControlSemantics();
+        }""")
+        page.wait_for_function("window.__releaseOldControls !== null")
+        page.evaluate("""() => {
+          window.__fakeApi.responses.Race.controls.toggles.KeyRace.name = 'Newest';
+          window.__newControls = window.modViewer.refreshControlSemantics();
+        }""")
+        page.evaluate("async () => await window.__newControls")
+        page.evaluate("window.__releaseOldControls()")
+        page.evaluate("async () => await window.__oldControls")
+
+        assert page.locator("#toggle-list .toggle-name").inner_text() == "Newest"
+    finally:
+        context.close()
+
+
+def test_failed_semantic_refresh_still_updates_pending_state(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"Failure": _payload("Failure")},
+        pending={"Failure": True})
+    try:
+        _open(page, "Failure")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""() => {
+          window.pywebview.api.get_mesh_semantics = async () => ({
+            error: 'semantic refresh failed',
+          });
+          window.__failedRefresh = window.modViewer.refreshMeshSemantics();
+        }""")
+        page.locator("#dialog-backdrop.show").wait_for()
+        page.locator("#dialog-ok").click()
+        page.evaluate("async () => await window.__failedRefresh")
+
+        assert "show" in (page.locator("#pending-indicator").get_attribute("class") or "")
+        assert not page.locator("#export-btn").is_disabled()
     finally:
         context.close()
 

--- a/src/tests/test_load_pipeline.py
+++ b/src/tests/test_load_pipeline.py
@@ -6,6 +6,7 @@ import struct
 import tempfile
 import base64
 import io
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -16,7 +17,8 @@ from core.ini_analysis import analyze_ini
 from core.ini_document import IniDocument
 from core.ini_sections import (extract_resources, sections_from_document)
 from core.mesh_builder import (GeometryBlob, MeshBuildResult,
-                               build_mesh_payload, build_mesh_result)
+                               build_mesh_payload, build_mesh_result,
+                               build_mesh_semantics)
 from core.textures import encode_texture_file
 
 
@@ -102,6 +104,82 @@ def test_geometry_blob_bypasses_base64_intermediate():
                 and loaded_entry["material_kind_reliable"] is False
                 and loaded_entry["material_profile_id"] == "none"), ("mesh material identity is assigned conservatively")
         assert set(loaded["metadata"]["material_profiles"]) == {"none"}, ("profile metadata is deduplicated at payload scope")
+
+
+def test_mesh_semantics_include_conditional_texture_roles_without_geometry(
+        tmp_path):
+    for name in ("base.png", "alt.png", "normal.png", "normal-alt.png",
+                 "light.png", "light-alt.png", "material.png",
+                 "material-alt.png"):
+        (tmp_path / name).touch()
+    condition = [{"var": "skin", "value": "1", "negate": False}]
+    groups = [{
+        "name": "Body", "draws": [{
+            "label": "Body-1", "count": 3, "start": 0, "base": 0,
+            "conditions": [],
+            "texture_default_file": "base.png",
+            "texture_assignments": [
+                {"conditions": [], "file": "base.png"},
+                {"conditions": [condition], "file": "alt.png"},
+            ],
+            "normal_map_default_file": "normal.png",
+            "normal_map_variants": [{"conditions": [condition], "file": "normal-alt.png"}],
+            "light_map_default_file": "light.png",
+            "light_map_variants": [{"conditions": [condition], "file": "light-alt.png"}],
+            "material_map_default_file": "material.png",
+            "material_map_variants": [{"conditions": [condition], "file": "material-alt.png"}],
+        }],
+        "ib_file": "i.buf", "index_size": 4,
+        "position_file": "p.buf", "position_stride": 12,
+        "texcoord_file": "t.buf", "texcoord_stride": 8,
+    }]
+
+    entry = build_mesh_semantics(groups, str(tmp_path), game_profile="wuwa")["Body-1"]
+
+    assert entry["tex_key"] == "diffuse::base.png"
+    assert {variant["tex_key"] for variant in entry["texture_variants"]} == {
+        "diffuse::base.png", "diffuse::alt.png"}
+    assert entry["normal_map_key"] is None
+    assert entry["normal_data_key"] == "normal_data::normal.png"
+    assert entry["normal_data_variants"][0]["tex_key"] == "normal_data::normal-alt.png"
+    assert entry["light_map_key"] == "light_map::light.png"
+    assert entry["material_map_key"] == "material_map::material.png"
+
+
+def test_control_semantics_filter_wired_toggles_to_displayed_meshes(
+        tmp_path):
+    def toggle_info(section, variable):
+        return {
+            "name": section, "key_display": "", "key": "",
+            "source": None, "ini_path": str(tmp_path / "mod.ini"),
+            "section": section, "vars": {variable: ["0", "1"]},
+        }
+
+    parsed = mod_loader.ParsedModAnalysis(
+        groups=[{"draws": []}],
+        toggles={
+            "KeyVisible": toggle_info("KeyVisible", "visible"),
+            "KeyPhantom": toggle_info("KeyPhantom", "phantom"),
+        },
+        menu={}, defaults={"visible": "0", "phantom": "0"},
+        state_rules=[], present={},
+        game=SimpleNamespace(game="unknown"),
+    )
+    context = mod_loader.ModLoadContext(
+        str(tmp_path), [str(tmp_path / "mod.ini")], {}, {})
+    with patch.object(mod_loader, "_parse_inis", return_value=parsed), \
+            patch.object(mod_loader, "build_mesh_semantics", return_value={
+                "Body-1": {"conditions": [[{
+                    "var": "visible", "value": "1", "negate": False,
+                }]]},
+                "Broken-1": {"conditions": [[{
+                    "var": "phantom", "value": "1", "negate": False,
+                }]]},
+            }):
+        result = mod_loader.load_control_state(
+            context, active_mesh_keys={"Body-1"})
+
+    assert set(result["controls"]["toggles"]) == {"KeyVisible"}
 
 
 def test_diagnostics_cache_tracks_authoritative_revision():

--- a/src/tests/test_load_pipeline.py
+++ b/src/tests/test_load_pipeline.py
@@ -10,7 +10,8 @@ from unittest.mock import patch
 
 import pytest
 
-from app import edit_session, metadata, mod_loader, server
+from app import edit_session, metadata, mod_loader, present_api, server
+from app.api import ModViewerAPI
 from core.ini_analysis import analyze_ini
 from core.ini_document import IniDocument
 from core.ini_sections import (extract_resources, sections_from_document)
@@ -124,6 +125,42 @@ def test_diagnostics_cache_tracks_authoritative_revision():
             assert (edit_session.cached_diagnostics(root) is None), ("viewer metadata changes can invalidate diagnostics independently")
         finally:
             edit_session.discard(root)
+
+
+def test_present_state_read_uses_staged_documents_without_geometry(
+        tmp_path):
+    root = os.path.normcase(os.path.abspath(str(tmp_path)))
+    ini_path = os.path.join(root, "mod.ini")
+    with open(ini_path, "w", encoding="utf-8") as fh:
+        fh.write(
+            "[KeyOutfit]\n"
+            "key = 1\n"
+            "type = cycle\n"
+            "$Outfit = 0,1\n"
+            "[TextureOverrideBody]\n"
+            "if $Outfit == 0\n"
+            "drawindexed = 3, 0, 0\n"
+            "endif\n")
+
+    edit_session.load_documents(root, [ini_path])
+    added = present_api.add_present(
+        root, "ctrl p", "", {"mod.ini": {"Outfit": "0"}})
+    assert added.get("ok") is True
+
+    api = ModViewerAPI()
+    api._authorized_folders.add(os.path.normcase(os.path.abspath(root)))
+    with patch.object(mod_loader, "build_mesh_result",
+                      side_effect=AssertionError("geometry must not be built")):
+        result = api.get_present_state(root)
+
+    try:
+        assert result.get("error") is None
+        present = result["present"]
+        assert present["item"]["key_raw"] == "ctrl p"
+        assert present["item"]["count"] == 1
+        assert present["item"]["names"] == ["Present 1"]
+    finally:
+        edit_session.discard(root)
 
 
 def test_wuwa_publishes_one_intact_normal_data_source():

--- a/src/web/js/control-state.js
+++ b/src/web/js/control-state.js
@@ -33,11 +33,46 @@ export function dnfSatisfied(condGroups) {
   }));
 }
 
-export function setControlStateRules(rules, defaults) {
-  stateRules = rules || [];
-  for (const [variable, value] of Object.entries(defaults || {})) {
-    if (values[variable] === undefined) values[variable] = value;
+function controlValues(controls) {
+  const legal = new Map();
+  for (const info of Object.values(controls?.toggles || {})) {
+    for (const variable of (info.cycle_vars || info.vars || [])) {
+      legal.set(variable.var, variable.values || []);
+    }
   }
+  for (const info of Object.values(controls?.menu || {})) {
+    if (info.values) legal.set(info.var, info.values);
+  }
+  return legal;
+}
+
+/** Reconcile authoritative control semantics without resetting live values. */
+export function reconcileControlState(rules, defaults, controls = null) {
+  stateRules = rules || [];
+  const next = controls === null ? { ...values } : {};
+  const legal = controls === null ? new Map() : controlValues(controls);
+  const configured = new Map(Object.entries(defaults || {}));
+  if (controls !== null) {
+    for (const [variable] of legal) {
+      if (!configured.has(variable)) configured.set(variable, undefined);
+    }
+  }
+  for (const [variable, defaultValue] of configured) {
+    const allowed = legal.get(variable);
+    const current = values[variable];
+    if (current !== undefined && (!allowed || allowed.includes(current))) {
+      next[variable] = current;
+    } else if (allowed?.length) {
+      next[variable] = allowed.includes(defaultValue) ? defaultValue : allowed[0];
+    } else {
+      next[variable] = defaultValue;
+    }
+  }
+  values = next;
+}
+
+export function setControlStateRules(rules, defaults, controls = null) {
+  reconcileControlState(rules, defaults, controls);
 }
 
 /** Replay safe [Present] assignments in source order. Later rules deliberately

--- a/src/web/js/control-state.js
+++ b/src/web/js/control-state.js
@@ -35,13 +35,17 @@ export function dnfSatisfied(condGroups) {
 
 function controlValues(controls) {
   const legal = new Map();
+  const addLegalValues = (variable, values) => {
+    const existing = legal.get(variable) || [];
+    legal.set(variable, [...new Set([...existing, ...(values || [])])]);
+  };
   for (const info of Object.values(controls?.toggles || {})) {
     for (const variable of (info.cycle_vars || info.vars || [])) {
-      legal.set(variable.var, variable.values || []);
+      addLegalValues(variable.var, variable.values);
     }
   }
   for (const info of Object.values(controls?.menu || {})) {
-    if (info.values) legal.set(info.var, info.values);
+    if (info.values) addLegalValues(info.var, info.values);
   }
   return legal;
 }

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -248,6 +248,7 @@ function initToolbarOverflow() {
 // actions know which session to update and reloadCurrentMod() knows what to
 // refresh afterward.
 let currentModPath = null;
+let semanticRefreshEpoch = 0;
 // Unlike currentModPath, this changes only after a payload is displayed.
 // Camera framing follows displayed model identity so a failed switch and retry
 // still frames the replacement, while a reload of the visible mod does not.
@@ -284,8 +285,9 @@ function hasUnwiredToggle() {
 // Reflects the currently open mod's staged-but-not-yet-exported edits onto
 // the toolbar: Export only enables once there's something to export, and
 // the indicator is the persistent signal that something is unsaved.
-async function refreshPendingState() {
-  const pending = currentModPath ? await window.pywebview.api.has_pending_changes(currentModPath) : false;
+async function refreshPendingState(path = currentModPath, guard = null) {
+  const pending = path ? await window.pywebview.api.has_pending_changes(path) : false;
+  if ((guard && !guard()) || (path && !samePath(currentModPath, path))) return false;
   $('pending-indicator').classList.toggle('show', pending);
   const blocked = pending && hasUnwiredToggle();
   $('export-btn').disabled = !pending || blocked;
@@ -331,6 +333,7 @@ function clearPendingState() {
  * mod visible under the new folder's toolbar state. */
 function beginModLoad(path, message, { preserveModelOrientation = false } = {}) {
   currentModPath = path;
+  semanticRefreshEpoch += 1;
   clearScene({ preserveModelOrientation });
   clearPendingState();
   window.dispatchEvent(new CustomEvent('mod-viewer-mod-load-started', {
@@ -393,32 +396,51 @@ async function displayMeshPayload(payload, { preserveCamera = false } = {}) {
   showLoading(false);
 }
 
+function beginSemanticRefresh() {
+  return { path: currentModPath, epoch: ++semanticRefreshEpoch };
+}
+
+function semanticRefreshIsCurrent(path, epoch) {
+  return !!path && epoch === semanticRefreshEpoch
+    && samePath(currentModPath, path);
+}
+
+async function finishSemanticRefresh(path, epoch) {
+  if (!semanticRefreshIsCurrent(path, epoch)) return;
+  await refreshPendingState(
+    path, () => semanticRefreshIsCurrent(path, epoch));
+  if (semanticRefreshIsCurrent(path, epoch)) void refreshHealthReport();
+}
+
 async function refreshPresentState(change = {}) {
-  if (!currentModPath) return false;
-  let result;
+  const { path, epoch } = beginSemanticRefresh();
   try {
-    result = await window.pywebview.api.get_present_state(currentModPath);
-  } catch (error) {
-    await alertDialog('Could not refresh PRESENT:\n\n' + error);
-    return false;
+    if (!path) return false;
+    let result;
+    try {
+      result = await window.pywebview.api.get_present_state(path);
+    } catch (error) {
+      if (semanticRefreshIsCurrent(path, epoch)) {
+        await alertDialog('Could not refresh PRESENT:\n\n' + error);
+      }
+      return false;
+    }
+    if (!semanticRefreshIsCurrent(path, epoch)) return false;
+    if (result?.error) {
+      await alertDialog('Could not refresh PRESENT:\n\n' + result.error);
+      return false;
+    }
+    const context = { modPath: path, onChange: handlePresentChange };
+    if (Object.hasOwn(change, 'selectedPosition')) {
+      context.selectedPosition = change.selectedPosition;
+      context.applySelection = change.applySelection === true;
+    }
+    buildPresentPanel(result.present, context);
+    syncViewportControlPlacement();
+    return true;
+  } finally {
+    await finishSemanticRefresh(path, epoch);
   }
-  if (result?.error) {
-    await alertDialog('Could not refresh PRESENT:\n\n' + result.error);
-    return false;
-  }
-  const context = {
-    modPath: currentModPath,
-    onChange: handlePresentChange,
-  };
-  if (Object.hasOwn(change, 'selectedPosition')) {
-    context.selectedPosition = change.selectedPosition;
-    context.applySelection = change.applySelection === true;
-  }
-  buildPresentPanel(result.present, context);
-  syncViewportControlPlacement();
-  await refreshPendingState();
-  void refreshHealthReport();
-  return true;
 }
 
 async function handlePresentChange(change = {}) {
@@ -426,64 +448,79 @@ async function handlePresentChange(change = {}) {
 }
 
 async function refreshControlSemantics() {
-  if (!currentModPath) return false;
-  let result;
+  const { path, epoch } = beginSemanticRefresh();
   try {
-    result = await window.pywebview.api.get_control_state(currentModPath);
-  } catch (error) {
-    await alertDialog('Could not refresh controls:\n\n' + error);
-    return false;
+    if (!path) return false;
+    let result;
+    try {
+      result = await window.pywebview.api.get_control_state(path);
+    } catch (error) {
+      if (semanticRefreshIsCurrent(path, epoch)) {
+        await alertDialog('Could not refresh controls:\n\n' + error);
+      }
+      return false;
+    }
+    if (!semanticRefreshIsCurrent(path, epoch)) return false;
+    if (result?.error) {
+      await alertDialog('Could not refresh controls:\n\n' + result.error);
+      return false;
+    }
+    const controls = result.controls || {};
+    const state = result.state || {};
+    lastToggles = controls.toggles || {};
+    setStateRules(state.rules || [], state.defaults || {}, {
+      toggles: controls.toggles || {}, menu: controls.menu || {},
+    });
+    buildTogglePanel(controls.toggles, {
+      modPath: path, onChange: handleToggleChange,
+    });
+    buildMenuPanel(controls.menu);
+    buildPresentPanel(controls.present, {
+      modPath: path, onChange: handlePresentChange,
+    });
+    syncViewportControlPlacement();
+    refreshAll();
+    return true;
+  } finally {
+    await finishSemanticRefresh(path, epoch);
   }
-  if (result?.error) {
-    await alertDialog('Could not refresh controls:\n\n' + result.error);
-    return false;
-  }
-  const controls = result.controls || {};
-  const state = result.state || {};
-  lastToggles = controls.toggles || {};
-  setStateRules(state.rules || [], state.defaults || {}, {
-    toggles: controls.toggles || {}, menu: controls.menu || {},
-  });
-  buildTogglePanel(controls.toggles, {
-    modPath: currentModPath, onChange: handleToggleChange,
-  });
-  buildMenuPanel(controls.menu);
-  buildPresentPanel(controls.present, {
-    modPath: currentModPath, onChange: handlePresentChange,
-  });
-  syncViewportControlPlacement();
-  refreshAll();
-  await refreshPendingState();
-  void refreshHealthReport();
-  return true;
 }
 
 async function refreshMeshSemantics() {
-  if (!currentModPath) return false;
-  let result;
+  const { path, epoch } = beginSemanticRefresh();
   try {
-    result = await window.pywebview.api.get_mesh_semantics(currentModPath);
-  } catch (error) {
-    await alertDialog('Could not refresh mesh visibility:\n\n' + error);
-    return false;
+    if (!path) return false;
+    let result;
+    try {
+      result = await window.pywebview.api.get_mesh_semantics(path);
+    } catch (error) {
+      if (semanticRefreshIsCurrent(path, epoch)) {
+        await alertDialog('Could not refresh mesh render semantics:\n\n' + error);
+      }
+      return false;
+    }
+    if (!semanticRefreshIsCurrent(path, epoch)) return false;
+    if (result?.error) {
+      await alertDialog('Could not refresh mesh render semantics:\n\n' + result.error);
+      return false;
+    }
+    if (!updateMeshSemantics(result.meshes)) {
+      await alertDialog('Could not refresh mesh render semantics:\n\n' +
+        'The staged draw set no longer matches the displayed model.');
+      return false;
+    }
+    refreshAll();
+    return true;
+  } finally {
+    await finishSemanticRefresh(path, epoch);
   }
-  if (result?.error) {
-    await alertDialog('Could not refresh mesh visibility:\n\n' + result.error);
-    return false;
-  }
-  if (!updateMeshSemantics(result.meshes)) {
-    await alertDialog('Could not refresh mesh visibility:\n\n' +
-      'The staged draw set no longer matches the displayed model.');
-    return false;
-  }
-  refreshAll();
-  await refreshPendingState();
-  void refreshHealthReport();
-  return true;
 }
 
 async function handleToggleChange(change = {}) {
-  if (change.type === 'record') return refreshMeshSemantics();
+  if (change.type === 'record') {
+    const meshesRefreshed = await refreshMeshSemantics();
+    return meshesRefreshed ? refreshControlSemantics() : false;
+  }
   if (change.type === 'delete') {
     const controlsRefreshed = await refreshControlSemantics();
     return controlsRefreshed ? refreshMeshSemantics() : false;

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -522,8 +522,11 @@ async function handleToggleChange(change = {}) {
     return meshesRefreshed ? refreshControlSemantics() : false;
   }
   if (change.type === 'delete') {
-    const controlsRefreshed = await refreshControlSemantics();
-    return controlsRefreshed ? refreshMeshSemantics() : false;
+    // Deleting a toggle rewrites every safe branch that references its
+    // variable, including resource bindings before drawindexed.  The draw
+    // label can survive while its geometry identity changes, so semantic
+    // patching is not safe here; rebuild from the authoritative session.
+    return reloadCurrentMod();
   }
   return refreshControlSemantics();
 }
@@ -661,12 +664,11 @@ async function exportChanges() {
         `${result.saved.length} ini file(s) exported, but ${result.failed.length} failed ` +
         `and are still pending:\n\n${detail}`);
     }
-    // Refreshes the panel/badges from the now-partly-or-fully-exported session
-    // state either way, and re-syncs the indicator via its own call to
-    // refreshPendingState (a partial failure leaves those inis' edits
-    // pending, so it stays lit rather than clearing, and the button
-    // re-enables for a retry).
-    await reloadCurrentMod();
+    // Export writes the authoritative staged documents but does not change
+    // the current model or control semantics. Refresh only session status;
+    // partial failures leave the affected edits pending for retry.
+    await refreshPendingState();
+    void refreshHealthReport();
   } catch (e) {
     await alertDialog('Unexpected error while exporting:\n\n' + e);
     await refreshPendingState();

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -6,7 +6,9 @@ import { fitTo, resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterT
          setEnvironmentPreset, setLightMode, getRenderCount } from './scene.js';
 import { ENVIRONMENT_PRESETS } from './environment.js';
 import { refreshMeshTexture, setTextures } from './mesh-factory.js';
-import { activeMeshes, reset, resetMeshState, setStateRules, toggleWireframe, toggleSmoothShading, toggleGlossy } from './visibility.js';
+import { activeMeshes, refreshAll, reset, resetMeshState, setStateRules,
+         toggleWireframe, toggleSmoothShading, toggleGlossy,
+         updateMeshSemantics } from './visibility.js';
 import { initSelection, clearSelection } from './selection.js';
 import { buildMeshPanel } from './mesh-panel.js';
 import { buildTogglePanel } from './toggle-panel.js';
@@ -360,7 +362,9 @@ async function displayMeshPayload(payload, { preserveCamera = false } = {}) {
   const state = payload.state || {};
   const meshes = payload.meshes || {};
   lastToggles = controls.toggles || {};
-  setStateRules(state.rules || [], state.defaults || {});
+  setStateRules(state.rules || [], state.defaults || {}, {
+    toggles: controls.toggles || {}, menu: controls.menu || {},
+  });
   setTextures(payload.textures);
   buildMeshPanel(
     meshes, currentModPath, payload.metadata?.mesh_names || {},
@@ -369,9 +373,13 @@ async function displayMeshPayload(payload, { preserveCamera = false } = {}) {
       onMaterialKindChanged: reloadCurrentMod,
       texturePools: payload.texture_pools || {},
     });
-  buildTogglePanel(controls.toggles, { modPath: currentModPath, onChange: reloadCurrentMod });
+  buildTogglePanel(controls.toggles, {
+    modPath: currentModPath, onChange: handleToggleChange,
+  });
   buildMenuPanel(controls.menu);
-  buildPresentPanel(controls.present, { modPath: currentModPath, onChange: reloadCurrentMod });
+  buildPresentPanel(controls.present, {
+    modPath: currentModPath, onChange: handlePresentChange,
+  });
   rightDockEnabled = true;
   syncViewportControlPlacement();
   fitTo(activeMeshes, {
@@ -383,6 +391,104 @@ async function displayMeshPayload(payload, { preserveCamera = false } = {}) {
   });
 
   showLoading(false);
+}
+
+async function refreshPresentState(change = {}) {
+  if (!currentModPath) return false;
+  let result;
+  try {
+    result = await window.pywebview.api.get_present_state(currentModPath);
+  } catch (error) {
+    await alertDialog('Could not refresh PRESENT:\n\n' + error);
+    return false;
+  }
+  if (result?.error) {
+    await alertDialog('Could not refresh PRESENT:\n\n' + result.error);
+    return false;
+  }
+  const context = {
+    modPath: currentModPath,
+    onChange: handlePresentChange,
+  };
+  if (Object.hasOwn(change, 'selectedPosition')) {
+    context.selectedPosition = change.selectedPosition;
+    context.applySelection = change.applySelection === true;
+  }
+  buildPresentPanel(result.present, context);
+  syncViewportControlPlacement();
+  await refreshPendingState();
+  void refreshHealthReport();
+  return true;
+}
+
+async function handlePresentChange(change = {}) {
+  return refreshPresentState(change);
+}
+
+async function refreshControlSemantics() {
+  if (!currentModPath) return false;
+  let result;
+  try {
+    result = await window.pywebview.api.get_control_state(currentModPath);
+  } catch (error) {
+    await alertDialog('Could not refresh controls:\n\n' + error);
+    return false;
+  }
+  if (result?.error) {
+    await alertDialog('Could not refresh controls:\n\n' + result.error);
+    return false;
+  }
+  const controls = result.controls || {};
+  const state = result.state || {};
+  lastToggles = controls.toggles || {};
+  setStateRules(state.rules || [], state.defaults || {}, {
+    toggles: controls.toggles || {}, menu: controls.menu || {},
+  });
+  buildTogglePanel(controls.toggles, {
+    modPath: currentModPath, onChange: handleToggleChange,
+  });
+  buildMenuPanel(controls.menu);
+  buildPresentPanel(controls.present, {
+    modPath: currentModPath, onChange: handlePresentChange,
+  });
+  syncViewportControlPlacement();
+  refreshAll();
+  await refreshPendingState();
+  void refreshHealthReport();
+  return true;
+}
+
+async function refreshMeshSemantics() {
+  if (!currentModPath) return false;
+  let result;
+  try {
+    result = await window.pywebview.api.get_mesh_semantics(currentModPath);
+  } catch (error) {
+    await alertDialog('Could not refresh mesh visibility:\n\n' + error);
+    return false;
+  }
+  if (result?.error) {
+    await alertDialog('Could not refresh mesh visibility:\n\n' + result.error);
+    return false;
+  }
+  if (!updateMeshSemantics(result.meshes)) {
+    await alertDialog('Could not refresh mesh visibility:\n\n' +
+      'The staged draw set no longer matches the displayed model.');
+    return false;
+  }
+  refreshAll();
+  await refreshPendingState();
+  void refreshHealthReport();
+  return true;
+}
+
+async function handleToggleChange(change = {}) {
+  if (change.type === 'record') return refreshMeshSemantics();
+  if (change.type === 'delete') {
+    const controlsRefreshed = await refreshControlSemantics();
+    return controlsRefreshed ? refreshMeshSemantics() : false;
+  }
+  return refreshControlSemantics();
 }
 
 async function loadModAt(path) {
@@ -670,7 +776,8 @@ rendererReady.then(ready => {
     return normalized;
   };
   window.modViewer = {
-    displayMeshPayload, openMod, switchMod, reloadCurrentMod, exportChanges, activeMeshes,
+    displayMeshPayload, openMod, switchMod, reloadCurrentMod, exportChanges,
+    refreshPresentState, refreshControlSemantics, refreshMeshSemantics, activeMeshes,
     setEnvironmentPreset: applyEnvironmentPreset, getEnvironmentPreset,
     getMaterialState, getRenderCount,
     setMaterialDebugMode: setMaterialDebugModeForMeshes,

--- a/src/web/js/menu-panel.js
+++ b/src/web/js/menu-panel.js
@@ -93,7 +93,7 @@ function buildShapeSlider(info) {
   input.min = info.min;
   input.max = info.max;
   input.step = info.step;
-  input.value = info.default;
+  input.value = getToggleValue(info.var) ?? info.default;
   const valSpan = document.createElement('span');
   valSpan.className = 'menu-value';
   valSpan.textContent = Number(input.value).toFixed(2);
@@ -147,7 +147,9 @@ export function buildMenuPanel(menu) {
   // wrong branch outputs (notably WWMI qipao combinations).
   for (const key of keys) {
     const info = menu[key];
-    setToggleValue(info.var, String(info.default));
+    if (getToggleValue(info.var) === undefined) {
+      setToggleValue(info.var, String(info.default));
+    }
   }
 
   const bySource = groupKeysBySource(menu, keys);

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -338,6 +338,7 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
         const entry = meshes[name];
         const materialProfile = materialProfiles?.[entry.material_profile_id] || null;
         const mesh = buildMesh(name, entry, materialProfile);
+        mesh.userData.semanticKey = name;
         mesh.userData.metadataKey = meshMetadataKey(name, meshes[name]);
         mesh.userData.texturePool = texturePool;
         mesh.userData.displayName = meshNames[mesh.userData.metadataKey] || null;

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -60,15 +60,39 @@ export function resetMeshVisibility() {
   requestRender();
 }
 
-/** Replace only draw visibility semantics on the existing meshes. */
+/** Replace draw visibility and texture semantics on the existing meshes. */
 export function updateMeshSemantics(semantics) {
   const next = semantics || {};
-  if (activeMeshes.some(mesh => !next[mesh.userData.semanticKey])) return false;
+  const keys = activeMeshes.map(mesh => mesh.userData.semanticKey);
+  if (keys.some(key => !next[key])
+      || Object.keys(next).length !== keys.length) return false;
   activeMeshes.forEach(mesh => {
-    mesh.userData.conditions = next[mesh.userData.semanticKey].conditions || [];
-    if (next[mesh.userData.semanticKey].sources) {
-      mesh.userData.sources = next[mesh.userData.semanticKey].sources;
+    const semantic = next[mesh.userData.semanticKey];
+    mesh.userData.conditions = semantic.conditions || [];
+    mesh.userData.sources = semantic.sources || [];
+    const variants = [
+      ['textureVariants', 'texture_variants'],
+      ['normalMapVariants', 'normal_map_variants'],
+      ['normalDataVariants', 'normal_data_variants'],
+      ['lightMapVariants', 'light_map_variants'],
+      ['materialMapVariants', 'material_map_variants'],
+    ];
+    for (const [target, source] of variants) {
+      mesh.userData[target] = semantic[source] || [];
     }
+    const defaults = [
+      ['defaultTexKey', 'tex_key'],
+      ['defaultNormalMapKey', 'normal_map_key'],
+      ['defaultNormalDataKey', 'normal_data_key'],
+      ['defaultLightMapKey', 'light_map_key'],
+      ['defaultMaterialMapKey', 'material_map_key'],
+    ];
+    for (const [target, source] of defaults) {
+      if (Object.hasOwn(semantic, source)) {
+        mesh.userData[target] = semantic[source] || null;
+      }
+    }
+    applyTextureVariant(mesh);
   });
   return true;
 }

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -60,6 +60,19 @@ export function resetMeshVisibility() {
   requestRender();
 }
 
+/** Replace only draw visibility semantics on the existing meshes. */
+export function updateMeshSemantics(semantics) {
+  const next = semantics || {};
+  if (activeMeshes.some(mesh => !next[mesh.userData.semanticKey])) return false;
+  activeMeshes.forEach(mesh => {
+    mesh.userData.conditions = next[mesh.userData.semanticKey].conditions || [];
+    if (next[mesh.userData.semanticKey].sources) {
+      mesh.userData.sources = next[mesh.userData.semanticKey].sources;
+    }
+  });
+  return true;
+}
+
 /** Pin or clear one mesh's highlighted diffuse. Ordered component propagation
  * remains the texture-state module's responsibility. */
 export function setManualTexOverride(mesh, value, { notify = true } = {}) {

--- a/src/web/js/present-modal.js
+++ b/src/web/js/present-modal.js
@@ -58,12 +58,18 @@ async function submit(event) {
       return;
     }
     const saved = context.onSaved;
+    const change = {
+      type: context.mode === 'add' ? 'add-key'
+        : context.mode === 'complete' ? 'complete-key' : 'edit-key',
+      applySelection: false,
+    };
+    if (context.mode === 'add') change.selectedPosition = 0;
     close();
     $('present-list').classList.remove('collapsed');
     const toggle = $('present-panel').querySelector('.group-toggle');
     toggle.classList.remove('collapsed');
     toggle.setAttribute('aria-expanded', 'true');
-    if (saved) await saved();
+    if (saved) await saved(change);
   } catch (error) {
     setError(String(error));
   } finally {

--- a/src/web/js/present-panel.js
+++ b/src/web/js/present-panel.js
@@ -9,8 +9,13 @@ import { createIcon } from './ui-icons.js';
 const $ = (id) => document.getElementById(id);
 const MAX_PRESENTS = 10;
 let current = { modPath: null, present: null, onChange: null };
-let pendingSelection = null;
+let presentViewState = { modPath: null, selectedPosition: 0 };
 let syncCurrentValue = () => {};
+
+function clampPosition(item, position) {
+  if (!item?.count) return 0;
+  return Math.min(Math.max(Number(position) || 0, 0), item.count - 1);
+}
 
 async function removeKey() {
   const confirmed = await confirmDialog(
@@ -19,7 +24,9 @@ async function removeKey() {
   if (!confirmed) return;
   const result = await window.pywebview.api.delete_present(current.modPath);
   if (result.error) return alertDialog('Could not delete PRESENT:\n\n' + result.error);
-  if (current.onChange) await current.onChange();
+  if (current.onChange) await current.onChange({
+    type: 'delete-key', selectedPosition: null, applySelection: false,
+  });
 }
 
 function closeKeyMenu() {
@@ -84,22 +91,15 @@ async function capture(item, position, name, allowDuplicate = false) {
   return result;
 }
 
-function buildItem(item) {
-  let position = 0;
+function buildItem(item, { applySelection = false } = {}) {
+  let position = clampPosition(item, presentViewState.selectedPosition);
   const synchronized = !item.sync_error && item.count > 0;
-  const restoreSelection = pendingSelection &&
-    synchronized &&
-    pendingSelection.modPath === current.modPath &&
-    pendingSelection.position >= 0 && pendingSelection.position < item.count;
-  if (restoreSelection) position = pendingSelection.position;
-  if (synchronized) {
+  if (synchronized && applySelection) {
     for (const variable of item.vars) {
       setToggleValue(variable.var, variable.values[position]);
     }
   }
-  if (restoreSelection) {
-    pendingSelection = null;
-  }
+  presentViewState.selectedPosition = position;
 
   const wrap = document.createElement('div');
   wrap.className = 'toggle-item';
@@ -140,12 +140,14 @@ function buildItem(item) {
           .find(matches);
         if (next !== undefined) position = next;
       }
+      presentViewState.selectedPosition = position;
     }
     showName();
   };
   showName();
   cycle.onclick = () => {
     position = (position + 1) % item.count;
+    presentViewState.selectedPosition = position;
     for (const variable of item.vars) {
       setToggleValue(variable.var, variable.values[position]);
     }
@@ -176,8 +178,10 @@ function buildItem(item) {
     if (chosen === null) return;
     if (!chosen) return alertDialog('A present name is required.');
     if (!await capture(item, null, chosen)) return;
-    pendingSelection = { modPath: current.modPath, position: item.count };
-    if (current.onChange) await current.onChange();
+    if (current.onChange) await current.onChange({
+      type: 'new-position', selectedPosition: item.count,
+      applySelection: true,
+    });
   });
   const replace = document.createElement('button');
   replace.textContent = 'Update';
@@ -191,8 +195,10 @@ function buildItem(item) {
     if (chosen === null) return;
     if (!chosen) return alertDialog('A present name is required.');
     if (!await capture(item, position, chosen)) return;
-    pendingSelection = { modPath: current.modPath, position };
-    if (current.onChange) await current.onChange();
+    if (current.onChange) await current.onChange({
+      type: 'update-position', selectedPosition: position,
+      applySelection: false,
+    });
   });
   const remove = document.createElement('button');
   remove.textContent = 'Delete';
@@ -204,11 +210,11 @@ function buildItem(item) {
     const result = await window.pywebview.api.delete_present_position(
       current.modPath, position);
     if (result.error) return alertDialog('Could not delete present:\n\n' + result.error);
-    pendingSelection = {
-      modPath: current.modPath,
-      position: Math.min(position, item.count - 2),
-    };
-    if (current.onChange) await current.onChange();
+    if (current.onChange) await current.onChange({
+      type: 'delete-position',
+      selectedPosition: Math.min(position, item.count - 2),
+      applySelection: true,
+    });
   });
   actions.append(add, replace, remove);
   wrap.append(header, row, actions);
@@ -216,8 +222,17 @@ function buildItem(item) {
 }
 
 export function buildPresentPanel(present, context = {}) {
-  current = { modPath: context.modPath || null, present: present || {},
-    onChange: context.onChange || null };
+  const modPath = context.modPath || null;
+  if (presentViewState.modPath !== modPath) {
+    presentViewState = { modPath, selectedPosition: 0 };
+  }
+  if (Object.hasOwn(context, 'selectedPosition')) {
+    presentViewState.selectedPosition = context.selectedPosition === null
+      ? 0 : Number(context.selectedPosition) || 0;
+  }
+  current = { modPath, present: present || {},
+    onChange: context.onChange || null,
+    applySelection: context.applySelection === true };
   const panel = $('present-panel');
   const list = $('present-list');
   const action = $('present-action-btn');
@@ -257,8 +272,11 @@ export function buildPresentPanel(present, context = {}) {
     return;
   }
 
-  const built = buildItem(item);
+  presentViewState.selectedPosition = clampPosition(
+    item, presentViewState.selectedPosition);
+  const built = buildItem(item, { applySelection: current.applySelection });
   syncCurrentValue = built.sync;
   list.appendChild(built.wrap);
-  refreshAll();
+  if (current.applySelection) refreshAll();
+  else syncCurrentValue();
 }

--- a/src/web/js/record-session.js
+++ b/src/web/js/record-session.js
@@ -199,7 +199,7 @@ async function save() {
     const summary = summarizeSkips(result.result || {});
     exitRecordingUI();
     if (summary) await alertDialog('Recorded, but review these lines by hand:\n\n' + summary);
-    if (ctx.onChange) await ctx.onChange();
+    if (ctx.onChange) await ctx.onChange({ type: 'record' });
   } finally {
     ui.saveBtn.disabled = false;
   }

--- a/src/web/js/toggle-modal.js
+++ b/src/web/js/toggle-modal.js
@@ -174,12 +174,13 @@ async function handleSubmit(evt) {
       return;
     }
 
+    const changeType = currentMode === 'add' ? 'add' : 'edit';
     closeModal();
     // A brand-new toggle now appears in the list right away (see
     // mod_loader.build_toggle_panel's "wired" flag) with a ⚠ badge instead of
     // a one-off alert — its ⏺ Record button already works with zero prior
     // gating, so there's nothing further the user needs telling here.
-    if (onSaved) await onSaved();
+    if (onSaved) await onSaved({ type: changeType });
   } catch (e) {
     setError(String(e));
   } finally {

--- a/src/web/js/toggle-panel.js
+++ b/src/web/js/toggle-panel.js
@@ -84,11 +84,13 @@ async function handleDelete(info, ctx) {
   }
   const summary = summarizeReport(result.result || {});
   if (summary) await alertDialog('Toggle deleted, but review these lines by hand:\n\n' + summary);
-  if (ctx.onChange) await ctx.onChange();
+  if (ctx.onChange) await ctx.onChange({ type: 'delete' });
 }
 
 function buildToggleItem(info, ctx) {
-  for (const v of info.vars) setToggleValue(v.var, v.default);
+  for (const v of info.vars) {
+    if (getToggleValue(v.var) === undefined) setToggleValue(v.var, v.default);
+  }
 
   const positions = cyclePositionCount(info.vars);
   let cyclePosition = findCyclePosition(info.vars, positions);

--- a/src/web/js/visibility.js
+++ b/src/web/js/visibility.js
@@ -15,7 +15,7 @@ import { clearViewSyncs, syncView, syncViews } from './view-sync.js';
 
 export {
   activeMeshes, addMesh, applyMeshVisibility, conditionsSatisfied,
-  setManualTexOverride,
+  setManualTexOverride, updateMeshSemantics,
 } from './mesh-state.js';
 
 export const setToggleValue = setControlValue;


### PR DESCRIPTION
## Summary
- add staged PRESENT, control-semantic, and mesh-semantic refresh APIs without geometry rebuilds
- preserve Three.js model identity and explicit PRESENT selection during authoring
- route Toggle edits to the lowest sufficient refresh level
- document the repository test environment and PR workflow