### PR TITLE
Add asset folders and unify dock tab behavior

### DIFF
--- a/src/app/api.py
+++ b/src/app/api.py
@@ -16,8 +16,8 @@ from core.mod_discovery import discover_ini_paths
 from core.ini_health import analyze_mod
 from core.texture_profiles import texture_profile_for
 
-from . import (edit_session, ini_api, metadata, mod_folders, mod_loader,
-               present_api, server, toggle_api)
+from . import (asset_folders, edit_session, ini_api, metadata, mod_folders,
+               mod_loader, present_api, server, toggle_api)
 
 
 class ModViewerAPI:
@@ -30,6 +30,8 @@ class ModViewerAPI:
         self._authorized_folders = set()
         self._picker_authorized_folders = set()
         self._authorized_roots = set()
+        self._authorized_asset_folders = set()
+        self._authorized_asset_roots = set()
         self._active_mesh_keys = {}
         try:
             self._authorized_roots = mod_folders.registered_paths(
@@ -37,6 +39,11 @@ class ModViewerAPI:
         except mod_folders.ModFolderError:
             # The UI can report the readable config error. Do not let malformed
             # optional configuration prevent the viewer from starting.
+            pass
+        try:
+            self._authorized_asset_roots = asset_folders.registered_paths(
+                asset_folders.load_registry())
+        except asset_folders.AssetFolderError:
             pass
 
     def _folder(self, folder_path):
@@ -52,6 +59,17 @@ class ModViewerAPI:
         if not requested:
             raise PermissionError("This folder was not selected through the native folder picker.")
         raise PermissionError("This folder was not selected through the native folder picker.")
+
+    def _asset_folder(self, folder_path):
+        requested = asset_folders.normalize_path(folder_path)
+        if requested in self._authorized_asset_folders:
+            return requested
+        if any(asset_folders.is_within(requested, root)
+               for root in self._authorized_asset_roots):
+            self._authorized_asset_folders.add(requested)
+            return requested
+        raise PermissionError(
+            "This folder is not inside a registered Asset Folder.")
 
     @staticmethod
     def _active_texture_source(folder_path, validate=False):
@@ -86,6 +104,9 @@ class ModViewerAPI:
 
     def _refresh_authorized_roots(self, entries):
         self._authorized_roots = mod_folders.registered_paths(entries)
+
+    def _refresh_authorized_asset_roots(self, entries):
+        self._authorized_asset_roots = asset_folders.registered_paths(entries)
 
     def get_mod_folders(self):
         try:
@@ -161,6 +182,75 @@ class ModViewerAPI:
         except mod_folders.ModFolderError as error:
             return {"error": str(error)}
 
+    # -- persistent Asset Folders registry ----------------------------------
+
+    def get_asset_folders(self):
+        try:
+            entries = asset_folders.load_registry()
+        except asset_folders.AssetFolderError as error:
+            return {"folders": [], "error": str(error)}
+        self._refresh_authorized_asset_roots(entries)
+        return {"folders": self._asset_folder_entries(entries)}
+
+    @staticmethod
+    def _asset_folder_entries(entries):
+        return [{**entry, "exists": os.path.isdir(entry["path"])}
+                for entry in entries]
+
+    def add_asset_folder(self, asset_type, folder_path):
+        folder_path = asset_folders.normalize_path(folder_path)
+        if folder_path not in self._picker_authorized_folders:
+            return {"error": "Choose the Asset Folder through the native folder picker first."}
+        try:
+            entries = asset_folders.add_folder(asset_type, folder_path)
+        except asset_folders.AssetFolderError as error:
+            return {"error": str(error)}
+        self._refresh_authorized_asset_roots(entries)
+        self._authorized_asset_folders.add(folder_path)
+        return {"folders": self._asset_folder_entries(entries)}
+
+    def edit_asset_folder(self, original_path, asset_type, folder_path):
+        original_path = asset_folders.normalize_path(original_path)
+        folder_path = asset_folders.normalize_path(folder_path)
+        try:
+            entries = asset_folders.load_registry()
+            if not any(item["path"] == original_path for item in entries):
+                raise asset_folders.AssetFolderError("That Asset Folder is not registered.")
+            if (folder_path != original_path and
+                    folder_path not in self._picker_authorized_folders):
+                raise asset_folders.AssetFolderError(
+                    "Choose the new Asset Folder through the native folder picker first.")
+            entries = asset_folders.edit_folder(original_path, asset_type, folder_path)
+        except asset_folders.AssetFolderError as error:
+            return {"error": str(error)}
+        self._refresh_authorized_asset_roots(entries)
+        self._authorized_asset_folders.add(folder_path)
+        return {"folders": self._asset_folder_entries(entries)}
+
+    def delete_asset_folder(self, folder_path):
+        try:
+            entries = asset_folders.delete_folder(folder_path)
+        except asset_folders.AssetFolderError as error:
+            return {"error": str(error)}
+        self._refresh_authorized_asset_roots(entries)
+        return {"folders": self._asset_folder_entries(entries)}
+
+    def list_asset_subfolders(self, folder_path):
+        requested = asset_folders.normalize_path(folder_path)
+        try:
+            entries = asset_folders.load_registry()
+            roots = [entry["path"] for entry in entries
+                     if asset_folders.is_within(requested, entry["path"])]
+            if not roots:
+                raise PermissionError(
+                    "That folder is not inside a registered Asset Folder.")
+            root = max(roots, key=len)
+            return {"folders": asset_folders.list_subfolders(requested, root)}
+        except PermissionError as error:
+            return {"error": str(error)}
+        except asset_folders.AssetFolderError as error:
+            return {"error": str(error)}
+
     def pick_texture_file(self, folder_path, texture_role=None):
         """Open a native file-picker rooted at the mod folder for the
         per-mesh/per-component texture picker. Returns {"tex_key", "uri"} / {"error"} on
@@ -200,6 +290,12 @@ class ModViewerAPI:
         context = mod_loader.ModLoadContext(
             folder_path, ini_paths, edit_session.documents_for(folder_path),
             metadata.load(folder_path))
+        try:
+            context.asset_folders = asset_folders.load_registry()
+        except asset_folders.AssetFolderError:
+            # Optional asset configuration must not make an otherwise valid
+            # mod unloadable; the asset UI reports the config error directly.
+            context.asset_folders = []
         return folder_path, overrides, pending_new_sections, context
 
     @staticmethod

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -95,6 +95,15 @@ class ModViewerAPI:
         self._picker_authorized_folders.add(folder)
         return folder
 
+    def select_asset_folder(self):
+        """Pick an Asset Folder without granting mod-folder access."""
+        result = self._window.create_file_dialog(webview.FileDialog.FOLDER)
+        if not result:
+            return None
+        folder = asset_folders.normalize_path(result[0])
+        self._picker_authorized_folders.add(folder)
+        return folder
+
     # -- persistent Mod Folders registry -----------------------------------
 
     @staticmethod

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -106,7 +106,12 @@ class ModViewerAPI:
         self._authorized_roots = mod_folders.registered_paths(entries)
 
     def _refresh_authorized_asset_roots(self, entries):
-        self._authorized_asset_roots = asset_folders.registered_paths(entries)
+        roots = asset_folders.registered_paths(entries)
+        self._authorized_asset_roots = roots
+        self._authorized_asset_folders = {
+            path for path in self._authorized_asset_folders
+            if any(asset_folders.is_within(path, root) for root in roots)
+        }
 
     def get_mod_folders(self):
         try:

--- a/src/app/asset_folders.py
+++ b/src/app/asset_folders.py
@@ -1,0 +1,141 @@
+"""Persistent registry and lazy browsing for extracted asset roots."""
+
+import os
+
+from . import config
+
+
+ASSET_TYPES = frozenset({"GIMI", "ZZMI", "WWMI"})
+
+
+class AssetFolderError(ValueError):
+    """A readable asset-folder validation or enumeration failure."""
+
+
+def normalize_path(value):
+    return config.normalize_path(value)
+
+
+def is_within(path, root):
+    return config.is_within(path, root)
+
+
+def _read_config(config_file=None):
+    try:
+        return config.read_config(config_file)
+    except ValueError as error:
+        raise AssetFolderError(str(error)) from error
+
+
+def _read_entries(config_file=None):
+    raw_entries = _read_config(config_file).get("assetFolders", [])
+    if not isinstance(raw_entries, list):
+        raise AssetFolderError("config.json assetFolders must be a list.")
+    entries = []
+    seen = set()
+    for raw in raw_entries:
+        if not isinstance(raw, dict):
+            raise AssetFolderError("Each Asset Folder entry must be an object.")
+        asset_type = raw.get("type")
+        folder = raw.get("path")
+        if asset_type not in ASSET_TYPES:
+            raise AssetFolderError("Asset Folder type must be GIMI, ZZMI or WWMI.")
+        if not isinstance(folder, str) or not os.path.isabs(folder):
+            raise AssetFolderError("Asset Folder path must be absolute.")
+        normalized = normalize_path(folder)
+        if normalized in seen:
+            raise AssetFolderError("config.json contains duplicate Asset Folder paths.")
+        seen.add(normalized)
+        entries.append({"type": asset_type, "path": normalized})
+    return entries
+
+
+def load_registry(config_file=None):
+    return _read_entries(config_file)
+
+
+def registered_paths(entries):
+    return {entry["path"] for entry in entries}
+
+
+def _validated_entry(asset_type, folder, *, require_exists):
+    if asset_type not in ASSET_TYPES:
+        raise AssetFolderError("Asset Folder type must be GIMI, ZZMI or WWMI.")
+    if not isinstance(folder, str) or not os.path.isabs(folder):
+        raise AssetFolderError("Asset Folder path must be absolute.")
+    normalized = normalize_path(folder)
+    if require_exists and not os.path.isdir(normalized):
+        raise AssetFolderError("Asset Folder path must be an existing directory.")
+    return {"type": asset_type, "path": normalized}
+
+
+def _write_entries(entries, config_file=None):
+    value = _read_config(config_file)
+    value["assetFolders"] = entries
+    try:
+        config.write_config(value, config_file)
+    except ValueError as error:
+        raise AssetFolderError(str(error)) from error
+
+
+def add_folder(asset_type, folder, config_file=None):
+    entries = _read_entries(config_file)
+    entry = _validated_entry(asset_type, folder, require_exists=True)
+    if any(item["path"] == entry["path"] for item in entries):
+        raise AssetFolderError("That Asset Folder path is already registered.")
+    entries.append(entry)
+    _write_entries(entries, config_file)
+    return entries
+
+
+def edit_folder(original_folder, asset_type, folder, config_file=None):
+    entries = _read_entries(config_file)
+    original = normalize_path(original_folder)
+    index = next((i for i, item in enumerate(entries)
+                  if item["path"] == original), None)
+    if index is None:
+        raise AssetFolderError("That Asset Folder is not registered.")
+    target = normalize_path(folder)
+    entry = _validated_entry(
+        asset_type, folder, require_exists=(target != original))
+    if any(i != index and item["path"] == entry["path"]
+           for i, item in enumerate(entries)):
+        raise AssetFolderError("That Asset Folder path is already registered.")
+    entries[index] = entry
+    _write_entries(entries, config_file)
+    return entries
+
+
+def delete_folder(folder, config_file=None):
+    entries = _read_entries(config_file)
+    target = normalize_path(folder)
+    filtered = [item for item in entries if item["path"] != target]
+    if len(filtered) == len(entries):
+        raise AssetFolderError("That Asset Folder is not registered.")
+    _write_entries(filtered, config_file)
+    return filtered
+
+
+def list_subfolders(folder, authorized_root):
+    """Return immediate directory children without following root escapes."""
+    folder = normalize_path(folder)
+    authorized_root = normalize_path(authorized_root)
+    if not is_within(folder, authorized_root):
+        raise AssetFolderError("That folder is outside the registered Asset Folder.")
+    if not os.path.isdir(folder):
+        raise AssetFolderError("Folder not found or is not a directory.")
+    children = []
+    try:
+        with os.scandir(folder) as entries:
+            for entry in entries:
+                try:
+                    if not entry.is_dir(follow_symlinks=True):
+                        continue
+                    child = normalize_path(entry.path)
+                    if is_within(child, authorized_root):
+                        children.append({"name": entry.name, "path": child})
+                except OSError:
+                    continue
+    except OSError as error:
+        raise AssetFolderError(f"Unable to read this folder: {error}") from error
+    return sorted(children, key=lambda item: (item["name"].casefold(), item["name"]))

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -1,0 +1,77 @@
+"""Shared persistence and filesystem comparison helpers for app config."""
+
+import json
+import os
+
+from . import paths
+
+
+CONFIG_VERSION = 1
+
+
+def normalize_path(value):
+    """Return the canonical comparison form for a filesystem path."""
+    if value is None:
+        return ""
+    try:
+        value = os.fspath(value)
+    except TypeError:
+        return ""
+    if not isinstance(value, str) or not value.strip():
+        return ""
+    return os.path.normcase(os.path.realpath(os.path.abspath(value)))
+
+
+def is_within(path, root):
+    """Return whether *path* is *root* or a canonical descendant of it."""
+    path = normalize_path(path)
+    root = normalize_path(root)
+    if not path or not root:
+        return False
+    try:
+        return os.path.commonpath([path, root]) == root
+    except ValueError:
+        return False
+
+
+def read_config(config_file=None):
+    """Read the versioned config, preserving optional fields as authored."""
+    filename = config_file_path(config_file)
+    if not os.path.exists(filename):
+        return {"version": CONFIG_VERSION, "modFolders": []}
+    try:
+        with open(filename, encoding="utf-8") as stream:
+            value = json.load(stream)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"Could not read config.json: {error}") from error
+    if not isinstance(value, dict) or value.get("version") != CONFIG_VERSION:
+        raise ValueError(
+            f"Unsupported config.json version; expected {CONFIG_VERSION}.")
+    if not isinstance(value.get("modFolders"), list):
+        raise ValueError("config.json modFolders must be a list.")
+    return value
+
+
+def config_file_path(config_file=None):
+    return os.fspath(config_file or paths.config_path())
+
+
+def write_config(value, config_file=None):
+    """Atomically replace config.json after fully writing and syncing a temp."""
+    filename = config_file_path(config_file)
+    temp_name = filename + ".tmp"
+    try:
+        with open(temp_name, "w", encoding="utf-8", newline="\n") as stream:
+            json.dump(value, stream, indent=2, ensure_ascii=False)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temp_name, filename)
+    except OSError as error:
+        raise ValueError(f"Could not write config.json: {error}") from error
+    finally:
+        if os.path.exists(temp_name):
+            try:
+                os.remove(temp_name)
+            except OSError:
+                pass

--- a/src/app/mod_folders.py
+++ b/src/app/mod_folders.py
@@ -7,13 +7,12 @@ supplies the native-picker authorization needed before a root can be added or
 changed.
 """
 
-import json
 import os
 
-from . import paths
+from . import config
 
 
-CONFIG_VERSION = 1
+CONFIG_VERSION = config.CONFIG_VERSION
 DEFAULT_PANEL_OPACITY = 58
 PANEL_OPACITY_KEY = "panelOpacity"
 
@@ -22,56 +21,15 @@ class ModFolderError(ValueError):
     """A readable validation, config or enumeration failure."""
 
 
-def normalize_path(value):
-    """Return the canonical comparison form for a filesystem path."""
-    if value is None:
-        return ""
-    try:
-        value = os.fspath(value)
-    except TypeError:
-        return ""
-    if not isinstance(value, str):
-        return ""
-    if not value.strip():
-        return ""
-    return os.path.normcase(os.path.realpath(os.path.abspath(value)))
-
-
-def is_within(path, root):
-    """Return whether *path* is *root* or a canonical descendant of it."""
-    path = normalize_path(path)
-    root = normalize_path(root)
-    if not path or not root:
-        return False
-    try:
-        return os.path.commonpath([path, root]) == root
-    except ValueError:
-        # Windows drives (and other incompatible path roots) have no common
-        # path and must never be treated as descendants.
-        return False
-
-
-def _config_file(config_file=None):
-    return os.fspath(config_file or paths.config_path())
+normalize_path = config.normalize_path
+is_within = config.is_within
 
 
 def _read_config(config_file=None):
-    filename = _config_file(config_file)
-    if not os.path.exists(filename):
-        return {"version": CONFIG_VERSION, "modFolders": []}
     try:
-        with open(filename, encoding="utf-8") as stream:
-            config = json.load(stream)
-    except (OSError, json.JSONDecodeError) as error:
-        raise ModFolderError(f"Could not read config.json: {error}") from error
-
-    if not isinstance(config, dict) or config.get("version") != CONFIG_VERSION:
-        raise ModFolderError(
-            f"Unsupported config.json version; expected {CONFIG_VERSION}.")
-    raw_entries = config.get("modFolders")
-    if not isinstance(raw_entries, list):
-        raise ModFolderError("config.json modFolders must be a list.")
-    return config
+        return config.read_config(config_file)
+    except ValueError as error:
+        raise ModFolderError(str(error)) from error
 
 
 def _read_entries(config_file=None):
@@ -112,24 +70,11 @@ def _validated_entry(name, folder, *, require_exists):
     return {"name": name.strip(), "path": normalized}
 
 
-def _write_config(config, config_file=None):
-    filename = _config_file(config_file)
-    temp_name = filename + ".tmp"
+def _write_config(value, config_file=None):
     try:
-        with open(temp_name, "w", encoding="utf-8", newline="\n") as stream:
-            json.dump(config, stream, indent=2, ensure_ascii=False)
-            stream.write("\n")
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(temp_name, filename)
-    except OSError as error:
-        raise ModFolderError(f"Could not write config.json: {error}") from error
-    finally:
-        if os.path.exists(temp_name):
-            try:
-                os.remove(temp_name)
-            except OSError:
-                pass
+        config.write_config(value, config_file)
+    except ValueError as error:
+        raise ModFolderError(str(error)) from error
 
 
 def _write_entries(entries, config_file=None):

--- a/src/app/mod_loader.py
+++ b/src/app/mod_loader.py
@@ -46,6 +46,7 @@ class ModLoadContext:
     ini_paths: list[str]
     docs: dict = field(default_factory=dict)
     metadata: dict = field(default_factory=dict)
+    asset_folders: list = field(default_factory=list)
 
 
 @dataclass

--- a/src/tests/test_asset_folders.py
+++ b/src/tests/test_asset_folders.py
@@ -1,0 +1,95 @@
+import json
+import os
+
+import pytest
+
+from app import asset_folders, mod_folders, paths
+from app.api import ModViewerAPI
+
+
+def _config(tmp_path, entries=None):
+    filename = str(tmp_path / "config.json")
+    with open(filename, "w", encoding="utf-8") as stream:
+        json.dump({"version": 1, "modFolders": entries or []}, stream)
+    return filename
+
+
+def _directory(parent, name):
+    path = parent / name
+    path.mkdir()
+    return str(path)
+
+
+def test_missing_asset_folders_defaults_to_empty_and_preserves_existing_config(tmp_path):
+    filename = _config(tmp_path)
+    assert asset_folders.load_registry(filename) == []
+    root = _directory(tmp_path, "gimi")
+    asset_folders.add_folder("GIMI", root, filename)
+    saved = json.loads(open(filename, encoding="utf-8").read())
+    assert saved["assetFolders"] == [{"type": "GIMI", "path": mod_folders.normalize_path(root)}]
+    assert saved["modFolders"] == []
+
+
+@pytest.mark.parametrize("asset_type", ["GIMI", "ZZMI", "WWMI"])
+def test_supported_asset_types_and_multiple_roots(tmp_path, asset_type):
+    filename = _config(tmp_path)
+    first = _directory(tmp_path, f"{asset_type}-one")
+    second = _directory(tmp_path, f"{asset_type}-two")
+    entries = asset_folders.add_folder(asset_type, first, filename)
+    entries = asset_folders.add_folder(asset_type, second, filename)
+    assert [entry["type"] for entry in entries] == [asset_type, asset_type]
+
+
+@pytest.mark.parametrize("asset_type", ["gimi", "SRMI", ""])
+def test_invalid_asset_type_is_rejected(tmp_path, asset_type):
+    with pytest.raises(asset_folders.AssetFolderError, match="GIMI, ZZMI or WWMI"):
+        asset_folders.add_folder(asset_type, _directory(tmp_path, "root"), _config(tmp_path))
+
+
+def test_duplicate_normalized_path_is_rejected(tmp_path):
+    filename = _config(tmp_path)
+    root = _directory(tmp_path, "root")
+    asset_folders.add_folder("GIMI", root, filename)
+    with pytest.raises(asset_folders.AssetFolderError, match="already registered"):
+        asset_folders.add_folder("ZZMI", os.path.join(root, "."), filename)
+
+
+def test_edit_type_and_delete_preserve_files(tmp_path):
+    filename = _config(tmp_path)
+    root = _directory(tmp_path, "root")
+    asset_folders.add_folder("GIMI", root, filename)
+    entries = asset_folders.edit_folder(root, "WWMI", root, filename)
+    assert entries == [{"type": "WWMI", "path": mod_folders.normalize_path(root)}]
+    assert asset_folders.delete_folder(root, filename) == []
+    assert os.path.isdir(root)
+
+
+def test_asset_child_listing_is_lazy_and_contained(tmp_path):
+    filename = _config(tmp_path)
+    root = _directory(tmp_path, "root")
+    child = _directory(tmp_path / "root", "Character")
+    nested = _directory(tmp_path / "root" / "Character", "Nested")
+    asset_folders.add_folder("GIMI", root, filename)
+    result = asset_folders.list_subfolders(root, root)
+    assert [item["path"] for item in result] == [mod_folders.normalize_path(child)]
+    assert nested not in [item["path"] for item in result]
+
+
+def test_api_asset_authorization_is_separate_from_mod_roots(tmp_path, monkeypatch):
+    filename = _config(tmp_path)
+    mod_root = _directory(tmp_path, "mods")
+    asset_root = _directory(tmp_path, "assets")
+    monkeypatch.setattr(paths, "config_path", lambda: filename)
+    api = ModViewerAPI()
+    api._authorized_folders.add(mod_folders.normalize_path(mod_root))
+    api._picker_authorized_folders.update({
+        mod_folders.normalize_path(mod_root),
+        mod_folders.normalize_path(asset_root),
+    })
+    assert api.add_mod_folder("Mods", mod_root).get("folders")
+    assert api.add_asset_folder("GIMI", asset_root).get("folders")
+    with pytest.raises(PermissionError):
+        api._folder(asset_root)
+    with pytest.raises(PermissionError):
+        api._asset_folder(mod_root)
+    assert api._asset_folder(asset_root) == mod_folders.normalize_path(asset_root)

--- a/src/tests/test_asset_folders.py
+++ b/src/tests/test_asset_folders.py
@@ -1,5 +1,6 @@
 import json
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -93,6 +94,21 @@ def test_api_asset_authorization_is_separate_from_mod_roots(tmp_path, monkeypatc
     with pytest.raises(PermissionError):
         api._asset_folder(mod_root)
     assert api._asset_folder(asset_root) == mod_folders.normalize_path(asset_root)
+
+
+def test_asset_picker_does_not_grant_mod_folder_access(tmp_path, monkeypatch):
+    filename = _config(tmp_path)
+    asset_root = _directory(tmp_path, "assets")
+    monkeypatch.setattr(paths, "config_path", lambda: filename)
+    api = ModViewerAPI()
+    api._window = SimpleNamespace(
+        create_file_dialog=lambda *_args: [asset_root])
+
+    assert api.select_asset_folder() == mod_folders.normalize_path(asset_root)
+    assert mod_folders.normalize_path(asset_root) in api._picker_authorized_folders
+    assert mod_folders.normalize_path(asset_root) not in api._authorized_folders
+    with pytest.raises(PermissionError):
+        api._folder(asset_root)
 
 
 def test_api_asset_authorization_is_revoked_when_root_is_deleted(tmp_path, monkeypatch):

--- a/src/tests/test_asset_folders.py
+++ b/src/tests/test_asset_folders.py
@@ -93,3 +93,19 @@ def test_api_asset_authorization_is_separate_from_mod_roots(tmp_path, monkeypatc
     with pytest.raises(PermissionError):
         api._asset_folder(mod_root)
     assert api._asset_folder(asset_root) == mod_folders.normalize_path(asset_root)
+
+
+def test_api_asset_authorization_is_revoked_when_root_is_deleted(tmp_path, monkeypatch):
+    filename = _config(tmp_path)
+    asset_root = _directory(tmp_path, "assets")
+    monkeypatch.setattr(paths, "config_path", lambda: filename)
+    api = ModViewerAPI()
+    api._picker_authorized_folders.add(mod_folders.normalize_path(asset_root))
+
+    assert api.add_asset_folder("GIMI", asset_root).get("folders")
+    cached_child = os.path.join(asset_root, "Character")
+    assert api._asset_folder(cached_child) == mod_folders.normalize_path(cached_child)
+
+    assert api.delete_asset_folder(asset_root).get("folders") == []
+    with pytest.raises(PermissionError):
+        api._asset_folder(cached_child)

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -532,10 +532,14 @@ def test_left_dock_tabs_toggle_and_keep_aria_state(edge_browser, frontend_url):
     try:
         page.locator("#mod-library-tab").click()
         assert page.locator("#mod-folder-panel").is_visible()
+        assert page.locator("#mod-folder-list").is_hidden()
+        assert page.locator("#mod-folder-empty").is_visible()
         assert page.locator("#mod-library-tab").get_attribute("aria-selected") == "true"
         page.locator("#assets-tab").click()
         assert page.locator("#mod-folder-panel").is_hidden()
         assert page.locator("#asset-folder-panel").is_visible()
+        assert page.locator("#asset-folder-list").is_hidden()
+        assert page.locator("#asset-folder-empty").is_visible()
         assert page.locator("#assets-tab").get_attribute("aria-expanded") == "true"
         page.locator("#assets-tab").click()
         assert page.locator("#asset-folder-panel").is_hidden()
@@ -590,7 +594,7 @@ def test_assets_panel_uses_badges_and_lazy_browse_only_children(
         page.locator(".asset-folder-select", has_text="Character").click()
         assert page.evaluate("window.__fakeApi.calls.loadMod") == []
         page.locator("#asset-folder-add").click()
-        assert page.locator("#afm-type option").all_inner_texts() == ["GIMI", "ZZMI", "WWMI"]
+        assert page.locator("#afm-type option").all_inner_texts() == ["ZZMI", "GIMI", "WWMI"]
     finally:
         context.close()
 

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -321,6 +321,7 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
         "panelOpacity": panel_opacity,
         "panelOpacityApi": panel_opacity_api,
         "calls": {"loadMod": [], "listSubfolders": [], "listAssetSubfolders": [],
+                   "selectAssetFolder": [],
                    "discardChanges": [], "switches": [], "diagnostics": [],
                    "panelOpacity": [], "presentState": [],
                    "controlState": [], "meshSemantics": [],
@@ -342,6 +343,12 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
             select_folder: async () => {
               const path = state.nextPath || null;
               state.nextPath = null;
+              return path;
+            },
+            select_asset_folder: async () => {
+              const path = state.nextPath || null;
+              state.nextPath = null;
+              state.calls.selectAssetFolder.push(path);
               return path;
             },
             load_mod: async path => {
@@ -543,6 +550,8 @@ def test_left_dock_tabs_toggle_and_keep_aria_state(edge_browser, frontend_url):
         assert page.locator("#assets-tab").get_attribute("aria-expanded") == "true"
         page.locator("#assets-tab").click()
         assert page.locator("#asset-folder-panel").is_hidden()
+        assert page.locator("#left-panel-container").is_hidden()
+        assert page.locator("#left-dock-tabs").is_visible()
         assert page.locator(".left-dock-tabs .active").count() == 0
         assert all(value == "false" for value in page.locator(
             ".left-dock-tabs > button").evaluate_all(
@@ -558,13 +567,17 @@ def test_right_dock_tabs_toggle_without_reopening_on_refresh(edge_browser, front
         _open(page, path)
         page.locator("#right-dock.ui-visible").wait_for()
         assert page.locator("#controls-panel").is_visible()
+        assert page.locator("body.right-dock-visible").count() == 1
         page.locator("#controls-tab").click()
         assert page.locator("#controls-panel").is_hidden()
+        assert page.locator("body.right-dock-visible").count() == 0
         assert page.locator("#right-dock .right-dock-tabs").is_visible()
         page.locator("#inspector-tab").click()
         assert page.locator("#inspector-panel").is_visible()
+        assert page.locator("body.right-dock-visible").count() == 1
         page.locator("#inspector-tab").click()
         assert page.locator("#inspector-panel").is_hidden()
+        assert page.locator("body.right-dock-visible").count() == 0
         page.evaluate("window.modViewer.reloadCurrentMod()")
         page.wait_for_function("window.__fakeApi.calls.loadMod.length === 2")
         assert page.locator("#inspector-panel").is_hidden()
@@ -595,6 +608,11 @@ def test_assets_panel_uses_badges_and_lazy_browse_only_children(
         assert page.evaluate("window.__fakeApi.calls.loadMod") == []
         page.locator("#asset-folder-add").click()
         assert page.locator("#afm-type option").all_inner_texts() == ["ZZMI", "GIMI", "WWMI"]
+        page.evaluate("window.__fakeApi.nextPath = 'picked-asset-folder'")
+        page.locator("#afm-browse").click()
+        assert page.locator("#afm-path").input_value() == "picked-asset-folder"
+        assert page.evaluate("window.__fakeApi.calls.selectAssetFolder") == [
+            "picked-asset-folder"]
     finally:
         context.close()
 

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -303,7 +303,7 @@ def edge_browser():
 
 def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
           mod_folders=None, subfolders=None, diagnostics=None, panel_opacity=58,
-          panel_opacity_api=True):
+          panel_opacity_api=True, asset_folders=None, asset_subfolders=None):
     # Playwright's wait_for_function uses eval internally. Bypass the app's
     # production CSP only in this isolated test context so behavioral waits
     # do not require weakening the served application's policy.
@@ -314,11 +314,13 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
         "picks": picks or [],
         "modFolders": mod_folders or [],
         "subfolders": subfolders or {},
+        "assetFolders": asset_folders or [],
+        "assetSubfolders": asset_subfolders or {},
         "diagnostics": diagnostics or {
             "summary": {"issues": 0, "errors": 0}, "files": {}, "issues": []},
         "panelOpacity": panel_opacity,
         "panelOpacityApi": panel_opacity_api,
-        "calls": {"loadMod": [], "listSubfolders": [],
+        "calls": {"loadMod": [], "listSubfolders": [], "listAssetSubfolders": [],
                    "discardChanges": [], "switches": [], "diagnostics": [],
                    "panelOpacity": [], "presentState": [],
                    "controlState": [], "meshSemantics": [],
@@ -414,6 +416,24 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
               state.calls.listSubfolders.push(path);
               return copy({folders: state.subfolders[path] || []});
             },
+            get_asset_folders: async () => copy({folders: state.assetFolders}),
+            add_asset_folder: async (type, path) => {
+              state.assetFolders.push({type, path, exists: true});
+              return copy({folders: state.assetFolders});
+            },
+            edit_asset_folder: async (original, type, path) => {
+              const item = state.assetFolders.find(folder => folder.path === original);
+              if (item) Object.assign(item, {type, path, exists: true});
+              return copy({folders: state.assetFolders});
+            },
+            delete_asset_folder: async path => {
+              state.assetFolders = state.assetFolders.filter(folder => folder.path !== path);
+              return copy({folders: state.assetFolders});
+            },
+            list_asset_subfolders: async path => {
+              state.calls.listAssetSubfolders.push(path);
+              return copy({folders: state.assetSubfolders[path] || []});
+            },
             get_diagnostics: async path => {
               state.calls.diagnostics.push(path);
               return copy(state.diagnostics);
@@ -447,17 +467,8 @@ def _open(page, path):
 
 
 def _open_library(page):
-    launcher = page.locator("#mod-folder-toggle")
-    if launcher.is_visible():
-        launcher.click()
-    else:
-        action = page.locator("#empty-add-folder-btn")
-        opens_dialog = action.inner_text() == "Add Mod Folder"
-        action.click()
-        page.locator("#mod-folder-dock.expanded").wait_for()
-        if opens_dialog:
-            page.locator("#mfm-cancel").click()
-    page.locator("#mod-folder-dock.expanded").wait_for()
+    page.locator("#mod-library-tab").click()
+    page.locator("#mod-folder-panel:not([hidden])").wait_for()
 
 
 def _sample_mesh_pixel(page):
@@ -512,6 +523,74 @@ def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
         assert state["outputColorSpace"] == "srgb"
         assert state["toneMapping"] == 0
         assert state["clearAlpha"] == 1
+    finally:
+        context.close()
+
+
+def test_left_dock_tabs_toggle_and_keep_aria_state(edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {}, asset_folders=[])
+    try:
+        page.locator("#mod-library-tab").click()
+        assert page.locator("#mod-folder-panel").is_visible()
+        assert page.locator("#mod-library-tab").get_attribute("aria-selected") == "true"
+        page.locator("#assets-tab").click()
+        assert page.locator("#mod-folder-panel").is_hidden()
+        assert page.locator("#asset-folder-panel").is_visible()
+        assert page.locator("#assets-tab").get_attribute("aria-expanded") == "true"
+        page.locator("#assets-tab").click()
+        assert page.locator("#asset-folder-panel").is_hidden()
+        assert page.locator(".left-dock-tabs .active").count() == 0
+        assert all(value == "false" for value in page.locator(
+            ".left-dock-tabs > button").evaluate_all(
+                "buttons => buttons.map(button => button.getAttribute('aria-selected'))"))
+    finally:
+        context.close()
+
+
+def test_right_dock_tabs_toggle_without_reopening_on_refresh(edge_browser, frontend_url):
+    path = "fixture-model"
+    context, page = _page(edge_browser, frontend_url, {path: _payload()})
+    try:
+        _open(page, path)
+        page.locator("#right-dock.ui-visible").wait_for()
+        assert page.locator("#controls-panel").is_visible()
+        page.locator("#controls-tab").click()
+        assert page.locator("#controls-panel").is_hidden()
+        assert page.locator("#right-dock .right-dock-tabs").is_visible()
+        page.locator("#inspector-tab").click()
+        assert page.locator("#inspector-panel").is_visible()
+        page.locator("#inspector-tab").click()
+        assert page.locator("#inspector-panel").is_hidden()
+        page.evaluate("window.modViewer.reloadCurrentMod()")
+        page.wait_for_function("window.__fakeApi.calls.loadMod.length === 2")
+        assert page.locator("#inspector-panel").is_hidden()
+        assert page.locator("#controls-panel").is_hidden()
+        assert page.locator("#controls-tab").get_attribute("aria-selected") == "false"
+        assert page.locator("#inspector-tab").get_attribute("aria-expanded") == "false"
+    finally:
+        context.close()
+
+
+def test_assets_panel_uses_badges_and_lazy_browse_only_children(
+        edge_browser, frontend_url):
+    root = "fixture-assets"
+    child = root + r"\Character"
+    context, page = _page(
+        edge_browser, frontend_url, {},
+        asset_folders=[{"type": "GIMI", "path": root, "exists": True}],
+        asset_subfolders={root: [{"name": "Character", "path": child}]},
+    )
+    try:
+        page.locator("#assets-tab").click()
+        page.locator("#asset-folder-list .asset-folder-select").first.wait_for()
+        assert "GIMI" in page.locator("#asset-folder-list").first.inner_text()
+        page.locator("#asset-folder-list .asset-folder-expand").first.click()
+        page.locator(".asset-folder-select", has_text="Character").wait_for()
+        assert page.evaluate("window.__fakeApi.calls.listAssetSubfolders") == [root]
+        page.locator(".asset-folder-select", has_text="Character").click()
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == []
+        page.locator("#asset-folder-add").click()
+        assert page.locator("#afm-type option").all_inner_texts() == ["GIMI", "ZZMI", "WWMI"]
     finally:
         context.close()
 
@@ -2278,7 +2357,7 @@ def test_feature_flag_css_keeps_cycle_preview_and_core_invariants(
         context.close()
 
 
-def test_mod_folder_panel_overlays_sidebar_and_browses_children_lazily(
+def test_mod_folder_panel_browses_children_lazily(
         edge_browser, frontend_url):
     root = _MOD_LIBRARY
     alice = root + r"\Alice"
@@ -2295,35 +2374,12 @@ def test_mod_folder_panel_overlays_sidebar_and_browses_children_lazily(
         },
     )
     try:
-        page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
-        sidebar_before = page.locator("#sidebar").bounding_box()
-        assert "expanded" not in page.locator("#mod-folder-dock").get_attribute("class")
-
         assert page.locator("#empty-add-folder-btn").inner_text() == "Open Mod Folder"
         _open_library(page)
         assert page.locator("#mod-folder-modal-backdrop.show").count() == 0
-        assert page.locator("#mod-folder-panel > .panel-hdr > *").evaluate_all(
-            "nodes => nodes.map(node => node.id || node.tagName)") == [
-                "H3", "mod-folder-add", "mod-folder-close"]
-        header_positions = page.evaluate("""() => {
-          const rect = selector => document.querySelector(selector).getBoundingClientRect();
-          const panel = rect('#mod-folder-panel');
-          const label = rect('#mod-folder-panel > .panel-hdr h3');
-          const add = rect('#mod-folder-add');
-          const close = rect('#mod-folder-close');
-          return {
-            addBesideLabel: add.left >= label.right && add.left - label.right <= 8,
-            closeAtRight: close.right >= panel.right - 16,
-          };
-        }""")
-        assert header_positions == {"addBesideLabel": True, "closeAtRight": True}
-        sidebar_after = page.locator("#sidebar").bounding_box()
-        assert sidebar_after == sidebar_before
-        z_indices = page.evaluate("""() => ({
-          dock: getComputedStyle(document.querySelector('#mod-folder-dock')).zIndex,
-          leftDock: getComputedStyle(document.querySelector('#left-dock')).zIndex,
-        })""")
-        assert int(z_indices["dock"]) > int(z_indices["leftDock"])
+        assert page.locator("#mod-folder-panel").is_visible()
+        assert page.locator("#sidebar").is_hidden()
+        assert page.locator("#mod-library-tab").get_attribute("aria-expanded") == "true"
 
         root_node = page.locator("#mod-folder-list > .mod-folder-node").first
         arrow_style = page.evaluate("""() => {
@@ -2331,7 +2387,7 @@ def test_mod_folder_panel_overlays_sidebar_and_browses_children_lazily(
           const style = getComputedStyle(arrow);
           return {width: style.width, height: style.height, fontSize: style.fontSize};
         }""")
-        assert arrow_style == {"width": "20px", "height": "22px", "fontSize": "13px"}
+        assert arrow_style == {"width": "20px", "height": "22px", "fontSize": "18px"}
         root_node.locator(":scope > .mod-folder-row > .mod-folder-expand").click()
         page.locator(".mod-folder-select", has_text="Alice").wait_for()
         assert page.evaluate("window.__fakeApi.calls.listSubfolders") == [root]
@@ -2350,33 +2406,33 @@ def test_mod_folder_panel_overlays_sidebar_and_browses_children_lazily(
         root_arrow.click()
         assert not root_children.is_hidden()
         assert page.evaluate("window.__fakeApi.calls.listSubfolders") == [root, alice]
+        page.locator("#mod-library-tab").click()
+        assert page.locator("#mod-folder-panel").is_hidden()
+        assert page.locator("#sidebar").is_hidden()
+        assert page.locator(".left-dock-tabs .active").count() == 0
     finally:
         context.close()
 
 
-def test_empty_mod_folder_panel_keeps_fixed_height_above_navigation_hint(
+def test_empty_mod_folder_panel_stays_above_navigation_hint(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {}, mod_folders=[])
     try:
         assert page.locator("#empty-add-folder-btn").inner_text() == "Add Mod Folder"
         page.locator("#empty-add-folder-btn").click()
-        page.locator("#mod-folder-dock.expanded").wait_for()
+        page.locator("#mod-folder-panel:not([hidden])").wait_for()
         page.locator("#mod-folder-modal-backdrop.show").wait_for()
         page.locator("#mfm-cancel").click()
         panel = page.locator("#mod-folder-panel").bounding_box()
         info = page.locator("#footer").bounding_box()
-        viewport_height = page.evaluate("window.innerHeight")
-        assert page.locator("#sidebar > .panel-hdr #mod-folder-toggle").count() == 1
-        assert page.locator("#mod-folder-dock > #mod-folder-toggle").count() == 0
-        assert abs(panel["height"] - (viewport_height - 112)) < 1
         assert panel["y"] + panel["height"] <= info["y"]
         assert page.locator("#mod-folder-list").inner_text() == ""
         assert page.evaluate("""() => {
           const panel = document.querySelector('#mod-folder-panel');
           return {inert: panel.inert, ariaHidden: panel.getAttribute('aria-hidden')};
         }""") == {"inert": False, "ariaHidden": "false"}
-        page.locator("#mod-folder-close").click()
-        assert "expanded" not in page.locator("#mod-folder-dock").get_attribute("class")
+        page.locator("#mod-library-tab").click()
+        assert page.locator("#mod-folder-panel").is_hidden()
         assert page.evaluate("document.querySelector('#mod-folder-panel').inert")
     finally:
         context.close()
@@ -2392,24 +2448,23 @@ def test_mod_folder_name_selection_preserves_dock_state_across_reload(
         subfolders={root: [{"name": "Alice", "path": alice}]},
     )
     try:
-        page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
         _open_library(page)
         page.locator("#mod-folder-list > .mod-folder-node .mod-folder-expand").click()
         page.locator(".mod-folder-select", has_text="Alice").click()
         page.locator(".draw-item").wait_for(state="attached")
         assert page.evaluate("window.__fakeApi.calls.loadMod") == [alice]
-        assert "expanded" in page.locator("#mod-folder-dock").get_attribute("class")
+        assert page.locator("#mod-library-tab").get_attribute("aria-expanded") == "true"
         page.locator("#mod-folder-list > .mod-folder-node > .mod-folder-row > .mod-folder-expand").click()
         assert "active-descendant" in page.locator(
             "#mod-folder-list > .mod-folder-node > .mod-folder-row").get_attribute("class")
 
         page.evaluate("window.modViewer.reloadCurrentMod()")
         page.wait_for_function("window.__fakeApi.calls.loadMod.length === 2")
-        assert "expanded" in page.locator("#mod-folder-dock").get_attribute("class")
-        page.locator("#mod-folder-close").click()
+        assert page.locator("#mod-library-tab").get_attribute("aria-expanded") == "true"
+        page.locator("#mod-library-tab").click()
         page.evaluate("window.modViewer.reloadCurrentMod()")
         page.wait_for_function("window.__fakeApi.calls.loadMod.length === 3")
-        assert "expanded" not in page.locator("#mod-folder-dock").get_attribute("class")
+        assert page.locator("#mod-folder-panel").is_hidden()
     finally:
         context.close()
 
@@ -2917,7 +2972,6 @@ def test_reload_and_tree_selection_share_one_transition_guard(
         ]},
     )
     try:
-        page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
         _open_library(page)
         page.locator("#mod-folder-list > .mod-folder-node .mod-folder-expand").click()
         page.locator(".mod-folder-select", has_text="Alice").click()
@@ -2958,7 +3012,6 @@ def test_mod_folder_failed_selection_keeps_panel_open_and_reports_error(
         ],
     )
     try:
-        page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
         _open_library(page)
         page.locator(".mod-folder-select", has_text="Alice").click()
         page.locator(".draw-item").wait_for(state="attached")
@@ -2966,7 +3019,8 @@ def test_mod_folder_failed_selection_keeps_panel_open_and_reports_error(
 
         page.locator(".mod-folder-select", has_text="Broken").click()
         page.locator("#dialog-backdrop.show").wait_for()
-        assert page.locator("#mod-folder-dock.expanded").count() == 1
+        assert page.locator("#mod-folder-panel").is_visible()
+        assert page.locator("#mod-library-tab").get_attribute("aria-expanded") == "true"
         assert page.locator(".mod-folder-row.active").count() == 0
         assert page.locator(".draw-item").count() == 0
         page.locator("#dialog-ok").click()
@@ -2990,7 +3044,6 @@ def test_mod_folder_tree_switch_respects_pending_change_confirmation(
         ]},
     )
     try:
-        page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
         _open_library(page)
         page.locator("#mod-folder-list > .mod-folder-node .mod-folder-expand").click()
         page.locator(".mod-folder-select", has_text="First").click()
@@ -3002,7 +3055,8 @@ def test_mod_folder_tree_switch_respects_pending_change_confirmation(
             "This mod has unsaved changes")
         page.locator("#dialog-cancel").click()
         assert page.evaluate("window.__fakeApi.calls.loadMod") == [first]
-        assert page.locator("#mod-folder-dock.expanded").count() == 1
+        assert page.locator("#mod-folder-panel").is_visible()
+        assert page.locator("#mod-library-tab").get_attribute("aria-expanded") == "true"
     finally:
         context.close()
 
@@ -3016,7 +3070,6 @@ def test_mod_folder_add_edit_delete_modal_flow(
         mod_folders=[{"name": "Original", "path": original, "exists": True}],
     )
     try:
-        page.locator("#mod-folder-list .mod-folder-select").first.wait_for()
         _open_library(page)
 
         page.locator("#mod-folder-add").click()
@@ -3065,7 +3118,7 @@ def test_mod_folder_add_edit_delete_modal_flow(
         }""")
         assert all(item["button"] >= item["menu"] - 12 for item in menu_widths)
         assert original_menu.locator("button").all_inner_texts() == [
-            "Edit", "Remove from Mod Library"]
+            "Edit", "Remove"]
         page.locator(".mod-folder-node").filter(has_text="Original").locator(
             ".mod-folder-action-menu button", has_text="Edit").click()
         assert page.locator(
@@ -3099,8 +3152,9 @@ def test_missing_opacity_bridge_does_not_block_open_or_mod_library(
         page.locator("#empty-add-folder-btn").click()
         page.locator("#mod-folder-modal-backdrop.show").wait_for()
         page.locator("#mfm-cancel").click()
-        page.locator("#mod-folder-close").click()
+        page.locator("#mod-library-tab").click()
         _open(page, "A")
+        page.locator("#meshes-tab").click()
         page.locator(".draw-item").wait_for()
     finally:
         context.close()
@@ -3257,47 +3311,27 @@ def test_inspector_follows_component_and_mesh_selection(
         assert page.locator("#interaction-help").inner_text() == "LMB Orbit · RMB Pan · Wheel Zoom"
         assert page.locator("#sidebar > .panel-hdr .group-toggle").evaluate(
             "button => button.tagName") == "BUTTON"
-        assert page.locator("#sidebar > .panel-hdr #mod-folder-toggle").count() == 1
-        assert page.locator("#mod-folder-dock > #mod-folder-toggle").count() == 0
         assert page.locator("#sidebar > .panel-hdr #reset-state-btn").count() == 1
         assert page.locator("#sidebar > .panel-hdr > *").evaluate_all(
             "nodes => nodes.map(node => node.id || node.tagName)") == [
-                "BUTTON", "H3", "reset-state-btn", "mod-folder-toggle"]
-        header_positions = page.evaluate("""() => {
-          const rect = selector => document.querySelector(selector).getBoundingClientRect();
-          const label = rect('#sidebar > .panel-hdr h3');
-          const reset = rect('#reset-state-btn');
-          const library = rect('#mod-folder-toggle');
-              return {
-                resetAfterLabel: reset.left >= label.right,
-                libraryAfterReset: library.left >= reset.right,
-                libraryAtRight: library.right >=
-                  document.querySelector('#sidebar').getBoundingClientRect().right - 16,
-              };
-            }""")
-        assert header_positions == {
-            "resetAfterLabel": True,
-            "libraryAfterReset": True,
-            "libraryAtRight": True,
-        }, header_positions
+                "BUTTON", "H3", "reset-state-btn"]
         assert page.locator("#sidebar > .panel-hdr .group-toggle").get_attribute(
             "aria-expanded") == "true"
         assert page.locator("#sidebar").is_visible()
-        left_dock_before = page.locator("#left-dock").evaluate(
-            "dock => ({width: dock.offsetWidth, height: dock.offsetHeight})")
-        page.locator("#mod-folder-toggle").click()
+        assert page.locator("#meshes-tab").get_attribute("aria-expanded") == "true"
+        page.locator("#mod-library-tab").click()
         assert page.locator("#sidebar").is_hidden()
-        assert page.locator("#left-dock").evaluate(
-            "dock => ({width: dock.offsetWidth, height: dock.offsetHeight})") == (
-                left_dock_before)
-        assert page.locator("#mod-folder-close").evaluate(
-            "button => document.activeElement === button")
+        assert page.locator("#mod-folder-panel").is_visible()
+        assert page.locator("#mod-library-tab").get_attribute("aria-expanded") == "true"
         assert page.locator("#sidebar > .panel-hdr .group-toggle").get_attribute(
             "aria-expanded") == "true"
-        page.locator("#mod-folder-close").click()
+        page.locator("#mod-library-tab").click()
+        assert page.locator("#sidebar").is_hidden()
+        assert page.locator("#mod-folder-panel").is_hidden()
+        assert page.locator(".left-dock-tabs .active").count() == 0
+        page.locator("#meshes-tab").click()
         assert page.locator("#sidebar").is_visible()
-        assert page.locator("#mod-folder-toggle").evaluate(
-            "button => document.activeElement === button")
+        assert page.locator("#meshes-tab").get_attribute("aria-expanded") == "true"
         page.locator("#reset-state-btn").click()
         assert page.locator("#sidebar > .panel-hdr .group-toggle").get_attribute(
             "aria-expanded") == "true"
@@ -3516,9 +3550,9 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
           const panel = document.querySelector('#mod-folder-panel');
           return panel.inert && panel.getAttribute('aria-hidden') === 'true';
         }""")
-        page.locator("#mod-folder-toggle").click()
+        page.locator("#mod-library-tab").click()
         assert page.evaluate("document.querySelector('#mod-folder-panel').inert === false")
-        page.locator("#mod-folder-close").click()
+        page.locator("#mod-library-tab").click()
         assert page.evaluate("""() => {
           const panel = document.querySelector('#mod-folder-panel');
           return panel.inert && panel.getAttribute('aria-hidden') === 'true';

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -197,32 +197,6 @@ body {
   max-height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
 }
 
-/* Mod Folders is an overlay owned by the left dock. It must not become a
- * flex item: opening it covers MESHES instead of moving the model panel. */
-#mod-folder-dock {
-  position: fixed; top: calc(var(--toolbar-height) + 4px); left: 12px; z-index: 130;
-  width: 288px; max-width: min(288px, calc(50vw - 36px));
-  height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
-  pointer-events: none;
-}
-#mod-folder-panel {
-  width: 100%; height: 100%; min-height: 0;
-  display: flex; flex-direction: column; overflow: hidden;
-  background: rgba(13,17,23,.96); border: 1px solid var(--border);
-  border-radius: 8px; padding: 10px 14px; backdrop-filter: blur(8px);
-  opacity: 0; pointer-events: none; transform: translateX(-106%);
-  transition: transform .16s ease, opacity .16s ease;
-}
-#mod-folder-dock.expanded #mod-folder-panel {
-  opacity: 1; pointer-events: auto; transform: translateX(0);
-}
-#mod-folder-dock.expanded ~ #sidebar {
-  visibility: hidden; opacity: 0; pointer-events: none;
-}
-#mod-folder-dock .panel-hdr { margin-bottom: 8px; cursor: default; }
-#mod-folder-dock h3 { font-size: 10px; color: var(--text-muted); text-transform: uppercase;
-  letter-spacing: .1em; margin: 0; flex: 0 0 auto; }
-.mod-folder-close { margin-left: auto; }
 .mod-folder-error {
   display: none; margin-bottom: 8px; padding: 6px 8px; border-radius: 5px;
   color: var(--danger); background: rgba(248,81,73,.1);
@@ -347,7 +321,6 @@ body {
   letter-spacing: .1em; margin: 0; flex: 1;
 }
 #sidebar > .panel-hdr h3 { flex: 0 0 auto; }
-#sidebar > .panel-hdr #mod-folder-toggle { margin-left: auto; }
 
 /* ── toolbox (wireframe / grid) ───────────────────────────────────────────── */
 #tool-panel {
@@ -848,7 +821,6 @@ body.feature-modify-toggle-off .present-author-actions { display: none; }
 
 @media (max-width: 900px) {
   #sidebar { width: 230px; max-width: calc(50vw - 28px); }
-  #mod-folder-dock { width: 230px; max-width: calc(50vw - 28px); }
   #present-panel, #toggle-panel, #menu-panel { width: 250px; max-width: calc(50vw - 20px); }
   #menu-list.image-layout { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   #menu-list.image-layout > .toggle-src-items {
@@ -1135,4 +1107,103 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 @media (max-width: 680px) {
   #toolbar-more { display: inline-grid; place-items: center; }
   #toolbar .toolbar-secondary { display: none; }
+}
+
+/* Dock navigation and shared registry panels.  The tab row remains mounted
+ * while its selected panel is hidden, so a second click is a true close. */
+#left-dock {
+  display: flex; flex-direction: column; align-items: stretch; gap: 8px;
+  width: 288px; max-width: min(288px, calc(50vw - 36px));
+}
+#left-dock-tabs { width: 100%; }
+.dock-tabs {
+  display: grid; gap: 3px; padding: 3px;
+  background: rgba(13,17,23,var(--panel-opacity));
+  border: 1px solid rgba(139,148,158,.45);
+  border-radius: var(--radius-md); backdrop-filter: blur(var(--panel-blur));
+  box-shadow: 0 6px 20px rgba(0,0,0,var(--panel-shadow-opacity));
+}
+.left-dock-tabs { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.dock-tab, .right-dock-tab {
+  min-height: 32px; border: 0; border-radius: var(--radius-sm);
+  color: var(--text-muted); background: transparent; cursor: pointer;
+  font-size: 11px; font-weight: 700; letter-spacing: .02em;
+}
+.dock-tab { display: inline-flex; align-items: center; justify-content: center; gap: 5px; padding: 0 5px; }
+.dock-tab .ui-icon { width: 15px; height: 15px; }
+.dock-tab:hover, .right-dock-tab:hover { color: var(--text); background: var(--surface-hover); }
+.dock-tab.active, .right-dock-tab.active { color: var(--text); background: var(--accent); }
+.dock-tab:disabled { color: var(--text-muted); opacity: .45; cursor: default; }
+#left-panel-container {
+  width: 100%; height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
+  min-height: 0;
+}
+.left-dock-panel {
+  box-sizing: border-box; width: 100%; height: 100%; min-height: 0;
+  display: flex !important; flex-direction: column; overflow: hidden;
+  padding: 10px 14px; border-radius: 8px;
+  background: rgba(13,17,23,var(--panel-opacity));
+  border: 1px solid rgba(139,148,158,.45);
+  backdrop-filter: blur(var(--panel-blur));
+  box-shadow: 0 6px 20px rgba(0,0,0,var(--panel-shadow-opacity));
+}
+.left-dock-panel[hidden] { display: none !important; }
+.left-dock-panel .panel-hdr { margin-bottom: 8px; cursor: default; }
+.left-dock-panel h3 { font-size: 10px; color: var(--text-muted); text-transform: uppercase;
+  letter-spacing: .1em; margin: 0; flex: 0 0 auto; }
+.left-dock-panel .mod-folder-list,
+.left-dock-panel .asset-folder-list { flex: 1; overflow-y: auto; min-height: 0; }
+.asset-folder-error { display: none; margin-bottom: 8px; padding: 6px 8px; border-radius: 5px;
+  color: var(--danger); background: rgba(248,81,73,.1); border: 1px solid rgba(248,81,73,.35);
+  font-size: 11px; white-space: pre-wrap; }
+.asset-folder-error.show { display: block; }
+.asset-folder-empty[hidden] { display: none; }
+.asset-folder-empty .ui-button { margin-top: 5px; }
+.folder-node { min-width: 0; }
+.folder-row { position: relative; display: flex; align-items: center; gap: 4px; min-height: 32px;
+  padding: 3px 0; border-radius: 5px; }
+.folder-row.active { background: rgba(31,111,235,.24); }
+.folder-row.active-descendant { box-shadow: inset 2px 0 0 var(--accent-soft); background: rgba(31,111,235,.09); }
+.folder-row.missing { opacity: .58; }
+.folder-expand { width: 20px; height: 22px; flex: 0 0 20px; padding: 0; border: 0;
+  background: transparent; color: var(--text-muted); cursor: pointer; font-size: 18px; line-height: 1; }
+.folder-expand.expanded { transform: rotate(90deg); }
+.folder-expand.leaf { visibility: hidden; pointer-events: none; }
+.folder-select { min-width: 0; flex: 1; min-height: 28px; padding: 3px 4px; border: 0;
+  background: transparent; color: var(--text); text-align: left; cursor: pointer;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: inherit; }
+.folder-select:hover { color: var(--accent-soft); }
+.folder-actions { position: relative; display: inline-flex; align-items: center; gap: 4px; flex: 0 0 auto; }
+.folder-actions button { width: 28px; height: 28px; padding: 0; border: 0; border-radius: 4px;
+  background: transparent; color: var(--text-muted); cursor: pointer; }
+.folder-actions button .ui-icon { width: 16px; height: 16px; }
+.folder-actions button:hover { color: var(--text); background: var(--accent); }
+.folder-action-menu { position: absolute; top: calc(100% + 5px); right: 0; z-index: 180;
+  display: flex; flex-direction: column; gap: 2px; width: max-content; min-width: 170px;
+  max-width: calc(100vw - 16px); padding: 5px; background: rgba(22,27,34,.98);
+  border: 1px solid var(--border); border-radius: var(--radius-md); box-shadow: 0 10px 28px rgba(0,0,0,.45); }
+.folder-action-menu[hidden] { display: none; }
+.folder-action-menu button { display: block; width: 100%; height: auto; min-height: 30px; padding: 5px 8px;
+  border: 0; border-radius: var(--radius-sm); color: var(--text); background: transparent;
+  text-align: left; cursor: pointer; font: inherit; font-size: 11px; white-space: nowrap; }
+.folder-action-menu button:hover { background: var(--surface-active); }
+.folder-children { display: flex; flex-direction: column; gap: 1px; margin-left: 20px; }
+.folder-children[hidden] { display: none; }
+.folder-child-error { padding: 4px 4px 4px 20px; color: var(--danger); font-size: 10px; }
+.folder-missing { display: flex; align-items: center; gap: 4px; padding: 0 4px 4px 24px;
+  color: var(--text-muted); font-size: 10px; }
+.folder-missing .ui-icon { width: 13px; height: 13px; color: var(--warning); }
+.asset-folder-label { display: inline-flex; align-items: center; gap: 7px; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.asset-folder-badge { flex: 0 0 auto; padding: 2px 5px; border-radius: 4px; color: var(--accent-soft);
+  background: var(--surface-active); font-size: 9px; font-weight: 800; letter-spacing: .05em; }
+#sidebar.left-dock-panel { overflow-x: hidden; overflow-y: auto; }
+#mod-folder-panel .mod-folder-empty,
+#asset-folder-panel .asset-folder-empty { flex: 1; }
+#sidebar[hidden], #mod-folder-panel[hidden], #asset-folder-panel[hidden] { display: none !important; }
+#left-dock.ui-visible { /* the row is kept for compatibility with viewport math */ }
+
+@media (max-width: 900px) {
+  #left-dock { width: 230px; max-width: calc(50vw - 28px); }
+  .dock-tab { font-size: 10px; }
+  .dock-tab .ui-icon { display: none; }
 }

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -1142,6 +1142,7 @@ button:focus-visible, input:focus-visible, select:focus-visible,
   width: 100%; height: calc(100vh - var(--toolbar-height) - var(--footer-height) - var(--dock-gap));
   min-height: 0;
 }
+#left-dock:not(.ui-visible) #left-panel-container { display: none; }
 .left-dock-panel {
   box-sizing: border-box; width: 100%; height: 100%; min-height: 0;
   display: flex !important; flex-direction: column; overflow: hidden;
@@ -1203,7 +1204,6 @@ button:focus-visible, input:focus-visible, select:focus-visible,
   background: var(--surface-active); font-size: 9px; font-weight: 800; letter-spacing: .05em; }
 #sidebar.left-dock-panel { overflow-x: hidden; overflow-y: auto; }
 #sidebar[hidden], #mod-folder-panel[hidden], #asset-folder-panel[hidden] { display: none !important; }
-#left-dock.ui-visible { /* the row is kept for compatibility with viewport math */ }
 
 @media (max-width: 900px) {
   #left-dock { width: 230px; max-width: calc(50vw - 28px); }

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -969,13 +969,16 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 #controls-panel > #menu-panel {
   width: 100%; max-width: none; flex: 0 0 auto; max-height: none; overflow: visible;
 }
-.inspector-empty, .mod-folder-empty {
+.inspector-empty, .folder-registry-empty {
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 7px; min-height: 150px; padding: 20px; text-align: center; color: var(--text-muted);
   font-size: 11px; line-height: 1.4;
 }
 #inspector-empty[hidden] { display: none; }
-.inspector-empty strong, .mod-folder-empty strong { color: var(--text); font-size: 12px; }
+.folder-registry-empty {
+  flex: 1; align-items: flex-start; gap: 8px; min-height: 0; text-align: left;
+}
+.inspector-empty strong, .folder-registry-empty strong { color: var(--text); font-size: 12px; }
 .empty-icon {
   display: grid; place-items: center; width: 34px; height: 34px; margin-bottom: 3px;
   border: 1px solid var(--border); border-radius: 10px; color: var(--accent-soft);
@@ -1123,13 +1126,14 @@ button:focus-visible, input:focus-visible, select:focus-visible,
   border-radius: var(--radius-md); backdrop-filter: blur(var(--panel-blur));
   box-shadow: 0 6px 20px rgba(0,0,0,var(--panel-shadow-opacity));
 }
-.left-dock-tabs { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.left-dock-tabs { grid-template-columns: .9fr 1.2fr .9fr; }
 .dock-tab, .right-dock-tab {
   min-height: 32px; border: 0; border-radius: var(--radius-sm);
   color: var(--text-muted); background: transparent; cursor: pointer;
   font-size: 11px; font-weight: 700; letter-spacing: .02em;
 }
-.dock-tab { display: inline-flex; align-items: center; justify-content: center; gap: 5px; padding: 0 5px; }
+.dock-tab { display: inline-flex; align-items: center; justify-content: center; gap: 4px; padding: 0 5px; }
+.dock-tab span { white-space: nowrap; }
 .dock-tab .ui-icon { width: 15px; height: 15px; }
 .dock-tab:hover, .right-dock-tab:hover { color: var(--text); background: var(--surface-hover); }
 .dock-tab.active, .right-dock-tab.active { color: var(--text); background: var(--accent); }
@@ -1153,12 +1157,13 @@ button:focus-visible, input:focus-visible, select:focus-visible,
   letter-spacing: .1em; margin: 0; flex: 0 0 auto; }
 .left-dock-panel .mod-folder-list,
 .left-dock-panel .asset-folder-list { flex: 1; overflow-y: auto; min-height: 0; }
+.folder-registry-list[hidden] { display: none; }
 .asset-folder-error { display: none; margin-bottom: 8px; padding: 6px 8px; border-radius: 5px;
   color: var(--danger); background: rgba(248,81,73,.1); border: 1px solid rgba(248,81,73,.35);
   font-size: 11px; white-space: pre-wrap; }
 .asset-folder-error.show { display: block; }
-.asset-folder-empty[hidden] { display: none; }
-.asset-folder-empty .ui-button { margin-top: 5px; }
+.folder-registry-empty[hidden] { display: none; }
+.folder-registry-empty .ui-button { margin-top: 5px; }
 .folder-node { min-width: 0; }
 .folder-row { position: relative; display: flex; align-items: center; gap: 4px; min-height: 32px;
   padding: 3px 0; border-radius: 5px; }
@@ -1197,8 +1202,6 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 .asset-folder-badge { flex: 0 0 auto; padding: 2px 5px; border-radius: 4px; color: var(--accent-soft);
   background: var(--surface-active); font-size: 9px; font-weight: 800; letter-spacing: .05em; }
 #sidebar.left-dock-panel { overflow-x: hidden; overflow-y: auto; }
-#mod-folder-panel .mod-folder-empty,
-#asset-folder-panel .asset-folder-empty { flex: 1; }
 #sidebar[hidden], #mod-folder-panel[hidden], #asset-folder-panel[hidden] { display: none !important; }
 #left-dock.ui-visible { /* the row is kept for compatibility with viewport math */ }
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -148,8 +148,8 @@
                 title="Add Mod Folder"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
       </div>
       <div id="mod-folder-error" class="mod-folder-error" role="alert"></div>
-      <div id="mod-folder-list" class="mod-folder-list"></div>
-      <div id="mod-folder-empty" class="mod-folder-empty" hidden>
+      <div id="mod-folder-list" class="mod-folder-list folder-registry-list"></div>
+      <div id="mod-folder-empty" class="mod-folder-empty folder-registry-empty" hidden>
         <div class="empty-icon" aria-hidden="true"><svg class="ui-icon"><use href="#icon-library"></use></svg></div>
         <strong>No mod folders yet</strong>
         <span>Add frequently used mod folders here for quick access.</span>
@@ -164,8 +164,8 @@
                 title="Add Asset Folder" aria-label="Add Asset Folder"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
       </div>
       <div id="asset-folder-error" class="asset-folder-error" role="alert"></div>
-      <div id="asset-folder-list" class="asset-folder-list"></div>
-      <div id="asset-folder-empty" class="asset-folder-empty" hidden>
+      <div id="asset-folder-list" class="asset-folder-list folder-registry-list"></div>
+      <div id="asset-folder-empty" class="asset-folder-empty folder-registry-empty" hidden>
         <div class="empty-icon" aria-hidden="true"><svg class="ui-icon"><use href="#icon-assets"></use></svg></div>
         <strong>No asset folders yet</strong>
         <span>Add extracted asset folders for future asset-aware loading.</span>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -12,6 +12,8 @@
 
 <svg id="ui-icon-sprite" aria-hidden="true" focusable="false">
   <symbol id="icon-library" viewBox="0 0 24 24"><path d="M4 6h6l2 2h8v11H4z"/><path d="M4 9h16"/></symbol>
+  <symbol id="icon-mesh" viewBox="0 0 24 24"><path d="m12 3 8 4.5v9L12 21l-8-4.5v-9L12 3Z"/><path d="m4 7.5 8 4.5 8-4.5M12 12v9"/></symbol>
+  <symbol id="icon-assets" viewBox="0 0 24 24"><path d="M4 7h5l2 2h9v11H4z"/><path d="M4 7V4h7l2 3M8 13h8M8 17h5"/></symbol>
   <symbol id="icon-inspector" viewBox="0 0 24 24"><path d="M5 4h14v16H5zM8 8h8M8 12h5M8 16h8"/></symbol>
   <symbol id="icon-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></symbol>
   <symbol id="icon-more" viewBox="0 0 24 24"><circle cx="5" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="19" cy="12" r="1.5"/></symbol>
@@ -123,14 +125,27 @@
 </div>
 
 <div id="left-dock">
-  <div id="mod-folder-dock" class="mod-folder-dock">
-    <section id="mod-folder-panel" class="mod-folder-panel" aria-label="Mod Library">
+  <nav id="left-dock-tabs" class="dock-tabs left-dock-tabs" role="tablist" aria-label="Viewer panels">
+    <button id="meshes-tab" class="dock-tab" data-left-tab="meshes" type="button" role="tab"
+            aria-selected="false" aria-expanded="false" aria-controls="sidebar" aria-disabled="true">
+      <svg class="ui-icon" aria-hidden="true"><use href="#icon-mesh"></use></svg><span>Meshes</span>
+    </button>
+    <button id="mod-library-tab" class="dock-tab" data-left-tab="mod-library" type="button" role="tab"
+            aria-selected="false" aria-expanded="false" aria-controls="mod-folder-panel">
+      <svg class="ui-icon" aria-hidden="true"><use href="#icon-library"></use></svg><span>Mod Library</span>
+    </button>
+    <button id="assets-tab" class="dock-tab" data-left-tab="assets" type="button" role="tab"
+            aria-selected="false" aria-expanded="false" aria-controls="asset-folder-panel">
+      <svg class="ui-icon" aria-hidden="true"><use href="#icon-assets"></use></svg><span>Assets</span>
+    </button>
+  </nav>
+
+  <div id="left-panel-container">
+    <section id="mod-folder-panel" class="left-dock-panel" role="tabpanel" aria-labelledby="mod-library-tab" aria-label="Mod Library" hidden>
       <div class="panel-hdr">
         <h3>Mod Library</h3>
         <button id="mod-folder-add" class="icon-btn" type="button"
                 title="Add Mod Folder"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
-        <button id="mod-folder-close" class="icon-btn mod-folder-close" type="button"
-                aria-label="Close Mod Library"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-left"></use></svg></button>
       </div>
       <div id="mod-folder-error" class="mod-folder-error" role="alert"></div>
       <div id="mod-folder-list" class="mod-folder-list"></div>
@@ -141,17 +156,31 @@
         <button id="mod-folder-empty-add" class="ui-button ui-button-primary" type="button">Add Mod Folder</button>
       </div>
     </section>
-  </div>
 
-  <div id="sidebar">
-    <div class="panel-hdr">
-      <button type="button" class="group-toggle" aria-expanded="true" aria-controls="mesh-list"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
-      <h3>Meshes</h3>
-      <button id="reset-state-btn" class="icon-btn" title="Reset mesh visibility" aria-label="Reset mesh visibility"><svg class="ui-icon" aria-hidden="true"><use href="#icon-reset"></use></svg></button>
-      <button id="mod-folder-toggle" class="icon-btn mesh-library-btn" type="button"
-              title="Open Mod Library" aria-label="Open Mod Library" aria-expanded="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-library"></use></svg></button>
-    </div>
-    <div id="mesh-list"></div>
+    <section id="asset-folder-panel" class="left-dock-panel" role="tabpanel" aria-labelledby="assets-tab" aria-label="Assets" hidden>
+      <div class="panel-hdr">
+        <h3>Assets</h3>
+        <button id="asset-folder-add" class="icon-btn" type="button"
+                title="Add Asset Folder" aria-label="Add Asset Folder"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
+      </div>
+      <div id="asset-folder-error" class="asset-folder-error" role="alert"></div>
+      <div id="asset-folder-list" class="asset-folder-list"></div>
+      <div id="asset-folder-empty" class="asset-folder-empty" hidden>
+        <div class="empty-icon" aria-hidden="true"><svg class="ui-icon"><use href="#icon-assets"></use></svg></div>
+        <strong>No asset folders yet</strong>
+        <span>Add extracted asset folders for future asset-aware loading.</span>
+        <button id="asset-folder-empty-add" class="ui-button ui-button-primary" type="button">Add Asset Folder</button>
+      </div>
+    </section>
+
+    <section id="sidebar" class="left-dock-panel" role="tabpanel" aria-labelledby="meshes-tab" hidden>
+      <div class="panel-hdr">
+        <button type="button" class="group-toggle" aria-expanded="true" aria-controls="mesh-list"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
+        <h3>Meshes</h3>
+        <button id="reset-state-btn" class="icon-btn" title="Reset mesh visibility" aria-label="Reset mesh visibility"><svg class="ui-icon" aria-hidden="true"><use href="#icon-reset"></use></svg></button>
+      </div>
+      <div id="mesh-list"></div>
+    </section>
   </div>
 
   <div id="camera-panel">
@@ -197,10 +226,10 @@
 
 <div id="right-dock">
   <div class="right-dock-tabs" role="tablist" aria-label="Details panels">
-    <button id="controls-tab" class="right-dock-tab active" type="button" role="tab"
-            aria-selected="true" aria-controls="controls-panel">Controls</button>
+    <button id="controls-tab" class="right-dock-tab" type="button" role="tab"
+            aria-selected="false" aria-expanded="false" aria-controls="controls-panel">Controls</button>
     <button id="inspector-tab" class="right-dock-tab" type="button" role="tab"
-            aria-selected="false" aria-controls="inspector-panel">Inspector</button>
+            aria-selected="false" aria-expanded="false" aria-controls="inspector-panel">Inspector</button>
   </div>
   <section id="inspector-panel" class="right-dock-pane" role="tabpanel" aria-labelledby="inspector-tab" hidden>
     <div class="inspector-empty" id="inspector-empty">
@@ -250,6 +279,30 @@
   </div>
   <div id="texture-popover" class="ui-popover tool-popover" role="menu" aria-label="Texture display options" hidden></div>
   <div id="light-popover" class="ui-popover tool-popover" role="menu" aria-label="Light options" hidden></div>
+</div>
+
+<div id="asset-folder-modal-backdrop" class="modal-backdrop">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="afm-title">
+    <h4 id="afm-title">Add Asset Folder</h4>
+    <div id="afm-error" class="modal-error"></div>
+    <form id="afm-form">
+      <label class="modal-field">
+        <span>Type</span>
+        <select id="afm-type"></select>
+      </label>
+      <label class="modal-field">
+        <span>Folder</span>
+        <div class="mod-folder-path-field">
+          <input id="afm-path" type="text" readonly />
+          <button id="afm-browse" type="button">Browse</button>
+        </div>
+      </label>
+      <div class="modal-actions">
+        <button type="button" id="afm-cancel">Cancel</button>
+        <button type="submit" id="afm-save">Add</button>
+      </div>
+    </form>
+  </div>
 </div>
 
 <div id="mod-folder-modal-backdrop" class="modal-backdrop">

--- a/src/web/js/asset-folder-panel.js
+++ b/src/web/js/asset-folder-panel.js
@@ -4,7 +4,7 @@ import { confirmDialog } from './dialogs.js';
 import { createFolderRegistryPanel } from './folder-registry-panel.js';
 
 const $ = id => document.getElementById(id);
-const ASSET_TYPES = ['GIMI', 'ZZMI', 'WWMI'];
+const ASSET_TYPES = ['ZZMI', 'GIMI', 'WWMI'];
 
 function baseName(path) {
   return String(path || '').replace(/[\\/]+$/, '').split(/[\\/]/).pop() || '';

--- a/src/web/js/asset-folder-panel.js
+++ b/src/web/js/asset-folder-panel.js
@@ -104,7 +104,7 @@ export function initAssetFolderPanel() {
     if (event.target === backdrop) closeEditor();
   });
   browse.addEventListener('click', async () => {
-    const picked = await window.pywebview.api.select_folder();
+    const picked = await window.pywebview.api.select_asset_folder();
     if (!picked) return;
     selectedPath = picked;
     pathInput.value = picked;

--- a/src/web/js/asset-folder-panel.js
+++ b/src/web/js/asset-folder-panel.js
@@ -1,9 +1,10 @@
-// Mod Library registry and its feature-specific editor.
+// Asset Folder registry UI. Character rows are browse-only in this phase.
 
 import { confirmDialog } from './dialogs.js';
 import { createFolderRegistryPanel } from './folder-registry-panel.js';
 
 const $ = id => document.getElementById(id);
+const ASSET_TYPES = ['GIMI', 'ZZMI', 'WWMI'];
 
 function baseName(path) {
   return String(path || '').replace(/[\\/]+$/, '').split(/[\\/]/).pop() || '';
@@ -14,50 +15,56 @@ function setTextError(element, message) {
   element.classList.toggle('show', !!message);
 }
 
-export function initModFolderPanel({ switchMod, onRegistryChanged }) {
-  const list = $('mod-folder-list');
-  const error = $('mod-folder-error');
-  const add = $('mod-folder-add');
-  const empty = $('mod-folder-empty');
-  const backdrop = $('mod-folder-modal-backdrop');
-  const title = $('mfm-title');
-  const form = $('mfm-form');
-  const nameInput = $('mfm-name');
-  const pathInput = $('mfm-path');
-  const browse = $('mfm-browse');
-  const cancel = $('mfm-cancel');
-  const save = $('mfm-save');
-  const modalError = $('mfm-error');
+export function initAssetFolderPanel() {
+  const list = $('asset-folder-list');
+  const error = $('asset-folder-error');
+  const add = $('asset-folder-add');
+  const empty = $('asset-folder-empty');
+  const backdrop = $('asset-folder-modal-backdrop');
+  const title = $('afm-title');
+  const form = $('afm-form');
+  const typeInput = $('afm-type');
+  const pathInput = $('afm-path');
+  const browse = $('afm-browse');
+  const cancel = $('afm-cancel');
+  const save = $('afm-save');
+  const modalError = $('afm-error');
 
   let editorMode = 'add';
   let originalPath = null;
   let selectedPath = null;
 
+  typeInput.replaceChildren(...ASSET_TYPES.map(value => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    return option;
+  }));
+
   const tree = createFolderRegistryPanel({
     listElement: list,
     emptyElement: empty,
     errorElement: error,
-    listChildren: path => window.pywebview.api.list_subfolders(path),
-    onRootSelected: path => selectFolder(path),
-    onChildSelected: path => selectFolder(path),
+    listChildren: path => window.pywebview.api.list_asset_subfolders(path),
+    onRootSelected: path => tree.setActivePath(path),
+    onChildSelected: path => tree.setActivePath(path),
     onEdit: entry => openEditor('edit', entry),
     onDelete: entry => removeFolder(entry),
-    renderLabel: entry => entry.name,
-    classPrefix: 'mod-folder',
+    renderLabel: (entry, isRoot) => {
+      if (!isRoot) return entry.name;
+      const wrapper = document.createElement('span');
+      wrapper.className = 'asset-folder-label';
+      const badge = document.createElement('span');
+      badge.className = 'asset-folder-badge';
+      badge.textContent = entry.type;
+      wrapper.append(badge, document.createTextNode(baseName(entry.path)));
+      return wrapper;
+    },
+    classPrefix: 'asset-folder',
   });
 
-  function selectFolder(path) {
-    return Promise.resolve(switchMod(path)).then(loaded => {
-      if (loaded) tree.setActivePath(path);
-      return loaded;
-    });
-  }
-
   function applyRegistryResponse(response) {
-    const applied = tree.applyResponse(response);
-    if (applied) onRegistryChanged?.(tree.getRoots().length > 0);
-    else onRegistryChanged?.(false);
-    return applied;
+    return tree.applyResponse(response);
   }
 
   function closeEditor() {
@@ -69,13 +76,13 @@ export function initModFolderPanel({ switchMod, onRegistryChanged }) {
     editorMode = mode;
     originalPath = entry?.path || null;
     selectedPath = entry?.path || null;
-    title.textContent = mode === 'edit' ? 'Edit Mod Folder' : 'Add Mod Folder';
+    title.textContent = mode === 'edit' ? 'Edit Asset Folder' : 'Add Asset Folder';
     save.textContent = mode === 'edit' ? 'Save' : 'Add';
-    nameInput.value = entry?.name || '';
+    typeInput.value = entry?.type || 'GIMI';
     pathInput.value = entry?.path || '';
     setTextError(modalError, '');
     backdrop.classList.add('show');
-    nameInput.focus();
+    typeInput.focus();
   }
 
   function openAddDialog() {
@@ -84,10 +91,10 @@ export function initModFolderPanel({ switchMod, onRegistryChanged }) {
 
   async function removeFolder(entry) {
     const confirmed = await confirmDialog(
-      `Remove "${entry.name}" from Mod Folders?\n\n` +
+      'Remove this Asset Folder?\n\n' +
       'This only removes it from Mod Viewer.\nFiles on disk will not be deleted.');
     if (!confirmed) return;
-    const response = await window.pywebview.api.delete_mod_folder(entry.path);
+    const response = await window.pywebview.api.delete_asset_folder(entry.path);
     applyRegistryResponse(response);
   }
 
@@ -101,18 +108,10 @@ export function initModFolderPanel({ switchMod, onRegistryChanged }) {
     if (!picked) return;
     selectedPath = picked;
     pathInput.value = picked;
-    if (editorMode === 'add' && !nameInput.value.trim()) {
-      nameInput.value = baseName(picked);
-    }
   });
   form.addEventListener('submit', async event => {
     event.preventDefault();
-    const name = nameInput.value.trim();
     const path = selectedPath || pathInput.value.trim();
-    if (!name) {
-      setTextError(modalError, 'Enter a Mod Folder name.');
-      return;
-    }
     if (!path) {
       setTextError(modalError, 'Choose a folder with Browse.');
       return;
@@ -120,8 +119,9 @@ export function initModFolderPanel({ switchMod, onRegistryChanged }) {
     save.disabled = true;
     try {
       const response = editorMode === 'edit'
-        ? await window.pywebview.api.edit_mod_folder(originalPath, name, path)
-        : await window.pywebview.api.add_mod_folder(name, path);
+        ? await window.pywebview.api.edit_asset_folder(
+          originalPath, typeInput.value, path)
+        : await window.pywebview.api.add_asset_folder(typeInput.value, path);
       if (response?.error) {
         setTextError(modalError, response.error);
         return;
@@ -135,20 +135,18 @@ export function initModFolderPanel({ switchMod, onRegistryChanged }) {
     }
   });
 
-  window.addEventListener('mod-viewer-mod-loaded', event => {
-    tree.setActivePath(event.detail?.path);
-  });
-  window.addEventListener('mod-viewer-mod-load-started', () => {
-    tree.setActivePath(null);
-  });
-
-  window.pywebview.api.get_mod_folders()
-    .then(applyRegistryResponse)
-    .catch(caught => setTextError(error, caught.message || String(caught)));
+  const getAssetFolders = window.pywebview.api.get_asset_folders;
+  if (typeof getAssetFolders === 'function') {
+    getAssetFolders()
+      .then(applyRegistryResponse)
+      .catch(caught => setTextError(error, caught.message || String(caught)));
+  } else {
+    applyRegistryResponse({folders: []});
+  }
 
   return {
-    refresh: () => window.pywebview.api.get_mod_folders().then(applyRegistryResponse),
-    setActivePath: tree.setActivePath,
+    refresh: () => window.pywebview.api.get_asset_folders().then(applyRegistryResponse),
     openAddDialog,
+    setActivePath: tree.setActivePath,
   };
 }

--- a/src/web/js/folder-registry-panel.js
+++ b/src/web/js/folder-registry-panel.js
@@ -1,0 +1,240 @@
+// Shared lazy tree rendering for the Mod Library and Assets registries.
+
+import { createIcon } from './ui-icons.js';
+
+function canonicalPath(path) {
+  return String(path || '').replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+}
+
+function setTextError(element, message) {
+  if (!element) return;
+  element.textContent = message || '';
+  element.classList.toggle('show', !!message);
+}
+
+export function createFolderRegistryPanel({
+  listElement,
+  emptyElement,
+  errorElement,
+  listChildren,
+  onRootSelected,
+  onChildSelected,
+  onEdit,
+  onDelete,
+  renderLabel,
+  classPrefix = 'folder',
+}) {
+  const childCache = new Map();
+  let roots = [];
+  let activePath = null;
+
+  const className = suffix => `${classPrefix}-${suffix} folder-${suffix}`;
+  const selector = suffix => `.${classPrefix}-${suffix}`;
+  const pathAttribute = `data-${classPrefix}-path`;
+
+  function closeMenus(except = null) {
+    listElement.querySelectorAll(selector('action-menu')).forEach(menu => {
+      if (menu !== except) {
+        menu.hidden = true;
+        menu.parentElement?.querySelector(`:scope > ${selector('more')}`)
+          ?.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
+
+  document.addEventListener('click', event => {
+    if (!event.target.closest(selector('actions'))) closeMenus();
+  });
+
+  function setActivePath(path) {
+    activePath = canonicalPath(path);
+    listElement.querySelectorAll(`[${pathAttribute}]`).forEach(row => {
+      const rowPath = canonicalPath(row.getAttribute(pathAttribute));
+      row.classList.toggle('active', rowPath === activePath);
+      row.classList.toggle('active-descendant', !!activePath && rowPath !== activePath
+        && activePath.startsWith(`${rowPath}/`));
+    });
+  }
+
+  function renderChildren(node, children) {
+    const childList = node.querySelector(`:scope > ${selector('children')}`);
+    childList.innerHTML = '';
+    node.querySelector(`:scope > ${selector('row')} ${selector('expand')}`)
+      .classList.toggle('leaf', children.length === 0 && !node.classList.contains('expanded'));
+    children.forEach(child => childList.appendChild(createNode(child, false)));
+  }
+
+  async function expandNode(node, path, arrow) {
+    const childList = node.querySelector(`:scope > ${selector('children')}`);
+    if (node.classList.contains('expanded')) {
+      node.classList.remove('expanded');
+      arrow.classList.remove('expanded');
+      childList.hidden = true;
+      arrow.classList.toggle('leaf', childCache.get(canonicalPath(path))?.length === 0);
+      arrow.setAttribute('aria-expanded', 'false');
+      arrow.setAttribute('aria-label', `Expand ${arrow.dataset.folderName}`);
+      return;
+    }
+
+    node.classList.add('expanded');
+    arrow.classList.add('expanded');
+    childList.hidden = false;
+    arrow.setAttribute('aria-expanded', 'true');
+    arrow.setAttribute('aria-label', `Collapse ${arrow.dataset.folderName}`);
+    const key = canonicalPath(path);
+    if (childCache.has(key)) {
+      renderChildren(node, childCache.get(key));
+      return;
+    }
+
+    childList.innerHTML = '';
+    const loading = document.createElement('div');
+    loading.className = className('child-error');
+    loading.textContent = 'Loading...';
+    childList.appendChild(loading);
+    try {
+      const response = await listChildren(path);
+      if (response?.error) throw new Error(response.error);
+      const children = Array.isArray(response) ? response : response?.folders || [];
+      childCache.set(key, children);
+      renderChildren(node, children);
+    } catch (caught) {
+      childList.innerHTML = '';
+      const message = document.createElement('div');
+      message.className = className('child-error');
+      message.textContent = caught.message || String(caught);
+      childList.appendChild(message);
+    }
+  }
+
+  function appendLabel(select, entry, isRoot) {
+    const label = renderLabel?.(entry, isRoot);
+    if (label instanceof Node) select.appendChild(label);
+    else select.textContent = label ?? entry.name ?? entry.path;
+  }
+
+  function createNode(entry, isRoot) {
+    const node = document.createElement('div');
+    node.className = className('node');
+    const row = document.createElement('div');
+    row.className = className('row');
+    row.setAttribute(pathAttribute, entry.path);
+    if (entry.exists === false) row.classList.add('missing');
+
+    const arrow = document.createElement('button');
+    arrow.type = 'button';
+    arrow.className = className('expand');
+    arrow.textContent = '›';
+    arrow.dataset.folderName = entry.name || entry.path;
+    arrow.setAttribute('aria-label', `Expand ${arrow.dataset.folderName}`);
+    arrow.setAttribute('aria-expanded', 'false');
+    arrow.addEventListener('click', event => {
+      event.stopPropagation();
+      void expandNode(node, entry.path, arrow);
+    });
+
+    const select = document.createElement('button');
+    select.type = 'button';
+    select.className = className('select');
+    appendLabel(select, entry, isRoot);
+    select.title = entry.path;
+    select.addEventListener('click', event => {
+      event.stopPropagation();
+      const callback = isRoot ? onRootSelected : onChildSelected;
+      callback?.(entry.path, entry);
+    });
+    row.append(arrow, select);
+
+    if (isRoot && (onEdit || onDelete)) {
+      const actions = document.createElement('span');
+      actions.className = className('actions');
+      const more = document.createElement('button');
+      more.type = 'button';
+      more.className = className('more');
+      more.appendChild(createIcon('more'));
+      more.title = 'More folder actions';
+      more.setAttribute('aria-label', `More actions for ${entry.name || entry.path}`);
+      more.setAttribute('aria-haspopup', 'menu');
+      more.setAttribute('aria-expanded', 'false');
+      const menu = document.createElement('span');
+      menu.className = className('action-menu');
+      menu.setAttribute('role', 'menu');
+      menu.hidden = true;
+      if (onEdit) {
+        const edit = document.createElement('button');
+        edit.type = 'button';
+        edit.setAttribute('role', 'menuitem');
+        edit.textContent = 'Edit';
+        edit.addEventListener('click', event => {
+          event.stopPropagation();
+          menu.hidden = true;
+          more.setAttribute('aria-expanded', 'false');
+          onEdit(entry);
+        });
+        menu.appendChild(edit);
+      }
+      if (onDelete) {
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.setAttribute('role', 'menuitem');
+        remove.textContent = 'Remove';
+        remove.addEventListener('click', event => {
+          event.stopPropagation();
+          menu.hidden = true;
+          more.setAttribute('aria-expanded', 'false');
+          onDelete(entry);
+        });
+        menu.appendChild(remove);
+      }
+      more.addEventListener('click', event => {
+        event.stopPropagation();
+        closeMenus(menu);
+        menu.hidden = !menu.hidden;
+        more.setAttribute('aria-expanded', String(!menu.hidden));
+      });
+      actions.append(more, menu);
+      row.appendChild(actions);
+    }
+
+    const children = document.createElement('div');
+    children.className = className('children');
+    children.hidden = true;
+    node.append(row, children);
+    if (entry.exists === false && isRoot) {
+      const missing = document.createElement('div');
+      missing.className = className('missing');
+      missing.append(createIcon('diagnostics'), document.createTextNode('Folder not found'));
+      node.appendChild(missing);
+    }
+    return node;
+  }
+
+  function render(entries) {
+    roots = entries || [];
+    listElement.innerHTML = '';
+    roots.forEach(entry => listElement.appendChild(createNode(entry, true)));
+    if (emptyElement) emptyElement.hidden = roots.length !== 0;
+    setActivePath(activePath);
+  }
+
+  function applyResponse(response) {
+    if (response?.error) {
+      childCache.clear();
+      render([]);
+      setTextError(errorElement, response.error);
+      return false;
+    }
+    childCache.clear();
+    setTextError(errorElement, '');
+    render(response?.folders || []);
+    return true;
+  }
+
+  return {
+    render,
+    applyResponse,
+    setActivePath,
+    clearCache: () => childCache.clear(),
+    getRoots: () => roots.slice(),
+  };
+}

--- a/src/web/js/folder-registry-panel.js
+++ b/src/web/js/folder-registry-panel.js
@@ -212,6 +212,7 @@ export function createFolderRegistryPanel({
   function render(entries) {
     roots = entries || [];
     listElement.innerHTML = '';
+    listElement.hidden = roots.length === 0;
     roots.forEach(entry => listElement.appendChild(createNode(entry, true)));
     if (emptyElement) emptyElement.hidden = roots.length !== 0;
     setActivePath(activePath);

--- a/src/web/js/inspector-panel.js
+++ b/src/web/js/inspector-panel.js
@@ -1,7 +1,7 @@
 // Selection-aware details panel.  Mesh creation remains owned by mesh-panel;
 // this module only presents the already-authoritative mesh/component state.
 
-import { setRightDockTab } from './right-dock.js';
+import { isRightDockOpen, setRightDockTab } from './right-dock.js';
 import { clearSelection } from './selection.js';
 
 const meshRecords = new WeakMap();
@@ -300,7 +300,9 @@ function updateInspectorState() {
 function selectComponent(record) {
   if (current?.type === 'component') current.record.header?.classList.remove('selected');
   clearSelection();
-  if (selectionCount++ === 0) setRightDockTab('inspector', { persist: false });
+  if (selectionCount++ === 0 && isRightDockOpen()) {
+    setRightDockTab('inspector', { persist: false });
+  }
   current = { type: 'component', record };
   record.header?.classList.add('selected');
   buildComponent(record);
@@ -311,7 +313,9 @@ function selectComponent(record) {
 function selectMesh(mesh) {
   const record = meshRecords.get(mesh);
   if (!record) return;
-  if (selectionCount++ === 0) setRightDockTab('inspector', { persist: false });
+  if (selectionCount++ === 0 && isRightDockOpen()) {
+    setRightDockTab('inspector', { persist: false });
+  }
   if (current?.type === 'component') current.record.header?.classList.remove('selected');
   current = { type: 'mesh', mesh, record };
   buildMesh(mesh, record);

--- a/src/web/js/left-dock.js
+++ b/src/web/js/left-dock.js
@@ -1,0 +1,89 @@
+// Navigation state for the Meshes, Mod Library and Assets panels.
+
+export const LEFT_TABS = new Set(['meshes', 'mod-library', 'assets']);
+
+let activeTab = null;
+let meshesAvailable = false;
+let userHasChosenDockState = false;
+let ready = false;
+
+function elements() {
+  const tabs = [...document.querySelectorAll('[data-left-tab]')];
+  const panels = Object.fromEntries(
+    tabs.map(tab => [tab.dataset.leftTab,
+      document.getElementById(tab.getAttribute('aria-controls'))]));
+  return { dock: document.getElementById('left-dock'), tabs, panels };
+}
+
+function tabCanOpen(tab) {
+  return tab !== 'meshes' || meshesAvailable;
+}
+
+function render() {
+  const { dock, tabs, panels } = elements();
+  const visible = !!activeTab && tabCanOpen(activeTab);
+  tabs.forEach(tab => {
+    const name = tab.dataset.leftTab;
+    const active = visible && name === activeTab;
+    const disabled = name === 'meshes' && !meshesAvailable;
+    tab.disabled = disabled;
+    tab.classList.toggle('active', active);
+    tab.setAttribute('aria-selected', String(active));
+    tab.setAttribute('aria-expanded', String(active));
+    tab.setAttribute('aria-disabled', String(disabled));
+  });
+  Object.entries(panels).forEach(([name, panel]) => {
+    if (!panel) return;
+    const shown = visible && name === activeTab;
+    panel.hidden = !shown;
+    panel.inert = !shown;
+    panel.setAttribute('aria-hidden', String(!shown));
+  });
+  dock?.classList.toggle('ui-visible', visible);
+}
+
+export function setLeftDockTab(tab, { userInitiated = true } = {}) {
+  if (!LEFT_TABS.has(tab) || !tabCanOpen(tab)) return false;
+  activeTab = tab;
+  if (userInitiated) userHasChosenDockState = true;
+  render();
+  return true;
+}
+
+export function toggleLeftDockTab(tab) {
+  if (!LEFT_TABS.has(tab) || !tabCanOpen(tab)) return false;
+  userHasChosenDockState = true;
+  activeTab = activeTab === tab ? null : tab;
+  render();
+  return true;
+}
+
+export function getLeftDockTab() {
+  return activeTab;
+}
+
+export function isLeftDockOpen() {
+  return !!activeTab && tabCanOpen(activeTab);
+}
+
+export function setMeshesAvailable(value) {
+  meshesAvailable = !!value;
+  render();
+  if (meshesAvailable && !userHasChosenDockState && !activeTab) {
+    activeTab = 'meshes';
+    render();
+  }
+}
+
+export function initLeftDock() {
+  if (ready) {
+    render();
+    return;
+  }
+  const { tabs } = elements();
+  tabs.forEach(tab => tab.addEventListener('click', () => {
+    toggleLeftDockTab(tab.dataset.leftTab);
+  }));
+  ready = true;
+  render();
+}

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -15,6 +15,8 @@ import { buildTogglePanel } from './toggle-panel.js';
 import { buildMenuPanel } from './menu-panel.js';
 import { buildPresentPanel } from './present-panel.js';
 import { initModFolderPanel } from './mod-folder-panel.js';
+import { initAssetFolderPanel } from './asset-folder-panel.js';
+import { initLeftDock, setLeftDockTab, setMeshesAvailable } from './left-dock.js';
 import { alertDialog, confirmDialog } from './dialogs.js';
 import { setGeometryBlob } from './decode.js';
 import { refreshHealthReport, setHealthLoader, setHealthReport } from './health-report.js';
@@ -23,7 +25,7 @@ import { getMaterialDebugMode, setMaterialDebugMode } from './material-profile.j
 import { requestRender } from './render-scheduler.js';
 import { setTextureDisplayMode } from './render-modes.js';
 import { clearInspector, initInspectorPanel } from './inspector-panel.js';
-import { initRightDock, setRightDockVisible } from './right-dock.js';
+import { initRightDock, isRightDockOpen, setRightDockEnabled } from './right-dock.js';
 import { initPanelOpacityControl } from './appearance.js';
 import {
   getOutlineState as getMeshOutlineState,
@@ -206,14 +208,9 @@ function initToolPopovers() {
 }
 
 function syncViewportControlPlacement() {
-  const rightDock = $('right-dock');
-  const panelIds = ['inspector-panel', 'present-panel', 'toggle-panel', 'menu-panel'];
-  const hasVisiblePanel = rightDockEnabled && panelIds.some(id => {
-    const panel = $(id);
-    return panel && !panel.hidden && getComputedStyle(panel).display !== 'none';
-  });
-  setRightDockVisible(hasVisiblePanel);
-  document.body.classList.toggle('right-dock-visible', hasVisiblePanel);
+  setRightDockEnabled(rightDockEnabled);
+  const visible = rightDockEnabled && isRightDockOpen();
+  document.body.classList.toggle('right-dock-visible', visible);
 }
 
 function initToolbarOverflow() {
@@ -308,7 +305,6 @@ function clearScene({ preserveModelOrientation = false } = {}) {
   setTextures(null);
   setGeometryBlob(null);
   lastToggles = {};
-  $('sidebar').style.display = 'none';
   $('mesh-list').innerHTML = '';
   $('camera-panel').style.display = 'none';
   $('toggle-list').innerHTML = '';
@@ -317,7 +313,8 @@ function clearScene({ preserveModelOrientation = false } = {}) {
   $('present-panel').style.display = 'none';
   $('menu-list').innerHTML = '';
   $('menu-panel').style.display = 'none';
-  setRightDockVisible(false);
+  setMeshesAvailable(false);
+  setRightDockEnabled(false);
   syncViewportControlPlacement();
 }
 
@@ -383,6 +380,7 @@ async function displayMeshPayload(payload, { preserveCamera = false } = {}) {
   buildPresentPanel(controls.present, {
     modPath: currentModPath, onChange: handlePresentChange,
   });
+  setMeshesAvailable(true);
   rightDockEnabled = true;
   syncViewportControlPlacement();
   fitTo(activeMeshes, {
@@ -735,6 +733,7 @@ rendererReady.then(ready => {
   $('camera-flip-btn').addEventListener('click', () => rotateModelQuarterTurn(activeMeshes));
   $('camera-flip-horizontal-btn').addEventListener('click', () => rotateModelHorizontalQuarterTurn(activeMeshes));
   const applyEnvironmentPreset = initEnvironmentControl();
+  initLeftDock();
   initRightDock();
   initInspectorPanel();
   initSelection();
@@ -759,14 +758,16 @@ rendererReady.then(ready => {
     switchMod,
     onRegistryChanged: updateEmptyFolderAction,
   });
+  const assetFolderPanel = initAssetFolderPanel();
   $('empty-open-btn').disabled = false;
   emptyFolderAction.disabled = false;
   $('empty-open-btn').addEventListener('click', openMod);
   emptyFolderAction.addEventListener('click', () => {
-    modFolderPanel.setExpanded(true);
+    setLeftDockTab('mod-library');
     if (!hasModFolders) modFolderPanel.openAddDialog();
   });
   $('mod-folder-empty-add')?.addEventListener('click', modFolderPanel.openAddDialog);
+  $('asset-folder-empty-add')?.addEventListener('click', assetFolderPanel.openAddDialog);
 
   // Exposed for automated smoke tests and for poking at the app from the
   // devtools console; the UI itself always goes through the listeners above.

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -25,7 +25,7 @@ import { getMaterialDebugMode, setMaterialDebugMode } from './material-profile.j
 import { requestRender } from './render-scheduler.js';
 import { setTextureDisplayMode } from './render-modes.js';
 import { clearInspector, initInspectorPanel } from './inspector-panel.js';
-import { initRightDock, isRightDockOpen, setRightDockEnabled } from './right-dock.js';
+import { initRightDock, setRightDockEnabled } from './right-dock.js';
 import { initPanelOpacityControl } from './appearance.js';
 import {
   getOutlineState as getMeshOutlineState,
@@ -209,8 +209,6 @@ function initToolPopovers() {
 
 function syncViewportControlPlacement() {
   setRightDockEnabled(rightDockEnabled);
-  const visible = rightDockEnabled && isRightDockOpen();
-  document.body.classList.toggle('right-dock-visible', visible);
 }
 
 function initToolbarOverflow() {

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -396,7 +396,6 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
     }
   }
 
-  document.getElementById('sidebar').style.display = 'block';
   document.getElementById('camera-panel').style.display = 'none';
   return activeMeshes;
 }

--- a/src/web/js/right-dock.js
+++ b/src/web/js/right-dock.js
@@ -1,11 +1,17 @@
-// The right side of the viewer has two intentionally separate destinations:
-// selection details and mod controls.  Keeping the tab state here means the
-// panel modules do not need to know how they are presented.
+// Right-dock navigation keeps the user's preferred tab separate from the
+// transient choice to have the dock open at all.
 
 const STORAGE_KEY = 'mod-viewer.right-dock-tab';
 
-let activeTab = 'controls';
+let selectedTab = 'controls';
+let openTab = null;
+let dockEnabled = false;
+let userHasChosenDockState = false;
 let ready = false;
+
+function validTab(tab) {
+  return tab === 'controls' || tab === 'inspector';
+}
 
 function elements() {
   return {
@@ -17,42 +23,73 @@ function elements() {
   };
 }
 
-export function setRightDockTab(tab, { persist = true } = {}) {
-  if (tab !== 'controls' && tab !== 'inspector') return;
-  activeTab = tab;
-  const { inspectorTab, controlsTab, inspector, controls } = elements();
-  const inspectorActive = tab === 'inspector';
+function renderRightDock() {
+  const { inspectorTab, controlsTab, inspector, controls, dock } = elements();
+  const visible = dockEnabled && validTab(openTab);
+  const inspectorActive = visible && openTab === 'inspector';
+  const controlsActive = visible && openTab === 'controls';
   inspectorTab?.classList.toggle('active', inspectorActive);
-  controlsTab?.classList.toggle('active', !inspectorActive);
+  controlsTab?.classList.toggle('active', controlsActive);
   inspectorTab?.setAttribute('aria-selected', String(inspectorActive));
-  controlsTab?.setAttribute('aria-selected', String(!inspectorActive));
+  controlsTab?.setAttribute('aria-selected', String(controlsActive));
+  inspectorTab?.setAttribute('aria-expanded', String(inspectorActive));
+  controlsTab?.setAttribute('aria-expanded', String(controlsActive));
   if (inspector) inspector.hidden = !inspectorActive;
-  if (controls) controls.hidden = inspectorActive;
+  if (controls) controls.hidden = !controlsActive;
+  dock?.classList.toggle('ui-visible', dockEnabled);
+}
+
+export function setRightDockTab(tab, { persist = true, userInitiated = false } = {}) {
+  if (!validTab(tab)) return false;
+  selectedTab = tab;
+  openTab = tab;
+  if (userInitiated) userHasChosenDockState = true;
   if (persist) {
     try { localStorage.setItem(STORAGE_KEY, tab); } catch (_) { /* private mode */ }
   }
+  renderRightDock();
+  return true;
+}
+
+export function toggleRightDockTab(tab) {
+  if (!validTab(tab)) return false;
+  userHasChosenDockState = true;
+  if (openTab === tab) {
+    openTab = null;
+  } else {
+    selectedTab = tab;
+    openTab = tab;
+    try { localStorage.setItem(STORAGE_KEY, tab); } catch (_) { /* private mode */ }
+  }
+  renderRightDock();
+  return true;
 }
 
 export function getRightDockTab() {
-  return activeTab;
+  return selectedTab;
 }
 
-export function setRightDockVisible(visible) {
-  elements().dock?.classList.toggle('ui-visible', !!visible);
+export function isRightDockOpen() {
+  return dockEnabled && validTab(openTab);
+}
+
+export function setRightDockEnabled(enabled) {
+  dockEnabled = !!enabled;
+  if (dockEnabled && !userHasChosenDockState && !openTab) openTab = selectedTab;
+  renderRightDock();
 }
 
 export function initRightDock() {
   const { inspectorTab, controlsTab } = elements();
   if (!inspectorTab || !controlsTab) return;
-  inspectorTab.addEventListener('click', () => setRightDockTab('inspector'));
-  controlsTab.addEventListener('click', () => setRightDockTab('controls'));
+  inspectorTab.addEventListener('click', () => toggleRightDockTab('inspector'));
+  controlsTab.addEventListener('click', () => toggleRightDockTab('controls'));
   if (!ready) {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored === 'controls' || stored === 'inspector') activeTab = stored;
+      if (validTab(stored)) selectedTab = stored;
     } catch (_) { /* private mode */ }
     ready = true;
   }
-  setRightDockTab(activeTab, { persist: false });
-  setRightDockVisible(false);
+  renderRightDock();
 }

--- a/src/web/js/right-dock.js
+++ b/src/web/js/right-dock.js
@@ -25,9 +25,9 @@ function elements() {
 
 function renderRightDock() {
   const { inspectorTab, controlsTab, inspector, controls, dock } = elements();
-  const visible = dockEnabled && validTab(openTab);
-  const inspectorActive = visible && openTab === 'inspector';
-  const controlsActive = visible && openTab === 'controls';
+  const panelVisible = dockEnabled && validTab(openTab);
+  const inspectorActive = panelVisible && openTab === 'inspector';
+  const controlsActive = panelVisible && openTab === 'controls';
   inspectorTab?.classList.toggle('active', inspectorActive);
   controlsTab?.classList.toggle('active', controlsActive);
   inspectorTab?.setAttribute('aria-selected', String(inspectorActive));
@@ -37,6 +37,7 @@ function renderRightDock() {
   if (inspector) inspector.hidden = !inspectorActive;
   if (controls) controls.hidden = !controlsActive;
   dock?.classList.toggle('ui-visible', dockEnabled);
+  document.body?.classList.toggle('right-dock-visible', panelVisible);
 }
 
 export function setRightDockTab(tab, { persist = true, userInitiated = false } = {}) {


### PR DESCRIPTION
## Summary

- Add shared versioned configuration and a separate asset-folder registry with API authorization boundaries.
- Add persistent Meshes, Mod Library, and Assets tabs with consistent active-tab toggle behavior.
- Replace the legacy Mod Library overlay with content-only registry panels and update frontend coverage.

## Validation

- `pytest -q`