### PR TITLE
Add WuWa component filename texture fallback

### DIFF
--- a/src/app/asset_enrichment.py
+++ b/src/app/asset_enrichment.py
@@ -9,7 +9,7 @@ import re
 from core.geometry_identity import normalize_geometry_hash
 from core.ini_parser import TextureOverrideIndex, _condition_difference
 from core.dds_classifier import (DDSClassification, classification_cache_key,
-                                 classify_dds)
+                                 classify_dds, is_color_candidate)
 from core.resource_paths import safe_resource_path
 
 from . import asset_folders
@@ -343,11 +343,20 @@ def _classify_replacements(texture_hash, replacements, mod_dir, cache):
                 result = _cached_dds_classification(path, cache)
         classifications.append(result)
         by_replacement[id(replacement)] = result
-    role_results = [result for result in classifications if result.role]
-    roles = {result.role for result in role_results}
+    def analysis_role(result):
+        if result.role == "normal_map":
+            return ("normal_map"
+                    if result.confidence == "high" else None)
+        return "diffuse" if is_color_candidate(result) else None
+
+    role_results = [
+        (result, analysis_role(result)) for result in classifications
+    ]
+    roles = {role for _result, role in role_results if role}
     role = (next(iter(roles))
             if len(roles) == 1
-            and all(result.confidence == "high" for result in role_results)
+            and all(result_role for _result, result_role in role_results
+                    if result_role)
             else None)
     return role, by_replacement, len(roles) > 1
 
@@ -613,7 +622,9 @@ def apply(groups, bindings, metadata_cache=None, *, include_not_found=False,
                     if accepted:
                         role_result = next(
                             (item for item in details.values()
-                             if item.role == role), None)
+                             if ((item.role == role)
+                                 or (role == "diffuse"
+                                     and is_color_candidate(item)))), None)
                         dds_evidence.append(TextureSemanticEvidence(
                             role, texture_hash, source="dds_analysis",
                             texture_class=(role_result.texture_class

--- a/src/app/asset_enrichment.py
+++ b/src/app/asset_enrichment.py
@@ -506,22 +506,26 @@ def apply(groups, bindings, metadata_cache=None, *, include_not_found=False,
                                     or "mod_slot_mapping"),
                             })
                             known_roles.add(item.role_hint)
-                            role_hint_evidence.append(
-                                TextureSemanticEvidence(
-                                    item.role_hint, usage["texture_hash"],
-                                    source=(item.role_hint_source
-                                           or "mod_slot_mapping")))
+                            # The slot mapping remains diagnostic and the
+                            # parsed mod binding remains authoritative. Do
+                            # not bridge WWMI TextureUsage hashes into the
+                            # replacement/rendering evidence path.
                         draw.asset_slot_evidence.append(slot_evidence)
                 for usage_values in slots.values():
                     for usage in usage_values:
-
                         texture_hash = usage["texture_hash"]
                         contexts = diagnostic_contexts.setdefault(
                             texture_hash, [])
                         if usage not in contexts:
                             contexts.append(usage)
-                        roleless_evidence.append(TextureSemanticEvidence(
-                            None, texture_hash, source="asset_slot_usage"))
+                        if not any(
+                                item.get("texture_hash") == texture_hash
+                                and item.get("slot") == usage.get("slot")
+                                for item in draw.asset_slot_evidence):
+                            draw.asset_slot_evidence.append(dict(usage))
+                        # WWMI TextureUsage is diagnostic context only. WuWa
+                        # render-role recovery is owned by the component
+                        # filename + DDS fallback, not Asset JSON.
 
             # Raw slot hashes provide diagnostic context for every adapter.
             # Only an Asset-proven association may trigger DDS role recovery;

--- a/src/app/asset_enrichment.py
+++ b/src/app/asset_enrichment.py
@@ -524,8 +524,9 @@ def apply(groups, bindings, metadata_cache=None, *, include_not_found=False,
                                 for item in draw.asset_slot_evidence):
                             draw.asset_slot_evidence.append(dict(usage))
                         # WWMI TextureUsage is diagnostic context only. WuWa
-                        # render-role recovery is owned by the component
-                        # filename + DDS fallback, not Asset JSON.
+                        # render-role recovery is owned by direct draw
+                        # bindings and the component filename + DDS fallback,
+                        # not Asset JSON.
 
             # Raw slot hashes provide diagnostic context for every adapter.
             # Only an Asset-proven association may trigger DDS role recovery;

--- a/src/app/mod_loader.py
+++ b/src/app/mod_loader.py
@@ -522,14 +522,14 @@ def _register_material_profile(table, profile):
 
 def _apply_texture_enrichment(parsed, context, bindings, complete_index):
     """Run all semantic texture enrichment in the shared load order."""
-    if str(getattr(parsed.game, "game", "")).casefold() == "wuwa":
-        wuwa_texture_fallback.apply(
-            parsed.groups, context.mod_dir,
-            dds_classification_cache=context.dds_classification_cache)
     asset_enrichment.apply(
         parsed.groups, bindings, include_not_found=complete_index,
         mod_dir=context.mod_dir,
         dds_classification_cache=context.dds_classification_cache)
+    if str(getattr(parsed.game, "game", "")).casefold() == "wuwa":
+        wuwa_texture_fallback.apply(
+            parsed.groups, context.mod_dir,
+            dds_classification_cache=context.dds_classification_cache)
 
 
 def _assign_material_profiles(meshes, game):

--- a/src/app/mod_loader.py
+++ b/src/app/mod_loader.py
@@ -27,7 +27,7 @@ from core.game_profile import GameDetection, resolve_game_detection
 from core.material_kind import detect_material_kind
 from core.material_profiles import material_profile_for
 
-from . import asset_enrichment, asset_resolver
+from . import asset_enrichment, asset_resolver, wuwa_texture_fallback
 
 # Kept for scripts that still inspect the low-level mesh-builder result.  These
 # keys are no longer emitted by load_mod's public application payload.
@@ -501,10 +501,7 @@ def load_mesh_semantics(context, overrides=None, active_mesh_keys=None):
         availability.get("configured_roots", 0) > 0
         and availability.get("ready_roots", 0)
         == availability.get("configured_roots", 0))
-    asset_enrichment.apply(
-        parsed.groups, bindings, include_not_found=complete_index,
-        mod_dir=context.mod_dir,
-        dds_classification_cache=context.dds_classification_cache)
+    _apply_texture_enrichment(parsed, context, bindings, complete_index)
     return {
         "meshes": build_mesh_semantics(
             parsed.groups, context.mod_dir, game_profile=parsed.game.game,
@@ -521,6 +518,18 @@ def _register_material_profile(table, profile):
     if existing is not None and existing != metadata:
         raise RuntimeError(f"Material profile ID collision: {profile.id}")
     table[profile.id] = metadata
+
+
+def _apply_texture_enrichment(parsed, context, bindings, complete_index):
+    """Run all semantic texture enrichment in the shared load order."""
+    if str(getattr(parsed.game, "game", "")).casefold() == "wuwa":
+        wuwa_texture_fallback.apply(
+            parsed.groups, context.mod_dir,
+            dds_classification_cache=context.dds_classification_cache)
+    asset_enrichment.apply(
+        parsed.groups, bindings, include_not_found=complete_index,
+        mod_dir=context.mod_dir,
+        dds_classification_cache=context.dds_classification_cache)
 
 
 def _assign_material_profiles(meshes, game):
@@ -701,10 +710,7 @@ def load_mod(folder_path=None, overrides=None, pending_new_sections=None, *,
             availability.get("configured_roots", 0) > 0
             and availability.get("ready_roots", 0)
             == availability.get("configured_roots", 0))
-        asset_enrichment.apply(
-            groups, bindings, include_not_found=complete_index,
-            mod_dir=context.mod_dir,
-            dds_classification_cache=context.dds_classification_cache)
+        _apply_texture_enrichment(parsed, context, bindings, complete_index)
         asset_resolution = asset_resolver.summarize_groups(
             groups, bindings, availability).to_dict()
 

--- a/src/app/wuwa_texture_fallback.py
+++ b/src/app/wuwa_texture_fallback.py
@@ -1,6 +1,7 @@
-"""Conservative WuWa texture roles from generated replacement filenames."""
+"""Conservative WuWa texture roles from direct bindings and filenames."""
 
 from dataclasses import dataclass
+import os
 import re
 
 from core.dds_classifier import DDSClassification
@@ -71,6 +72,43 @@ def _component_priority(components, ordinal):
     else:
         tier = 2
     return tier, len(components)
+
+
+def _direct_dds_candidates(draw, mod_dir, cache):
+    """Return unique high-confidence roles from this draw's bound DDS files."""
+    by_role = {}
+    for binding in draw.slot_textures:
+        if binding.role_hint is not None:
+            continue
+        filename = binding.file
+        if (not isinstance(filename, str)
+                or not filename.casefold().endswith(".dds")):
+            continue
+        path = safe_resource_path(mod_dir, filename)
+        if path is None:
+            continue
+        classification = _cached_dds_classification(path, cache)
+        if (classification.role not in _INFERRED_ROLES
+                or classification.confidence != "high"):
+            continue
+        path_key = os.path.normcase(os.path.normpath(path))
+        by_role.setdefault(classification.role, {})[path_key] = (
+            binding, classification)
+    return {
+        role: next(iter(files.values()))
+        for role, files in by_role.items()
+        if len(files) == 1
+    }
+
+
+def _apply_direct_dds(draw, mod_dir, cache):
+    """Apply roles proven by unique direct resource bindings on one draw."""
+    for role, (binding, _classification) in _direct_dds_candidates(
+            draw, mod_dir, cache).items():
+        if _has_mod_texture(draw, role):
+            continue
+        draw.set_texture_default(role, binding.file)
+        draw.texture_provenance.setdefault(role, "wuwa_direct_dds")
 
 
 def _parse_filename_replacement(replacement):
@@ -181,11 +219,11 @@ def _select_candidates(ordinal, mod_dir, cache, parsed_index):
 
 
 def apply(groups, mod_dir, *, dds_classification_cache=None):
-    """Apply conservative WuWa filename/DDS semantic texture evidence.
+    """Apply conservative WuWa direct-binding and filename/DDS evidence.
 
-    The pass is intentionally independent of Asset resolution. It only reads
-    replacement files already referenced by each INI's own texture index and
-    delegates all conditional texture mutation to the shared enrichment path.
+    Direct effective draw bindings are stronger evidence than generated
+    replacement filenames. Asset and slot semantics must run before this pass;
+    this function only fills roles that remain unresolved.
     """
     cache = (dds_classification_cache
              if dds_classification_cache is not None else {})
@@ -194,6 +232,8 @@ def apply(groups, mod_dir, *, dds_classification_cache=None):
         ordinal = _component_ordinal(group)
         if ordinal is None or _uses_slotfix(group):
             continue
+        for draw in group.get("draws", []):
+            _apply_direct_dds(draw, mod_dir, cache)
         texture_index = group.get("_texture_override_index")
         if not isinstance(texture_index, TextureOverrideIndex):
             continue

--- a/src/app/wuwa_texture_fallback.py
+++ b/src/app/wuwa_texture_fallback.py
@@ -1,10 +1,10 @@
-"""Conservative WuWa texture roles from direct bindings and filenames."""
+"""Contextual WuWa texture analysis and candidate discovery."""
 
 from dataclasses import dataclass
 import os
 import re
 
-from core.dds_classifier import DDSClassification
+from core.dds_classifier import DDSClassification, is_color_candidate
 from core.ini_parser import TextureOverrideIndex
 from core.resource_paths import safe_resource_path
 
@@ -24,22 +24,25 @@ _WUWA_COMPONENT_TEXTURE_RE = re.compile(
     re.I,
 )
 _INFERRED_ROLES = frozenset(("diffuse", "normal_map"))
+_DIRECT_SOURCE = "wuwa_direct_analysis"
+_FILENAME_SOURCE = "wuwa_filename_analysis"
 
 
 @dataclass(frozen=True, slots=True)
 class _FilenameReplacement:
     replacement: object
     components: tuple[int, ...]
-    specificity: int
     filename_tag: str
 
 
 @dataclass(frozen=True, slots=True)
 class _Candidate:
-    original_hash: str
+    original_hash: str | None
     role: str
-    priority: tuple[int, int]
+    priority: tuple[int, ...]
     classification: DDSClassification
+    file: str | None = None
+    association_source: str = _FILENAME_SOURCE
 
 
 def _component_ordinal(group):
@@ -62,21 +65,24 @@ def _basename(filename):
     return str(filename).replace("\\", "/").rsplit("/", 1)[-1]
 
 
-def _component_priority(components, ordinal):
-    if ordinal not in components:
-        return None
-    if components == (ordinal,):
-        tier = 0
-    elif components[0] == ordinal:
-        tier = 1
-    else:
-        tier = 2
-    return tier, len(components)
+def _file_key(path):
+    return os.path.normcase(os.path.normpath(path))
+
+
+def _analysis_roles(classification):
+    """Map structural analysis to roles the contextual resolver may use."""
+    roles = []
+    if (classification.role == "normal_map"
+            and classification.confidence == "high"):
+        roles.append("normal_map")
+    if is_color_candidate(classification):
+        roles.append("diffuse")
+    return tuple(roles)
 
 
 def _direct_dds_candidates(draw, mod_dir, cache):
-    """Return unique high-confidence roles from this draw's bound DDS files."""
-    by_role = {}
+    """Collect viable direct candidates for one effective draw state."""
+    candidates = {}
     for binding in draw.slot_textures:
         if binding.role_hint is not None:
             continue
@@ -88,27 +94,17 @@ def _direct_dds_candidates(draw, mod_dir, cache):
         if path is None:
             continue
         classification = _cached_dds_classification(path, cache)
-        if (classification.role not in _INFERRED_ROLES
-                or classification.confidence != "high"):
-            continue
-        path_key = os.path.normcase(os.path.normpath(path))
-        by_role.setdefault(classification.role, {})[path_key] = (
-            binding, classification)
-    return {
-        role: next(iter(files.values()))
-        for role, files in by_role.items()
-        if len(files) == 1
-    }
-
-
-def _apply_direct_dds(draw, mod_dir, cache):
-    """Apply roles proven by unique direct resource bindings on one draw."""
-    for role, (binding, _classification) in _direct_dds_candidates(
-            draw, mod_dir, cache).items():
-        if _has_mod_texture(draw, role):
-            continue
-        draw.set_texture_default(role, binding.file)
-        draw.texture_provenance.setdefault(role, "wuwa_direct_dds")
+        for role in _analysis_roles(classification):
+            key = (role, _file_key(path))
+            candidates.setdefault(key, _Candidate(
+                original_hash=None,
+                role=role,
+                priority=(0, 0, 0),
+                classification=classification,
+                file=filename,
+                association_source=_DIRECT_SOURCE,
+            ))
+    return list(candidates.values())
 
 
 def _parse_filename_replacement(replacement):
@@ -125,11 +121,27 @@ def _parse_filename_replacement(replacement):
     return _FilenameReplacement(
         replacement=replacement,
         components=components,
-        specificity=len(components),
         # This value is deliberately opaque. It is diagnostic metadata only;
         # it is never compared with the INI original hash or normalized.
         filename_tag=match.group("tag"),
     )
+
+
+def _component_priority(components, ordinal):
+    if ordinal not in components:
+        return None
+    if components == (ordinal,):
+        tier = 0
+    elif components[0] == ordinal:
+        tier = 1
+    else:
+        tier = 2
+    return tier, len(components)
+
+
+def _filename_priority(components, ordinal):
+    priority = _component_priority(components, ordinal)
+    return (1, *priority) if priority is not None else None
 
 
 def _index_metadata(texture_index):
@@ -146,49 +158,99 @@ def _index_metadata(texture_index):
     return result
 
 
-def _classify_candidate_family(original_hash, items, ordinal, mod_dir, cache):
-    """Return one role candidate when a hash family is unambiguous."""
+def _classify_items(items, ordinal, mod_dir, cache):
+    """Classify one hash family after verifying component membership."""
     if not items or any(item is None for item in items):
         return None
     if any(_component_priority(item.components, ordinal) is None
            for item in items):
         return None
-
     classified = []
     for item in items:
         path = safe_resource_path(mod_dir, item.replacement.file)
         if path is None:
             return None
         classified.append(_cached_dds_classification(path, cache))
+    return list(zip(items, classified))
 
+
+def _classify_candidate_family(original_hash, items, ordinal, mod_dir, cache):
+    """Return one automatic candidate for an unambiguous hash family."""
+    classified = _classify_items(items, ordinal, mod_dir, cache)
+    if not classified:
+        return None
     role_items = [
-        (item, classification)
-        for item, classification in zip(items, classified)
-        if (classification.role in _INFERRED_ROLES
-            and classification.confidence == "high")
+        (item, classification, role)
+        for item, classification in classified
+        for role in _analysis_roles(classification)
     ]
-    roles = {classification.role for _item, classification in role_items}
+    roles = {role for _item, _classification, role in role_items}
     if len(roles) != 1:
         return None
     role = next(iter(roles))
-    role_items = [
-        (item, classification)
-        for item, classification in role_items
-        if classification.role == role
-    ]
-    _strongest_item, strongest_classification = min(
+    role_items = [item for item in role_items if item[2] == role]
+    _strongest_item, strongest_classification, _role = min(
         role_items,
-        key=lambda pair: _component_priority(pair[0].components, ordinal))
+        key=lambda item: _filename_priority(item[0].components, ordinal),
+    )
     return _Candidate(
-        # Keep the index key as the TextureOverride identity. The filename's
-        # opaque tag and replacement object cannot define that identity.
+        # The filename tag and replacement object cannot define identity.
         original_hash=original_hash,
         role=role,
         priority=min(
-            _component_priority(item.components, ordinal)
-            for item, _ in role_items),
+            _filename_priority(item.components, ordinal)
+            for item, _classification, _role in role_items),
         classification=strongest_classification,
+        association_source=_FILENAME_SOURCE,
     )
+
+
+def _filename_inventory(ordinal, mod_dir, cache, parsed_index):
+    """Return every viable filename-associated candidate for the pool."""
+    result = []
+    for original_hash, items in parsed_index.items():
+        classified = _classify_items(items, ordinal, mod_dir, cache)
+        if not classified:
+            continue
+        for item, classification in classified:
+            priority = _filename_priority(item.components, ordinal)
+            for role in _analysis_roles(classification):
+                result.append(_Candidate(
+                    original_hash=original_hash,
+                    role=role,
+                    priority=priority,
+                    classification=classification,
+                    file=item.replacement.file,
+                    association_source=_FILENAME_SOURCE,
+                ))
+    return result
+
+
+def _candidate_identity(candidate, mod_dir):
+    if candidate.file:
+        path = safe_resource_path(mod_dir, candidate.file)
+        if path is not None:
+            return ("file", _file_key(path))
+        return ("file", candidate.file.casefold())
+    return ("hash", candidate.original_hash)
+
+
+def _select_role_candidate(candidates, role, mod_dir):
+    role_candidates = [item for item in candidates if item.role == role]
+    if not role_candidates:
+        return None
+    priority = min(item.priority for item in role_candidates)
+    strongest = [
+        item for item in role_candidates if item.priority == priority
+    ]
+    identities = {
+        _candidate_identity(item, mod_dir) for item in strongest
+    }
+    if len(identities) != 1:
+        # Equal-strength direct files or hash families are ambiguous. A
+        # weaker candidate must not silently resolve that ambiguity.
+        return None
+    return strongest[0]
 
 
 def _select_candidates(ordinal, mod_dir, cache, parsed_index):
@@ -198,32 +260,69 @@ def _select_candidates(ordinal, mod_dir, cache, parsed_index):
             original_hash, items, ordinal, mod_dir, cache)
         if candidate is not None:
             candidates.append(candidate)
+    return {
+        role: selected
+        for role in _INFERRED_ROLES
+        if (selected := _select_role_candidate(candidates, role, mod_dir))
+    }
 
-    selected = {}
-    for role in _INFERRED_ROLES:
-        role_candidates = [item for item in candidates if item.role == role]
-        if not role_candidates:
+
+def _record_discovered(group, candidates, mod_dir):
+    """Store viable candidates as enrichment-owned, temporary group state."""
+    discovered = {}
+    for candidate in candidates:
+        if not candidate.file:
             continue
-        priority = min(item.priority for item in role_candidates)
-        strongest = [
-            item for item in role_candidates
-            if item.priority == priority
-        ]
-        hashes = {item.original_hash for item in strongest}
-        if len(hashes) != 1:
-            # Equal-strength distinct hash families are ambiguous. The
-            # fallback must never make a first/lexicographic choice.
+        path = safe_resource_path(mod_dir, candidate.file)
+        if path is None:
             continue
-        selected[role] = strongest[0]
-    return selected
+        key = (candidate.role, _file_key(path))
+        record = {
+            "file": candidate.file,
+            "role": candidate.role,
+            "semantic_candidate": candidate.role,
+            "source": candidate.association_source,
+            "priority": candidate.priority,
+            "texture_class": candidate.classification.texture_class,
+            "confidence": candidate.classification.confidence,
+            "evidence": candidate.classification.evidence,
+        }
+        existing = discovered.get(key)
+        if existing is None or record["priority"] < existing["priority"]:
+            discovered[key] = record
+    group["discovered_textures"] = list(discovered.values())
+
+
+def _apply_candidate(draw, candidate, texture_index):
+    if _has_mod_texture(draw, candidate.role):
+        return
+    if candidate.file:
+        draw.set_texture_default(candidate.role, candidate.file)
+        draw.texture_provenance.setdefault(
+            candidate.role, candidate.association_source)
+        return
+    draw.texture_provenance.setdefault(
+        candidate.role, candidate.association_source)
+    _apply_hash_replacements(
+        draw,
+        [TextureSemanticEvidence(
+            role=candidate.role,
+            texture_hash=candidate.original_hash,
+            source=candidate.association_source,
+            texture_class=candidate.classification.texture_class,
+            confidence=candidate.classification.confidence,
+            evidence=candidate.classification.evidence,
+        )],
+        texture_index,
+    )
 
 
 def apply(groups, mod_dir, *, dds_classification_cache=None):
-    """Apply conservative WuWa direct-binding and filename/DDS evidence.
+    """Resolve WuWa roles and expose viable candidates to texture pools.
 
-    Direct effective draw bindings are stronger evidence than generated
-    replacement filenames. Asset and slot semantics must run before this pass;
-    this function only fills roles that remain unresolved.
+    Direct bindings are stronger than generated filename associations. The
+    parser-owned diffuse pool is not mutated; discovered candidates are kept
+    in enrichment-owned group state for the mesh builder to merge later.
     """
     cache = (dds_classification_cache
              if dds_classification_cache is not None else {})
@@ -232,34 +331,35 @@ def apply(groups, mod_dir, *, dds_classification_cache=None):
         ordinal = _component_ordinal(group)
         if ordinal is None or _uses_slotfix(group):
             continue
+
+        direct_by_draw = []
+        all_candidates = []
         for draw in group.get("draws", []):
-            _apply_direct_dds(draw, mod_dir, cache)
+            direct = _direct_dds_candidates(draw, mod_dir, cache)
+            direct_by_draw.append(direct)
+            all_candidates.extend(direct)
+
         texture_index = group.get("_texture_override_index")
-        if not isinstance(texture_index, TextureOverrideIndex):
-            continue
-        index_key = id(texture_index)
-        parsed_index = parsed_indexes.get(index_key)
-        if parsed_index is None:
-            parsed_index = _index_metadata(texture_index)
-            parsed_indexes[index_key] = parsed_index
-        selected = _select_candidates(
-            ordinal, mod_dir, cache, parsed_index)
-        if not selected:
-            continue
-        for draw in group.get("draws", []):
-            evidence = []
-            for candidate in selected.values():
-                if _has_mod_texture(draw, candidate.role):
-                    continue
-                draw.texture_provenance.setdefault(
-                    candidate.role, "wuwa_filename_dds")
-                evidence.append(TextureSemanticEvidence(
-                    role=candidate.role,
-                    texture_hash=candidate.original_hash,
-                    source="wuwa_filename_dds",
-                    texture_class=candidate.classification.texture_class,
-                    confidence=candidate.classification.confidence,
-                    evidence=candidate.classification.evidence,
-                ))
-            if evidence:
-                _apply_hash_replacements(draw, evidence, texture_index)
+        filename_selected = {}
+        filename_inventory = []
+        if isinstance(texture_index, TextureOverrideIndex):
+            index_key = id(texture_index)
+            parsed_index = parsed_indexes.get(index_key)
+            if parsed_index is None:
+                parsed_index = _index_metadata(texture_index)
+                parsed_indexes[index_key] = parsed_index
+            filename_selected = _select_candidates(
+                ordinal, mod_dir, cache, parsed_index)
+            filename_inventory = _filename_inventory(
+                ordinal, mod_dir, cache, parsed_index)
+            all_candidates.extend(filename_inventory)
+
+        _record_discovered(group, all_candidates, mod_dir)
+
+        for draw, direct_candidates in zip(
+                group.get("draws", []), direct_by_draw):
+            candidates = direct_candidates + list(filename_selected.values())
+            for role in _INFERRED_ROLES:
+                selected = _select_role_candidate(candidates, role, mod_dir)
+                if selected is not None:
+                    _apply_candidate(draw, selected, texture_index)

--- a/src/app/wuwa_texture_fallback.py
+++ b/src/app/wuwa_texture_fallback.py
@@ -69,15 +69,24 @@ def _file_key(path):
     return os.path.normcase(os.path.normpath(path))
 
 
-def _analysis_roles(classification):
-    """Map structural analysis to roles the contextual resolver may use."""
+def _is_strong_normal_candidate(classification):
+    return (classification.role == "normal_map"
+            and classification.confidence == "high")
+
+
+def _direct_analysis_roles(classification):
+    """Map direct draw evidence to roles the contextual resolver may use."""
     roles = []
-    if (classification.role == "normal_map"
-            and classification.confidence == "high"):
+    if _is_strong_normal_candidate(classification):
         roles.append("normal_map")
     if is_color_candidate(classification):
         roles.append("diffuse")
     return tuple(roles)
+
+
+def _filename_analysis_roles(classification):
+    """Filename association is allowed to produce Diffuse candidates only."""
+    return ("diffuse",) if is_color_candidate(classification) else ()
 
 
 def _direct_dds_candidates(draw, mod_dir, cache):
@@ -94,7 +103,7 @@ def _direct_dds_candidates(draw, mod_dir, cache):
         if path is None:
             continue
         classification = _cached_dds_classification(path, cache)
-        for role in _analysis_roles(classification):
+        for role in _direct_analysis_roles(classification):
             key = (role, _file_key(path))
             candidates.setdefault(key, _Candidate(
                 original_hash=None,
@@ -182,7 +191,7 @@ def _classify_candidate_family(original_hash, items, ordinal, mod_dir, cache):
     role_items = [
         (item, classification, role)
         for item, classification in classified
-        for role in _analysis_roles(classification)
+        for role in _filename_analysis_roles(classification)
     ]
     roles = {role for _item, _classification, role in role_items}
     if len(roles) != 1:
@@ -214,7 +223,7 @@ def _filename_inventory(ordinal, mod_dir, cache, parsed_index):
             continue
         for item, classification in classified:
             priority = _filename_priority(item.components, ordinal)
-            for role in _analysis_roles(classification):
+            for role in _filename_analysis_roles(classification):
                 result.append(_Candidate(
                     original_hash=original_hash,
                     role=role,

--- a/src/app/wuwa_texture_fallback.py
+++ b/src/app/wuwa_texture_fallback.py
@@ -1,0 +1,209 @@
+"""Conservative WuWa texture roles from generated replacement filenames."""
+
+from dataclasses import dataclass
+import re
+
+from core.dds_classifier import DDSClassification
+from core.ini_parser import TextureOverrideIndex
+from core.resource_paths import safe_resource_path
+
+from .asset_enrichment import (
+    TextureSemanticEvidence,
+    _apply_hash_replacements,
+    _cached_dds_classification,
+    _has_mod_texture,
+)
+
+
+_COMPONENT_RE = re.compile(
+    r"^Component(?P<ordinal>\d+)(?:_\d+)?$", re.I)
+_WUWA_COMPONENT_TEXTURE_RE = re.compile(
+    r"^Components-(?P<components>\d+(?:-\d+)*)"
+    r"\s+t=(?P<tag>.+?)\.dds$",
+    re.I,
+)
+_INFERRED_ROLES = frozenset(("diffuse", "normal_map"))
+
+
+@dataclass(frozen=True, slots=True)
+class _FilenameReplacement:
+    replacement: object
+    components: frozenset[int]
+    specificity: int
+    filename_tag: str
+
+
+@dataclass(frozen=True, slots=True)
+class _Candidate:
+    original_hash: str
+    role: str
+    specificity: int
+    classification: DDSClassification
+
+
+def _component_ordinal(group):
+    name = group.get("display_name") or group.get("name")
+    match = _COMPONENT_RE.fullmatch(str(name or ""))
+    return int(match.group("ordinal")) if match else None
+
+
+def _uses_slotfix(group):
+    return any(
+        item.role_hint_source == "mod_slot_mapping"
+        for draw in group.get("draws", [])
+        for item in draw.slot_textures
+    )
+
+
+def _basename(filename):
+    # Resource paths are normally POSIX-like even on Windows. Splitting both
+    # separators keeps the filename parser independent of the host platform.
+    return str(filename).replace("\\", "/").rsplit("/", 1)[-1]
+
+
+def _parse_filename_replacement(replacement):
+    filename = replacement.file
+    if not isinstance(filename, str):
+        return None
+    match = _WUWA_COMPONENT_TEXTURE_RE.fullmatch(_basename(filename))
+    if not match:
+        return None
+    components = frozenset(
+        int(value) for value in match.group("components").split("-"))
+    if not components:
+        return None
+    return _FilenameReplacement(
+        replacement=replacement,
+        components=components,
+        specificity=len(components),
+        # This value is deliberately opaque. It is diagnostic metadata only;
+        # it is never compared with the INI original hash or normalized.
+        filename_tag=match.group("tag"),
+    )
+
+
+def _index_metadata(texture_index):
+    """Parse replacement filename metadata once for one INI index."""
+    result = {}
+    for original_hash, replacements in (
+            texture_index.replacements_by_hash or {}).items():
+        items = []
+        for replacement in replacements:
+            if not replacement.file:
+                continue
+            items.append(_parse_filename_replacement(replacement))
+        result[original_hash] = tuple(items)
+    return result
+
+
+def _classify_candidate_family(original_hash, items, ordinal, mod_dir, cache):
+    """Return one role candidate when a hash family is unambiguous."""
+    if not items or any(item is None for item in items):
+        return None
+    if any(ordinal not in item.components for item in items):
+        return None
+
+    classified = []
+    for item in items:
+        path = safe_resource_path(mod_dir, item.replacement.file)
+        if path is None:
+            return None
+        classified.append(_cached_dds_classification(path, cache))
+
+    role_items = [
+        (item, classification)
+        for item, classification in zip(items, classified)
+        if (classification.role in _INFERRED_ROLES
+            and classification.confidence == "high")
+    ]
+    roles = {classification.role for _item, classification in role_items}
+    if len(roles) != 1:
+        return None
+    role = next(iter(roles))
+    role_items = [
+        (item, classification)
+        for item, classification in role_items
+        if classification.role == role
+    ]
+    _strongest_item, strongest_classification = min(
+        role_items, key=lambda pair: pair[0].specificity)
+    return _Candidate(
+        # Keep the index key as the TextureOverride identity. The filename's
+        # opaque tag and replacement object cannot define that identity.
+        original_hash=original_hash,
+        role=role,
+        specificity=min(item.specificity for item, _ in role_items),
+        classification=strongest_classification,
+    )
+
+
+def _select_candidates(ordinal, mod_dir, cache, parsed_index):
+    candidates = []
+    for original_hash, items in parsed_index.items():
+        candidate = _classify_candidate_family(
+            original_hash, items, ordinal, mod_dir, cache)
+        if candidate is not None:
+            candidates.append(candidate)
+
+    selected = {}
+    for role in _INFERRED_ROLES:
+        role_candidates = [item for item in candidates if item.role == role]
+        if not role_candidates:
+            continue
+        specificity = min(item.specificity for item in role_candidates)
+        strongest = [
+            item for item in role_candidates
+            if item.specificity == specificity
+        ]
+        hashes = {item.original_hash for item in strongest}
+        if len(hashes) != 1:
+            # Equal-strength distinct hash families are ambiguous. The
+            # fallback must never make a first/lexicographic choice.
+            continue
+        selected[role] = strongest[0]
+    return selected
+
+
+def apply(groups, mod_dir, *, dds_classification_cache=None):
+    """Apply conservative WuWa filename/DDS semantic texture evidence.
+
+    The pass is intentionally independent of Asset resolution. It only reads
+    replacement files already referenced by each INI's own texture index and
+    delegates all conditional texture mutation to the shared enrichment path.
+    """
+    cache = (dds_classification_cache
+             if dds_classification_cache is not None else {})
+    parsed_indexes = {}
+    for group in groups or ():
+        ordinal = _component_ordinal(group)
+        if ordinal is None or _uses_slotfix(group):
+            continue
+        texture_index = group.get("_texture_override_index")
+        if not isinstance(texture_index, TextureOverrideIndex):
+            continue
+        index_key = id(texture_index)
+        parsed_index = parsed_indexes.get(index_key)
+        if parsed_index is None:
+            parsed_index = _index_metadata(texture_index)
+            parsed_indexes[index_key] = parsed_index
+        selected = _select_candidates(
+            ordinal, mod_dir, cache, parsed_index)
+        if not selected:
+            continue
+        for draw in group.get("draws", []):
+            evidence = []
+            for candidate in selected.values():
+                if _has_mod_texture(draw, candidate.role):
+                    continue
+                draw.texture_provenance.setdefault(
+                    candidate.role, "wuwa_filename_dds")
+                evidence.append(TextureSemanticEvidence(
+                    role=candidate.role,
+                    texture_hash=candidate.original_hash,
+                    source="wuwa_filename_dds",
+                    texture_class=candidate.classification.texture_class,
+                    confidence=candidate.classification.confidence,
+                    evidence=candidate.classification.evidence,
+                ))
+            if evidence:
+                _apply_hash_replacements(draw, evidence, texture_index)

--- a/src/app/wuwa_texture_fallback.py
+++ b/src/app/wuwa_texture_fallback.py
@@ -28,7 +28,7 @@ _INFERRED_ROLES = frozenset(("diffuse", "normal_map"))
 @dataclass(frozen=True, slots=True)
 class _FilenameReplacement:
     replacement: object
-    components: frozenset[int]
+    components: tuple[int, ...]
     specificity: int
     filename_tag: str
 
@@ -37,7 +37,7 @@ class _FilenameReplacement:
 class _Candidate:
     original_hash: str
     role: str
-    specificity: int
+    priority: tuple[int, int]
     classification: DDSClassification
 
 
@@ -61,6 +61,18 @@ def _basename(filename):
     return str(filename).replace("\\", "/").rsplit("/", 1)[-1]
 
 
+def _component_priority(components, ordinal):
+    if ordinal not in components:
+        return None
+    if components == (ordinal,):
+        tier = 0
+    elif components[0] == ordinal:
+        tier = 1
+    else:
+        tier = 2
+    return tier, len(components)
+
+
 def _parse_filename_replacement(replacement):
     filename = replacement.file
     if not isinstance(filename, str):
@@ -68,7 +80,7 @@ def _parse_filename_replacement(replacement):
     match = _WUWA_COMPONENT_TEXTURE_RE.fullmatch(_basename(filename))
     if not match:
         return None
-    components = frozenset(
+    components = tuple(
         int(value) for value in match.group("components").split("-"))
     if not components:
         return None
@@ -100,7 +112,8 @@ def _classify_candidate_family(original_hash, items, ordinal, mod_dir, cache):
     """Return one role candidate when a hash family is unambiguous."""
     if not items or any(item is None for item in items):
         return None
-    if any(ordinal not in item.components for item in items):
+    if any(_component_priority(item.components, ordinal) is None
+           for item in items):
         return None
 
     classified = []
@@ -126,13 +139,16 @@ def _classify_candidate_family(original_hash, items, ordinal, mod_dir, cache):
         if classification.role == role
     ]
     _strongest_item, strongest_classification = min(
-        role_items, key=lambda pair: pair[0].specificity)
+        role_items,
+        key=lambda pair: _component_priority(pair[0].components, ordinal))
     return _Candidate(
         # Keep the index key as the TextureOverride identity. The filename's
         # opaque tag and replacement object cannot define that identity.
         original_hash=original_hash,
         role=role,
-        specificity=min(item.specificity for item, _ in role_items),
+        priority=min(
+            _component_priority(item.components, ordinal)
+            for item, _ in role_items),
         classification=strongest_classification,
     )
 
@@ -150,10 +166,10 @@ def _select_candidates(ordinal, mod_dir, cache, parsed_index):
         role_candidates = [item for item in candidates if item.role == role]
         if not role_candidates:
             continue
-        specificity = min(item.specificity for item in role_candidates)
+        priority = min(item.priority for item in role_candidates)
         strongest = [
             item for item in role_candidates
-            if item.specificity == specificity
+            if item.priority == priority
         ]
         hashes = {item.original_hash for item in strongest}
         if len(hashes) != 1:

--- a/src/core/dds_classifier.py
+++ b/src/core/dds_classifier.py
@@ -1,4 +1,4 @@
-"""Game-agnostic, conservative semantic hints for DDS replacement files."""
+"""Game-agnostic structural analysis for DDS texture candidates."""
 
 from dataclasses import dataclass
 import math
@@ -10,12 +10,39 @@ from .textures import load_texture_image
 
 @dataclass(frozen=True, slots=True)
 class DDSClassification:
-    """The evidence available without relying on a mod or game naming scheme."""
+    """Structural evidence available without mod or game naming schemes.
+
+    ``role`` remains as a compatibility field for genuinely strong normal-map
+    evidence and older callers. Color analysis intentionally does not assign
+    ``diffuse``; a contextual resolver must combine it with association
+    evidence before choosing that semantic role.
+    """
 
     role: str | None
     texture_class: str
     confidence: str
     evidence: tuple[str, ...] = ()
+    color_score: float = 0.0
+    normal_score: float = 0.0
+    mask_score: float = 0.0
+    data_score: float = 0.0
+
+
+def is_color_candidate(classification):
+    """Return whether analysis supports using a file as a color candidate."""
+    if classification.role == "normal_map":
+        return False
+    if classification.role == "diffuse":
+        # Compatibility with older test doubles/callers. Production analysis
+        # no longer emits this role for color images.
+        return classification.confidence in {"medium", "high"}
+    if classification.texture_class not in {"color", "effect"}:
+        return False
+    # A zero score denotes a legacy four-field DDSClassification constructed
+    # by an adapter. Its class/confidence fields remain authoritative.
+    if classification.color_score == 0:
+        return classification.confidence in {"medium", "high"}
+    return classification.color_score >= 0.35
 
 
 def classification_cache_key(path):
@@ -30,6 +57,29 @@ def classification_cache_key(path):
 
 def _unknown(texture_class="unknown", *evidence):
     return DDSClassification(None, texture_class, "low", tuple(evidence))
+
+
+def _color_score(stats, is_srgb):
+    if not is_srgb:
+        return 0.0
+    deviations = stats["deviations"]
+    score = 0.35
+    score += min(min(deviations) / 64.0, 1.0) * 0.20
+    score += min(stats["chroma"] / 100.0, 1.0) * 0.15
+    score += min(stats["color_entropy"] / 5.0, 1.0) * 0.15
+    score += min(stats["spatial_detail"] / 40.0, 1.0) * 0.10
+    score -= max(0.0, stats["gray_fraction"] - 0.40) * 0.30
+    if stats["dominant_channel_fraction"] >= 0.90:
+        score -= 0.35
+    return max(0.0, min(1.0, score))
+
+
+def _score_confidence(score):
+    if score >= 0.70:
+        return "high"
+    if score >= 0.35:
+        return "medium"
+    return "low"
 
 
 def _channel_stats(image):
@@ -119,7 +169,9 @@ def _decoded_classification(info, image):
         return _unknown("lookup", "tiny_dimensions")
     if (sum(deviations) < 9 and chroma < 8
             or stats["black_fraction"] >= 0.75):
-        return _unknown("packed_mask", "low_variation", "low_chroma")
+        return DDSClassification(
+            None, "packed_mask", "low",
+            ("low_variation", "low_chroma"), mask_score=0.85)
 
     # A packed XY normal is centered around 0.5 in R/G and has an almost
     # empty blue channel.  The unit-circle test rejects arbitrary low-blue
@@ -138,57 +190,23 @@ def _decoded_classification(info, image):
         return DDSClassification(
             "normal_map", "packed_normal", "high",
             (f"format:{info.format}", "centered_xy", "low_blue",
-             "valid_xy"))
+             "valid_xy"), normal_score=0.95)
 
     if (info.format in {"bc7_unorm", "rgba8", "bgra8"}
             and means[2] / 255.0 < 0.15 and chroma > 20):
         return DDSClassification(
             None, "packed_data", "medium",
             (f"format:{info.format}", "linear_channels",
-             "invalid_normal_layout"))
+             "invalid_normal_layout"), data_score=0.85)
 
     is_srgb = info.format.endswith("_srgb")
     if is_srgb and info.width >= 2 and info.height >= 2:
-        normalized_means = [mean / 255.0 for mean in means]
-        ordered_means = sorted(normalized_means)
-        strong_channel_dominance = (
-            ordered_means[-1] >= 0.75 and ordered_means[-2] <= 0.25)
-        diffuse_variation = (
-            min(deviations) >= 32
-            and chroma >= 40
-            and stats["quantized_occupancy"] >= 32
-            and not strong_channel_dominance
-        )
-        diffuse_layout = (
-            diffuse_variation
-            and stats["black_fraction"] < 0.30
-            and stats["gray_fraction"] < 0.45
-            and stats["color_entropy"] >= 3.5
-            and stats["spatial_detail"] >= 4
-        )
-        # Some base-color atlases use a dark or grayscale background while
-        # retaining strong channel variation and spatial texture. Those
-        # properties are diffuse evidence even when palette entropy is low;
-        # dominant-channel mean encoding remains rejected above.
-        structured_atlas_layout = (
-            diffuse_variation
-            and stats["black_fraction"] < 0.60
-            and stats["gray_fraction"] < 0.60
-            and stats["spatial_detail"] >= 20
-        )
-        if diffuse_layout or structured_atlas_layout:
-            return DDSClassification(
-                "diffuse", "color", "high",
-                (f"format:{info.format}", "color_complexity",
-                 "channel_variance", "spatial_detail"))
-        if (stats["color_entropy"] < 3.5
-                or stats["spatial_detail"] < 4
-                or stats["gray_fraction"] >= 0.45):
-            texture_class = "effect"
-        else:
-            texture_class = "color"
-        return _unknown(texture_class, f"format:{info.format}",
-                        "insufficient_diffuse_evidence")
+        color_score = _color_score(stats, is_srgb)
+        texture_class = "color" if color_score >= 0.55 else "effect"
+        return DDSClassification(
+            None, texture_class, _score_confidence(color_score),
+            (f"format:{info.format}", "srgb_color_space",
+             "pixel_color_evidence"), color_score=color_score)
 
     if chroma < 12:
         return _unknown("packed_mask", f"format:{info.format}",
@@ -205,13 +223,18 @@ def classify_dds(path):
     if info.format in {"bc5_unorm", "bc5_snorm"}:
         return DDSClassification(
             "normal_map", "packed_normal", "high",
-            (f"format:{info.format}", "two_channel_block_format"))
+            (f"format:{info.format}", "two_channel_block_format"),
+            normal_score=1.0)
     if info.format in {"bc4_unorm", "bc4_snorm"}:
-        return _unknown("single_channel_mask", f"format:{info.format}")
+        return DDSClassification(
+            None, "single_channel_mask", "high",
+            (f"format:{info.format}",), mask_score=0.95)
     if max(info.width, info.height) <= 4:
         return _unknown("lookup", "tiny_dimensions")
     if info.format in {"bc6h_ufloat", "bc6h_float"}:
-        return _unknown("effect", f"format:{info.format}")
+        return DDSClassification(
+            None, "effect", "high", (f"format:{info.format}",),
+            data_score=0.75)
 
     image = load_texture_image(path, max_size=128, preserve_alpha=True)
     if image is None:

--- a/src/core/dds_classifier.py
+++ b/src/core/dds_classifier.py
@@ -153,20 +153,30 @@ def _decoded_classification(info, image):
         ordered_means = sorted(normalized_means)
         strong_channel_dominance = (
             ordered_means[-1] >= 0.75 and ordered_means[-2] <= 0.25)
-        restricted_palette = (
-            stats["dominant_channel_fraction"] >= 0.95)
-        diffuse_layout = (
-            stats["black_fraction"] < 0.30
-            and stats["gray_fraction"] < 0.45
-            and min(deviations) >= 32
+        diffuse_variation = (
+            min(deviations) >= 32
             and chroma >= 40
-            and stats["color_entropy"] >= 3.5
             and stats["quantized_occupancy"] >= 32
-            and stats["spatial_detail"] >= 4
             and not strong_channel_dominance
-            and not restricted_palette
         )
-        if diffuse_layout:
+        diffuse_layout = (
+            diffuse_variation
+            and stats["black_fraction"] < 0.30
+            and stats["gray_fraction"] < 0.45
+            and stats["color_entropy"] >= 3.5
+            and stats["spatial_detail"] >= 4
+        )
+        # Some base-color atlases use a dark or grayscale background while
+        # retaining strong channel variation and spatial texture. Those
+        # properties are diffuse evidence even when palette entropy is low;
+        # dominant-channel mean encoding remains rejected above.
+        structured_atlas_layout = (
+            diffuse_variation
+            and stats["black_fraction"] < 0.60
+            and stats["gray_fraction"] < 0.60
+            and stats["spatial_detail"] >= 20
+        )
+        if diffuse_layout or structured_atlas_layout:
             return DDSClassification(
                 "diffuse", "color", "high",
                 (f"format:{info.format}", "color_complexity",

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -579,20 +579,61 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 tex_uris[key] = value or ""
             return key
 
-        # Every diffuse this component's ini ever references, resolved once
-        # and shared by every draw in the group -- the UI's per-mesh texture
-        # picker list (core/ini_parser.py's build_draw_groups). Uses the same
-        # _tex_key cache/registry as the draws' own textures so an option
-        # that's also someone's active default doesn't get encoded twice.
+        # Every parser-derived or enrichment-discovered diffuse this
+        # component references, resolved once and shared by every draw in the
+        # group -- the UI's per-mesh texture picker list. The parser-owned
+        # diffuse pool remains separate from WuWa discovery; both use the same
+        # role-aware registry so duplicate files produce one option.
         texture_options = []
+        texture_option_keys = set()
+
+        def _append_texture_option(key, filename, label, **metadata):
+            if not key or key in texture_option_keys:
+                return
+            texture_option_keys.add(key)
+            option = {"tex_key": key, "file": filename, "label": label}
+            option.update(metadata)
+            texture_options.append(option)
+
         for pool_entry in grp.get("diffuse_pool_files") or []:
             key = _tex_key(safe_resource_path(mod_dir, pool_entry["file"]))
             if key:
                 res_name = pool_entry["res"]
                 label = res_name[8:] if res_name.startswith("Resource") else res_name
-                texture_options.append({"tex_key": key,
-                                        "file": pool_entry["file"],
-                                        "label": label})
+                _append_texture_option(key, pool_entry["file"], label)
+
+        discovered_normals = {}
+        normal_role = texture_profile.normal_transport_role
+        for candidate in grp.get("discovered_textures") or []:
+            filename = candidate.get("file")
+            role = candidate.get("role") or candidate.get(
+                "semantic_candidate")
+            path = safe_resource_path(mod_dir, filename)
+            if path is None:
+                continue
+            if role == "diffuse":
+                key = _tex_key(path)
+                label = os.path.splitext(
+                    str(filename).replace("\\", "/").rsplit("/", 1)[-1]
+                )[0]
+                _append_texture_option(
+                    key, filename, label,
+                    candidate_source=candidate.get("source"),
+                    candidate_priority=candidate.get("priority"),
+                )
+            elif role == "normal_map":
+                key = _tex_key(path, normal_role)
+                if key:
+                    discovered_normals[key] = key
+
+        # A unique discovered normal is safe to pair with every diffuse pool
+        # option. Ambiguous normals remain available only as analysis data;
+        # guessing a color/normal Cartesian product would create false pairs.
+        if len(discovered_normals) == 1:
+            normal_key = next(iter(discovered_normals.values()))
+            for option in texture_options:
+                if not option.get("normal_map") and not option.get("normal_data"):
+                    option[normal_role] = normal_key
 
         for draw in unique:
             lbl = draw.label

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -621,7 +621,8 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                     candidate_source=candidate.get("source"),
                     candidate_priority=candidate.get("priority"),
                 )
-            elif role == "normal_map":
+            elif (role == "normal_map"
+                  and candidate.get("source") == "wuwa_direct_analysis"):
                 key = _tex_key(path, normal_role)
                 if key:
                     discovered_normals[key] = key

--- a/src/tests/test_asset_resolver.py
+++ b/src/tests/test_asset_resolver.py
@@ -1066,7 +1066,8 @@ def test_roleless_gimi_hash_uses_generic_dds_fallback(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "app.asset_enrichment.classify_dds",
         lambda _path: dds_classifier.DDSClassification(
-            "diffuse", "color", "high", ("synthetic_color",)))
+            None, "effect", "medium", ("synthetic_color",),
+            color_score=0.5))
     draw = DrawCall()
     binding = AssetComponentBinding(
         status="exact", asset_type="GIMI", asset="Alice", root=root,

--- a/src/tests/test_asset_resolver.py
+++ b/src/tests/test_asset_resolver.py
@@ -998,7 +998,7 @@ def test_wwmi_hash_replacement_is_component_diagnostic_without_role_guess(
     assert draw.asset_texture_defaults == {}
 
 
-def test_dds_classification_cache_is_reused_for_semantic_refresh(
+def test_wwmi_textureusage_does_not_trigger_dds_classification(
         tmp_path, monkeypatch):
     root = os.path.normcase(os.path.abspath(str(tmp_path / "assets")))
     mod_dir = tmp_path / "mod"

--- a/src/tests/test_asset_resolver.py
+++ b/src/tests/test_asset_resolver.py
@@ -992,11 +992,8 @@ def test_wwmi_hash_replacement_is_component_diagnostic_without_role_guess(
     assert draw.asset_slot_evidence == [{
         "slot": 3, "texture_hash": "553ed32b",
         "vs_hash": "aaaaaaaa", "ps_hash": "bbbbbbbb",
-        "replacement_resource": "ResourceTexture0",
-        "replacement_file": "textures/texture0.dds",
-        "replacement_conditions": [],
-        "source": "mod_texture_hash",
     }]
+    assert draw.texture_default("diffuse") is None
     assert draw.texture_provenance == {}
     assert draw.asset_texture_defaults == {}
 
@@ -1042,9 +1039,9 @@ def test_dds_classification_cache_is_reused_for_semantic_refresh(
     apply([{"draws": [second]}], [[binding]], texture_index=index,
          mod_dir=str(mod_dir), dds_classification_cache=cache)
 
-    assert len(calls) == 1
-    assert first.texture_default("diffuse") == "textures/replacement.dds"
-    assert second.texture_default("diffuse") == "textures/replacement.dds"
+    assert calls == []
+    assert first.texture_default("diffuse") is None
+    assert second.texture_default("diffuse") is None
 
 
 def test_roleless_gimi_hash_uses_generic_dds_fallback(tmp_path, monkeypatch):
@@ -1162,10 +1159,10 @@ def test_wwmi_replacements_use_component_local_dds_roles(tmp_path, monkeypatch):
     apply([{"draws": [draw]}], [[binding]], texture_index=index,
          mod_dir=str(mod_dir))
 
-    assert draw.texture_default("diffuse") == "diffuse.dds"
-    assert draw.texture_default("normal_map") == "normal.dds"
-    assert {item["role_source"] for item in draw.asset_slot_evidence
-            if item.get("role")} == {"dds_analysis"}
+    assert draw.texture_default("diffuse") is None
+    assert draw.texture_default("normal_map") is None
+    assert {item["texture_hash"] for item in draw.asset_slot_evidence} == {
+        "11111111", "22222222"}
 
 
 def test_asset_fallback_uses_trusted_source_and_keeps_diagnostic(tmp_path):

--- a/src/tests/test_dds_classifier.py
+++ b/src/tests/test_dds_classifier.py
@@ -49,10 +49,11 @@ def test_bc5_is_a_high_confidence_normal_without_decoding(tmp_path):
 
     assert result == dds_classifier.DDSClassification(
         "normal_map", "packed_normal", "high",
-        ("format:bc5_unorm", "two_channel_block_format"))
+        ("format:bc5_unorm", "two_channel_block_format"),
+        normal_score=1.0)
 
 
-def test_srgb_color_pixels_are_diffuse_and_filename_is_ignored(
+def test_srgb_color_pixels_are_color_candidates_and_filename_is_ignored(
         tmp_path, monkeypatch):
     image = Image.new("RGB", (8, 8))
     image.putdata([
@@ -66,9 +67,10 @@ def test_srgb_color_pixels_are_diffuse_and_filename_is_ignored(
     first = dds_classifier.classify_dds(tmp_path / "first.dds")
     second = dds_classifier.classify_dds(tmp_path / "different-name.dds")
 
-    assert first.role == "diffuse"
+    assert first.role is None
     assert first.texture_class == "color"
     assert first.confidence == "high"
+    assert first.color_score >= 0.70
     assert second == first
 
 
@@ -157,7 +159,7 @@ def test_channel_dominant_color_data_is_not_diffuse(tmp_path, monkeypatch):
     assert result.role is None
 
 
-def test_dominant_channel_palette_can_be_diffuse_with_spatial_detail(
+def test_dominant_channel_palette_exposes_structural_color_evidence(
         tmp_path, monkeypatch):
     image = Image.new("RGB", (8, 8))
     image.putdata([
@@ -172,9 +174,10 @@ def test_dominant_channel_palette_can_be_diffuse_with_spatial_detail(
 
     result = dds_classifier.classify_dds(tmp_path / "restricted.dds")
 
-    assert result.role == "diffuse"
-    assert result.confidence == "high"
-    assert result.texture_class == "color"
+    assert result.role is None
+    assert result.confidence == "medium"
+    assert result.texture_class == "effect"
+    assert result.color_score >= 0.35
 
 
 def test_tiny_texture_is_diagnostic_lookup_only(tmp_path, monkeypatch):

--- a/src/tests/test_dds_classifier.py
+++ b/src/tests/test_dds_classifier.py
@@ -157,7 +157,7 @@ def test_channel_dominant_color_data_is_not_diffuse(tmp_path, monkeypatch):
     assert result.role is None
 
 
-def test_restricted_palette_is_not_diffuse_despite_spatial_detail(
+def test_dominant_channel_palette_can_be_diffuse_with_spatial_detail(
         tmp_path, monkeypatch):
     image = Image.new("RGB", (8, 8))
     image.putdata([
@@ -172,7 +172,8 @@ def test_restricted_palette_is_not_diffuse_despite_spatial_detail(
 
     result = dds_classifier.classify_dds(tmp_path / "restricted.dds")
 
-    assert result.role is None
+    assert result.role == "diffuse"
+    assert result.confidence == "high"
     assert result.texture_class == "color"
 
 

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -614,25 +614,16 @@ def test_asset_identity_and_texture_provenance_are_diagnostic_only(
         page.locator("#inspector-tab").click()
         page.locator(".draw-item").first.click()
         inspector = page.locator("#inspector-content")
-        assert inspector.locator(".inspector-asset-section").inner_text() == (
-            "ASSET MATCH\nAsset\nAlice\nType\nGIMI\nComponent\nBody\nObject\nB\n"
-            "Geometry hash\n73c8cae2\nRange\n43845 / 24\nComponent match\nExact\n"
-            "Range match\nExact\nMatch\nExact")
-        assert "Normal (automatic)\nAsset fallback" in inspector.inner_text()
-        assert "Diffuse (automatic)\nMod slot mapping" in inspector.inner_text()
-        assert "ps-t1" in inspector.locator(".inspector-slot-section").inner_text()
-        assert "Role\nUnknown" in inspector.locator(
-            ".inspector-slot-section").inner_text()
-        conflict = inspector.locator(
-            '.inspector-slot-evidence[data-conflict="true"]')
-        assert conflict.inner_text() == (
-            "ps-t2\nTexture\n22222222\nVS\n—\nPS\n—\nRole\nDiffuse\n"
-            "Role source\nMod slot mapping\nAsset hash role\nNormal\nConflict\nYes")
+        assert inspector.locator(".inspector-asset-section").count() == 0
+        assert inspector.locator(".inspector-slot-section").count() == 0
+        assert "Asset resolution" not in inspector.inner_text()
+        assert "Texture provenance" not in inspector.inner_text()
+        assert "Slot evidence" not in inspector.inner_text()
 
         page.locator(".inspector-texture-option", has_text="Asset two").click()
-        assert inspector.locator(
-            '[data-provenance-kind="viewer"] .inspector-value').inner_text() == (
-                "Viewer override (diffuse::Asset-two.png)")
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].userData.manualTexOverride") == (
+                "diffuse::Asset-two.png")
         page.locator("#health-btn").click()
         page.locator("#health-modal-backdrop.show").wait_for()
         assert page.locator("#health-asset-summary").inner_text() == (
@@ -640,7 +631,7 @@ def test_asset_identity_and_texture_provenance_are_diagnostic_only(
         page.locator("#health-close").click()
 
         page.locator(".group-hdr .group-name").first.click()
-        assert "1 of 1 matched" in inspector.inner_text()
+        assert "Asset resolution" not in inspector.inner_text()
     finally:
         context.close()
 
@@ -692,7 +683,8 @@ def test_asset_diagnostics_refresh_with_semantic_updates(
         page.locator(".draw-item").wait_for()
         page.locator("#inspector-tab").click()
         page.locator(".draw-item").first.click()
-        assert "Alice" in page.locator(".inspector-asset-section").inner_text()
+        inspector = page.locator("#inspector-content")
+        assert inspector.locator(".inspector-asset-section").count() == 0
 
         page.evaluate("""() => {
           const state = window.__fakeApi;
@@ -720,15 +712,13 @@ def test_asset_diagnostics_refresh_with_semantic_updates(
         }""")
         page.evaluate("window.modViewer.refreshMeshSemantics()")
         page.wait_for_function(
-            "document.querySelector('#inspector-content')?.innerText.includes('Not found')")
-        assert "Normal (automatic)\nMod" in page.locator(
-            "#inspector-content").inner_text()
+            "document.querySelector('#inspector-content .inspector-material-kind-control')")
         assert page.evaluate(
             "window.modViewer.activeMeshes[0].userData.assetEntry"
             ".asset_binding.status === 'not_found'")
         assert page.locator(".asset-draw-label").count() == 0
-        assert "Match\nNot found" in page.locator(
-            ".inspector-asset-section").inner_text()
+        assert inspector.locator(".inspector-asset-section").count() == 0
+        assert "Not found" not in inspector.inner_text()
         assert page.locator(".asset-component-label").inner_text() == (
             "Asset: Partial")
         page.locator("#health-btn").click()
@@ -3725,11 +3715,27 @@ def test_inspector_follows_component_and_mesh_selection(
         page.locator("#inspector-tab").click()
         page.locator(".group-hdr .group-name").first.click()
         page.locator("#inspector-content").wait_for()
-        assert "Draw calls" in page.locator("#inspector-content").inner_text()
+        inspector = page.locator("#inspector-content")
+        assert "Draw calls" not in inspector.inner_text()
+        assert inspector.locator(".inspector-header h3").inner_text() == "Body A"
+        assert inspector.locator(".inspector-context").inner_text() == (
+            "1 mesh · 1 visible")
+        assert inspector.locator(".inspector-section-title").all_inner_texts() == [
+            "MATERIAL", "TEXTURES"]
+        assert inspector.locator(".inspector-manage-textures").count() == 1
         assert page.locator("#inspector-empty").is_hidden()
 
         page.locator(".draw-item").first.click()
-        assert page.locator("#inspector-content .inspector-header h3").inner_text()
+        assert inspector.locator(".inspector-header h3").inner_text()
+        assert inspector.locator(".inspector-context").inner_text() == "Body A"
+        assert inspector.locator(".inspector-section-title").all_inner_texts() == [
+            "MATERIAL", "TEXTURE"]
+        assert "State" not in inspector.inner_text()
+        assert "Material kind" not in inspector.inner_text()
+        assert "Texture provenance" not in inspector.inner_text()
+        assert "Slot evidence" not in inspector.inner_text()
+        assert "Draw" not in inspector.inner_text()
+        assert "Resolved" not in inspector.inner_text()
         assert "Body A >" in page.locator("#selected-mesh-status").inner_text()
         assert page.locator(".draw-item.selected").count() == 1
         page.evaluate("import('./js/selection.js').then(({clearSelection}) => clearSelection())")
@@ -3739,11 +3745,13 @@ def test_inspector_follows_component_and_mesh_selection(
         page.locator(".group-hdr .group-name").first.click()
         assert page.locator(".draw-item.selected").count() == 0
         assert "selected" in page.locator(".group-hdr").first.get_attribute("class")
-        assert page.locator("#inspector-content .inspector-row", has_text="1 of 1").count() == 1
+        assert inspector.locator(".inspector-context").inner_text() == (
+            "1 mesh · 1 visible")
         assert page.locator("#inspector-empty").is_hidden()
 
         page.locator(".draw-item .mesh-state-btn").first.click()
-        assert page.locator("#inspector-content .inspector-row", has_text="0 of 1").count() == 1
+        assert inspector.locator(".inspector-context").inner_text() == (
+            "1 mesh · 0 visible")
         eye = page.locator(".draw-item .mesh-state-btn").first
         assert eye.get_attribute("aria-pressed") == "false"
         assert "state-hidden" in eye.get_attribute("class")
@@ -3751,7 +3759,8 @@ def test_inspector_follows_component_and_mesh_selection(
         assert page.evaluate(
             "window.modViewer.activeMeshes[0].userData.manuallyToggled") is True
         page.locator("#reset-state-btn").click()
-        assert page.locator("#inspector-content .inspector-row", has_text="1 of 1").count() == 1
+        assert inspector.locator(".inspector-context").inner_text() == (
+            "1 mesh · 1 visible")
         assert eye.get_attribute("aria-pressed") == "true"
         assert "state-hidden" not in eye.get_attribute("class")
         assert "state-manual" not in eye.get_attribute("class")

--- a/src/tests/test_wuwa_texture_candidates.py
+++ b/src/tests/test_wuwa_texture_candidates.py
@@ -1,0 +1,77 @@
+import os
+import struct
+
+from app import metadata
+from core.mesh_builder import GeometryBlob, build_mesh_result
+
+
+def _write_geometry(root):
+    (root / "p.buf").write_bytes(struct.pack(
+        "<9f", 0, 0, 0, 1, 0, 0, 0, 1, 0))
+    (root / "t.buf").write_bytes(struct.pack(
+        "<6f", 0, 0, 1, 0, 0, 1))
+    (root / "i.buf").write_bytes(struct.pack("<3I", 0, 1, 2))
+
+
+def _group(root, *, normals=("normal.dds",)):
+    for filename in ("A.dds", "B.dds", *normals):
+        (root / filename).write_bytes(b"synthetic dds")
+    return [{
+        "name": "Component4", "display_name": "Component4",
+        "position_file": "p.buf", "position_stride": 12,
+        "texcoord_file": "t.buf", "texcoord_stride": 8,
+        "ib_file": "i.buf", "index_size": 4,
+        "diffuse_pool_files": [{"res": "ResourceA", "file": "A.dds"}],
+        "discovered_textures": [
+            {"file": "A.dds", "role": "diffuse",
+             "source": "wuwa_direct_analysis", "priority": (0, 0, 0)},
+            {"file": "B.dds", "role": "diffuse",
+             "source": "wuwa_filename_analysis", "priority": (1, 1, 2)},
+            *[
+                {"file": filename, "role": "normal_map",
+                 "source": "wuwa_filename_analysis", "priority": (1, 0, 1)}
+                for filename in normals
+            ],
+        ],
+        "draws": [{"label": "Component4-1", "count": 3,
+                   "start": 0, "base": 0}],
+    }]
+
+
+def _build(root, *, normals=("normal.dds",)):
+    _write_geometry(root)
+
+    def register(path, role, transform=None):
+        return f"/texture/{role}/{os.path.basename(path)}"
+
+    return build_mesh_result(
+        _group(root, normals=normals), str(root), geometry=GeometryBlob(),
+        texture_source=register, game_profile="wuwa")
+
+
+def test_manage_texture_pool_deduplicates_parser_and_discovered_files(
+        tmp_path):
+    built = _build(tmp_path)
+    entry = built.meshes["Component4-1"]
+
+    assert [item["file"] for item in entry["texture_options"]] == [
+        "A.dds", "B.dds"]
+    assert all(item["normal_data"] == "normal_data::normal.dds"
+               for item in entry["texture_options"])
+
+    payload = {"meshes": built.meshes, "textures": {}}
+    metadata.hydrate_textures(
+        str(tmp_path), payload, texture_profile="wuwa")
+
+    pool = payload["texture_pools"]["p0"]
+    assert [item["file"] for item in pool] == ["A.dds", "B.dds"]
+    assert all(item["normal_data"] == "normal_data::normal.dds"
+               for item in pool)
+
+
+def test_manage_texture_pool_does_not_pair_ambiguous_normals(tmp_path):
+    built = _build(tmp_path, normals=("normal-a.dds", "normal-b.dds"))
+    options = built.meshes["Component4-1"]["texture_options"]
+
+    assert [item["file"] for item in options] == ["A.dds", "B.dds"]
+    assert all("normal_data" not in item for item in options)

--- a/src/tests/test_wuwa_texture_candidates.py
+++ b/src/tests/test_wuwa_texture_candidates.py
@@ -29,7 +29,7 @@ def _group(root, *, normals=("normal.dds",)):
              "source": "wuwa_filename_analysis", "priority": (1, 1, 2)},
             *[
                 {"file": filename, "role": "normal_map",
-                 "source": "wuwa_filename_analysis", "priority": (1, 0, 1)}
+                 "source": "wuwa_direct_analysis", "priority": (0, 0, 0)}
                 for filename in normals
             ],
         ],

--- a/src/tests/test_wuwa_texture_fallback.py
+++ b/src/tests/test_wuwa_texture_fallback.py
@@ -153,7 +153,8 @@ def test_direct_dds_binding_beats_filename_fallback(
         direct, fallback.file}
 
 
-def test_direct_and_filename_dds_roles_can_coexist(tmp_path, monkeypatch):
+def test_filename_normal_is_ignored_even_when_direct_diffuse_exists(
+        tmp_path, monkeypatch):
     direct = _direct_file(tmp_path, "direct.dds")
     normal = _replacement(
         tmp_path, "aaaaaaaa", "Components-4 t=normal.dds")
@@ -162,17 +163,30 @@ def test_direct_and_filename_dds_roles_can_coexist(tmp_path, monkeypatch):
     })
     draw = DrawCall(slot_textures=[SlotTextureBinding(
         0, "ResourceDirect", file=direct)])
+    group = _group("Component4", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (normal,)}), draw)
 
-    apply([_group("Component4", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (normal,)}), draw)],
-        str(tmp_path))
+    apply([group], str(tmp_path))
 
     assert draw.texture_default("diffuse") == direct
-    assert draw.texture_default("normal_map") == normal.file
-    assert draw.texture_provenance == {
-        "diffuse": "wuwa_direct_analysis",
-        "normal_map": "wuwa_filename_analysis",
-    }
+    assert draw.texture_default("normal_map") is None
+    assert draw.texture_provenance == {"diffuse": "wuwa_direct_analysis"}
+    assert [item["file"] for item in group["discovered_textures"]] == [direct]
+
+
+def test_direct_strong_normal_still_resolves_and_is_discovered(
+        tmp_path, monkeypatch):
+    normal = _direct_file(tmp_path, "direct-normal.dds")
+    _classify(monkeypatch, {"direct-normal.dds": "normal_map"})
+    draw = DrawCall(slot_textures=[SlotTextureBinding(
+        0, "ResourceNormal", file=normal)])
+    group = _group("Component4", None, draw)
+
+    apply([group], str(tmp_path))
+
+    assert draw.texture_default("normal_map") == normal
+    assert draw.texture_provenance == {"normal_map": "wuwa_direct_analysis"}
+    assert group["discovered_textures"][0]["file"] == normal
 
 
 def test_multiple_direct_files_with_one_role_are_ambiguous(
@@ -313,7 +327,7 @@ def test_different_roles_compete_per_role(tmp_path, monkeypatch):
         replacements_by_hash={"aaaaaaaa": (normal,), "bbbbbbbb": (diffuse,)}),
         draw)], str(tmp_path))
 
-    assert draw.texture_default("normal_map") == normal.file
+    assert draw.texture_default("normal_map") is None
     assert draw.texture_default("diffuse") == diffuse.file
 
 
@@ -369,10 +383,8 @@ def test_existing_role_is_preserved_while_missing_role_is_filled(
         draw)], str(tmp_path))
 
     assert draw.texture_default("diffuse") == existing
-    assert draw.texture_default("normal_map") == normal.file
-    assert draw.texture_provenance == {
-        "normal_map": "wuwa_filename_analysis",
-    }
+    assert draw.texture_default("normal_map") is None
+    assert draw.texture_provenance == {}
 
 
 def test_conditional_same_hash_family_keeps_all_variants(

--- a/src/tests/test_wuwa_texture_fallback.py
+++ b/src/tests/test_wuwa_texture_fallback.py
@@ -1,0 +1,266 @@
+import os
+from types import SimpleNamespace
+
+from app import mod_loader
+from app.asset_resolver import AssetComponentBinding
+from app.wuwa_texture_fallback import apply
+from core import dds_classifier
+from core.draw_call import DrawCall, SlotTextureBinding
+from core.ini_parser import TextureOverrideIndex, TextureReplacement
+
+
+def _replacement(tmp_path, original_hash, filename, *, conditions=()):
+    path = tmp_path / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"synthetic dds")
+    return TextureReplacement(
+        original_hash, f"Resource{original_hash}", conditions,
+        "TextureOverrideGenerated", filename)
+
+
+def _group(name, index, draw=None):
+    return {
+        "name": name,
+        "display_name": name,
+        "draws": [draw or DrawCall()],
+        "_texture_override_index": index,
+    }
+
+
+def _classify(monkeypatch, roles, calls=None):
+    def classify(path):
+        filename = os.path.basename(path)
+        if calls is not None:
+            calls.append(filename)
+        role = roles[filename]
+        return dds_classifier.DDSClassification(
+            role, "packed_normal" if role == "normal_map" else "color",
+            "high", (f"synthetic_{role}",))
+
+    monkeypatch.setattr("app.asset_enrichment.classify_dds", classify)
+
+
+def test_no_asset_component_fallback_prefers_exact_filename_candidate(
+        tmp_path, monkeypatch):
+    shared = _replacement(
+        tmp_path, "aaaaaaaa", "Components-0-1-2-3 t=randomA.dds")
+    exact = _replacement(
+        tmp_path, "bbbbbbbb", "Components-2 t=randomB.dds")
+    index = TextureOverrideIndex(replacements_by_hash={
+        "aaaaaaaa": (shared,), "bbbbbbbb": (exact,),
+    })
+    _classify(monkeypatch, {
+        shared.file: "diffuse", exact.file: "diffuse",
+    })
+    draw = DrawCall()
+
+    apply([_group("Component2", index, draw)], str(tmp_path))
+
+    assert draw.texture_default("diffuse") == exact.file
+    assert draw.texture_provenance == {"diffuse": "wuwa_filename_dds"}
+    assert draw.asset_binding is None
+
+
+def test_filename_tag_is_opaque_and_does_not_need_to_match_ini_hash(
+        tmp_path, monkeypatch):
+    first = _replacement(
+        tmp_path, "aaaaaaaa", "Components-2 t=bbbbbbbb.dds")
+    _classify(monkeypatch, {first.file: "diffuse"})
+    first_draw = DrawCall()
+    apply([_group("Component2", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (first,)}), first_draw)],
+        str(tmp_path))
+
+    second = _replacement(
+        tmp_path, "aaaaaaaa", "Components-2 t=completely-different-tag.dds")
+    _classify(monkeypatch, {second.file: "diffuse"})
+    second_draw = DrawCall()
+    apply([_group("Component2", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (second,)}), second_draw)],
+        str(tmp_path))
+
+    assert first_draw.texture_default("diffuse") == first.file
+    assert second_draw.texture_default("diffuse") == second.file
+
+
+def test_equal_specificity_distinct_hashes_are_ambiguous(tmp_path, monkeypatch):
+    first = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=A.dds")
+    second = _replacement(tmp_path, "bbbbbbbb", "Components-0 t=B.dds")
+    _classify(monkeypatch, {first.file: "diffuse", second.file: "diffuse"})
+    draw = DrawCall()
+
+    apply([_group("Component0", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (first,), "bbbbbbbb": (second,)}),
+        draw)], str(tmp_path))
+
+    assert draw.texture_default("diffuse") is None
+
+
+def test_different_roles_compete_per_role(tmp_path, monkeypatch):
+    normal = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=normal.dds")
+    diffuse = _replacement(
+        tmp_path, "bbbbbbbb", "Components-0-1-2 t=diffuse.dds")
+    _classify(monkeypatch, {
+        normal.file: "normal_map", diffuse.file: "diffuse",
+    })
+    draw = DrawCall()
+
+    apply([_group("Component0", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (normal,), "bbbbbbbb": (diffuse,)}),
+        draw)], str(tmp_path))
+
+    assert draw.texture_default("normal_map") == normal.file
+    assert draw.texture_default("diffuse") == diffuse.file
+
+
+def test_unknown_dds_does_not_create_a_render_role(tmp_path, monkeypatch):
+    unknown = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=unknown.dds")
+
+    def classify(_path):
+        return dds_classifier.DDSClassification(
+            None, "packed_data", "medium", ("synthetic_unknown",))
+
+    monkeypatch.setattr("app.asset_enrichment.classify_dds", classify)
+    draw = DrawCall()
+    apply([_group("Component0", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (unknown,)}), draw)], str(tmp_path))
+
+    assert draw.texture_default("diffuse") is None
+    assert draw.texture_default("normal_map") is None
+
+
+def test_slotfix_skips_filename_inference_and_dds_classification(
+        tmp_path, monkeypatch):
+    replacement = _replacement(
+        tmp_path, "aaaaaaaa", "Components-0 t=slotfix.dds")
+    calls = []
+    _classify(monkeypatch, {replacement.file: "diffuse"}, calls)
+    draw = DrawCall(slot_textures=[SlotTextureBinding(
+        0, "ResourceSlot", role_hint="diffuse",
+        role_hint_source="mod_slot_mapping")])
+
+    apply([_group("Component0", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (replacement,)}), draw)],
+        str(tmp_path))
+
+    assert calls == []
+    assert draw.texture_default("diffuse") is None
+
+
+def test_existing_role_is_preserved_while_missing_role_is_filled(
+        tmp_path, monkeypatch):
+    existing = "existing.dds"
+    diffuse = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=other.dds")
+    normal = _replacement(tmp_path, "bbbbbbbb", "Components-0 t=normal.dds")
+    _classify(monkeypatch, {
+        diffuse.file: "diffuse", normal.file: "normal_map",
+    })
+    draw = DrawCall(texture_default_file=existing)
+
+    apply([_group("Component0", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (diffuse,), "bbbbbbbb": (normal,)}),
+        draw)], str(tmp_path))
+
+    assert draw.texture_default("diffuse") == existing
+    assert draw.texture_default("normal_map") == normal.file
+    assert draw.texture_provenance == {
+        "normal_map": "wuwa_filename_dds",
+    }
+
+
+def test_conditional_same_hash_family_keeps_all_variants(
+        tmp_path, monkeypatch):
+    first = _replacement(
+        tmp_path, "aaaaaaaa", "Components-0 t=A.dds", conditions=(
+            (("style", "0", False),),))
+    second = _replacement(
+        tmp_path, "aaaaaaaa", "Components-0 t=B.dds", conditions=(
+            (("style", "1", False),),))
+    _classify(monkeypatch, {first.file: "diffuse", second.file: "diffuse"})
+    draw = DrawCall()
+
+    apply([_group("Component0", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (first, second)}), draw)],
+        str(tmp_path))
+
+    assert [item["file"] for item in draw.texture_rules("diffuse")] == [
+        first.file, second.file,
+    ]
+
+
+def test_cross_component_variants_do_not_promote_a_hash_family(
+        tmp_path, monkeypatch):
+    first = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=A.dds")
+    second = _replacement(tmp_path, "aaaaaaaa", "Components-1 t=B.dds")
+    calls = []
+    _classify(monkeypatch, {first.file: "diffuse", second.file: "diffuse"},
+              calls)
+    draw = DrawCall()
+
+    apply([_group("Component0", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (first, second)}), draw)],
+        str(tmp_path))
+
+    assert calls == []
+    assert draw.texture_default("diffuse") is None
+
+
+def test_loader_runs_wuwa_fallback_without_asset_configuration(
+        tmp_path, monkeypatch):
+    replacement = _replacement(
+        tmp_path, "aaaaaaaa", "Components-0 t=no-asset.dds")
+    _classify(monkeypatch, {replacement.file: "diffuse"})
+    draw = DrawCall()
+    parsed = mod_loader.ParsedModAnalysis(
+        groups=[_group("Component0", TextureOverrideIndex(
+            replacements_by_hash={"aaaaaaaa": (replacement,)}), draw)],
+        toggles={}, menu={}, defaults={}, state_rules=[], present={},
+        game=SimpleNamespace(game="wuwa"),
+    )
+    context = mod_loader.ModLoadContext(str(tmp_path), [], {}, {})
+    binding = AssetComponentBinding(status="not_found")
+
+    mod_loader._apply_texture_enrichment(
+        parsed, context, [[binding]], complete_index=False)
+
+    assert draw.texture_default("diffuse") == replacement.file
+    assert draw.texture_provenance == {"diffuse": "wuwa_filename_dds"}
+
+
+def test_wwmi_asset_json_does_not_change_filename_texture_result(
+        tmp_path, monkeypatch):
+    replacement = _replacement(
+        tmp_path, "aaaaaaaa", "Components-0 t=filename-authority.dds")
+    _classify(monkeypatch, {replacement.file: "diffuse"})
+    index = TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (replacement,)})
+
+    def parsed(draw):
+        return mod_loader.ParsedModAnalysis(
+            groups=[_group("Component0", index, draw)],
+            toggles={}, menu={}, defaults={}, state_rules=[], present={},
+            game=SimpleNamespace(game="wuwa"),
+        )
+
+    without_asset = DrawCall()
+    context = mod_loader.ModLoadContext(str(tmp_path), [], {}, {})
+    mod_loader._apply_texture_enrichment(
+        parsed(without_asset), context,
+        [[AssetComponentBinding(status="not_found")]], False)
+
+    asset_root = tmp_path / "assets"
+    asset_dir = asset_root / "Alice"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "TextureUsage.json").write_text(
+        '{"Component 1": {"ps-t0": '
+        '["bbbbbbbb-vs=aaaa-ps=bbbb"]}}', encoding="utf-8")
+    with_asset = DrawCall()
+    binding = AssetComponentBinding(
+        status="exact", component_status="exact", range_status="exact",
+        asset_type="WWMI", asset="Alice", root=str(asset_root),
+        component_ordinal=1, detail_metadata="Alice/TextureUsage.json")
+    mod_loader._apply_texture_enrichment(
+        parsed(with_asset), context, [[binding]], True)
+
+    assert with_asset.texture_default("diffuse") == \
+        without_asset.texture_default("diffuse") == replacement.file

--- a/src/tests/test_wuwa_texture_fallback.py
+++ b/src/tests/test_wuwa_texture_fallback.py
@@ -64,8 +64,23 @@ def test_no_asset_component_fallback_prefers_exact_filename_candidate(
     apply([_group("Component2", index, draw)], str(tmp_path))
 
     assert draw.texture_default("diffuse") == exact.file
-    assert draw.texture_provenance == {"diffuse": "wuwa_filename_dds"}
+    assert draw.texture_provenance == {"diffuse": "wuwa_filename_analysis"}
     assert draw.asset_binding is None
+
+
+def test_color_candidate_without_diffuse_role_is_contextually_selected(
+        tmp_path, monkeypatch):
+    candidate = _replacement(
+        tmp_path, "aaaaaaaa", "Components-1-2 t=color-candidate.dds")
+    _classify(monkeypatch, {candidate.file: "color"})
+    draw = DrawCall()
+
+    apply([_group("Component1", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (candidate,)}), draw)],
+        str(tmp_path))
+
+    assert draw.texture_default("diffuse") == candidate.file
+    assert draw.texture_provenance == {"diffuse": "wuwa_filename_analysis"}
 
 
 def test_component_priority_prefers_leading_target_over_shorter_shared_list(
@@ -97,7 +112,7 @@ def test_direct_dds_binding_works_without_index_or_filename_convention(
     apply([_group("Component4", None, draw)], str(tmp_path))
 
     assert draw.texture_default("diffuse") == filename
-    assert draw.texture_provenance == {"diffuse": "wuwa_direct_dds"}
+    assert draw.texture_provenance == {"diffuse": "wuwa_direct_analysis"}
 
 
 def test_direct_dds_bindings_are_resolved_per_draw(tmp_path, monkeypatch):
@@ -127,13 +142,15 @@ def test_direct_dds_binding_beats_filename_fallback(
     })
     draw = DrawCall(slot_textures=[SlotTextureBinding(
         0, "ResourceDirect", file=direct)])
+    group = _group("Component4", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (fallback,)}), draw)
 
-    apply([_group("Component4", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (fallback,)}), draw)],
-        str(tmp_path))
+    apply([group], str(tmp_path))
 
     assert draw.texture_default("diffuse") == direct
-    assert draw.texture_provenance == {"diffuse": "wuwa_direct_dds"}
+    assert draw.texture_provenance == {"diffuse": "wuwa_direct_analysis"}
+    assert {item["file"] for item in group["discovered_textures"]} == {
+        direct, fallback.file}
 
 
 def test_direct_and_filename_dds_roles_can_coexist(tmp_path, monkeypatch):
@@ -153,8 +170,8 @@ def test_direct_and_filename_dds_roles_can_coexist(tmp_path, monkeypatch):
     assert draw.texture_default("diffuse") == direct
     assert draw.texture_default("normal_map") == normal.file
     assert draw.texture_provenance == {
-        "diffuse": "wuwa_direct_dds",
-        "normal_map": "wuwa_filename_dds",
+        "diffuse": "wuwa_direct_analysis",
+        "normal_map": "wuwa_filename_analysis",
     }
 
 
@@ -210,7 +227,7 @@ def test_unknown_direct_dds_does_not_block_filename_fallback(
         str(tmp_path))
 
     assert draw.texture_default("diffuse") == fallback.file
-    assert draw.texture_provenance == {"diffuse": "wuwa_filename_dds"}
+    assert draw.texture_provenance == {"diffuse": "wuwa_filename_analysis"}
 
 
 def test_non_dds_direct_binding_is_skipped(tmp_path, monkeypatch):
@@ -263,6 +280,24 @@ def test_equal_specificity_distinct_hashes_are_ambiguous(tmp_path, monkeypatch):
         draw)], str(tmp_path))
 
     assert draw.texture_default("diffuse") is None
+
+
+def test_ambiguous_filename_candidates_remain_discovered(tmp_path, monkeypatch):
+    first = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=A.dds")
+    second = _replacement(tmp_path, "bbbbbbbb", "Components-0 t=B.dds")
+    _classify(monkeypatch, {first.file: "diffuse", second.file: "diffuse"})
+    draw = DrawCall()
+    group = _group("Component0", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (first,), "bbbbbbbb": (second,)}),
+        draw)
+    group["diffuse_pool_files"] = []
+
+    apply([group], str(tmp_path))
+
+    assert draw.texture_default("diffuse") is None
+    assert {item["file"] for item in group["discovered_textures"]} == {
+        first.file, second.file}
+    assert group["diffuse_pool_files"] == []
 
 
 def test_different_roles_compete_per_role(tmp_path, monkeypatch):
@@ -336,7 +371,7 @@ def test_existing_role_is_preserved_while_missing_role_is_filled(
     assert draw.texture_default("diffuse") == existing
     assert draw.texture_default("normal_map") == normal.file
     assert draw.texture_provenance == {
-        "normal_map": "wuwa_filename_dds",
+        "normal_map": "wuwa_filename_analysis",
     }
 
 
@@ -396,7 +431,7 @@ def test_loader_runs_wuwa_fallback_without_asset_configuration(
         parsed, context, [[binding]], complete_index=False)
 
     assert draw.texture_default("diffuse") == replacement.file
-    assert draw.texture_provenance == {"diffuse": "wuwa_filename_dds"}
+    assert draw.texture_provenance == {"diffuse": "wuwa_filename_analysis"}
 
 
 def test_wuwa_fallback_reuses_cache_across_semantic_refresh(

--- a/src/tests/test_wuwa_texture_fallback.py
+++ b/src/tests/test_wuwa_texture_fallback.py
@@ -18,6 +18,13 @@ def _replacement(tmp_path, original_hash, filename, *, conditions=()):
         "TextureOverrideGenerated", filename)
 
 
+def _direct_file(tmp_path, filename):
+    path = tmp_path / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"synthetic dds")
+    return filename
+
+
 def _group(name, index, draw=None):
     return {
         "name": name,
@@ -78,6 +85,149 @@ def test_component_priority_prefers_leading_target_over_shorter_shared_list(
         str(tmp_path))
 
     assert draw.texture_default("diffuse") == leading.file
+
+
+def test_direct_dds_binding_works_without_index_or_filename_convention(
+        tmp_path, monkeypatch):
+    filename = _direct_file(tmp_path, "Textures/completely-opaque-name.dds")
+    _classify(monkeypatch, {"completely-opaque-name.dds": "diffuse"})
+    draw = DrawCall(slot_textures=[SlotTextureBinding(
+        0, "ResourceMystery", file=filename)])
+
+    apply([_group("Component4", None, draw)], str(tmp_path))
+
+    assert draw.texture_default("diffuse") == filename
+    assert draw.texture_provenance == {"diffuse": "wuwa_direct_dds"}
+
+
+def test_direct_dds_bindings_are_resolved_per_draw(tmp_path, monkeypatch):
+    first = _direct_file(tmp_path, "first.dds")
+    second = _direct_file(tmp_path, "second.dds")
+    _classify(monkeypatch, {"first.dds": "diffuse", "second.dds": "diffuse"})
+    first_draw = DrawCall(slot_textures=[SlotTextureBinding(
+        0, "ResourceFirst", file=first)])
+    second_draw = DrawCall(slot_textures=[SlotTextureBinding(
+        0, "ResourceSecond", file=second)])
+    group = _group("Component4", None, first_draw)
+    group["draws"] = [first_draw, second_draw]
+
+    apply([group], str(tmp_path))
+
+    assert first_draw.texture_default("diffuse") == first
+    assert second_draw.texture_default("diffuse") == second
+
+
+def test_direct_dds_binding_beats_filename_fallback(
+        tmp_path, monkeypatch):
+    direct = _direct_file(tmp_path, "direct.dds")
+    fallback = _replacement(
+        tmp_path, "aaaaaaaa", "Components-4 t=fallback.dds")
+    _classify(monkeypatch, {
+        "direct.dds": "diffuse", fallback.file: "diffuse",
+    })
+    draw = DrawCall(slot_textures=[SlotTextureBinding(
+        0, "ResourceDirect", file=direct)])
+
+    apply([_group("Component4", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (fallback,)}), draw)],
+        str(tmp_path))
+
+    assert draw.texture_default("diffuse") == direct
+    assert draw.texture_provenance == {"diffuse": "wuwa_direct_dds"}
+
+
+def test_direct_and_filename_dds_roles_can_coexist(tmp_path, monkeypatch):
+    direct = _direct_file(tmp_path, "direct.dds")
+    normal = _replacement(
+        tmp_path, "aaaaaaaa", "Components-4 t=normal.dds")
+    _classify(monkeypatch, {
+        "direct.dds": "diffuse", normal.file: "normal_map",
+    })
+    draw = DrawCall(slot_textures=[SlotTextureBinding(
+        0, "ResourceDirect", file=direct)])
+
+    apply([_group("Component4", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (normal,)}), draw)],
+        str(tmp_path))
+
+    assert draw.texture_default("diffuse") == direct
+    assert draw.texture_default("normal_map") == normal.file
+    assert draw.texture_provenance == {
+        "diffuse": "wuwa_direct_dds",
+        "normal_map": "wuwa_filename_dds",
+    }
+
+
+def test_multiple_direct_files_with_one_role_are_ambiguous(
+        tmp_path, monkeypatch):
+    first = _direct_file(tmp_path, "first.dds")
+    second = _direct_file(tmp_path, "second.dds")
+    _classify(monkeypatch, {"first.dds": "diffuse", "second.dds": "diffuse"})
+    draw = DrawCall(slot_textures=[
+        SlotTextureBinding(0, "ResourceFirst", file=first),
+        SlotTextureBinding(3, "ResourceSecond", file=second),
+    ])
+
+    apply([_group("Component4", None, draw)], str(tmp_path))
+
+    assert draw.texture_default("diffuse") is None
+    assert draw.texture_provenance == {}
+
+
+def test_same_direct_file_in_multiple_slots_is_one_candidate(
+        tmp_path, monkeypatch):
+    filename = _direct_file(tmp_path, "shared.dds")
+    _classify(monkeypatch, {"shared.dds": "diffuse"})
+    draw = DrawCall(slot_textures=[
+        SlotTextureBinding(0, "ResourceShared", file=filename),
+        SlotTextureBinding(3, "ResourceShared", file=filename),
+    ])
+
+    apply([_group("Component4", None, draw)], str(tmp_path))
+
+    assert draw.texture_default("diffuse") == filename
+
+
+def test_unknown_direct_dds_does_not_block_filename_fallback(
+        tmp_path, monkeypatch):
+    unknown = _direct_file(tmp_path, "unknown.dds")
+    fallback = _replacement(
+        tmp_path, "aaaaaaaa", "Components-4 t=fallback.dds")
+
+    def classify(path):
+        if os.path.basename(path) == "unknown.dds":
+            return dds_classifier.DDSClassification(
+                None, "packed_data", "medium", ("synthetic_unknown",))
+        return dds_classifier.DDSClassification(
+            "diffuse", "color", "high", ("synthetic_diffuse",))
+
+    monkeypatch.setattr("app.asset_enrichment.classify_dds", classify)
+    draw = DrawCall(slot_textures=[SlotTextureBinding(
+        0, "ResourceUnknown", file=unknown)])
+
+    apply([_group("Component4", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (fallback,)}), draw)],
+        str(tmp_path))
+
+    assert draw.texture_default("diffuse") == fallback.file
+    assert draw.texture_provenance == {"diffuse": "wuwa_filename_dds"}
+
+
+def test_non_dds_direct_binding_is_skipped(tmp_path, monkeypatch):
+    calls = []
+
+    def classify(path):
+        calls.append(path)
+        raise AssertionError("non-DDS bindings must not be classified")
+
+    monkeypatch.setattr("app.asset_enrichment.classify_dds", classify)
+    draw = DrawCall(slot_textures=[SlotTextureBinding(
+        2, "ResourceImage", file="image.jpg")])
+
+    apply([_group("Component4", None, draw)], str(tmp_path))
+
+    assert calls == []
+    assert draw.texture_provenance == {}
 
 
 def test_filename_tag_is_opaque_and_does_not_need_to_match_ini_hash(
@@ -150,12 +300,15 @@ def test_unknown_dds_does_not_create_a_render_role(tmp_path, monkeypatch):
 
 def test_slotfix_skips_filename_inference_and_dds_classification(
         tmp_path, monkeypatch):
+    direct = _direct_file(tmp_path, "slotfix-direct.dds")
     replacement = _replacement(
         tmp_path, "aaaaaaaa", "Components-0 t=slotfix.dds")
     calls = []
-    _classify(monkeypatch, {replacement.file: "diffuse"}, calls)
+    _classify(monkeypatch, {
+        "slotfix-direct.dds": "diffuse", replacement.file: "diffuse",
+    }, calls)
     draw = DrawCall(slot_textures=[SlotTextureBinding(
-        0, "ResourceSlot", role_hint="diffuse",
+        0, "ResourceSlot", file=direct, role_hint="diffuse",
         role_hint_source="mod_slot_mapping")])
 
     apply([_group("Component0", TextureOverrideIndex(

--- a/src/tests/test_wuwa_texture_fallback.py
+++ b/src/tests/test_wuwa_texture_fallback.py
@@ -61,6 +61,25 @@ def test_no_asset_component_fallback_prefers_exact_filename_candidate(
     assert draw.asset_binding is None
 
 
+def test_component_priority_prefers_leading_target_over_shorter_shared_list(
+        tmp_path, monkeypatch):
+    shared = _replacement(
+        tmp_path, "aaaaaaaa", "Components-0-1-2-3 t=shared.dds")
+    leading = _replacement(
+        tmp_path, "bbbbbbbb", "Components-1-2-4-5-7 t=leading.dds")
+    _classify(monkeypatch, {
+        shared.file: "diffuse", leading.file: "diffuse",
+    })
+    draw = DrawCall()
+
+    apply([_group("Component1", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (shared,),
+                              "bbbbbbbb": (leading,)}), draw)],
+        str(tmp_path))
+
+    assert draw.texture_default("diffuse") == leading.file
+
+
 def test_filename_tag_is_opaque_and_does_not_need_to_match_ini_hash(
         tmp_path, monkeypatch):
     first = _replacement(
@@ -225,6 +244,36 @@ def test_loader_runs_wuwa_fallback_without_asset_configuration(
 
     assert draw.texture_default("diffuse") == replacement.file
     assert draw.texture_provenance == {"diffuse": "wuwa_filename_dds"}
+
+
+def test_wuwa_fallback_reuses_cache_across_semantic_refresh(
+        tmp_path, monkeypatch):
+    replacement = _replacement(
+        tmp_path, "aaaaaaaa", "Components-0 t=cache.dds")
+    calls = []
+    _classify(monkeypatch, {replacement.file: "diffuse"}, calls)
+    index = TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (replacement,)})
+    context = mod_loader.ModLoadContext(str(tmp_path), [], {}, {})
+
+    def parsed(draw):
+        return mod_loader.ParsedModAnalysis(
+            groups=[_group("Component0", index, draw)],
+            toggles={}, menu={}, defaults={}, state_rules=[], present={},
+            game=SimpleNamespace(game="wuwa"),
+        )
+
+    first = DrawCall()
+    second = DrawCall()
+    binding = [AssetComponentBinding(status="not_found")]
+    mod_loader._apply_texture_enrichment(
+        parsed(first), context, [binding], complete_index=False)
+    mod_loader._apply_texture_enrichment(
+        parsed(second), context, [binding], complete_index=False)
+
+    assert calls == ["Components-0 t=cache.dds"]
+    assert first.texture_default("diffuse") == replacement.file
+    assert second.texture_default("diffuse") == replacement.file
 
 
 def test_wwmi_asset_json_does_not_change_filename_texture_result(

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -1011,17 +1011,25 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 }
 #inspector-content { min-height: 0; overflow-y: auto; }
 .inspector-header { padding-bottom: 11px; border-bottom: 1px solid var(--border); }
-.inspector-kicker, .inspector-section-title {
+.inspector-header h3 { margin: 0; color: var(--text); font-size: 15px; overflow-wrap: anywhere; }
+.inspector-context {
+  display: block; margin-top: 3px; color: var(--text-muted); font-size: 10px;
+}
+.inspector-section-title {
   color: var(--text-muted); font-size: 9px; font-weight: 700;
   letter-spacing: .1em; text-transform: uppercase;
 }
-.inspector-header h3 { margin-top: 4px; color: var(--text); font-size: 15px; overflow-wrap: anywhere; }
-.inspector-section { display: flex; flex-direction: column; gap: 7px; padding: 12px 0; border-bottom: 1px solid rgba(48,54,61,.72); }
+.inspector-section { display: flex; flex-direction: column; gap: 6px; padding: 10px 0; border-bottom: 1px solid rgba(48,54,61,.72); }
 .inspector-row { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; font-size: 11px; }
 .inspector-label { color: var(--text-muted); }
 .inspector-value { color: var(--text); text-align: right; overflow-wrap: anywhere; }
 .inspector-muted { color: var(--text-muted); font-size: 11px; }
-.inspector-material-kind-control { width: 100%; min-height: 30px; }
+.inspector-material-section .inspector-section-title { font-size: 10px; }
+.inspector-material-kind-control {
+  width: 100%; min-height: 34px; color: var(--text); background: var(--surface-raised);
+  border: 1px solid rgba(139,148,158,.62); border-radius: var(--radius-sm);
+}
+.inspector-texture-count { color: var(--text-muted); font-size: 11px; }
 .inspector-manage-textures { width: 100%; color: var(--text); background: var(--surface-raised); border: 1px solid var(--border); }
 .inspector-manage-textures:hover { background: var(--surface-hover); }
 .inspector-texture-list { display: flex; flex-direction: column; gap: 4px; }
@@ -1033,13 +1041,6 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 .inspector-texture-option:hover, .inspector-texture-option.selected {
   color: var(--accent-soft); border-color: var(--accent-soft); background: var(--surface-active);
 }
-.inspector-slot-evidence {
-  display: flex; flex-direction: column; gap: 5px; padding: 7px 8px;
-  border: 1px solid var(--border); border-radius: var(--radius-sm);
-  background: var(--bg-canvas);
-}
-.inspector-slot-evidence[data-conflict="true"] { border-color: var(--accent-soft); }
-.inspector-slot-name { color: var(--accent-soft); font-size: 11px; font-weight: 600; }
 
 #mod-folder-empty[hidden] { display: none; }
 #mod-folder-empty .ui-button { margin-top: 5px; }

--- a/src/web/js/asset-diagnostics.js
+++ b/src/web/js/asset-diagnostics.js
@@ -14,6 +14,7 @@ const PROVENANCE_LABELS = Object.freeze({
   mod_slot_semantic: 'Mod slot mapping',
   mod_slot_legacy: 'Legacy slot mapping',
   mod_texture_hash: 'Mod hash match',
+  wuwa_filename_dds: 'WuWa filename + DDS analysis',
   asset_original_fallback: 'Asset fallback',
   unresolved: 'Not resolved',
 });

--- a/src/web/js/asset-diagnostics.js
+++ b/src/web/js/asset-diagnostics.js
@@ -14,6 +14,7 @@ const PROVENANCE_LABELS = Object.freeze({
   mod_slot_semantic: 'Mod slot mapping',
   mod_slot_legacy: 'Legacy slot mapping',
   mod_texture_hash: 'Mod hash match',
+  wuwa_direct_dds: 'WuWa direct binding + DDS analysis',
   wuwa_filename_dds: 'WuWa filename + DDS analysis',
   asset_original_fallback: 'Asset fallback',
   unresolved: 'Not resolved',

--- a/src/web/js/asset-diagnostics.js
+++ b/src/web/js/asset-diagnostics.js
@@ -14,8 +14,8 @@ const PROVENANCE_LABELS = Object.freeze({
   mod_slot_semantic: 'Mod slot mapping',
   mod_slot_legacy: 'Legacy slot mapping',
   mod_texture_hash: 'Mod hash match',
-  wuwa_direct_dds: 'WuWa direct binding + DDS analysis',
-  wuwa_filename_dds: 'WuWa filename + DDS analysis',
+  wuwa_direct_analysis: 'WuWa direct binding + texture analysis',
+  wuwa_filename_analysis: 'WuWa filename association + texture analysis',
   asset_original_fallback: 'Asset fallback',
   unresolved: 'Not resolved',
 });

--- a/src/web/js/inspector-panel.js
+++ b/src/web/js/inspector-panel.js
@@ -1,13 +1,8 @@
-// Selection-aware details panel.  Mesh creation remains owned by mesh-panel;
+// Selection-aware details panel. Mesh creation remains owned by mesh-panel;
 // this module only presents the already-authoritative mesh/component state.
 
 import { isRightDockOpen, setRightDockTab } from './right-dock.js';
 import { clearSelection } from './selection.js';
-import {
-  assetMatchLabel, componentMatchLabel, normalizeAssetBinding,
-  rangeMatchLabel, summarizeAssetBindings, textureProvenance,
-  textureRoleLabel, textureRoleLabels, textureRoleSourceLabel,
-} from './asset-diagnostics.js';
 
 const meshRecords = new WeakMap();
 let current = null;
@@ -54,178 +49,42 @@ function addText(parent, className, text) {
   return node;
 }
 
-function addRow(parent, label, value) {
-  const row = document.createElement('div');
-  row.className = 'inspector-row';
-  addText(row, 'inspector-label', label);
-  addText(row, 'inspector-value', value == null || value === '' ? '—' : String(value));
-  parent.appendChild(row);
-  return row;
+function basename(value) {
+  return String(value || '').replaceAll('\\', '/').split('/').pop() || '';
 }
 
-function buildHeader(content, title, subtitle) {
+function textureOptionLabel(option) {
+  return option?.label || basename(option?.file)
+    || basename(String(option?.tex_key || '').split('::').slice(1).join('::'))
+    || 'Texture';
+}
+
+function automaticTextureLabel(resolved, pool) {
+  if (!resolved) return 'Automatic';
+  const option = pool.find(item => item.tex_key === resolved);
+  if (option) return `Automatic · ${textureOptionLabel(option)}`;
+  const file = String(resolved).split('::').slice(1).join('::');
+  return file ? `Automatic · ${basename(file)}` : 'Automatic';
+}
+
+function componentContext(record) {
+  const meshes = record.meshes || [];
+  const total = meshes.length;
+  const visible = meshes.filter(mesh => mesh.visible).length;
+  const meshWord = total === 1 ? 'mesh' : 'meshes';
+  return `${total} ${meshWord} · ${visible} visible`;
+}
+
+function buildHeader(content, title, context, titleHint = '') {
   const header = document.createElement('div');
   header.className = 'inspector-header';
-  addText(header, 'inspector-kicker', subtitle);
+  if (titleHint) header.title = titleHint;
   const heading = document.createElement('h3');
   heading.textContent = title;
   header.appendChild(heading);
+  const subtitle = addText(header, 'inspector-context', context || '');
+  subtitle.dataset.inspectorContext = 'true';
   content.appendChild(header);
-}
-
-function buildAssetSection(content, entry) {
-  const binding = normalizeAssetBinding(entry?.asset_binding);
-  if (!binding) return;
-  const section = document.createElement('section');
-  section.className = 'inspector-section inspector-asset-section';
-  const title = document.createElement('div');
-  title.className = 'inspector-section-title';
-  title.textContent = 'Asset match';
-  section.appendChild(title);
-  addRow(section, 'Asset', binding.asset);
-  addRow(section, 'Type', binding.assetType);
-  addRow(section, 'Component', binding.component);
-  addRow(section, 'Object', binding.classification);
-  addRow(section, 'Geometry hash', binding.geometryHash);
-  if (binding.firstIndex !== null || binding.indexCount !== null) {
-    const range = [binding.firstIndex, binding.indexCount]
-      .map(value => value == null ? '?' : value).join(' / ');
-    addRow(section, 'Range', range);
-  }
-  addRow(section, 'Component match', componentMatchLabel(binding));
-  addRow(section, 'Range match', rangeMatchLabel(binding));
-  addRow(section, 'Match', assetMatchLabel(binding));
-  content.appendChild(section);
-}
-
-function buildComponentAssetSection(content, record) {
-  const summary = record.assetSummary
-    || summarizeAssetBindings((record.meshes || [])
-      .map(mesh => mesh.userData.assetEntry), record.assetResolution);
-  if (!summary || summary.status === 'unavailable') return;
-  const section = document.createElement('section');
-  section.className = 'inspector-section inspector-asset-section';
-  const title = document.createElement('div');
-  title.className = 'inspector-section-title';
-  title.textContent = 'Asset resolution';
-  section.appendChild(title);
-  addRow(section, 'Match', summary.status.replace(/^./, value => value.toUpperCase()));
-  addRow(section, 'Asset', summary.asset);
-  addRow(section, 'Component', summary.component);
-  addRow(section, 'Draws', `${summary.matchedDraws} of ${summary.totalDraws} matched`);
-  if (summary.exact) addRow(section, 'Exact', summary.exact);
-  if (summary.partial) addRow(section, 'Partial', summary.partial);
-  if (summary.ambiguous) addRow(section, 'Ambiguous', summary.ambiguous);
-  if (summary.unmatched) addRow(section, 'Not found', summary.unmatched);
-  if (summary.indexUnavailable) {
-    addRow(section, 'Index unavailable', summary.indexUnavailable);
-  }
-  if (summary.rangesVary) addRow(section, 'Ranges', 'Vary by draw');
-  content.appendChild(section);
-}
-
-function buildTextureProvenanceSection(content, record, mesh) {
-  const entry = record.entry || {};
-  if (!entry.asset_binding && !entry.texture_resolution
-      && !(entry.asset_slot_evidence || []).length) return;
-  const section = document.createElement('section');
-  section.className = 'inspector-section inspector-provenance-section';
-  const title = document.createElement('div');
-  title.className = 'inspector-section-title';
-  title.textContent = 'Texture provenance';
-  section.appendChild(title);
-  const sources = textureProvenance(entry);
-  textureRoleLabels().forEach(([role, label]) => {
-    const row = addRow(section, `${label} (automatic)`, sources[role]);
-    row.dataset.provenanceRole = role;
-    row.dataset.provenanceKind = 'automatic';
-  });
-  const override = record.component?.getTextureOverride?.(mesh);
-  const current = override?.automatic
-    ? (override.resolved ? `Automatic (${override.resolved})` : 'Automatic')
-    : override?.value === null ? 'Viewer override (None)'
-      : `Viewer override (${override?.value || 'custom'})`;
-  const currentRow = addRow(section, 'Diffuse (viewer)', current);
-  currentRow.dataset.provenanceKind = 'viewer';
-  content.appendChild(section);
-}
-
-function buildSlotEvidenceSection(content, entry) {
-  const evidence = entry?.asset_slot_evidence;
-  if (!Array.isArray(evidence) || !evidence.length) return;
-  const section = document.createElement('section');
-  section.className = 'inspector-section inspector-slot-section';
-  const title = document.createElement('div');
-  title.className = 'inspector-section-title';
-  title.textContent = 'Slot evidence';
-  section.appendChild(title);
-  evidence.forEach(item => {
-    const card = document.createElement('div');
-    card.className = 'inspector-slot-evidence';
-    card.dataset.conflict = item.conflict ? 'true' : 'false';
-    addText(card, 'inspector-slot-name', item.resource || 'Texture slot');
-    addRow(card, 'Texture', item.texture_hash);
-    addRow(card, 'VS', item.vs_hash);
-    addRow(card, 'PS', item.ps_hash);
-    addRow(card, 'Role', textureRoleLabel(item.role));
-    if (item.role_source) {
-      addRow(card, 'Role source', textureRoleSourceLabel(item.role_source));
-    }
-    if (item.texture_class) addRow(card, 'Texture class', item.texture_class);
-    if (item.confidence) addRow(card, 'Confidence', item.confidence);
-    if (item.asset_hash_role) {
-      addRow(card, 'Asset hash role', textureRoleLabel(item.asset_hash_role));
-    }
-    if (item.conflict) addRow(card, 'Conflict', 'Yes');
-    section.appendChild(card);
-  });
-  content.appendChild(section);
-}
-
-function buildTextureControls(content, record, mesh) {
-  const component = record.component;
-  const section = document.createElement('section');
-  section.className = 'inspector-section';
-  const title = document.createElement('div');
-  title.className = 'inspector-section-title';
-  title.textContent = 'Texture override';
-  section.appendChild(title);
-
-  const pool = component?.texturePool || [];
-  const override = component?.getTextureOverride?.(mesh) || {
-    value: undefined, automatic: true, resolved: null,
-  };
-  const list = document.createElement('div');
-  list.className = 'inspector-texture-list';
-  const addOption = (label, value, selected, choice) => {
-    const option = document.createElement('button');
-    option.type = 'button';
-    option.className = 'inspector-texture-option';
-    option.textContent = label;
-    option.dataset.textureChoice = choice;
-    option.dataset.textureValue = value == null ? '' : value;
-    option.classList.toggle('selected', selected);
-    option.addEventListener('click', () => {
-      component?.setTextureOverride?.(mesh, value);
-    });
-    list.appendChild(option);
-  };
-  addOption(
-    override.resolved ? `Automatic (${override.resolved})` : 'Automatic',
-    undefined, override.automatic, 'automatic');
-  pool.forEach(option => addOption(
-    option.label || option.file || option.tex_key,
-    option.tex_key, !override.automatic && override.value === option.tex_key,
-    'texture'));
-  addOption('None', null, !override.automatic && override.value === null, 'none');
-  if (!pool.length) {
-    addText(section, 'inspector-muted', 'No texture variants registered.');
-  }
-  section.appendChild(list);
-  if (mesh?.userData?.resolvedTexKey) {
-    addRow(section, 'Resolved', mesh.userData.resolvedTexKey);
-  }
-  content.appendChild(section);
 }
 
 function buildMaterialControl(record) {
@@ -253,107 +112,132 @@ function buildMaterialControl(record) {
   return select;
 }
 
-function buildComponent(record) {
-  const content = showContent();
-  content.replaceChildren();
-  const meshes = record.meshes || [];
-  buildHeader(content, record.component || 'Component', record.source || 'Component');
-
-  const summary = document.createElement('section');
-  summary.className = 'inspector-section inspector-summary';
-  addRow(summary, 'Draw calls', String(meshes.length));
-  addRow(summary, 'Visible', `${meshes.filter(mesh => mesh.visible).length} of ${meshes.length}`);
-  content.appendChild(summary);
-  buildComponentAssetSection(content, record);
-
-  const material = document.createElement('section');
-  material.className = 'inspector-section';
+function buildMaterialSection(content, record) {
+  const section = document.createElement('section');
+  section.className = 'inspector-section inspector-material-section';
   const title = document.createElement('div');
   title.className = 'inspector-section-title';
   title.textContent = 'Material';
-  material.appendChild(title);
-  if (record.setMaterialKind) material.appendChild(buildMaterialControl(record));
-  if (record.openTextureManager) {
-    const manage = document.createElement('button');
-    manage.type = 'button';
-    manage.className = 'ui-button inspector-manage-textures';
-    manage.textContent = 'Manage textures';
-    manage.addEventListener('click', () => record.openTextureManager());
-    material.appendChild(manage);
+  section.appendChild(title);
+  if (record.getMaterialKind || record.setMaterialKind) {
+    section.appendChild(buildMaterialControl(record));
+  } else {
+    addText(section, 'inspector-muted', 'Auto');
   }
-  content.appendChild(material);
+  content.appendChild(section);
+}
 
-  const poolSection = document.createElement('section');
-  poolSection.className = 'inspector-section';
-  const poolTitle = document.createElement('div');
-  poolTitle.className = 'inspector-section-title';
-  poolTitle.textContent = 'Texture pool';
-  poolSection.appendChild(poolTitle);
+function buildManageTexturesButton(openTextureManager) {
+  if (typeof openTextureManager !== 'function') return null;
+  const manage = document.createElement('button');
+  manage.type = 'button';
+  manage.className = 'ui-button inspector-manage-textures';
+  manage.textContent = 'Manage textures';
+  manage.addEventListener('click', () => openTextureManager());
+  return manage;
+}
+
+function buildComponentTextureSection(content, record) {
+  const section = document.createElement('section');
+  section.className = 'inspector-section inspector-textures-section';
+  const title = document.createElement('div');
+  title.className = 'inspector-section-title';
+  title.textContent = 'Textures';
+  section.appendChild(title);
   const pool = record.texturePool || [];
-  if (!pool.length) addText(poolSection, 'inspector-muted', 'No texture variants registered.');
-  else pool.forEach(option => addRow(poolSection, option.label, option.file || option.tex_key));
-  content.appendChild(poolSection);
+  addText(section, 'inspector-texture-count', pool.length
+    ? `${pool.length} available`
+    : 'No textures discovered');
+  const manage = buildManageTexturesButton(record.openTextureManager);
+  if (manage) section.appendChild(manage);
+  content.appendChild(section);
+}
 
-  if (meshes.length) {
-    const meshList = document.createElement('section');
-    meshList.className = 'inspector-section';
-    const title = document.createElement('div');
-    title.className = 'inspector-section-title';
-    title.textContent = 'Meshes in component';
-    meshList.appendChild(title);
-    meshes.forEach(mesh => addRow(meshList, mesh.userData.displayName || 'Mesh',
-      mesh.visible ? 'Visible' : 'Hidden'));
-    content.appendChild(meshList);
+function buildTextureControls(content, record, mesh) {
+  const component = record.component;
+  const section = document.createElement('section');
+  section.className = 'inspector-section inspector-texture-section';
+  const title = document.createElement('div');
+  title.className = 'inspector-section-title';
+  title.textContent = 'Texture';
+  section.appendChild(title);
+
+  const pool = component?.texturePool || [];
+  const override = component?.getTextureOverride?.(mesh) || {
+    value: undefined, automatic: true, resolved: null,
+  };
+  if (!pool.length) addText(section, 'inspector-muted', 'No textures discovered');
+  const list = document.createElement('div');
+  list.className = 'inspector-texture-list';
+  const addOption = (label, value, selected, choice, titleText = '') => {
+    const option = document.createElement('button');
+    option.type = 'button';
+    option.className = 'inspector-texture-option';
+    option.textContent = label;
+    option.title = titleText || label;
+    option.dataset.textureChoice = choice;
+    option.dataset.textureValue = value == null ? '' : value;
+    option.classList.toggle('selected', selected);
+    option.addEventListener('click', () => {
+      component?.setTextureOverride?.(mesh, value);
+    });
+    list.appendChild(option);
+  };
+  addOption(
+    automaticTextureLabel(override.resolved, pool),
+    undefined, override.automatic, 'automatic', override.resolved || 'Automatic');
+  pool.forEach(option => addOption(
+    textureOptionLabel(option), option.tex_key,
+    !override.automatic && override.value === option.tex_key,
+    'texture', option.file || option.label || option.tex_key));
+  addOption('None', null, !override.automatic && override.value === null, 'none');
+  section.appendChild(list);
+  const manage = buildManageTexturesButton(component?.openTextureManager);
+  if (manage) section.appendChild(manage);
+  content.appendChild(section);
+}
+
+function updateTextureControlState(content, mesh, component) {
+  const pool = component?.texturePool || [];
+  const override = component?.getTextureOverride?.(mesh);
+  if (!override) return;
+  const automatic = content.querySelector(
+    '.inspector-texture-option[data-texture-choice="automatic"]');
+  if (automatic) {
+    automatic.textContent = automaticTextureLabel(override.resolved, pool);
+    automatic.title = override.resolved || 'Automatic';
   }
+  content.querySelectorAll('.inspector-texture-option').forEach(option => {
+    const selected = option.dataset.textureChoice === 'automatic'
+      ? override.automatic
+      : option.dataset.textureChoice === 'none'
+        ? !override.automatic && override.value === null
+        : !override.automatic && override.value === option.dataset.textureValue;
+    option.classList.toggle('selected', selected);
+  });
+}
+
+function buildComponent(record) {
+  const content = showContent();
+  content.replaceChildren();
+  buildHeader(
+    content,
+    record.component || 'Component',
+    componentContext(record),
+    record.source || '',
+  );
+  buildMaterialSection(content, record);
+  buildComponentTextureSection(content, record);
 }
 
 function buildMesh(mesh, record) {
   const content = showContent();
   content.replaceChildren();
   const name = mesh.userData.displayName || record.label || 'Mesh';
-  const componentName = record.component?.component || record.component || 'Mesh';
-  buildHeader(content, name, componentName);
-  const summary = document.createElement('section');
-  summary.className = 'inspector-section inspector-summary';
-  addRow(summary, 'State', mesh.visible ? 'Visible' : 'Hidden');
-  addRow(summary, 'Material kind', mesh.userData.materialKindOverride || mesh.userData.materialKind || 'Auto');
-  addRow(summary, 'Diffuse', mesh.userData.resolvedTexKey || mesh.userData.texKey || 'None');
-  content.appendChild(summary);
-  buildAssetSection(content, record.entry);
-  buildTextureProvenanceSection(content, record, mesh);
-  buildSlotEvidenceSection(content, record.entry);
-
-  const material = document.createElement('section');
-  material.className = 'inspector-section';
-  const materialTitle = document.createElement('div');
-  materialTitle.className = 'inspector-section-title';
-  materialTitle.textContent = 'Material';
-  material.appendChild(materialTitle);
   const component = record.component;
-  if (component?.setMaterialKind) material.appendChild(buildMaterialControl(component));
-  if (component?.openTextureManager) {
-    const manage = document.createElement('button');
-    manage.type = 'button';
-    manage.className = 'ui-button inspector-manage-textures';
-    manage.textContent = 'Manage textures';
-    manage.addEventListener('click', () => component.openTextureManager());
-    material.appendChild(manage);
-  }
-  content.appendChild(material);
-
-  const draw = record.entry?.drawindexed;
-  if (draw?.length) {
-    const drawInfo = document.createElement('section');
-    drawInfo.className = 'inspector-section';
-    const title = document.createElement('div');
-    title.className = 'inspector-section-title';
-    title.textContent = 'Draw';
-    drawInfo.appendChild(title);
-    addRow(drawInfo, 'Count', String(draw[0] ?? '—'));
-    addRow(drawInfo, 'Start', String(draw[1] ?? '—'));
-    addRow(drawInfo, 'Base', String(draw[2] ?? '—'));
-    content.appendChild(drawInfo);
-  }
+  const componentName = component?.component || component || 'Component';
+  buildHeader(content, name, componentName, record.entry?.source?.[0]?.ini || '');
+  buildMaterialSection(content, component || {});
   buildTextureControls(content, record, mesh);
 }
 
@@ -361,66 +245,22 @@ function updateInspectorState() {
   if (!current) return;
   const content = $('inspector-content');
   if (!content) return;
-  const values = new Map();
-  content.querySelectorAll('.inspector-row').forEach(row => {
-    const label = row.querySelector('.inspector-label')?.textContent;
-    const value = row.querySelector('.inspector-value');
-    if (label && value) values.set(label, value);
-  });
+  const material = content.querySelector('.inspector-material-kind-control');
+  if (material) {
+    const owner = current.type === 'mesh' ? current.record.component : current.record;
+    material.value = owner?.getMaterialKind?.() || 'auto';
+  }
   if (current.type === 'mesh') {
-    const mesh = current.mesh;
-    if (values.has('State')) values.get('State').textContent = mesh.visible ? 'Visible' : 'Hidden';
-    if (values.has('Material kind')) {
-      values.get('Material kind').textContent =
-        mesh.userData.materialKindOverride || mesh.userData.materialKind || 'Auto';
+    updateTextureControlState(
+      content, current.mesh, current.record.component);
+  } else {
+    const context = content.querySelector('[data-inspector-context="true"]');
+    if (context) context.textContent = componentContext(current.record);
+    const count = content.querySelector('.inspector-texture-count');
+    if (count) {
+      const total = current.record.texturePool?.length || 0;
+      count.textContent = total ? `${total} available` : 'No textures discovered';
     }
-    if (values.has('Diffuse')) {
-      values.get('Diffuse').textContent =
-        mesh.userData.resolvedTexKey || mesh.userData.texKey || 'None';
-    }
-    const resolved = [...content.querySelectorAll('.inspector-row')].find(row =>
-      row.querySelector('.inspector-label')?.textContent === 'Resolved');
-    if (resolved) {
-      resolved.querySelector('.inspector-value').textContent =
-        mesh.userData.resolvedTexKey || 'None';
-    }
-    const material = content.querySelector('.inspector-material-kind-control');
-    if (material) material.value = current.record.component.getMaterialKind?.() || 'auto';
-    const override = current.record.component.getTextureOverride?.(mesh);
-    if (override) {
-      content.querySelectorAll('.inspector-texture-option').forEach(option => {
-        const selected = option.dataset.textureChoice === 'automatic'
-          ? override.automatic
-          : option.dataset.textureChoice === 'none'
-            ? !override.automatic && override.value === null
-            : !override.automatic && override.value === option.dataset.textureValue;
-        option.classList.toggle('selected', selected);
-      });
-      const currentProvenance = content.querySelector(
-        '[data-provenance-kind="viewer"] .inspector-value');
-      if (currentProvenance) {
-        currentProvenance.textContent = override.automatic
-          ? (override.resolved ? `Automatic (${override.resolved})` : 'Automatic')
-          : override.value === null ? 'Viewer override (None)'
-            : `Viewer override (${override.value || 'custom'})`;
-      }
-    }
-  } else if (current.type === 'component') {
-    const meshes = current.record.meshes || [];
-    if (values.has('Visible')) {
-      values.get('Visible').textContent =
-        `${meshes.filter(mesh => mesh.visible).length} of ${meshes.length}`;
-    }
-    const material = content.querySelector('.inspector-material-kind-control');
-    if (material) material.value = current.record.getMaterialKind?.() || 'auto';
-    content.querySelectorAll('.inspector-row').forEach(row => {
-      const label = row.querySelector('.inspector-label')?.textContent;
-      if (!label || label === 'Visible' || label === 'Draw calls') return;
-      const mesh = meshes.find(item =>
-        (item.userData.displayName || 'Mesh') === label);
-      if (mesh) row.querySelector('.inspector-value').textContent =
-        mesh.visible ? 'Visible' : 'Hidden';
-    });
   }
 }
 


### PR DESCRIPTION
## Summary
- infer WuWa diffuse and normal roles from generated Components-* DDS replacements
- keep WWMI TextureUsage diagnostic-only while reusing the shared enrichment pipeline
- add conservative precedence, ambiguity, slotfix, conditional-variant, and no-Asset coverage

## Validation
- pytest -q