### PR TITLE
Add offline WuWa texture corpus tooling

### DIFF
--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+numpy
+scikit-learn
+joblib

--- a/src/core/texture_features.py
+++ b/src/core/texture_features.py
@@ -1,0 +1,277 @@
+"""Game-agnostic texture measurements for offline corpus experiments.
+
+This module deliberately does not assign a semantic texture role.  It only
+extracts repeatable measurements from a validated DDS header and a bounded,
+decoded preview.  Classifier output belongs to the corpus report as diagnostic
+evidence and is never used as a label here.
+"""
+
+from __future__ import annotations
+
+import math
+from statistics import fmean
+
+from .dds import inspect_dds
+from .textures import load_texture_image
+
+
+FEATURE_SCHEMA_VERSION = "wuwa-texture-features-v1.1"
+FEATURE_IMAGE_SIZE = 128
+
+
+def _percentile(values, fraction):
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * fraction
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def _mean(values):
+    return fmean(values) if values else None
+
+
+def _std(values, mean=None):
+    if not values:
+        return None
+    mean = _mean(values) if mean is None else mean
+    return math.sqrt(fmean((value - mean) ** 2 for value in values))
+
+
+def _correlation(first, second):
+    if not first or not second or len(first) != len(second):
+        return None
+    first_mean = _mean(first)
+    second_mean = _mean(second)
+    first_dev = _std(first, first_mean)
+    second_dev = _std(second, second_mean)
+    if not first_dev or not second_dev:
+        return 0.0
+    covariance = fmean(
+        (left - first_mean) * (right - second_mean)
+        for left, right in zip(first, second))
+    return covariance / (first_dev * second_dev)
+
+
+def _entropy(histogram, total):
+    if not total:
+        return None
+    return -sum(
+        (count / total) * math.log2(count / total)
+        for count in histogram.values() if count)
+
+
+def _pixel_features(image):
+    rgba = image.convert("RGBA")
+    width, height = rgba.size
+    pixels = list(rgba.getdata())
+    if not pixels:
+        return {"decode_status": "empty_image"}
+
+    channels = [
+        [pixel[index] / 255.0 for pixel in pixels]
+        for index in range(4)]
+    red, green, blue, alpha = channels
+    rgb = list(zip(red, green, blue))
+    chroma = [max(pixel) - min(pixel) for pixel in rgb]
+    saturation = [
+        (max(pixel) - min(pixel)) / max(pixel) if max(pixel) else 0.0
+        for pixel in rgb]
+    neutral = [value <= 8.0 / 255.0 for value in chroma]
+    dark = [max(pixel) <= 16.0 / 255.0 for pixel in rgb]
+    bright = [min(pixel) >= 240.0 / 255.0 for pixel in rgb]
+
+    result = {"decode_status": "decoded", "image_width": width,
+              "image_height": height}
+    for name, values in zip(("r", "g", "b", "a"), channels):
+        result[f"{name}_mean"] = _mean(values)
+        result[f"{name}_std"] = _std(values)
+        for label, fraction in (("p05", 0.05), ("p25", 0.25),
+                                ("p50", 0.50), ("p75", 0.75),
+                                ("p95", 0.95)):
+            result[f"{name}_{label}"] = _percentile(values, fraction)
+
+    result.update({
+        "rgb_corr_rg": _correlation(red, green),
+        "rgb_corr_rb": _correlation(red, blue),
+        "rgb_corr_gb": _correlation(green, blue),
+        "chroma_mean": _mean(chroma),
+        "chroma_std": _std(chroma),
+        "chroma_p05": _percentile(chroma, 0.05),
+        "chroma_p50": _percentile(chroma, 0.50),
+        "chroma_p95": _percentile(chroma, 0.95),
+        "saturation_mean": _mean(saturation),
+        "saturation_std": _std(saturation),
+        "neutral_fraction": sum(neutral) / len(pixels),
+        "dark_fraction": sum(dark) / len(pixels),
+        "bright_fraction": sum(bright) / len(pixels),
+    })
+
+    dominant_counts = [0, 0, 0]
+    dominant_margins = []
+    for pixel in rgb:
+        ordered = sorted(pixel, reverse=True)
+        dominant_margins.append(ordered[0] - ordered[1])
+        dominant_counts[max(range(3), key=pixel.__getitem__)] += 1
+    for name, count in zip(("r", "g", "b"), dominant_counts):
+        result[f"dominant_{name}_fraction"] = count / len(pixels)
+    result.update({
+        "dominant_margin_mean": _mean(dominant_margins),
+        "dominant_margin_std": _std(dominant_margins),
+        "dominant_margin_p10": _percentile(dominant_margins, 0.10),
+        "dominant_margin_p50": _percentile(dominant_margins, 0.50),
+        "dominant_margin_p90": _percentile(dominant_margins, 0.90),
+    })
+
+    quantized = {}
+    for pixel in rgb:
+        key = tuple(min(15, int(value * 16)) for value in pixel)
+        quantized[key] = quantized.get(key, 0) + 1
+    result["quantized_color_occupancy"] = len(quantized) / 4096.0
+    result["quantized_color_entropy"] = _entropy(quantized, len(pixels))
+
+    gray = [fmean(pixel) for pixel in rgb]
+    horizontal = []
+    vertical = []
+    edge_count = 0
+    edge_threshold = 20.0 / 255.0
+    for y in range(height):
+        for x in range(width):
+            index = y * width + x
+            if x + 1 < width:
+                delta = abs(gray[index] - gray[index + 1])
+                horizontal.append(delta)
+                edge_count += delta >= edge_threshold
+            if y + 1 < height:
+                delta = abs(gray[index] - gray[index + width])
+                vertical.append(delta)
+                edge_count += delta >= edge_threshold
+    result.update({
+        "gradient_h_mean": _mean(horizontal),
+        "gradient_h_std": _std(horizontal),
+        "gradient_v_mean": _mean(vertical),
+        "gradient_v_std": _std(vertical),
+        "edge_density": edge_count / max(1, len(horizontal) + len(vertical)),
+    })
+
+    # Four-by-four block means provide a small spatial/layout signal while
+    # remaining stable for large source textures after downsampling.
+    block_means = []
+    for block_y in range(4):
+        y0 = block_y * height // 4
+        y1 = max(y0 + 1, (block_y + 1) * height // 4)
+        for block_x in range(4):
+            x0 = block_x * width // 4
+            x1 = max(x0 + 1, (block_x + 1) * width // 4)
+            block = [gray[y * width + x]
+                     for y in range(y0, min(y1, height))
+                     for x in range(x0, min(x1, width))]
+            block_means.append(_mean(block))
+    block_mean = _mean(block_means)
+    result.update({
+        "block_mean_std": _std(block_means, block_mean),
+        "block_mean_min": min(block_means),
+        "block_mean_max": max(block_means),
+        "spatial_contrast": max(block_means) - min(block_means),
+    })
+
+    normal_xy_radius = [
+        math.sqrt((2 * red_value - 1.0) ** 2
+                  + (2 * green_value - 1.0) ** 2)
+        for red_value, green_value in zip(red, green)]
+    result.update({
+        "normal_xy_valid_fraction": sum(value <= 1.0
+                                         for value in normal_xy_radius)
+        / len(pixels),
+        "normal_xy_radius_mean": _mean(normal_xy_radius),
+        "normal_xy_radius_std": _std(normal_xy_radius),
+        "normal_rg_center_error": math.sqrt(
+            (fmean(red) - 0.5) ** 2 + (fmean(green) - 0.5) ** 2),
+        "normal_blue_low_fraction": sum(value <= 0.05 for value in blue)
+        / len(pixels),
+        "normal_blue_mean": _mean(blue),
+        "normal_blue_std": _std(blue),
+        "alpha_transparent_fraction": sum(value <= 1.0 / 255.0
+                                           for value in alpha) / len(pixels),
+        "alpha_nearly_transparent_fraction": sum(value < 0.10
+                                                  for value in alpha)
+        / len(pixels),
+        "alpha_partial_fraction": sum(0.10 <= value < 0.99
+                                       for value in alpha) / len(pixels),
+        "alpha_opaque_fraction": sum(value >= 0.99 for value in alpha)
+        / len(pixels),
+    })
+    alpha_histogram = {}
+    for value in alpha:
+        bucket = min(15, int(value * 16))
+        alpha_histogram[bucket] = alpha_histogram.get(bucket, 0) + 1
+    result["alpha_entropy"] = _entropy(alpha_histogram, len(alpha))
+    return result
+
+
+def extract_texture_features(path, *, dds_info=None, image=None,
+                              baseline=None, max_size=FEATURE_IMAGE_SIZE,
+                              decode=True):
+    """Return deterministic DDS and generic pixel features for ``path``.
+
+    ``baseline`` is an optional diagnostic object, for example the current
+    structural classifier result.  Its fields are explicitly prefixed with
+    ``baseline_`` so callers can exclude them from model input.
+    """
+    info = dds_info if dds_info is not None else inspect_dds(path)
+    result = {
+        "feature_version": FEATURE_SCHEMA_VERSION,
+        "dds_valid": bool(info),
+        "dds_format": info.format if info else None,
+        "dds_width": info.width if info else None,
+        "dds_height": info.height if info else None,
+        "dds_mip_count": info.mip_count if info else None,
+        "dds_compressed": info.compressed if info else None,
+        "dds_requires_bc": info.requires_bc if info else None,
+        "dds_aspect_ratio": (info.width / info.height) if info else None,
+        "dds_pixel_count": (info.width * info.height) if info else None,
+        "dds_log_pixel_count": (math.log2(info.width * info.height)
+                                if info else None),
+    }
+    if info:
+        format_name = info.format.lower()
+        result["format_is_srgb"] = format_name.endswith("_srgb")
+        for family in ("bc1", "bc2", "bc3", "bc4", "bc5", "bc6h",
+                       "bc7", "rgba8", "bgra8"):
+            result[f"format_{family}"] = format_name.startswith(family)
+
+    if image is None and info and decode:
+        image = load_texture_image(path, max_size=max_size,
+                                   preserve_alpha=True)
+    if image is None:
+        result["decode_status"] = "invalid_dds" if not info else "unavailable"
+    else:
+        result.update(_pixel_features(image))
+
+    if baseline is not None:
+        result.update({
+            "baseline_role": getattr(baseline, "role", None),
+            "baseline_texture_class": getattr(baseline, "texture_class", None),
+            "baseline_confidence": getattr(baseline, "confidence", None),
+            "baseline_color_score": getattr(baseline, "color_score", None),
+            "baseline_normal_score": getattr(baseline, "normal_score", None),
+            "baseline_mask_score": getattr(baseline, "mask_score", None),
+            "baseline_data_score": getattr(baseline, "data_score", None),
+            "baseline_evaluation_only": True,
+        })
+    return result
+
+
+def model_feature_columns(columns):
+    """Return columns safe to pass to a later model trainer."""
+    excluded = {
+        "sha256", "file_size", "example_mod_id", "example_relative_file",
+        "occurrence_count", "feature_version", "decode_status",
+    }
+    return sorted(
+        column for column in columns
+        if not column.startswith("baseline_")
+        and column not in excluded)

--- a/src/tests/test_wuwa_resolver.py
+++ b/src/tests/test_wuwa_resolver.py
@@ -26,26 +26,28 @@ def test_policies_have_distinct_association_and_model_orders():
         _candidate("direct", 0, 0.70),
     ]
 
-    assert resolver.rank_candidates(candidates, "association_first")[0][
+    assert resolver.rank_candidates(candidates, "association_then_model")[0][
         "texture_sha256"] == "direct"
     assert resolver.rank_candidates(candidates, "model_first")[0][
         "texture_sha256"] == "model"
 
 
-def test_resolver_accepts_any_member_of_legitimate_ambiguity():
+def test_resolver_abstains_for_legitimate_ambiguity():
     candidates = [
         _candidate("diffuse-a", 0, 0.91),
-        _candidate("diffuse-b", 0, 0.89),
+        _candidate("diffuse-b", 0, 0.90999),
     ]
     expected = {
-        "kind": "diffuse",
+        "kind": "ambiguous",
         "texture_shas": {"diffuse-a", "diffuse-b"},
-        "description": "trusted diffuse component label",
+        "description": "expected abstention for legitimate ambiguity",
     }
 
-    result = resolver.resolve_case(candidates, expected, "model_first")
+    result = resolver.resolve_case(
+        candidates, expected, "association_then_model")
 
-    assert result["status"] == "correct"
+    assert result["status"] == "correct_abstention"
+    assert result["predicted_texture_sha256"] is None
     assert result["ambiguous_expected"] is True
 
 
@@ -75,5 +77,17 @@ def test_association_threshold_can_abstain_on_weak_exact_evidence():
     result = resolver.resolve_case(
         candidates, expected, "association_thresholds")
 
-    assert result["status"] == "correct"
+    assert result["status"] == "correct_abstention"
     assert result["predicted_texture_sha256"] is None
+
+
+def test_membership_policy_compares_direct_and_exact_together():
+    candidates = [
+        _candidate("exact", 1, 0.99),
+        _candidate("direct", 0, 0.70),
+    ]
+
+    assert resolver.rank_candidates(
+        candidates, "association_then_model")[0]["texture_sha256"] == "direct"
+    assert resolver.rank_candidates(
+        candidates, "membership_then_model")[0]["texture_sha256"] == "exact"

--- a/src/tests/test_wuwa_resolver.py
+++ b/src/tests/test_wuwa_resolver.py
@@ -1,0 +1,79 @@
+"""Regression tests for offline WuWa resolver ranking and outcomes."""
+
+from tools import evaluate_wuwa_resolver as resolver
+
+
+def _candidate(sha, rank, model, baseline=0.0, tags=()):
+    return {
+        "texture_sha256": sha,
+        "association_rank": rank,
+        "association_kind": min(
+            resolver.ASSOCIATION_RANKS,
+            key=lambda name: abs(resolver.ASSOCIATION_RANKS[name] - rank)),
+        "association_kinds": set(),
+        "association_tiers": set(),
+        "filename_tags": set(tags),
+        "relative_files": set(),
+        "roles": set(),
+        "model_score": model,
+        "baseline_color_score": baseline,
+    }
+
+
+def test_policies_have_distinct_association_and_model_orders():
+    candidates = [
+        _candidate("model", 3, 0.99),
+        _candidate("direct", 0, 0.70),
+    ]
+
+    assert resolver.rank_candidates(candidates, "association_first")[0][
+        "texture_sha256"] == "direct"
+    assert resolver.rank_candidates(candidates, "model_first")[0][
+        "texture_sha256"] == "model"
+
+
+def test_resolver_accepts_any_member_of_legitimate_ambiguity():
+    candidates = [
+        _candidate("diffuse-a", 0, 0.91),
+        _candidate("diffuse-b", 0, 0.89),
+    ]
+    expected = {
+        "kind": "diffuse",
+        "texture_shas": {"diffuse-a", "diffuse-b"},
+        "description": "trusted diffuse component label",
+    }
+
+    result = resolver.resolve_case(candidates, expected, "model_first")
+
+    assert result["status"] == "correct"
+    assert result["ambiguous_expected"] is True
+
+
+def test_missing_filename_target_is_unavailable():
+    expected = resolver._expected_for_case(
+        {
+            "name": "missing",
+            "mod_id": "mod",
+            "component": "Component0",
+            "expected_filename_tag": "missing-tag",
+        },
+        [_candidate("sha", 1, 0.9)],
+        {},
+    )
+
+    assert expected["kind"] == "unavailable"
+
+
+def test_association_threshold_can_abstain_on_weak_exact_evidence():
+    candidates = [_candidate("weak-exact", 1, 0.65)]
+    expected = {
+        "kind": "unresolved",
+        "texture_shas": [],
+        "description": "expected unresolved",
+    }
+
+    result = resolver.resolve_case(
+        candidates, expected, "association_thresholds")
+
+    assert result["status"] == "correct"
+    assert result["predicted_texture_sha256"] is None

--- a/src/tests/test_wuwa_resolver.py
+++ b/src/tests/test_wuwa_resolver.py
@@ -91,3 +91,67 @@ def test_membership_policy_compares_direct_and_exact_together():
         candidates, "association_then_model")[0]["texture_sha256"] == "direct"
     assert resolver.rank_candidates(
         candidates, "membership_then_model")[0]["texture_sha256"] == "exact"
+
+
+def test_ambiguous_case_requires_two_expected_labels():
+    case = {
+        "name": "ambiguous",
+        "mod_id": "mod",
+        "component": "Component0",
+        "expected_status": "ambiguous",
+    }
+    candidates = [_candidate("a", 0, 0.9)]
+
+    no_labels = resolver._expected_for_case(case, candidates, {})
+    one_label = resolver._expected_for_case(
+        case, candidates, {("mod", "Component0"): {"a"}})
+    two_labels_one_candidate = resolver._expected_for_case(
+        case, candidates, {("mod", "Component0"): {"a", "b"}})
+
+    assert no_labels["kind"] == "unavailable"
+    assert one_label["kind"] == "unavailable"
+    assert two_labels_one_candidate["kind"] == "unavailable"
+
+
+def test_ambiguous_case_requires_two_available_candidates():
+    case = {
+        "name": "ambiguous",
+        "mod_id": "mod",
+        "component": "Component0",
+        "expected_status": "ambiguous",
+    }
+    candidates = [
+        _candidate("a", 0, 0.9),
+        _candidate("b", 0, 0.8),
+    ]
+
+    expected = resolver._expected_for_case(
+        case, candidates, {("mod", "Component0"): {"a", "b"}})
+
+    assert expected["kind"] == "ambiguous"
+    assert expected["texture_shas"] == {"a", "b"}
+
+
+def test_case_candidates_merge_all_matching_aliases():
+    case = {
+        "name": "aliases",
+        "mod_id": "canonical",
+        "mod_id_aliases": ["alias"],
+        "component": "Component0",
+        "expected_label": "diffuse",
+    }
+    candidates = {
+        ("canonical", "Component0"): [_candidate("a", 1, 0.8)],
+        ("alias", "Component0"): [_candidate("b", 2, 0.7)],
+    }
+
+    matched, merged = resolver._case_candidates(case, candidates)
+
+    assert matched == ["canonical", "alias"]
+    assert {row["texture_sha256"] for row in merged} == {"a", "b"}
+    expected = resolver._expected_for_case(
+        {**case, "resolved_mod_ids": matched}, merged, {
+            ("canonical", "Component0"): {"a"},
+            ("alias", "Component0"): {"b"},
+        })
+    assert expected["texture_shas"] == {"a", "b"}

--- a/src/tests/test_wuwa_texture_corpus.py
+++ b/src/tests/test_wuwa_texture_corpus.py
@@ -1,0 +1,143 @@
+"""Regression tests for the offline WuWa corpus tooling."""
+
+from types import SimpleNamespace
+
+from tools import wuwa_texture_corpus as corpus
+
+
+def _write_mod(root):
+    mod = root / "Character" / "Outfit"
+    mod.mkdir(parents=True)
+    ini = r"""[Constants]
+global $\WWMIv1\object_guid = 1
+
+[TextureOverrideComponent0]
+ib = ResourceComponent0IB
+vb0 = ResourceComponent0Position
+vb1 = ResourceComponent0Texcoord
+Resource\WWMI\Diffuse = ref ResourceDiffuse
+Resource\WWMI\NormalMap = ref ResourceNormal
+Resource\WWMI\LightMap = ref ResourceLight
+drawindexed = 3, 0, 0
+
+[ResourceComponent0IB]
+filename = component.ib
+format = R32_UINT
+[ResourceComponent0Position]
+filename = component-position.buf
+stride = 40
+[ResourceComponent0Texcoord]
+filename = component-texcoord.buf
+stride = 20
+[ResourceDiffuse]
+filename = Components-0 t=semantic.dds
+[ResourceNormal]
+filename = normal.dds
+[ResourceLight]
+filename = light.dds
+"""
+    (mod / "mod.ini").write_text(ini, encoding="utf-8")
+    (mod / "Components-0 t=semantic.dds").write_bytes(b"diffuse")
+    (mod / "normal.dds").write_bytes(b"normal")
+    (mod / "light.dds").write_bytes(b"light")
+    (mod / "Components-0-1 t=filename-only.dds").write_bytes(b"filename")
+    (mod / "unknown.dds").write_bytes(b"unknown")
+    (mod / "duplicate.dds").write_bytes(b"unknown")
+    (mod / "mod.zip").write_bytes(b"archive")
+    return mod
+
+
+def test_association_tiers_and_character_signature_are_diagnostic_only():
+    assert corpus.filename_association((0,), 0) == "exact"
+    assert corpus.filename_association((0, 1), 0) == "leading"
+    assert corpus.filename_association((0, 1, 2), 1) == "contains"
+    assert corpus.filename_association((1, 2), 0) is None
+    assert corpus.parse_component_filename(
+        r"folder\Components-0-1 t=abc123.dds") == {
+            "components": (0, 1), "tag": "abc123"}
+    assert "sha256" not in corpus.model_feature_columns(
+        {"sha256", "dds_width", "baseline_role", "example_mod_id"})
+    assert "dds_width" in corpus.model_feature_columns(
+        {"sha256", "dds_width", "baseline_role", "example_mod_id"})
+
+
+def test_scan_uses_parser_labels_and_keeps_unknown_separate(tmp_path, monkeypatch):
+    mod = _write_mod(tmp_path / "mods")
+    output = tmp_path / "corpus"
+
+    # Make the diagnostic classifier claim every file is a diffuse candidate.
+    # That must not create a trusted label: classifier output, Components
+    # filenames, and the t= tag are all excluded by the label policy.
+    monkeypatch.setattr(
+        corpus, "classify_dds",
+        lambda _path: SimpleNamespace(
+            role="diffuse", texture_class="color", confidence="high",
+            color_score=1.0, normal_score=0.0, mask_score=0.0,
+            data_score=0.0),
+    )
+
+    summary = corpus.scan_corpus(tmp_path / "mods", output)
+
+    assert summary["mods_in_dataset"] == 1
+    assert summary["archives_found"] == summary["archives_skipped"] == 1
+    assert summary["feature_extractions"] == 5
+    assert summary["unknown_candidates"] >= 1
+
+    labels = list((output / "trusted_labels.csv").read_text(
+        encoding="utf-8").splitlines())
+    assert any(",diffuse,explicit_semantic_binding,primary," in line
+               for line in labels)
+    assert any(",normal_map,explicit_semantic_binding,primary," in line
+               for line in labels)
+    assert any(",light_map,explicit_semantic_binding,primary," in line
+               for line in labels)
+    assert not any("filename_analysis" in line for line in labels)
+    assert not any("filename-only" in line for line in labels)
+
+    unknown = (output / "unknown_candidates.csv").read_text(encoding="utf-8")
+    assert "filename-only" in unknown
+    assert "unknown" in unknown
+
+    occurrences = (output / "occurrences.csv").read_text(encoding="utf-8")
+    assert "exact" in occurrences
+    assert "leading" in occurrences
+
+    second = corpus.scan_corpus(tmp_path / "mods", output)
+    assert second["feature_extractions"] == 0
+    texture_rows = (output / "textures.csv").read_text(encoding="utf-8")
+    assert "Character/Outfit" in texture_rows
+
+
+def test_non_wuwa_mods_are_reported_but_excluded(tmp_path):
+    root = tmp_path / "mods"
+    mod = root / "Foreign"
+    mod.mkdir(parents=True)
+    (mod / "mod.ini").write_text(
+        "[TextureOverrideBody]\n"
+        "ib = ResourceIB\n"
+        "drawindexed = 3, 0, 0\n"
+        "[ResourceIB]\nfilename = body.ib\n",
+        encoding="utf-8")
+    summary = corpus.scan_corpus(root, tmp_path / "corpus")
+    assert summary["mods_discovered"] == 1
+    assert summary["mods_in_dataset"] == 0
+    assert summary["mods_by_game"] == {"unknown": 1}
+
+
+def test_nested_ini_directories_are_independent_texture_boundaries(tmp_path):
+    root = tmp_path / "mods"
+    parent = root / "Parent"
+    child = parent / "Child"
+    child.mkdir(parents=True)
+    (parent / "parent.ini").write_text("[Constants]\n", encoding="utf-8")
+    (child / "child.ini").write_text("[Constants]\n", encoding="utf-8")
+    (parent / "parent.dds").write_bytes(b"parent")
+    (child / "child.dds").write_bytes(b"child")
+
+    directories = corpus.discover_mod_directories(root)
+    parent_files = list(corpus._walk_mod_textures(parent, directories))
+
+    assert str(parent) in directories
+    assert str(child) in directories
+    assert str(parent / "parent.dds") in parent_files
+    assert str(child / "child.dds") not in parent_files

--- a/src/tests/test_wuwa_texture_corpus.py
+++ b/src/tests/test_wuwa_texture_corpus.py
@@ -1,5 +1,6 @@
 """Regression tests for the offline WuWa corpus tooling."""
 
+import csv
 from types import SimpleNamespace
 
 from tools import wuwa_texture_corpus as corpus
@@ -102,8 +103,19 @@ def test_scan_uses_parser_labels_and_keeps_unknown_separate(tmp_path, monkeypatc
     assert "exact" in occurrences
     assert "leading" in occurrences
 
+    with (output / "unknown_candidates.csv").open(
+            encoding="utf-8", newline="") as stream:
+        first_unknown = next(csv.DictReader(stream))["texture_sha256"]
+    with (output / "manual_labels.csv").open(
+            "a", encoding="utf-8", newline="") as stream:
+        stream.write(
+            f"{first_unknown},diffuse,reviewed color texture,,visual_review\n")
+
     second = corpus.scan_corpus(tmp_path / "mods", output)
     assert second["feature_extractions"] == 0
+    assert second["manual_label_rows"] == 1
+    manual_labels = (output / "manual_labels.csv").read_text(encoding="utf-8")
+    assert f"{first_unknown},diffuse,reviewed color texture" in manual_labels
     texture_rows = (output / "textures.csv").read_text(encoding="utf-8")
     assert "Character/Outfit" in texture_rows
 

--- a/src/tests/test_wuwa_texture_corpus.py
+++ b/src/tests/test_wuwa_texture_corpus.py
@@ -1,6 +1,7 @@
 """Regression tests for the offline WuWa corpus tooling."""
 
 import csv
+import hashlib
 from types import SimpleNamespace
 
 from tools import wuwa_texture_corpus as corpus
@@ -153,3 +154,42 @@ def test_nested_ini_directories_are_independent_texture_boundaries(tmp_path):
     assert str(child) in directories
     assert str(parent / "parent.dds") in parent_files
     assert str(child / "child.dds") not in parent_files
+
+
+def test_known_labels_bypass_pixel_preview_budget(tmp_path, monkeypatch):
+    output = tmp_path / "corpus"
+    output.mkdir()
+    texture = tmp_path / "sample.dds"
+    texture.write_bytes(b"sample")
+    sha = hashlib.sha256(b"sample").hexdigest()
+    (output / "trusted_labels.csv").write_text(
+        "texture_sha256,label,label_source\n"
+        f"{sha},diffuse,explicit_semantic_binding\n",
+        encoding="utf-8")
+    (output / "feature_cache.json").write_text(
+        "{\"feature_schema_version\": \"wuwa-texture-features-v1.1\","
+        " \"pixel_decode_limit\": 1, \"entries\": {"
+        f"\"{sha}\": {{\"sha256\": \"{sha}\", "
+        "\"decode_status\": \"skipped_budget\"}}}}",
+        encoding="utf-8")
+
+    monkeypatch.setattr(corpus, "inspect_dds", lambda _path: object())
+    monkeypatch.setattr(corpus, "load_texture_image",
+                        lambda _path, **_kwargs: object())
+    monkeypatch.setattr(corpus, "_diagnostic_baseline",
+                        lambda *_args: None)
+    monkeypatch.setattr(
+        corpus, "extract_texture_features",
+        lambda _path, **_kwargs: {
+            "feature_version": "wuwa-texture-features-v1.1",
+            "decode_status": "decoded",
+        },
+    )
+
+    builder = corpus.CorpusBuilder(
+        tmp_path / "mods", output, pixel_limit=0)
+    builder._ensure_texture(texture, "Mod", "sample.dds")
+
+    assert builder.feature_extractions == 1
+    assert builder.pixel_decoded == 1
+    assert builder.feature_cache_hits == 0

--- a/src/tests/test_wuwa_texture_labels.py
+++ b/src/tests/test_wuwa_texture_labels.py
@@ -1,0 +1,10 @@
+"""Regression tests for the shared offline WuWa label vocabulary."""
+
+from tools.wuwa_texture_labels import MANUAL_LABELS, canonical_label
+
+
+def test_manual_and_training_labels_share_negative_and_ignored_values():
+    assert "not_diffuse" in MANUAL_LABELS
+    assert "skip" in MANUAL_LABELS
+    assert canonical_label(" NOT_DIFFUSE ") == ("not_diffuse", 0)
+    assert canonical_label(" skip ") is None

--- a/src/tests/test_wuwa_texture_model.py
+++ b/src/tests/test_wuwa_texture_model.py
@@ -1,0 +1,92 @@
+"""Regression tests for offline WuWa model-label preparation."""
+
+import csv
+import json
+
+from tools import train_wuwa_texture_model as model
+
+
+def _write_csv(path, fields, rows):
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_training_rows_exclude_unknowns_and_conflicts(tmp_path):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "manifest.json").write_text(json.dumps({
+        "model_feature_columns": ["dds_format", "dds_width"],
+        "feature_schema_version": "test",
+    }), encoding="utf-8")
+    _write_csv(corpus / "mods.csv", [
+        "mod_id", "character_signature",
+    ], [
+        {"mod_id": "A", "character_signature": "char-a"},
+        {"mod_id": "B", "character_signature": "char-b"},
+    ])
+    _write_csv(corpus / "textures.csv", [
+        "sha256", "dds_format", "dds_width",
+    ], [
+        {"sha256": "a", "dds_format": "bc7_srgb", "dds_width": "128"},
+        {"sha256": "b", "dds_format": "bc5_unorm", "dds_width": "128"},
+        {"sha256": "c", "dds_format": "bc7_srgb", "dds_width": "128"},
+        {"sha256": "d", "dds_format": "bc7_srgb", "dds_width": "128"},
+    ])
+    _write_csv(corpus / "occurrences.csv", [
+        "texture_sha256", "mod_id",
+    ], [
+        {"texture_sha256": "a", "mod_id": "A"},
+        {"texture_sha256": "a", "mod_id": "B"},
+        {"texture_sha256": "b", "mod_id": "A"},
+        {"texture_sha256": "c", "mod_id": "B"},
+        {"texture_sha256": "d", "mod_id": "A"},
+    ])
+    _write_csv(corpus / "trusted_labels.csv", [
+        "texture_sha256", "label", "label_source",
+    ], [
+        {"texture_sha256": "a", "label": "diffuse",
+         "label_source": "explicit_semantic_binding"},
+        {"texture_sha256": "b", "label": "normal_map",
+         "label_source": "explicit_semantic_binding"},
+        {"texture_sha256": "c", "label": "diffuse",
+         "label_source": "explicit_semantic_binding"},
+        {"texture_sha256": "c", "label": "light_map",
+         "label_source": "explicit_semantic_binding"},
+    ])
+    _write_csv(corpus / "manual_labels.csv", [
+        "texture_sha256", "label", "notes", "reviewer", "source",
+    ], [
+        {"texture_sha256": "d", "label": "unknown", "notes": "",
+         "reviewer": "", "source": "visual_review"},
+    ])
+
+    rows, stats, conflicts, missing = model.load_training_rows(corpus)
+
+    assert [row["texture_sha256"] for row in rows] == ["b"]
+    assert [row["target"] for row in rows] == [0]
+    assert stats["training_rows"] == 1
+    assert stats["positive_rows"] == 0
+    assert stats["negative_rows"] == 1
+    assert stats["conflict_rows_excluded"] == 1
+    assert stats["manual_unknown_rows"] == 1
+    assert stats["shared_texture_shas"] == 1
+    assert stats["shared_texture_rows_excluded"] == 1
+    assert conflicts[0]["texture_sha256"] == "c"
+    assert missing == []
+
+
+def test_model_feature_loader_rejects_baseline_columns(tmp_path):
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "manifest.json").write_text(json.dumps({
+        "model_feature_columns": ["mean", "baseline_role"],
+    }), encoding="utf-8")
+
+    try:
+        model._load_model_features(corpus)
+    except ValueError as exc:
+        assert "diagnostic baseline" in str(exc)
+    else:
+        raise AssertionError("baseline feature column was accepted")

--- a/tools/evaluate_wuwa_resolver.py
+++ b/tools/evaluate_wuwa_resolver.py
@@ -1,0 +1,500 @@
+"""Evaluate an offline WuWa diffuse-texture resolver.
+
+The evaluator combines the trained diffuse score with component association
+evidence. It is deliberately separate from the viewer runtime and writes
+benchmark artifacts only.
+
+Usage::
+
+    python -m tools.evaluate_wuwa_resolver <corpus> --model <model.joblib> \
+        --output <directory>
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import json
+from collections import defaultdict
+from pathlib import Path
+
+from tools import train_wuwa_texture_model as trainer
+
+
+ASSOCIATION_RANKS = {
+    "direct": 0,
+    "exact": 1,
+    "leading": 2,
+    "contains": 3,
+    "pool": 4,
+    "inventory": 5,
+    "unknown": 6,
+}
+DIRECT_SOURCES = frozenset({
+    "explicit_semantic_binding",
+    "mod_slot_mapping",
+})
+DIRECT_CONTEXTS = frozenset({
+    "parser_binding",
+    "parser_slot_binding",
+})
+FILENAME_TIERS = frozenset({"exact", "leading", "contains"})
+POLICIES = (
+    "current_heuristic",
+    "association_first",
+    "association_thresholds",
+    "model_first",
+    "combined",
+)
+ASSOCIATION_THRESHOLDS = {
+    "direct": 0.50,
+    "exact": 0.80,
+    "leading": 0.70,
+    "contains": 0.85,
+    "pool": 0.80,
+    "inventory": 0.90,
+    "unknown": 0.90,
+}
+COMBINED_BONUS = {
+    0: 0.25,
+    1: 0.15,
+    2: 0.08,
+    3: 0.0,
+    4: -0.05,
+    5: -0.10,
+    6: -0.15,
+}
+
+
+def _read_csv(path):
+    with Path(path).open(encoding="utf-8", newline="") as stream:
+        return list(csv.DictReader(stream))
+
+
+def _write_json(path, value):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2,
+                               sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _as_set(value):
+    if value is None:
+        return set()
+    if isinstance(value, (list, tuple, set)):
+        return {str(item) for item in value if str(item)}
+    return {str(value)} if str(value) else set()
+
+
+def _number(value, default=-1.0):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def association_kind(row):
+    """Return the strongest evidence kind represented by one occurrence."""
+    if ((row.get("source") or "") in DIRECT_SOURCES
+            or (row.get("context") or "") in DIRECT_CONTEXTS):
+        return "direct"
+    tier = (row.get("association_tier") or "").strip().lower()
+    if tier in FILENAME_TIERS:
+        return tier
+    if (row.get("context") or "") == "parser_resource_pool":
+        return "pool"
+    if (row.get("context") or "") == "file_inventory":
+        return "inventory"
+    return "unknown"
+
+
+def load_candidates(corpus_dir):
+    """Aggregate occurrence evidence into one candidate per component and SHA."""
+    corpus_dir = Path(corpus_dir)
+    textures = {
+        row.get("sha256"): row
+        for row in _read_csv(corpus_dir / "textures.csv")
+        if row.get("sha256")
+    }
+    grouped = {}
+    for row in _read_csv(corpus_dir / "occurrences.csv"):
+        mod_id = (row.get("mod_id") or "").strip()
+        component = (row.get("component") or "").strip()
+        sha = (row.get("texture_sha256") or "").strip()
+        if not mod_id or not component or not sha:
+            continue
+        key = (mod_id, component, sha)
+        candidate = grouped.setdefault(key, {
+            "mod_id": mod_id,
+            "component": component,
+            "texture_sha256": sha,
+            "relative_files": set(),
+            "association_kinds": set(),
+            "association_tiers": set(),
+            "filename_tags": set(),
+            "roles": set(),
+        })
+        if row.get("relative_file"):
+            candidate["relative_files"].add(row["relative_file"])
+        candidate["association_kinds"].add(association_kind(row))
+        if row.get("association_tier"):
+            candidate["association_tiers"].add(row["association_tier"])
+        if row.get("filename_tag"):
+            candidate["filename_tags"].add(row["filename_tag"])
+        if row.get("role"):
+            candidate["roles"].add(row["role"])
+
+    candidates = defaultdict(list)
+    for candidate in grouped.values():
+        rank = min(ASSOCIATION_RANKS[k]
+                   for k in candidate["association_kinds"])
+        texture = textures.get(candidate["texture_sha256"], {})
+        candidates[(candidate["mod_id"], candidate["component"])].append({
+            **candidate,
+            "association_rank": rank,
+            "association_kind": min(
+                candidate["association_kinds"],
+                key=lambda kind: ASSOCIATION_RANKS[kind]),
+            "model_score": None,
+            "baseline_color_score": _number(
+                texture.get("baseline_color_score")),
+        })
+    for values in candidates.values():
+        values.sort(key=lambda row: row["texture_sha256"])
+    return candidates
+
+
+def score_candidates(corpus_dir, model_path, candidates):
+    """Add trained model probabilities to every candidate with known features."""
+    import joblib
+
+    corpus_dir = Path(corpus_dir)
+    model_path = Path(model_path)
+    if model_path.is_dir():
+        model_path = model_path / "model.joblib"
+    model = joblib.load(model_path)
+    feature_columns, _schema_version = trainer._load_model_features(corpus_dir)
+    texture_rows = [
+        {"texture_sha256": sha}
+        for values in candidates.values()
+        for sha in {row["texture_sha256"] for row in values}
+    ]
+    feature_rows = [
+        {"texture_sha256": row["texture_sha256"]}
+        for row in texture_rows
+    ]
+    matrix, _missing = trainer._load_feature_matrix(
+        corpus_dir, feature_rows, feature_columns)
+    probabilities = model.predict_proba(matrix)[:, 1]
+    scores = {
+        row["texture_sha256"]: float(probability)
+        for row, probability in zip(feature_rows, probabilities)
+    }
+    for values in candidates.values():
+        for candidate in values:
+            candidate["model_score"] = scores.get(
+                candidate["texture_sha256"])
+    return candidates
+
+
+def load_expected_labels(corpus_dir):
+    expected = defaultdict(set)
+    for row in _read_csv(Path(corpus_dir) / "component_labels.csv"):
+        if ((row.get("label") or "").strip().lower() == "diffuse"
+                and row.get("mod_id") and row.get("component")
+                and row.get("texture_sha256")):
+            expected[(row["mod_id"], row["component"])].add(
+                row["texture_sha256"])
+    return expected
+
+
+def load_cases(path):
+    value = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(value, list):
+        raise ValueError("resolver cases must be a JSON list")
+    for index, case in enumerate(value):
+        if not isinstance(case, dict):
+            raise ValueError(f"resolver case {index} is not an object")
+        for field in ("name", "mod_id", "component"):
+            if not case.get(field):
+                raise ValueError(f"resolver case {index} lacks {field}")
+    return value
+
+
+def _expected_for_case(case, candidates, expected_labels):
+    key = (case["mod_id"], case["component"])
+    if case.get("expected_status") == "unresolved":
+        if not candidates:
+            return {"kind": "unavailable", "texture_shas": set(),
+                    "description": "expected unresolved case not in corpus"}
+        return {"kind": "unresolved", "texture_shas": set(),
+                "description": "expected unresolved"}
+    explicit_shas = _as_set(case.get("expected_texture_sha256"))
+    if explicit_shas:
+        target = explicit_shas
+        description = "explicit texture SHA"
+    else:
+        tags = _as_set(case.get("expected_filename_tag"))
+        if tags:
+            target = {
+                candidate["texture_sha256"]
+                for candidate in candidates
+                if candidate["filename_tags"] & tags
+            }
+            description = "filename tag " + ", ".join(sorted(tags))
+            if not target:
+                return {"kind": "unavailable", "texture_shas": set(),
+                        "description": description + " not in corpus"}
+        elif case.get("expected_label") == "diffuse":
+            target = set(expected_labels.get(key, set()))
+            description = "trusted diffuse component label"
+            if not target:
+                return {"kind": "unavailable", "texture_shas": set(),
+                        "description": description + " not in corpus"}
+        else:
+            raise ValueError(
+                f"resolver case {case['name']!r} has no expected outcome")
+    available = {candidate["texture_sha256"] for candidate in candidates}
+    if not target & available:
+        return {"kind": "unavailable", "texture_shas": target,
+                "description": description + " not among candidates"}
+    return {"kind": "diffuse", "texture_shas": target,
+            "description": description}
+
+
+def _sort_key(candidate, policy):
+    rank = candidate["association_rank"]
+    model_score = (candidate["model_score"]
+                   if candidate["model_score"] is not None else -1.0)
+    baseline = candidate["baseline_color_score"]
+    if policy == "current_heuristic":
+        return (-baseline, rank, -model_score, candidate["texture_sha256"])
+    if policy == "association_first":
+        return (rank, -model_score, -baseline, candidate["texture_sha256"])
+    if policy == "association_thresholds":
+        return (rank, -model_score, -baseline, candidate["texture_sha256"])
+    if policy == "model_first":
+        return (-model_score, rank, -baseline, candidate["texture_sha256"])
+    if policy == "combined":
+        combined = model_score + COMBINED_BONUS.get(rank, 0.0)
+        return (-combined, rank, -model_score, candidate["texture_sha256"])
+    raise ValueError(f"unknown resolver policy: {policy}")
+
+
+def rank_candidates(candidates, policy):
+    """Return candidates in deterministic policy order."""
+    return sorted(candidates, key=lambda row: _sort_key(row, policy))
+
+
+def _candidate_report(row):
+    return {
+        "texture_sha256": row["texture_sha256"],
+        "relative_files": sorted(row["relative_files"]),
+        "association_kind": row["association_kind"],
+        "association_rank": row["association_rank"],
+        "association_kinds": sorted(row["association_kinds"]),
+        "association_tiers": sorted(row["association_tiers"]),
+        "filename_tags": sorted(row["filename_tags"]),
+        "roles": sorted(row["roles"]),
+        "model_score": row["model_score"],
+        "baseline_color_score": row["baseline_color_score"],
+    }
+
+
+def resolve_case(candidates, expected, policy, min_score=0.5):
+    ordered = rank_candidates(candidates, policy)
+    predicted = None
+    if ordered:
+        top = ordered[0]
+        if policy == "current_heuristic":
+            predicted = top["texture_sha256"]
+        else:
+            threshold = min_score
+            if policy == "association_thresholds":
+                threshold = ASSOCIATION_THRESHOLDS.get(
+                    top["association_kind"], min_score)
+            if ((top["model_score"] is not None)
+                    and top["model_score"] >= threshold):
+                predicted = top["texture_sha256"]
+
+    if expected["kind"] == "unavailable":
+        status = "unavailable"
+    elif expected["kind"] == "unresolved":
+        status = "correct" if predicted is None else "wrong"
+    elif predicted is None:
+        status = "unresolved"
+    else:
+        status = ("correct" if predicted in expected["texture_shas"]
+                  else "wrong")
+    return {
+        "status": status,
+        "predicted_texture_sha256": predicted,
+        "expected_texture_shas": sorted(expected["texture_shas"]),
+        "expected_description": expected["description"],
+        "ambiguous_expected": len(expected["texture_shas"]) > 1,
+        "candidate_count": len(ordered),
+        "candidates": [_candidate_report(row) for row in ordered],
+    }
+
+
+def _summary(results):
+    counts = {status: 0 for status in
+              ("correct", "wrong", "unresolved", "unavailable")}
+    for result in results:
+        counts[result["status"]] += 1
+    automatic = counts["correct"] + counts["wrong"]
+    return {
+        **counts,
+        "total_cases": len(results),
+        "eligible_cases": len(results) - counts["unavailable"],
+        "automatic_cases": automatic,
+        "false_positive_rate": (
+            counts["wrong"] / automatic if automatic else None),
+    }
+
+
+def _compare_to_baseline(results, baseline_results):
+    baseline_by_name = {
+        row["name"]: row for row in baseline_results
+    }
+    fixed = 0
+    regressed = 0
+    for row in results:
+        previous = baseline_by_name.get(row["name"], {})
+        if previous.get("status") in {"wrong", "unresolved"} \
+                and row["status"] == "correct":
+            fixed += 1
+        if previous.get("status") == "correct" \
+                and row["status"] in {"wrong", "unresolved"}:
+            regressed += 1
+    return {"fixed": fixed, "regressed": regressed}
+
+
+def evaluate_corpus(corpus_dir, model_path, cases_path, *, min_score=0.5):
+    """Run all resolver policies against the supplied case set."""
+    candidates = load_candidates(corpus_dir)
+    score_candidates(corpus_dir, model_path, candidates)
+    expected_labels = load_expected_labels(corpus_dir)
+    cases = load_cases(cases_path)
+    baseline = []
+    policy_results = {}
+    for case in cases:
+        expected = _expected_for_case(
+            case, candidates.get((case["mod_id"], case["component"]), []),
+            expected_labels)
+        expected = {
+            **expected,
+            "texture_shas": sorted(expected["texture_shas"]),
+        }
+        row = {
+            "name": case["name"],
+            "mod_id": case["mod_id"],
+            "component": case["component"],
+            "expected": expected,
+        }
+        result = resolve_case(
+            candidates.get((case["mod_id"], case["component"]), []),
+            expected, "current_heuristic", min_score=min_score)
+        baseline.append({**row, **result})
+    for policy in POLICIES:
+        if policy == "current_heuristic":
+            results = baseline
+        else:
+            results = []
+            for base in baseline:
+                expected = {
+                    "kind": base["expected"]["kind"],
+                    "texture_shas": set(base["expected"]["texture_shas"]),
+                    "description": base["expected"]["description"],
+                }
+                candidates_for_case = candidates.get(
+                    (base["mod_id"], base["component"]), [])
+                results.append({
+                    **{key: base[key] for key in
+                       ("name", "mod_id", "component", "expected")},
+                    **resolve_case(candidates_for_case, expected, policy,
+                                   min_score=min_score),
+                })
+        summary = _summary(results)
+        if policy != "current_heuristic":
+            summary.update(_compare_to_baseline(results, baseline))
+        policy_results[policy] = {"summary": summary, "cases": results}
+    return {
+        "schema_version": "wuwa-resolver-evaluation-v1",
+        "corpus": str(Path(corpus_dir).resolve()),
+        "model": str(Path(model_path).resolve()),
+        "cases_file": str(Path(cases_path).resolve()),
+        "min_score": min_score,
+        "association_ranks": ASSOCIATION_RANKS,
+        "association_thresholds": ASSOCIATION_THRESHOLDS,
+        "combined_bonus": COMBINED_BONUS,
+        "policies": policy_results,
+    }
+
+
+def _write_html_report(path, report):
+    rows = []
+    for policy, value in report["policies"].items():
+        summary = value["summary"]
+        rows.append(
+            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td>"
+            "<td>{}</td><td>{}</td><td>{}</td></tr>".format(
+                html.escape(policy), summary["correct"], summary["wrong"],
+                summary["unresolved"], summary["unavailable"],
+                summary["false_positive_rate"],
+                summary.get("fixed", "-")))
+    page = """<!doctype html><meta charset='utf-8'>
+<title>WuWa resolver evaluation</title>
+<h1>WuWa resolver evaluation</h1>
+<p>Offline benchmark only. Runtime behavior is unchanged.</p>
+<pre>{summary}</pre>
+<table><tr><th>Policy</th><th>Correct</th><th>Wrong</th>
+<th>Unresolved</th><th>Unavailable</th><th>False-positive rate</th>
+<th>Fixed</th></tr>{rows}</table>
+""".format(
+        summary=html.escape(json.dumps({
+            "min_score": report["min_score"],
+            "policies": {
+                policy: value["summary"]
+                for policy, value in report["policies"].items()
+            },
+        }, indent=2, sort_keys=True)),
+        rows="".join(rows),
+    )
+    Path(path).write_text(page, encoding="utf-8")
+
+
+def evaluate_and_write(corpus_dir, model_path, cases_path, output_dir,
+                       *, min_score=0.5):
+    report = evaluate_corpus(
+        corpus_dir, model_path, cases_path, min_score=min_score)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(output_dir / "resolver_evaluation.json", report)
+    _write_html_report(output_dir / "resolver_evaluation.html", report)
+    return report
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("corpus", type=Path)
+    parser.add_argument("--model", required=True, type=Path)
+    parser.add_argument("--cases", default=Path(__file__).with_name(
+        "wuwa_resolver_regressions.json"), type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--min-score", default=0.5, type=float)
+    return parser
+
+
+def main(argv=None):
+    args = _build_parser().parse_args(argv)
+    report = evaluate_and_write(
+        args.corpus, args.model, args.cases, args.output,
+        min_score=args.min_score)
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/evaluate_wuwa_resolver.py
+++ b/tools/evaluate_wuwa_resolver.py
@@ -6,7 +6,8 @@ benchmark artifacts only.
 
 Usage::
 
-    python -m tools.evaluate_wuwa_resolver <corpus> --model <model.joblib> \
+    python -m tools.evaluate_wuwa_resolver <corpus> [<corpus> ...] \
+        --model <model.joblib> \
         --output <directory>
 """
 
@@ -42,8 +43,9 @@ DIRECT_CONTEXTS = frozenset({
 FILENAME_TIERS = frozenset({"exact", "leading", "contains"})
 POLICIES = (
     "current_heuristic",
-    "association_first",
+    "association_then_model",
     "association_thresholds",
+    "membership_then_model",
     "model_first",
     "combined",
 )
@@ -55,6 +57,15 @@ ASSOCIATION_THRESHOLDS = {
     "pool": 0.80,
     "inventory": 0.90,
     "unknown": 0.90,
+}
+ASSOCIATION_MARGINS = {
+    "direct": 0.00005,
+    "exact": 0.00005,
+    "leading": 0.00005,
+    "contains": 0.00005,
+    "pool": 0.00005,
+    "inventory": 0.00005,
+    "unknown": 0.00005,
 }
 COMBINED_BONUS = {
     0: 0.25,
@@ -77,6 +88,11 @@ def _write_json(path, value):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(value, ensure_ascii=False, indent=2,
                                sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _model_file(model_path):
+    model_path = Path(model_path)
+    return model_path / "model.joblib" if model_path.is_dir() else model_path
 
 
 def _as_set(value):
@@ -170,9 +186,7 @@ def score_candidates(corpus_dir, model_path, candidates):
     import joblib
 
     corpus_dir = Path(corpus_dir)
-    model_path = Path(model_path)
-    if model_path.is_dir():
-        model_path = model_path / "model.joblib"
+    model_path = _model_file(model_path)
     model = joblib.load(model_path)
     feature_columns, _schema_version = trainer._load_model_features(corpus_dir)
     texture_rows = [
@@ -209,6 +223,30 @@ def load_expected_labels(corpus_dir):
     return expected
 
 
+def _merge_candidate_maps(target, source):
+    for key, values in source.items():
+        by_sha = {row["texture_sha256"]: row for row in target[key]}
+        for value in values:
+            existing = by_sha.get(value["texture_sha256"])
+            if existing is None:
+                target[key].append(value)
+                by_sha[value["texture_sha256"]] = value
+                continue
+            for field in ("relative_files", "association_kinds",
+                          "association_tiers", "filename_tags", "roles"):
+                existing[field].update(value[field])
+            existing["association_rank"] = min(
+                existing["association_rank"], value["association_rank"])
+            existing["association_kind"] = min(
+                existing["association_kinds"],
+                key=lambda kind: ASSOCIATION_RANKS[kind])
+
+
+def _merge_expected_labels(target, source):
+    for key, values in source.items():
+        target[key].update(values)
+
+
 def load_cases(path):
     value = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(value, list):
@@ -216,20 +254,48 @@ def load_cases(path):
     for index, case in enumerate(value):
         if not isinstance(case, dict):
             raise ValueError(f"resolver case {index} is not an object")
-        for field in ("name", "mod_id", "component"):
+        for field in ("name", "component"):
             if not case.get(field):
                 raise ValueError(f"resolver case {index} lacks {field}")
+        if not case.get("mod_id") and not case.get("mod_id_aliases"):
+            raise ValueError(
+                f"resolver case {index} lacks mod_id or mod_id_aliases")
     return value
 
 
+def _case_mod_ids(case):
+    values = []
+    if case.get("mod_id"):
+        values.append(case["mod_id"])
+    values.extend(case.get("mod_id_aliases") or [])
+    return list(dict.fromkeys(str(value) for value in values if str(value)))
+
+
+def _case_candidates(case, candidates):
+    mod_ids = _case_mod_ids(case)
+    for mod_id in mod_ids:
+        key = (mod_id, case["component"])
+        if key in candidates:
+            return mod_id, candidates[key]
+    return (mod_ids[0] if mod_ids else ""), []
+
+
 def _expected_for_case(case, candidates, expected_labels):
-    key = (case["mod_id"], case["component"])
+    mod_id = case.get("resolved_mod_id") or case.get("mod_id")
+    key = (mod_id, case["component"])
     if case.get("expected_status") == "unresolved":
         if not candidates:
             return {"kind": "unavailable", "texture_shas": set(),
                     "description": "expected unresolved case not in corpus"}
         return {"kind": "unresolved", "texture_shas": set(),
                 "description": "expected unresolved"}
+    if case.get("expected_status") == "ambiguous":
+        target = set(expected_labels.get(key, set()))
+        if not target:
+            return {"kind": "unavailable", "texture_shas": set(),
+                    "description": "ambiguous diffuse labels not in corpus"}
+        return {"kind": "ambiguous", "texture_shas": target,
+                "description": "expected abstention for legitimate ambiguity"}
     explicit_shas = _as_set(case.get("expected_texture_sha256"))
     if explicit_shas:
         target = explicit_shas
@@ -265,15 +331,19 @@ def _expected_for_case(case, candidates, expected_labels):
 
 def _sort_key(candidate, policy):
     rank = candidate["association_rank"]
+    membership_rank = 0 if rank <= 1 else rank
     model_score = (candidate["model_score"]
                    if candidate["model_score"] is not None else -1.0)
     baseline = candidate["baseline_color_score"]
     if policy == "current_heuristic":
         return (-baseline, rank, -model_score, candidate["texture_sha256"])
-    if policy == "association_first":
+    if policy == "association_then_model":
         return (rank, -model_score, -baseline, candidate["texture_sha256"])
     if policy == "association_thresholds":
         return (rank, -model_score, -baseline, candidate["texture_sha256"])
+    if policy == "membership_then_model":
+        return (membership_rank, -model_score, -baseline,
+                candidate["texture_sha256"])
     if policy == "model_first":
         return (-model_score, rank, -baseline, candidate["texture_sha256"])
     if policy == "combined":
@@ -302,6 +372,39 @@ def _candidate_report(row):
     }
 
 
+def _passes_model_gate(ordered, policy, min_score):
+    if not ordered:
+        return None
+    top = ordered[0]
+    if top["model_score"] is None:
+        return None
+    threshold = min_score
+    if policy == "association_thresholds":
+        threshold = ASSOCIATION_THRESHOLDS.get(
+            top["association_kind"], min_score)
+    if top["model_score"] < threshold:
+        return None
+    if policy in {"association_then_model", "association_thresholds",
+                  "membership_then_model", "combined"}:
+        top_rank = (0 if policy == "membership_then_model"
+                    and top["association_rank"] <= 1
+                    else top["association_rank"])
+        same_tier = [row for row in ordered
+                     if ((0 if policy == "membership_then_model"
+                          and row["association_rank"] <= 1
+                          else row["association_rank"]) == top_rank)]
+        if len(same_tier) > 1:
+            second = same_tier[1]
+            second_score = (second["model_score"]
+                            if second["model_score"] is not None else -1.0)
+            margin = top["model_score"] - second_score
+            required = ASSOCIATION_MARGINS.get(
+                top["association_kind"], 0.0)
+            if margin < required:
+                return None
+    return top["texture_sha256"]
+
+
 def resolve_case(candidates, expected, policy, min_score=0.5):
     ordered = rank_candidates(candidates, policy)
     predicted = None
@@ -310,23 +413,19 @@ def resolve_case(candidates, expected, policy, min_score=0.5):
         if policy == "current_heuristic":
             predicted = top["texture_sha256"]
         else:
-            threshold = min_score
-            if policy == "association_thresholds":
-                threshold = ASSOCIATION_THRESHOLDS.get(
-                    top["association_kind"], min_score)
-            if ((top["model_score"] is not None)
-                    and top["model_score"] >= threshold):
-                predicted = top["texture_sha256"]
+            predicted = _passes_model_gate(ordered, policy, min_score)
 
     if expected["kind"] == "unavailable":
         status = "unavailable"
-    elif expected["kind"] == "unresolved":
-        status = "correct" if predicted is None else "wrong"
+    elif expected["kind"] in {"unresolved", "ambiguous"}:
+        status = ("correct_abstention" if predicted is None
+                  else "wrong_selection")
     elif predicted is None:
-        status = "unresolved"
+        status = "unnecessary_abstention"
     else:
-        status = ("correct" if predicted in expected["texture_shas"]
-                  else "wrong")
+        status = ("correct_selection"
+                  if predicted in expected["texture_shas"]
+                  else "wrong_selection")
     return {
         "status": status,
         "predicted_texture_sha256": predicted,
@@ -340,17 +439,18 @@ def resolve_case(candidates, expected, policy, min_score=0.5):
 
 def _summary(results):
     counts = {status: 0 for status in
-              ("correct", "wrong", "unresolved", "unavailable")}
+              ("correct_selection", "correct_abstention",
+               "wrong_selection", "unnecessary_abstention", "unavailable")}
     for result in results:
         counts[result["status"]] += 1
-    automatic = counts["correct"] + counts["wrong"]
+    automatic = counts["correct_selection"] + counts["wrong_selection"]
     return {
         **counts,
         "total_cases": len(results),
         "eligible_cases": len(results) - counts["unavailable"],
         "automatic_cases": automatic,
         "false_positive_rate": (
-            counts["wrong"] / automatic if automatic else None),
+            counts["wrong_selection"] / automatic if automatic else None),
     }
 
 
@@ -362,39 +462,57 @@ def _compare_to_baseline(results, baseline_results):
     regressed = 0
     for row in results:
         previous = baseline_by_name.get(row["name"], {})
-        if previous.get("status") in {"wrong", "unresolved"} \
-                and row["status"] == "correct":
+        if previous.get("status") in {
+                "wrong_selection", "unnecessary_abstention"} \
+                and row["status"] in {"correct_selection",
+                                       "correct_abstention"}:
             fixed += 1
-        if previous.get("status") == "correct" \
-                and row["status"] in {"wrong", "unresolved"}:
+        if previous.get("status") in {"correct_selection",
+                                       "correct_abstention"} \
+                and row["status"] in {
+                    "wrong_selection", "unnecessary_abstention"}:
             regressed += 1
     return {"fixed": fixed, "regressed": regressed}
 
 
+def _corpus_list(corpus_dir):
+    if isinstance(corpus_dir, (str, Path)):
+        return [Path(corpus_dir)]
+    return [Path(value) for value in corpus_dir]
+
+
 def evaluate_corpus(corpus_dir, model_path, cases_path, *, min_score=0.5):
-    """Run all resolver policies against the supplied case set."""
-    candidates = load_candidates(corpus_dir)
-    score_candidates(corpus_dir, model_path, candidates)
-    expected_labels = load_expected_labels(corpus_dir)
+    """Run all resolver policies against one or more corpus directories."""
+    corpus_dirs = _corpus_list(corpus_dir)
+    candidates = defaultdict(list)
+    expected_labels = defaultdict(set)
+    for current_corpus in corpus_dirs:
+        local_candidates = load_candidates(current_corpus)
+        score_candidates(current_corpus, model_path, local_candidates)
+        _merge_candidate_maps(candidates, local_candidates)
+        _merge_expected_labels(
+            expected_labels, load_expected_labels(current_corpus))
     cases = load_cases(cases_path)
     baseline = []
     policy_results = {}
     for case in cases:
+        resolved_mod_id, candidates_for_case = _case_candidates(
+            case, candidates)
+        resolved_case = {**case, "resolved_mod_id": resolved_mod_id}
         expected = _expected_for_case(
-            case, candidates.get((case["mod_id"], case["component"]), []),
-            expected_labels)
+            resolved_case, candidates_for_case, expected_labels)
         expected = {
             **expected,
             "texture_shas": sorted(expected["texture_shas"]),
         }
         row = {
             "name": case["name"],
-            "mod_id": case["mod_id"],
+            "mod_id": resolved_mod_id,
             "component": case["component"],
             "expected": expected,
         }
         result = resolve_case(
-            candidates.get((case["mod_id"], case["component"]), []),
+            candidates_for_case,
             expected, "current_heuristic", min_score=min_score)
         baseline.append({**row, **result})
     for policy in POLICIES:
@@ -420,15 +538,32 @@ def evaluate_corpus(corpus_dir, model_path, cases_path, *, min_score=0.5):
         if policy != "current_heuristic":
             summary.update(_compare_to_baseline(results, baseline))
         policy_results[policy] = {"summary": summary, "cases": results}
+    model_file = _model_file(model_path)
+    training_report = model_file.parent / "training_report.json"
     return {
         "schema_version": "wuwa-resolver-evaluation-v1",
-        "corpus": str(Path(corpus_dir).resolve()),
-        "model": str(Path(model_path).resolve()),
+        "corpora": [str(path.resolve()) for path in corpus_dirs],
+        "model": str(model_file.resolve()),
+        "training_report": (str(training_report.resolve())
+                             if training_report.exists() else None),
         "cases_file": str(Path(cases_path).resolve()),
         "min_score": min_score,
         "association_ranks": ASSOCIATION_RANKS,
         "association_thresholds": ASSOCIATION_THRESHOLDS,
+        "association_margins": ASSOCIATION_MARGINS,
         "combined_bonus": COMBINED_BONUS,
+        "policy_notes": {
+            "current_heuristic": "baseline color score, then association evidence",
+            "association_then_model": (
+                "strongest association tier, then model score"),
+            "association_thresholds": (
+                "association_then_model with tier-specific score thresholds"),
+            "membership_then_model": (
+                "direct and exact membership share one tier, then model score"),
+            "model_first": "model score before association evidence",
+            "combined": "model score plus association bonus",
+            "model_scores": "ranking probabilities; not calibrated runtime confidence",
+        },
         "policies": policy_results,
     }
 
@@ -439,9 +574,10 @@ def _write_html_report(path, report):
         summary = value["summary"]
         rows.append(
             "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td>"
-            "<td>{}</td><td>{}</td><td>{}</td></tr>".format(
-                html.escape(policy), summary["correct"], summary["wrong"],
-                summary["unresolved"], summary["unavailable"],
+            "<td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>".format(
+                html.escape(policy), summary["correct_selection"],
+                summary["correct_abstention"], summary["wrong_selection"],
+                summary["unnecessary_abstention"], summary["unavailable"],
                 summary["false_positive_rate"],
                 summary.get("fixed", "-")))
     page = """<!doctype html><meta charset='utf-8'>
@@ -449,9 +585,10 @@ def _write_html_report(path, report):
 <h1>WuWa resolver evaluation</h1>
 <p>Offline benchmark only. Runtime behavior is unchanged.</p>
 <pre>{summary}</pre>
-<table><tr><th>Policy</th><th>Correct</th><th>Wrong</th>
-<th>Unresolved</th><th>Unavailable</th><th>False-positive rate</th>
-<th>Fixed</th></tr>{rows}</table>
+<table><tr><th>Policy</th><th>Correct selection</th>
+<th>Correct abstention</th><th>Wrong selection</th>
+<th>Unnecessary abstention</th><th>Unavailable</th>
+<th>False-positive rate</th><th>Fixed</th></tr>{rows}</table>
 """.format(
         summary=html.escape(json.dumps({
             "min_score": report["min_score"],
@@ -478,7 +615,7 @@ def evaluate_and_write(corpus_dir, model_path, cases_path, output_dir,
 
 def _build_parser():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("corpus", type=Path)
+    parser.add_argument("corpus", nargs="+", type=Path)
     parser.add_argument("--model", required=True, type=Path)
     parser.add_argument("--cases", default=Path(__file__).with_name(
         "wuwa_resolver_regressions.json"), type=Path)

--- a/tools/evaluate_wuwa_resolver.py
+++ b/tools/evaluate_wuwa_resolver.py
@@ -225,21 +225,25 @@ def load_expected_labels(corpus_dir):
 
 def _merge_candidate_maps(target, source):
     for key, values in source.items():
-        by_sha = {row["texture_sha256"]: row for row in target[key]}
-        for value in values:
-            existing = by_sha.get(value["texture_sha256"])
-            if existing is None:
-                target[key].append(value)
-                by_sha[value["texture_sha256"]] = value
-                continue
-            for field in ("relative_files", "association_kinds",
-                          "association_tiers", "filename_tags", "roles"):
-                existing[field].update(value[field])
-            existing["association_rank"] = min(
-                existing["association_rank"], value["association_rank"])
-            existing["association_kind"] = min(
-                existing["association_kinds"],
-                key=lambda kind: ASSOCIATION_RANKS[kind])
+        _merge_candidate_values(target[key], values)
+
+
+def _merge_candidate_values(target, values):
+    by_sha = {row["texture_sha256"]: row for row in target}
+    for value in values:
+        existing = by_sha.get(value["texture_sha256"])
+        if existing is None:
+            target.append(value)
+            by_sha[value["texture_sha256"]] = value
+            continue
+        for field in ("relative_files", "association_kinds",
+                      "association_tiers", "filename_tags", "roles"):
+            existing[field].update(value[field])
+        existing["association_rank"] = min(
+            existing["association_rank"], value["association_rank"])
+        existing["association_kind"] = min(
+            existing["association_kinds"],
+            key=lambda kind: ASSOCIATION_RANKS[kind])
 
 
 def _merge_expected_labels(target, source):
@@ -273,16 +277,25 @@ def _case_mod_ids(case):
 
 def _case_candidates(case, candidates):
     mod_ids = _case_mod_ids(case)
+    matched = []
+    merged = []
     for mod_id in mod_ids:
         key = (mod_id, case["component"])
         if key in candidates:
-            return mod_id, candidates[key]
-    return (mod_ids[0] if mod_ids else ""), []
+            matched.append(mod_id)
+            _merge_candidate_values(merged, candidates[key])
+    return matched, merged
 
 
 def _expected_for_case(case, candidates, expected_labels):
-    mod_id = case.get("resolved_mod_id") or case.get("mod_id")
-    key = (mod_id, case["component"])
+    mod_ids = case.get("resolved_mod_ids") or [
+        case.get("resolved_mod_id") or case.get("mod_id")
+    ]
+    target_labels = set()
+    for mod_id in mod_ids:
+        if mod_id:
+            target_labels.update(expected_labels.get(
+                (mod_id, case["component"]), set()))
     if case.get("expected_status") == "unresolved":
         if not candidates:
             return {"kind": "unavailable", "texture_shas": set(),
@@ -290,11 +303,16 @@ def _expected_for_case(case, candidates, expected_labels):
         return {"kind": "unresolved", "texture_shas": set(),
                 "description": "expected unresolved"}
     if case.get("expected_status") == "ambiguous":
-        target = set(expected_labels.get(key, set()))
-        if not target:
+        available = target_labels & {
+            candidate["texture_sha256"] for candidate in candidates
+        }
+        if len(target_labels) < 2:
             return {"kind": "unavailable", "texture_shas": set(),
-                    "description": "ambiguous diffuse labels not in corpus"}
-        return {"kind": "ambiguous", "texture_shas": target,
+                    "description": "fewer than two ambiguous diffuse labels"}
+        if len(available) < 2:
+            return {"kind": "unavailable", "texture_shas": target_labels,
+                    "description": "fewer than two ambiguous labels are candidates"}
+        return {"kind": "ambiguous", "texture_shas": available,
                 "description": "expected abstention for legitimate ambiguity"}
     explicit_shas = _as_set(case.get("expected_texture_sha256"))
     if explicit_shas:
@@ -313,7 +331,7 @@ def _expected_for_case(case, candidates, expected_labels):
                 return {"kind": "unavailable", "texture_shas": set(),
                         "description": description + " not in corpus"}
         elif case.get("expected_label") == "diffuse":
-            target = set(expected_labels.get(key, set()))
+            target = target_labels
             description = "trusted diffuse component label"
             if not target:
                 return {"kind": "unavailable", "texture_shas": set(),
@@ -496,9 +514,16 @@ def evaluate_corpus(corpus_dir, model_path, cases_path, *, min_score=0.5):
     baseline = []
     policy_results = {}
     for case in cases:
-        resolved_mod_id, candidates_for_case = _case_candidates(
+        resolved_mod_ids, candidates_for_case = _case_candidates(
             case, candidates)
-        resolved_case = {**case, "resolved_mod_id": resolved_mod_id}
+        resolved_mod_id = ("|".join(resolved_mod_ids)
+                           if resolved_mod_ids
+                           else (_case_mod_ids(case) or [""])[0])
+        resolved_case = {
+            **case,
+            "resolved_mod_id": resolved_mod_id,
+            "resolved_mod_ids": resolved_mod_ids,
+        }
         expected = _expected_for_case(
             resolved_case, candidates_for_case, expected_labels)
         expected = {
@@ -508,6 +533,7 @@ def evaluate_corpus(corpus_dir, model_path, cases_path, *, min_score=0.5):
         row = {
             "name": case["name"],
             "mod_id": resolved_mod_id,
+            "mod_ids": resolved_mod_ids,
             "component": case["component"],
             "expected": expected,
         }
@@ -520,17 +546,17 @@ def evaluate_corpus(corpus_dir, model_path, cases_path, *, min_score=0.5):
             results = baseline
         else:
             results = []
-            for base in baseline:
+            for case, base in zip(cases, baseline):
                 expected = {
                     "kind": base["expected"]["kind"],
                     "texture_shas": set(base["expected"]["texture_shas"]),
                     "description": base["expected"]["description"],
                 }
-                candidates_for_case = candidates.get(
-                    (base["mod_id"], base["component"]), [])
+                _resolved_mod_ids, candidates_for_case = _case_candidates(
+                    case, candidates)
                 results.append({
                     **{key: base[key] for key in
-                       ("name", "mod_id", "component", "expected")},
+                       ("name", "mod_id", "mod_ids", "component", "expected")},
                     **resolve_case(candidates_for_case, expected, policy,
                                    min_score=min_score),
                 })

--- a/tools/evaluate_wuwa_resolver.py
+++ b/tools/evaluate_wuwa_resolver.py
@@ -51,7 +51,7 @@ ASSOCIATION_THRESHOLDS = {
     "direct": 0.50,
     "exact": 0.80,
     "leading": 0.70,
-    "contains": 0.85,
+    "contains": 0.999,
     "pool": 0.80,
     "inventory": 0.90,
     "unknown": 0.90,

--- a/tools/train_wuwa_texture_model.py
+++ b/tools/train_wuwa_texture_model.py
@@ -21,12 +21,10 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+from tools.wuwa_texture_labels import (IGNORED_LABELS, NEGATIVE_LABELS,
+                                       POSITIVE_LABELS, canonical_label)
 
-POSITIVE_LABELS = frozenset({"diffuse"})
-NEGATIVE_LABELS = frozenset({
-    "light_map", "material_map", "normal_map", "not_diffuse",
-})
-IGNORED_LABELS = frozenset({"", "skip", "unknown"})
+
 MODEL_EXCLUDED_PREFIXES = ("baseline_",)
 TRAINING_LABEL_FIELDS = [
     "texture_sha256", "label", "target", "label_sources", "source_labels",
@@ -56,14 +54,7 @@ def _write_json(path, value):
 
 
 def _canonical_label(label):
-    label = (label or "").strip().lower()
-    if label in POSITIVE_LABELS:
-        return "diffuse", 1
-    if label in NEGATIVE_LABELS:
-        return "not_diffuse", 0
-    if label in IGNORED_LABELS:
-        return None
-    raise ValueError(f"unsupported training label: {label}")
+    return canonical_label(label)
 
 
 def _signature_for_mod(row):

--- a/tools/train_wuwa_texture_model.py
+++ b/tools/train_wuwa_texture_model.py
@@ -1,0 +1,515 @@
+"""Train and evaluate an offline WuWa Diffuse classifier.
+
+This module is intentionally separate from the viewer runtime.  It consumes a
+corpus produced by ``wuwa_texture_corpus`` and uses only authoritative labels
+plus explicit manual labels.  Unknown examples are excluded from supervised
+training.
+
+Usage::
+
+    python -m tools.train_wuwa_texture_model <corpus> --output <directory>
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import html
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+POSITIVE_LABELS = frozenset({"diffuse"})
+NEGATIVE_LABELS = frozenset({
+    "light_map", "material_map", "normal_map", "not_diffuse",
+})
+IGNORED_LABELS = frozenset({"", "skip", "unknown"})
+MODEL_EXCLUDED_PREFIXES = ("baseline_",)
+TRAINING_LABEL_FIELDS = [
+    "texture_sha256", "label", "target", "label_sources", "source_labels",
+    "group_signature", "group_count",
+]
+
+
+def _read_csv(path):
+    with Path(path).open(encoding="utf-8", newline="") as stream:
+        return list(csv.DictReader(stream))
+
+
+def _write_csv(path, rows, fields):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_json(path, value):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2,
+                               sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _canonical_label(label):
+    label = (label or "").strip().lower()
+    if label in POSITIVE_LABELS:
+        return "diffuse", 1
+    if label in NEGATIVE_LABELS:
+        return "not_diffuse", 0
+    if label in IGNORED_LABELS:
+        return None
+    raise ValueError(f"unsupported training label: {label}")
+
+
+def _signature_for_mod(row):
+    signature = (row.get("character_signature") or "").strip()
+    if signature:
+        return signature
+    return f"mod:{row.get('mod_id') or row.get('relative_path') or ''}"
+
+
+def _load_group_map(corpus_dir):
+    mods = _read_csv(Path(corpus_dir) / "mods.csv")
+    mod_groups = {
+        row.get("mod_id", ""): _signature_for_mod(row)
+        for row in mods
+    }
+    texture_groups = defaultdict(set)
+    for row in _read_csv(Path(corpus_dir) / "occurrences.csv"):
+        sha = row.get("texture_sha256") or ""
+        mod_id = row.get("mod_id") or ""
+        if sha:
+            texture_groups[sha].add(
+                mod_groups.get(mod_id, f"mod:{mod_id}"))
+    textures = _read_csv(Path(corpus_dir) / "textures.csv")
+    for row in textures:
+        sha = row.get("sha256") or ""
+        if sha and not texture_groups[sha]:
+            texture_groups[sha].add(
+                mod_groups.get(row.get("example_mod_id", ""),
+                               f"mod:{row.get('example_mod_id', '')}"))
+    return mod_groups, texture_groups
+
+
+def _load_labels(corpus_dir, *, include_secondary=False):
+    label_sets = defaultdict(set)
+    source_sets = defaultdict(set)
+    original_sets = defaultdict(set)
+    manual_rows = 0
+    manual_unknown = 0
+    secondary_rows = 0
+    for row in _read_csv(Path(corpus_dir) / "trusted_labels.csv"):
+        if (row.get("label_source") == "legacy_slot_mapping"
+                and not include_secondary):
+            secondary_rows += 1
+            continue
+        sha = row.get("texture_sha256") or ""
+        if not sha:
+            continue
+        canonical = _canonical_label(row.get("label"))[0]
+        if canonical is None:
+            continue
+        label_sets[sha].add(canonical)
+        source_sets[sha].add(row.get("label_source") or "trusted")
+        original_sets[sha].add(row.get("label") or "")
+    for row in _read_csv(Path(corpus_dir) / "manual_labels.csv"):
+        manual_rows += 1
+        sha = row.get("texture_sha256") or ""
+        if not sha:
+            continue
+        parsed = _canonical_label(row.get("label"))
+        if parsed is None:
+            manual_unknown += 1
+            continue
+        canonical, _target = parsed
+        label_sets[sha].add(canonical)
+        source_sets[sha].add("manual")
+        original_sets[sha].add(row.get("label") or "")
+    return label_sets, source_sets, original_sets, {
+        "manual_rows": manual_rows,
+        "manual_unknown_rows": manual_unknown,
+        "secondary_rows_excluded": secondary_rows,
+    }
+
+
+def _group_signature(groups):
+    values = sorted(groups or {"group:missing"})
+    return hashlib.sha256("|".join(values).encode("utf-8")).hexdigest()[:16]
+
+
+def load_training_rows(corpus_dir, *, include_secondary=False):
+    """Load one conflict-free, one-texture training row per SHA."""
+    corpus_dir = Path(corpus_dir)
+    textures = {
+        row.get("sha256"): row
+        for row in _read_csv(corpus_dir / "textures.csv")
+        if row.get("sha256")
+    }
+    _mod_groups, texture_groups = _load_group_map(corpus_dir)
+    label_sets, source_sets, original_sets, label_stats = _load_labels(
+        corpus_dir, include_secondary=include_secondary)
+    rows = []
+    conflicts = []
+    missing_features = []
+    shared_shas = 0
+    for sha, labels in sorted(label_sets.items()):
+        if len(labels) != 1:
+            conflicts.append({"texture_sha256": sha,
+                              "labels": sorted(labels)})
+            continue
+        if sha not in textures:
+            missing_features.append(sha)
+            continue
+        groups = texture_groups.get(sha) or {"group:missing"}
+        if len(groups) > 1:
+            shared_shas += 1
+            continue
+        label = next(iter(labels))
+        rows.append({
+            "texture_sha256": sha,
+            "label": label,
+            "target": 1 if label == "diffuse" else 0,
+            "label_sources": json.dumps(sorted(source_sets[sha]),
+                                         separators=(",", ":")),
+            "source_labels": json.dumps(sorted(original_sets[sha]),
+                                         separators=(",", ":")),
+            "group_signature": _group_signature(groups),
+            "group_count": len(groups),
+        })
+    stats = {
+        **label_stats,
+        "candidate_label_shas": len(label_sets),
+        "training_rows": len(rows),
+        "positive_rows": sum(row["target"] == 1 for row in rows),
+        "negative_rows": sum(row["target"] == 0 for row in rows),
+        "conflict_rows_excluded": len(conflicts),
+        "missing_feature_rows_excluded": len(missing_features),
+        "shared_texture_shas": shared_shas,
+        "shared_texture_rows_excluded": shared_shas,
+        "character_groups": len({row["group_signature"] for row in rows}),
+        "character_groups_in_label_map": len({
+            group for groups in texture_groups.values() for group in groups
+        }),
+    }
+    return rows, stats, conflicts, missing_features
+
+
+def _load_feature_matrix(corpus_dir, rows, feature_columns):
+    import numpy as np
+
+    textures = {
+        row.get("sha256"): row
+        for row in _read_csv(Path(corpus_dir) / "textures.csv")
+    }
+    values = []
+    missing = []
+    for row in rows:
+        source = textures.get(row["texture_sha256"], {})
+        current = []
+        for column in feature_columns:
+            value = source.get(column, "")
+            if column == "dds_format":
+                current.append(value)
+                continue
+            if value in ("", None):
+                current.append(np.nan)
+                continue
+            lowered = str(value).lower()
+            if lowered == "true":
+                current.append(1.0)
+            elif lowered == "false":
+                current.append(0.0)
+            else:
+                try:
+                    current.append(float(value))
+                except (TypeError, ValueError):
+                    current.append(np.nan)
+        if not current:
+            missing.append(row["texture_sha256"])
+        values.append(current)
+    return np.asarray(values, dtype=object), missing
+
+
+def _load_model_features(corpus_dir):
+    manifest = json.loads((Path(corpus_dir) / "manifest.json").read_text(
+        encoding="utf-8"))
+    columns = list(manifest.get("model_feature_columns") or [])
+    if not columns:
+        raise ValueError("corpus manifest has no model_feature_columns")
+    excluded = [column for column in columns
+                if column.startswith(MODEL_EXCLUDED_PREFIXES)]
+    if excluded:
+        raise ValueError(
+            "diagnostic baseline features entered model columns: "
+            + ", ".join(excluded))
+    return columns, manifest.get("feature_schema_version")
+
+
+def _one_hot_encoder():
+    from sklearn.preprocessing import OneHotEncoder
+
+    try:
+        return OneHotEncoder(handle_unknown="ignore", sparse_output=False)
+    except TypeError:  # scikit-learn before 1.2
+        return OneHotEncoder(handle_unknown="ignore", sparse=False)
+
+
+def _build_pipeline(model, feature_columns):
+    from sklearn.compose import ColumnTransformer
+    from sklearn.impute import SimpleImputer
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+
+    categorical = [index for index, column in enumerate(feature_columns)
+                   if column == "dds_format"]
+    numeric = [index for index in range(len(feature_columns))
+               if index not in categorical]
+    transformers = []
+    if numeric:
+        transformers.append((
+            "numeric",
+            Pipeline([
+                ("impute", SimpleImputer(strategy="median")),
+                ("scale", StandardScaler()),
+            ]),
+            numeric,
+        ))
+    if categorical:
+        transformers.append((
+            "categorical",
+            Pipeline([
+                ("impute", SimpleImputer(strategy="most_frequent")),
+                ("onehot", _one_hot_encoder()),
+            ]),
+            categorical,
+        ))
+    return Pipeline([
+        ("features", ColumnTransformer(transformers=transformers,
+                                        remainder="drop")),
+        ("model", model),
+    ])
+
+
+def _splits(y, groups, folds, seed):
+    from sklearn.model_selection import GroupKFold, StratifiedGroupKFold
+
+    group_count = len(set(groups))
+    split_count = min(max(2, int(folds)), group_count)
+    if split_count < 2:
+        return []
+    try:
+        splitter = StratifiedGroupKFold(
+            n_splits=split_count, shuffle=True, random_state=seed)
+        return list(splitter.split(list(range(len(y))), y, groups))
+    except ValueError:
+        splitter = GroupKFold(n_splits=split_count)
+        return list(splitter.split(list(range(len(y))), y, groups))
+
+
+def _evaluate_model(model, X, y, groups, feature_columns, folds, seed):
+    import numpy as np
+    from sklearn.metrics import (average_precision_score, confusion_matrix,
+                                 f1_score, precision_score, recall_score)
+
+    splits = _splits(y, groups, folds, seed)
+    probabilities = np.full(len(y), np.nan, dtype=float)
+    fold_stats = []
+    for fold, (train_indices, test_indices) in enumerate(splits, start=1):
+        if len(set(y[train_indices])) < 2:
+            fold_stats.append({"fold": fold, "status": "skipped_one_class"})
+            continue
+        pipeline = _build_pipeline(model, feature_columns)
+        pipeline.fit(X[train_indices], y[train_indices])
+        probabilities[test_indices] = pipeline.predict_proba(
+            X[test_indices])[:, 1]
+        fold_stats.append({
+            "fold": fold,
+            "status": "evaluated",
+            "train_rows": int(len(train_indices)),
+            "validation_rows": int(len(test_indices)),
+            "train_groups": len(set(groups[train_indices])),
+            "validation_groups": len(set(groups[test_indices])),
+        })
+    evaluated = ~np.isnan(probabilities)
+    if not evaluated.any():
+        metrics = {key: None for key in
+                   ("average_precision", "precision", "recall", "f1")}
+        confusion = [[0, 0], [0, 0]]
+    else:
+        predicted = (probabilities[evaluated] >= 0.5).astype(int)
+        actual = y[evaluated]
+        metrics = {
+            "average_precision": float(average_precision_score(
+                actual, probabilities[evaluated])),
+            "precision": float(precision_score(actual, predicted,
+                                                zero_division=0)),
+            "recall": float(recall_score(actual, predicted, zero_division=0)),
+            "f1": float(f1_score(actual, predicted, zero_division=0)),
+        }
+        confusion = confusion_matrix(actual, predicted, labels=[0, 1]).tolist()
+    final = _build_pipeline(model, feature_columns)
+    final.fit(X, y)
+    return final, {
+        "metrics": metrics,
+        "confusion_matrix_labels": ["not_diffuse", "diffuse"],
+        "confusion_matrix": confusion,
+        "evaluated_rows": int((~np.isnan(probabilities)).sum()),
+        "folds": fold_stats,
+    }
+
+
+def _model_factories(seed):
+    from sklearn.ensemble import HistGradientBoostingClassifier
+    from sklearn.linear_model import LogisticRegression
+
+    return {
+        "logistic_regression": lambda: LogisticRegression(
+            max_iter=2000, class_weight="balanced", random_state=seed),
+        "hist_gradient_boosting": lambda: HistGradientBoostingClassifier(
+            learning_rate=0.05, max_iter=200, max_leaf_nodes=15,
+            random_state=seed),
+    }
+
+
+def _require_ml():
+    try:
+        import joblib  # noqa: F401
+        import numpy  # noqa: F401
+        import sklearn  # noqa: F401
+    except ImportError as exc:
+        raise SystemExit(
+            "ML dependencies are not installed. Install requirements-ml.txt "
+            "in an offline training environment.") from exc
+
+
+def train_corpus(corpus_dir, output_dir, *, folds=5, seed=42,
+                 include_secondary=False):
+    """Train both planned baseline models and write an evaluation report."""
+    _require_ml()
+    import joblib
+    import numpy as np
+
+    rows, label_stats, conflicts, missing_features = load_training_rows(
+        corpus_dir, include_secondary=include_secondary)
+    if len({row["target"] for row in rows}) < 2:
+        raise ValueError("training labels contain only one target class")
+    feature_columns, feature_schema_version = _load_model_features(corpus_dir)
+    X, feature_missing = _load_feature_matrix(corpus_dir, rows, feature_columns)
+    y = np.asarray([row["target"] for row in rows], dtype=int)
+    groups = np.asarray([row["group_signature"] for row in rows])
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_csv(output_dir / "training_labels.csv", rows, TRAINING_LABEL_FIELDS)
+    _write_json(output_dir / "feature_schema.json", {
+        "feature_schema_version": feature_schema_version,
+        "feature_columns": feature_columns,
+        "categorical_columns": [column for column in feature_columns
+                                 if column == "dds_format"],
+        "diagnostic_columns_excluded": [
+            "baseline_color_score", "baseline_confidence",
+            "baseline_data_score", "baseline_mask_score",
+            "baseline_normal_score", "baseline_role",
+            "baseline_texture_class",
+        ],
+    })
+    models_dir = output_dir / "models"
+    model_reports = {}
+    final_models = {}
+    for name, factory in _model_factories(seed).items():
+        final_model, report = _evaluate_model(
+            factory(), X, y, groups, feature_columns, folds, seed)
+        model_path = models_dir / f"{name}.joblib"
+        model_path.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump(final_model, model_path)
+        model_reports[name] = report
+        final_models[name] = final_model
+    eligible = {
+        name: report["metrics"].get("average_precision")
+        for name, report in model_reports.items()
+        if report["metrics"].get("average_precision") is not None
+    }
+    selected_name = max(eligible, key=eligible.get) if eligible else None
+    if selected_name:
+        joblib.dump(final_models[selected_name], output_dir / "model.joblib")
+    report = {
+        "schema_version": "wuwa-texture-model-v1",
+        "corpus": str(Path(corpus_dir).resolve()),
+        "seed": seed,
+        "folds_requested": folds,
+        "include_secondary": include_secondary,
+        "label_stats": label_stats,
+        "feature_rows_missing": len(set(feature_missing)),
+        "conflicts": conflicts,
+        "missing_features": missing_features,
+        "feature_schema_version": feature_schema_version,
+        "feature_columns": feature_columns,
+        "models": model_reports,
+        "selected_model": selected_name,
+        "leakage": {
+            "split_unit": "character_signature_group",
+            "duplicate_texture_unit": "texture_sha256",
+            "shared_texture_shas": label_stats["shared_texture_shas"],
+            "shared_texture_rows_excluded": label_stats[
+                "shared_texture_rows_excluded"],
+            "duplicate_validation_rows_removed": 0,
+        },
+    }
+    _write_json(output_dir / "training_report.json", report)
+    _write_html_report(output_dir / "training_report.html", report)
+    return report
+
+
+def _write_html_report(path, report):
+    rows = []
+    for name, model in report["models"].items():
+        metrics = model["metrics"]
+        rows.append(
+            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td>"
+            "<td>{}</td></tr>".format(
+                html.escape(name), metrics.get("average_precision"),
+                metrics.get("precision"), metrics.get("recall"),
+                metrics.get("f1")))
+    page = """<!doctype html><meta charset='utf-8'>
+<title>WuWa texture model report</title>
+<h1>WuWa texture model report</h1>
+<p>Offline evaluation only. Unknown labels are excluded; runtime behavior is unchanged.</p>
+<pre>{summary}</pre>
+<table><tr><th>Model</th><th>PR-AUC</th><th>Precision</th>
+<th>Recall</th><th>F1</th></tr>{rows}</table>
+""".format(
+        summary=html.escape(json.dumps({
+            "selected_model": report["selected_model"],
+            "label_stats": report["label_stats"],
+            "leakage": report["leakage"],
+        }, indent=2, sort_keys=True)),
+        rows="".join(rows),
+    )
+    Path(path).write_text(page, encoding="utf-8")
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("corpus", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--folds", default=5, type=int)
+    parser.add_argument("--seed", default=42, type=int)
+    parser.add_argument("--include-secondary", action="store_true")
+    return parser
+
+
+def main(argv=None):
+    args = _build_parser().parse_args(argv)
+    report = train_corpus(
+        args.corpus, args.output, folds=args.folds, seed=args.seed,
+        include_secondary=args.include_secondary)
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/wuwa_resolver_regressions.json
+++ b/tools/wuwa_resolver_regressions.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "Aemeath Component4 exact diffuse assignment",
+    "mod_id": "Aemeath/AllInOne/Alter",
+    "component": "Component4",
+    "expected_filename_tag": "3a5a08ac"
+  },
+  {
+    "name": "QingXiao Component0 reported diffuse assignment",
+    "mod_id": "QingXiao/AllInOne/Simple Toggle Update",
+    "component": "Component0",
+    "expected_filename_tag": "7cfe3ff0"
+  },
+  {
+    "name": "QingXiao Component1 reported diffuse assignment",
+    "mod_id": "QingXiao/AllInOne/Simple Toggle Update",
+    "component": "Component1",
+    "expected_filename_tag": "78b458d2"
+  },
+  {
+    "name": "QingXiao Component2 reported diffuse assignment",
+    "mod_id": "QingXiao/AllInOne/Simple Toggle Update",
+    "component": "Component2",
+    "expected_filename_tag": "3b5ef0bf"
+  },
+  {
+    "name": "QingXiao Component5 reported diffuse assignment",
+    "mod_id": "QingXiao/AllInOne/Simple Toggle Update",
+    "component": "Component5",
+    "expected_filename_tag": "3fe74f13"
+  },
+  {
+    "name": "QingXiao Component6 unresolved assignment",
+    "mod_id": "QingXiao/AllInOne/Simple Toggle Update",
+    "component": "Component6",
+    "expected_status": "unresolved"
+  },
+  {
+    "name": "Phoebe Component3 legitimate diffuse ambiguity",
+    "mod_id": "Phoebe/AllInOne/Bunny Shiny",
+    "component": "Component3",
+    "expected_label": "diffuse"
+  },
+  {
+    "name": "Phoebe Component4 legitimate diffuse ambiguity",
+    "mod_id": "Phoebe/AllInOne/Bunny Shiny",
+    "component": "Component4",
+    "expected_label": "diffuse"
+  }
+]

--- a/tools/wuwa_resolver_regressions.json
+++ b/tools/wuwa_resolver_regressions.json
@@ -8,30 +8,35 @@
   {
     "name": "QingXiao Component0 reported diffuse assignment",
     "mod_id": ".",
+    "mod_id_aliases": ["QingXiao/AllInOne/Simple Toggle Update", "Qingxiao Simple Toggle Update"],
     "component": "Component0",
     "expected_filename_tag": "7cfe3ff0"
   },
   {
     "name": "QingXiao Component1 reported diffuse assignment",
     "mod_id": ".",
+    "mod_id_aliases": ["QingXiao/AllInOne/Simple Toggle Update", "Qingxiao Simple Toggle Update"],
     "component": "Component1",
     "expected_filename_tag": "78b458d2"
   },
   {
     "name": "QingXiao Component2 reported diffuse assignment",
     "mod_id": ".",
+    "mod_id_aliases": ["QingXiao/AllInOne/Simple Toggle Update", "Qingxiao Simple Toggle Update"],
     "component": "Component2",
     "expected_filename_tag": "3b5ef0bf"
   },
   {
     "name": "QingXiao Component5 reported diffuse assignment",
     "mod_id": ".",
+    "mod_id_aliases": ["QingXiao/AllInOne/Simple Toggle Update", "Qingxiao Simple Toggle Update"],
     "component": "Component5",
     "expected_filename_tag": "3fe74f13"
   },
   {
     "name": "QingXiao Component6 unresolved assignment",
     "mod_id": ".",
+    "mod_id_aliases": ["QingXiao/AllInOne/Simple Toggle Update", "Qingxiao Simple Toggle Update"],
     "component": "Component6",
     "expected_status": "unresolved"
   },
@@ -39,12 +44,14 @@
     "name": "Phoebe Component3 legitimate diffuse ambiguity",
     "mod_id": "Phoebe/AllInOne/Bunny Shiny",
     "component": "Component3",
+    "expected_status": "ambiguous",
     "expected_label": "diffuse"
   },
   {
     "name": "Phoebe Component4 legitimate diffuse ambiguity",
     "mod_id": "Phoebe/AllInOne/Bunny Shiny",
     "component": "Component4",
+    "expected_status": "ambiguous",
     "expected_label": "diffuse"
   }
 ]

--- a/tools/wuwa_resolver_regressions.json
+++ b/tools/wuwa_resolver_regressions.json
@@ -7,31 +7,31 @@
   },
   {
     "name": "QingXiao Component0 reported diffuse assignment",
-    "mod_id": "QingXiao/AllInOne/Simple Toggle Update",
+    "mod_id": ".",
     "component": "Component0",
     "expected_filename_tag": "7cfe3ff0"
   },
   {
     "name": "QingXiao Component1 reported diffuse assignment",
-    "mod_id": "QingXiao/AllInOne/Simple Toggle Update",
+    "mod_id": ".",
     "component": "Component1",
     "expected_filename_tag": "78b458d2"
   },
   {
     "name": "QingXiao Component2 reported diffuse assignment",
-    "mod_id": "QingXiao/AllInOne/Simple Toggle Update",
+    "mod_id": ".",
     "component": "Component2",
     "expected_filename_tag": "3b5ef0bf"
   },
   {
     "name": "QingXiao Component5 reported diffuse assignment",
-    "mod_id": "QingXiao/AllInOne/Simple Toggle Update",
+    "mod_id": ".",
     "component": "Component5",
     "expected_filename_tag": "3fe74f13"
   },
   {
     "name": "QingXiao Component6 unresolved assignment",
-    "mod_id": "QingXiao/AllInOne/Simple Toggle Update",
+    "mod_id": ".",
     "component": "Component6",
     "expected_status": "unresolved"
   },

--- a/tools/wuwa_texture_corpus.py
+++ b/tools/wuwa_texture_corpus.py
@@ -97,6 +97,9 @@ MANUAL_FIELDS = [
 MANUAL_LABELS = frozenset({
     "", "unknown", "diffuse", "normal_map", "light_map", "material_map",
 })
+DECODE_TARGET_LABELS = frozenset({
+    "diffuse", "normal_map", "light_map", "material_map", "not_diffuse",
+})
 COMPONENT_LABEL_FIELDS = [
     "texture_sha256", "component", "label", "label_source", "label_tier",
     "mod_id", "relative_file", "role",
@@ -347,8 +350,11 @@ class CorpusBuilder:
         self.pixel_skipped_budget = 0
         self.manual_labels = []
         self.manual_label_errors = []
+        self._feature_cache_pixel_limit = None
+        self.decode_target_shas = set()
         self._load_feature_cache()
         self._load_manual_labels()
+        self._load_decode_targets()
 
     def _load_feature_cache(self):
         path = self.output_dir / "feature_cache.json"
@@ -358,6 +364,7 @@ class CorpusBuilder:
             return
         if payload.get("feature_schema_version") != FEATURE_SCHEMA_VERSION:
             return
+        self._feature_cache_pixel_limit = payload.get("pixel_decode_limit")
         for sha, row in (payload.get("entries") or {}).items():
             if isinstance(sha, str) and isinstance(row, dict):
                 self.textures[sha] = dict(row)
@@ -365,6 +372,7 @@ class CorpusBuilder:
     def _flush_feature_cache(self):
         _write_json(self.output_dir / "feature_cache.json", {
             "feature_schema_version": FEATURE_SCHEMA_VERSION,
+            "pixel_decode_limit": self.pixel_limit,
             "entries": {
                 sha: {key: value for key, value in row.items()
                       if key not in {"example_mod_id", "example_relative_file",
@@ -402,6 +410,23 @@ class CorpusBuilder:
                 "kind": "manual_label", "error": str(exc),
             })
 
+    def _load_decode_targets(self):
+        """Prioritize visual features for already-known training labels."""
+        for filename, label_field in (
+                ("trusted_labels.csv", "label"),
+                ("manual_labels.csv", "label")):
+            try:
+                with (self.output_dir / filename).open(
+                        encoding="utf-8", newline="") as stream:
+                    rows = csv.DictReader(stream)
+                    for row in rows:
+                        if ((row.get(label_field) or "").strip().lower()
+                                in DECODE_TARGET_LABELS
+                                and row.get("texture_sha256")):
+                            self.decode_target_shas.add(row["texture_sha256"])
+            except (OSError, UnicodeError, csv.Error):
+                continue
+
     def _ensure_texture(self, path, mod_id, relative_file):
         try:
             data = Path(path).read_bytes()
@@ -412,19 +437,30 @@ class CorpusBuilder:
         sha = hashlib.sha256(data).hexdigest()
         self.texture_occurrence_counts[sha] += 1
         if sha in self.textures:
-            self.feature_cache_hits += 1
             row = self.textures[sha]
             row.setdefault("sha256", sha)
             row["example_mod_id"] = row.get("example_mod_id") or mod_id
             row["example_relative_file"] = (
                 row.get("example_relative_file") or relative_file)
             self.texture_examples.setdefault(sha, (mod_id, relative_file, path))
-            return sha
+            refresh_pixels = row.get("decode_status") == "skipped_budget" \
+                and (
+                    sha in self.decode_target_shas
+                    or
+                    self.pixel_limit is None
+                    or self._feature_cache_pixel_limit is None
+                    or self.pixel_limit > self._feature_cache_pixel_limit
+                )
+            if not refresh_pixels:
+                self.feature_cache_hits += 1
+                return sha
 
         info = inspect_dds(path)
         decode_allowed = (
             bool(info)
-            and (self.pixel_limit is None or self.pixel_decoded < self.pixel_limit))
+            and (self.pixel_limit is None
+                 or self.pixel_decoded < self.pixel_limit
+                 or sha in self.decode_target_shas))
         image = load_texture_image(path, max_size=128, preserve_alpha=True) \
             if decode_allowed else None
         if image is not None:
@@ -823,6 +859,7 @@ class CorpusBuilder:
             "pixel_skipped_budget": pixel_skipped_total,
             "pixel_skipped_budget_this_run": self.pixel_skipped_budget,
             "pixel_decode_limit": self.pixel_limit,
+            "pixel_decode_target_count": len(self.decode_target_shas),
             "errors": len(self.errors),
             "error_details": self.errors[:100],
         }
@@ -862,6 +899,7 @@ class CorpusBuilder:
         _write_json(self.output_dir / "summary.json", summary)
         _write_json(self.output_dir / "feature_cache.json", {
             "feature_schema_version": FEATURE_SCHEMA_VERSION,
+            "pixel_decode_limit": self.pixel_limit,
             "entries": {
                 sha: {key: value for key, value in row.items()
                       if key not in {"example_mod_id", "example_relative_file"}}

--- a/tools/wuwa_texture_corpus.py
+++ b/tools/wuwa_texture_corpus.py
@@ -1,0 +1,983 @@
+"""Offline WuWa texture-corpus scanner.
+
+The scanner is intentionally read-only with respect to a mod library.  It
+parses active INIs with the application's pre-enrichment parser, records the
+parser's authoritative role evidence, and keeps filename/classifier evidence
+as diagnostics.  It does not call the runtime enrichment or mesh-building
+pipeline.
+
+Usage::
+
+    python -m tools.wuwa_texture_corpus scan <mods-root> --output <corpus>
+    python -m tools.wuwa_texture_corpus summary <corpus>
+    python -m tools.wuwa_texture_corpus review <corpus> --mods-root <mods-root>
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import html
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SRC_ROOT = _REPO_ROOT / "src"
+if str(_SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SRC_ROOT))
+
+from app import mod_loader  # noqa: E402
+from core import dds_classifier as _dds_classifier  # noqa: E402
+from core.dds import inspect_dds  # noqa: E402
+from core.dds_classifier import classify_dds  # noqa: E402
+from core.resource_paths import safe_resource_path  # noqa: E402
+from core.texture_features import (  # noqa: E402
+    FEATURE_SCHEMA_VERSION,
+    extract_texture_features,
+    model_feature_columns,
+)
+from core.textures import load_texture_image  # noqa: E402
+
+
+SCHEMA_VERSION = "wuwa-texture-corpus-v1"
+SCANNER_VERSION = "1"
+ARCHIVE_SUFFIXES = frozenset({".7z", ".rar", ".zip"})
+_COMPONENT_RE = re.compile(r"^Component(?P<ordinal>\d+)(?:_\d+)?$", re.I)
+_FILENAME_RE = re.compile(
+    r"^Components-(?P<components>\d+(?:-\d+)*)\s+t=(?P<tag>.+?)\.dds$",
+    re.I,
+)
+_SEMANTIC_RESOURCE_RE = re.compile(
+    r"^Resource[\\/](?:GIMI|ZZMI|RabbitFX|WWMI)[\\/]"
+    r"(?P<role>Diffuse|NormalMap|LightMap|MaterialMap)$",
+    re.I,
+)
+_ROLE_LABELS = {
+    "diffuse": "diffuse",
+    "normal_map": "normal_map",
+    "light_map": "light_map",
+    "material_map": "material_map",
+}
+_PRIMARY_SOURCES = frozenset({
+    "explicit_semantic_binding",
+    "mod_slot_mapping",
+})
+_SECONDARY_SOURCES = frozenset({"legacy_slot_mapping"})
+
+MOD_FIELDS = [
+    "mod_id", "relative_path", "game", "parse_status", "ini_count",
+    "component_count", "texture_count", "character_signature", "source",
+    "warnings",
+]
+OCCURRENCE_FIELDS = [
+    "mod_id", "game", "character_signature", "component",
+    "texture_sha256", "relative_file", "context", "source",
+    "association_tier", "association_count", "associated_components",
+    "ini", "resource", "slot", "role", "original_texture_hash",
+    "filename_tag",
+]
+LABEL_FIELDS = [
+    "texture_sha256", "label", "label_source", "label_tier", "mod_id",
+    "component", "relative_file", "role", "ini", "resource", "slot",
+]
+UNKNOWN_FIELDS = [
+    "texture_sha256", "label_status", "example_mod_id", "example_file",
+    "occurrence_count", "dds_format", "dds_width", "dds_height",
+    "baseline_texture_class", "baseline_role", "baseline_confidence",
+]
+MANUAL_FIELDS = [
+    "texture_sha256", "label", "notes", "reviewer", "source",
+]
+COMPONENT_LABEL_FIELDS = [
+    "texture_sha256", "component", "label", "label_source", "label_tier",
+    "mod_id", "relative_file", "role",
+]
+
+
+def _json(value):
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return "" if value is None else value
+
+
+def _write_csv(path, rows, fields):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    extra = sorted({key for row in rows for key in row if key not in fields})
+    columns = list(fields) + extra
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=columns, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: _json(row.get(key)) for key in columns})
+
+
+def _write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2,
+                               sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _relative(path, root):
+    return Path(os.path.relpath(path, root)).as_posix()
+
+
+def _active_ini_files(directory):
+    try:
+        names = os.listdir(directory)
+    except OSError:
+        return []
+    return [
+        os.path.join(directory, name)
+        for name in sorted(names, key=str.casefold)
+        if name.lower().endswith(".ini")
+        and not name.upper().startswith("DISABLED")
+        and os.path.isfile(os.path.join(directory, name))
+    ]
+
+
+def _walk_files(root, suffixes=None):
+    suffixes = {suffix.lower() for suffix in suffixes} if suffixes else None
+    for directory, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(
+            name for name in dirnames
+            if not name.upper().startswith("DISABLED"))
+        for name in sorted(filenames, key=str.casefold):
+            path = os.path.join(directory, name)
+            if suffixes and Path(name).suffix.lower() not in suffixes:
+                continue
+            yield path
+
+
+def discover_mod_directories(mods_root):
+    """Return every active-INI directory below ``mods_root``.
+
+    The directory itself is the dataset's mod boundary.  Child directories
+    with their own active INIs are also scanned independently, which avoids
+    sharing parser/resource state between sibling extracted mods.
+    """
+    result = []
+    for directory, dirnames, _filenames in os.walk(mods_root):
+        dirnames[:] = sorted(
+            name for name in dirnames
+            if not name.upper().startswith("DISABLED"))
+        if _active_ini_files(directory):
+            result.append(os.path.normpath(directory))
+    return result
+
+
+def discover_archives(mods_root):
+    return list(_walk_files(mods_root, ARCHIVE_SUFFIXES))
+
+
+def _walk_mod_textures(root, mod_boundaries):
+    """Yield textures owned by one mod without entering child mod roots."""
+    boundary_set = {os.path.normcase(os.path.normpath(path))
+                    for path in mod_boundaries}
+    root = os.path.normpath(root)
+    for directory, dirnames, filenames in os.walk(root):
+        normalized_directory = os.path.normcase(os.path.normpath(directory))
+        if normalized_directory != os.path.normcase(root):
+            if normalized_directory in boundary_set:
+                dirnames[:] = []
+                continue
+        kept_dirs = []
+        for name in sorted(dirnames):
+            if name.upper().startswith("DISABLED"):
+                continue
+            child = os.path.normcase(os.path.normpath(
+                os.path.join(directory, name)))
+            if child in boundary_set:
+                continue
+            kept_dirs.append(name)
+        dirnames[:] = kept_dirs
+        for name in sorted(filenames, key=str.casefold):
+            if Path(name).suffix.lower() == ".dds":
+                yield os.path.join(directory, name)
+
+
+def _basename(value):
+    return str(value).replace("\\", "/").rsplit("/", 1)[-1]
+
+
+def parse_component_ordinal(value):
+    match = _COMPONENT_RE.fullmatch(str(value or ""))
+    return int(match.group("ordinal")) if match else None
+
+
+def filename_association(components, ordinal):
+    """Return the diagnostic association tier used by the existing fallback."""
+    components = tuple(int(item) for item in components)
+    if ordinal not in components:
+        return None
+    if components == (ordinal,):
+        return "exact"
+    if components[0] == ordinal:
+        return "leading"
+    return "contains"
+
+
+def parse_component_filename(filename):
+    match = _FILENAME_RE.fullmatch(_basename(filename))
+    if not match:
+        return None
+    components = tuple(int(value) for value in match.group("components").split("-"))
+    return {
+        "components": components,
+        "tag": match.group("tag"),
+    }
+
+
+def _geometry_hash(value):
+    match = getattr(value, "hash", None)
+    if match:
+        return str(match).lower()
+    if isinstance(value, dict):
+        return value.get("hash")
+    return None
+
+
+def character_signature(groups, fallback):
+    hashes = set()
+    for group in groups or ():
+        hashes.add(_geometry_hash(group.get("geometry_match")))
+        for draw in group.get("draws", ()):
+            hashes.add(_geometry_hash(getattr(draw, "geometry_match", None)))
+    hashes.discard(None)
+    if not hashes:
+        return fallback
+    digest = hashlib.sha256("|".join(sorted(hashes)).encode("ascii")).hexdigest()
+    return digest[:16]
+
+
+def _get(value, key, default=None):
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _role_default(draw, role):
+    method = getattr(draw, "texture_default", None)
+    if method:
+        return method(role)
+    prefix = "texture" if role == "diffuse" else role
+    return _get(draw, f"{prefix}_default_file")
+
+
+def _role_variants(draw, role):
+    prefix = "texture" if role == "diffuse" else role
+    return list(_get(draw, f"{prefix}_variants", ()) or ())
+
+
+def _role_assignments(draw, role):
+    if role == "diffuse":
+        return list(_get(draw, "texture_assignments", ()) or ())
+    return []
+
+
+def _source_for_role(draw, role):
+    provenance = _get(draw, "texture_provenance", {}) or {}
+    value = provenance.get(role)
+    if value == "mod_slot_semantic":
+        return "mod_slot_mapping", "primary"
+    if value == "mod_slot_legacy":
+        return "legacy_slot_mapping", "secondary"
+    return "explicit_semantic_binding", "primary"
+
+
+def _semantic_resource_role(resource):
+    match = _SEMANTIC_RESOURCE_RE.fullmatch(str(resource or ""))
+    if not match:
+        return None
+    role = match.group("role").casefold()
+    return {
+        "diffuse": "diffuse",
+        "normalmap": "normal_map",
+        "lightmap": "light_map",
+        "materialmap": "material_map",
+    }[role]
+
+
+def _diagnostic_baseline(path, info, image):
+    """Evaluate the existing classifier without decoding the image twice."""
+    if (info and image and info.format not in {"bc5_unorm", "bc5_snorm",
+                                               "bc4_unorm", "bc4_snorm"}
+            and max(info.width, info.height) > 4
+            and info.format not in {"bc6h_ufloat", "bc6h_float"}):
+        return _dds_classifier._decoded_classification(info, image)
+    if (info and (info.format in {"bc5_unorm", "bc5_snorm", "bc4_unorm",
+                                  "bc4_snorm", "bc6h_ufloat", "bc6h_float"}
+                  or max(info.width, info.height) <= 4)):
+        return classify_dds(path)
+    return None
+
+
+class CorpusBuilder:
+    def __init__(self, mods_root, output_dir, *, wuwa_only=True,
+                 progress=False, pixel_limit=None, max_mods=None):
+        self.mods_root = os.path.normpath(os.path.abspath(mods_root))
+        self.output_dir = Path(output_dir)
+        self.wuwa_only = wuwa_only
+        self.progress = progress
+        self.pixel_limit = (None if pixel_limit is None
+                            else max(0, int(pixel_limit)))
+        self.max_mods = (None if max_mods is None
+                         else max(0, int(max_mods)))
+        self.textures = {}
+        self.texture_examples = {}
+        self.texture_occurrence_counts = Counter()
+        self.occurrences = []
+        self.trusted_labels = []
+        self._label_keys = set()
+        self.component_labels = []
+        self._component_label_keys = set()
+        self.mods = []
+        self.errors = []
+        self.feature_cache_hits = 0
+        self.feature_extractions = 0
+        self.pixel_decoded = 0
+        self.pixel_skipped_budget = 0
+        self._load_feature_cache()
+
+    def _load_feature_cache(self):
+        path = self.output_dir / "feature_cache.json"
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return
+        if payload.get("feature_schema_version") != FEATURE_SCHEMA_VERSION:
+            return
+        for sha, row in (payload.get("entries") or {}).items():
+            if isinstance(sha, str) and isinstance(row, dict):
+                self.textures[sha] = dict(row)
+
+    def _flush_feature_cache(self):
+        _write_json(self.output_dir / "feature_cache.json", {
+            "feature_schema_version": FEATURE_SCHEMA_VERSION,
+            "entries": {
+                sha: {key: value for key, value in row.items()
+                      if key not in {"example_mod_id", "example_relative_file",
+                                     "occurrence_count"}}
+                for sha, row in sorted(self.textures.items())
+            },
+        })
+
+    def _ensure_texture(self, path, mod_id, relative_file):
+        try:
+            data = Path(path).read_bytes()
+        except (OSError, ValueError) as exc:
+            self.errors.append({"kind": "texture_read", "file": relative_file,
+                                "mod_id": mod_id, "error": str(exc)})
+            return None
+        sha = hashlib.sha256(data).hexdigest()
+        self.texture_occurrence_counts[sha] += 1
+        if sha in self.textures:
+            self.feature_cache_hits += 1
+            row = self.textures[sha]
+            row.setdefault("sha256", sha)
+            row["example_mod_id"] = row.get("example_mod_id") or mod_id
+            row["example_relative_file"] = (
+                row.get("example_relative_file") or relative_file)
+            self.texture_examples.setdefault(sha, (mod_id, relative_file, path))
+            return sha
+
+        info = inspect_dds(path)
+        decode_allowed = (
+            bool(info)
+            and (self.pixel_limit is None or self.pixel_decoded < self.pixel_limit))
+        image = load_texture_image(path, max_size=128, preserve_alpha=True) \
+            if decode_allowed else None
+        if image is not None:
+            self.pixel_decoded += 1
+        elif info and not decode_allowed:
+            self.pixel_skipped_budget += 1
+        try:
+            baseline = _diagnostic_baseline(path, info, image)
+        except Exception as exc:  # diagnostics must never stop corpus scanning
+            baseline = None
+            self.errors.append({"kind": "baseline", "file": relative_file,
+                                "mod_id": mod_id, "error": str(exc)})
+        try:
+            features = extract_texture_features(
+                path, dds_info=info, image=image, baseline=baseline,
+                decode=decode_allowed)
+            if info and not decode_allowed and features.get("decode_status") == "unavailable":
+                features["decode_status"] = "skipped_budget"
+        except Exception as exc:
+            features = {
+                "feature_version": FEATURE_SCHEMA_VERSION,
+                "dds_valid": bool(info),
+                "decode_status": "feature_error",
+            }
+            self.errors.append({"kind": "feature", "file": relative_file,
+                                "mod_id": mod_id, "error": str(exc)})
+        self.feature_extractions += 1
+        row = {
+            "sha256": sha,
+            "file_size": len(data),
+            "example_mod_id": mod_id,
+            "example_relative_file": relative_file,
+            **features,
+        }
+        self.textures[sha] = row
+        self.texture_examples.setdefault(sha, (mod_id, relative_file, path))
+        if self.progress and self.feature_extractions % 250 == 0:
+            print(f"features: {self.feature_extractions} unique DDS",
+                  file=sys.stderr, flush=True)
+            self._flush_feature_cache()
+        return sha
+
+    def _resolve_texture(self, mod_dir, filename):
+        if not isinstance(filename, str) or not filename.lower().endswith(".dds"):
+            return None
+        path = safe_resource_path(mod_dir, filename)
+        if path is None or not os.path.isfile(path):
+            return None
+        return path
+
+    def _add_occurrence(self, *, mod, path, context, source, component=None,
+                        association_tier=None, associated_components=(), ini=None,
+                        resource=None, slot=None, role=None,
+                        original_texture_hash=None, filename_tag=None):
+        relative_file = _relative(path, mod["path"])
+        sha = self._ensure_texture(path, mod["mod_id"], relative_file)
+        if sha is None:
+            return None
+        associated_components = tuple(associated_components or ())
+        row = {
+            "mod_id": mod["mod_id"],
+            "game": mod["game"],
+            "character_signature": mod["character_signature"],
+            "component": component,
+            "texture_sha256": sha,
+            "relative_file": relative_file,
+            "context": context,
+            "source": source,
+            "association_tier": association_tier,
+            "association_count": len(associated_components)
+            if associated_components else None,
+            "associated_components": associated_components,
+            "ini": ini,
+            "resource": resource,
+            "slot": slot,
+            "role": role,
+            "original_texture_hash": original_texture_hash,
+            "filename_tag": filename_tag,
+        }
+        self.occurrences.append(row)
+        return sha
+
+    def _add_label(self, sha, *, label, source, tier, mod, component, path,
+                   role, ini=None, resource=None, slot=None):
+        if source not in _PRIMARY_SOURCES | _SECONDARY_SOURCES:
+            return
+        row = {
+            "texture_sha256": sha,
+            "label": label,
+            "label_source": source,
+            "label_tier": tier,
+            "mod_id": mod["mod_id"],
+            "component": component,
+            "relative_file": _relative(path, mod["path"]),
+            "role": role,
+            "ini": ini,
+            "resource": resource,
+            "slot": slot,
+        }
+        key = tuple(row.get(field) for field in LABEL_FIELDS)
+        if key in self._label_keys:
+            return
+        self._label_keys.add(key)
+        self.trusted_labels.append(row)
+        if component is not None:
+            component_row = {
+                "texture_sha256": sha,
+                "component": component,
+                "label": label,
+                "label_source": source,
+                "label_tier": tier,
+                "mod_id": mod["mod_id"],
+                "relative_file": row["relative_file"],
+                "role": role,
+            }
+            component_key = tuple(component_row.get(field)
+                                  for field in COMPONENT_LABEL_FIELDS)
+            if component_key not in self._component_label_keys:
+                self._component_label_keys.add(component_key)
+                self.component_labels.append(component_row)
+
+    def _record_parser_evidence(self, mod, group):
+        component = parse_component_ordinal(
+            group.get("display_name") or group.get("name"))
+        component_name = (f"Component{component}"
+                          if component is not None else None)
+        for draw in group.get("draws", ()):
+            source_info = _get(draw, "sources", ()) or ()
+            source_info = source_info[0] if source_info else {}
+            ini = (_relative(source_info["ini_path"], mod["path"])
+                   if source_info.get("ini_path") else None)
+            for role in ("diffuse", "normal_map", "light_map", "material_map"):
+                files = []
+                default_file = _role_default(draw, role)
+                if default_file:
+                    files.append((default_file, None))
+                for item in _role_variants(draw, role):
+                    if isinstance(item, dict) and item.get("file"):
+                        files.append((item["file"], item.get("texture_hashes")))
+                for item in _role_assignments(draw, role):
+                    if isinstance(item, dict) and item.get("file"):
+                        files.append((item["file"], item.get("texture_hashes")))
+                seen = set()
+                label_source, label_tier = _source_for_role(draw, role)
+                for filename, hashes in files:
+                    path = self._resolve_texture(mod["path"], filename)
+                    if path is None:
+                        continue
+                    key = (os.path.normcase(path), role)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    sha = self._add_occurrence(
+                        mod=mod, path=path, context="parser_binding",
+                        source=label_source, component=component_name,
+                        ini=ini, resource=None, role=role,
+                        original_texture_hash="|".join(hashes or ()) or None)
+                    if sha:
+                        self._add_label(
+                            sha, label=_ROLE_LABELS[role], source=label_source,
+                            tier=label_tier, mod=mod, component=component_name,
+                            path=path, role=role, ini=ini)
+
+            for binding in _get(draw, "slot_textures", ()) or ():
+                path = self._resolve_texture(
+                    mod["path"], _get(binding, "file"))
+                if path is None:
+                    continue
+                role = _get(binding, "role_hint")
+                source = _get(binding, "role_hint_source")
+                label_source = {
+                    "mod_slot_mapping": "mod_slot_mapping",
+                    "legacy_slot_mapping": "legacy_slot_mapping",
+                }.get(source)
+                tier = "primary" if label_source == "mod_slot_mapping" \
+                    else "secondary" if label_source else None
+                hashes = _get(binding, "texture_hashes", ()) or ()
+                sha = self._add_occurrence(
+                    mod=mod, path=path, context="parser_slot_binding",
+                    source=label_source or "slot_binding", component=component_name,
+                    ini=ini, resource=_get(binding, "resource"),
+                    slot=_get(binding, "slot"), role=role,
+                    original_texture_hash="|".join(hashes) or None)
+                if sha and label_source and role in _ROLE_LABELS:
+                    self._add_label(
+                        sha, label=_ROLE_LABELS[role], source=label_source,
+                        tier=tier, mod=mod, component=component_name, path=path,
+                        role=role, ini=ini, resource=_get(binding, "resource"),
+                        slot=_get(binding, "slot"))
+
+        for entry in group.get("diffuse_pool_files", ()) or ():
+            resource = entry.get("res")
+            role = _semantic_resource_role(resource)
+            path = self._resolve_texture(mod["path"], entry.get("file"))
+            if path is None:
+                continue
+            sha = self._add_occurrence(
+                mod=mod, path=path, context="parser_resource_pool",
+                source="explicit_semantic_binding" if role else "resource_pool",
+                component=component_name, resource=resource, role=role)
+            if sha and role == "diffuse":
+                self._add_label(
+                    sha, label="diffuse", source="explicit_semantic_binding",
+                    tier="primary", mod=mod, component=component_name, path=path,
+                    role=role, resource=resource)
+
+    def _record_filename_evidence(self, mod, dds_files, components):
+        for path in dds_files:
+            parsed = parse_component_filename(os.path.basename(path))
+            if not parsed:
+                continue
+            for component in components:
+                tier = filename_association(parsed["components"], component)
+                if tier is None:
+                    continue
+                self._add_occurrence(
+                    mod=mod, path=path, context="filename_association",
+                    source="filename_analysis", component=f"Component{component}",
+                    association_tier=tier,
+                    associated_components=parsed["components"],
+                    original_texture_hash=parsed["tag"],
+                    filename_tag=parsed["tag"])
+
+    def scan(self):
+        root = self.mods_root
+        all_mod_dirs = discover_mod_directories(root)
+        mod_dirs = (all_mod_dirs if self.max_mods is None
+                    else all_mod_dirs[:self.max_mods])
+        self._mods_total_discovered = len(all_mod_dirs)
+        mod_boundaries = set(mod_dirs)
+        archive_paths = discover_archives(root)
+        for mod_path in mod_dirs:
+            mod_id = _relative(mod_path, root)
+            ini_paths = _active_ini_files(mod_path)
+            mod = {
+                "mod_id": mod_id,
+                "relative_path": mod_id,
+                "path": mod_path,
+                "game": "unknown",
+                "character_signature": mod_id,
+                "parse_status": "error",
+                "ini_count": len(ini_paths),
+                "component_count": 0,
+                "texture_count": 0,
+                "source": "pre_enrichment_parser",
+                "warnings": [],
+            }
+            parsed = None
+            try:
+                parsed = mod_loader._parse_inis(ini_paths, mod_path)
+                mod["game"] = parsed.game.game
+                mod["parse_status"] = "ok" if parsed.groups else "no_geometry"
+                mod["character_signature"] = character_signature(
+                    parsed.groups, mod_id)
+                mod["component_count"] = len(parsed.groups)
+                if not parsed.groups:
+                    mod["warnings"].append("no_draw_groups")
+            except Exception as exc:
+                mod["warnings"].append(f"parse_error:{exc}")
+                self.errors.append({"kind": "parse", "mod_id": mod_id,
+                                    "error": str(exc)})
+            self.mods.append(mod)
+            if self.wuwa_only and mod["game"] != "wuwa":
+                mod["warnings"].append("excluded_non_wuwa")
+                continue
+
+            dds_files = list(_walk_mod_textures(mod_path, mod_boundaries))
+            mod_shas = set()
+            for path in dds_files:
+                relative_file = _relative(path, mod_path)
+                sha = self._ensure_texture(path, mod_id, relative_file)
+                if sha:
+                    mod_shas.add(sha)
+                    self.occurrences.append({
+                        "mod_id": mod_id,
+                        "game": mod["game"],
+                        "character_signature": mod["character_signature"],
+                        "component": None,
+                        "texture_sha256": sha,
+                        "relative_file": relative_file,
+                        "context": "file_inventory",
+                        "source": "file_inventory",
+                        "association_tier": "inventory",
+                        "association_count": None,
+                        "associated_components": (),
+                        "ini": None,
+                        "resource": None,
+                        "slot": None,
+                        "role": None,
+                        "original_texture_hash": None,
+                        "filename_tag": None,
+                    })
+            mod["texture_count"] = len(mod_shas)
+            if parsed:
+                components = set()
+                for group in parsed.groups:
+                    ordinal = parse_component_ordinal(
+                        group.get("display_name") or group.get("name"))
+                    if ordinal is not None:
+                        components.add(ordinal)
+                    self._record_parser_evidence(mod, group)
+                self._record_filename_evidence(mod, dds_files, sorted(components))
+
+        return self._write(archive_paths)
+
+    def _write(self, archive_paths):
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        for row in self.mods:
+            row["warnings"] = ";".join(row["warnings"])
+            row.pop("path", None)
+        for row in self.textures.values():
+            row["occurrence_count"] = self.texture_occurrence_counts[row["sha256"]]
+        _write_csv(self.output_dir / "mods.csv", self.mods, MOD_FIELDS)
+        _write_csv(self.output_dir / "textures.csv",
+                   sorted(self.textures.values(), key=lambda row: row["sha256"]),
+                   ["sha256", "file_size", "example_mod_id",
+                    "example_relative_file", "occurrence_count"])
+        _write_csv(self.output_dir / "occurrences.csv", self.occurrences,
+                   OCCURRENCE_FIELDS)
+        _write_csv(self.output_dir / "trusted_labels.csv",
+                   sorted(self.trusted_labels,
+                          key=lambda row: tuple(row.get(key) or ""
+                                                for key in LABEL_FIELDS)),
+                   LABEL_FIELDS)
+        trusted_shas = {row["texture_sha256"] for row in self.trusted_labels}
+        unknown = []
+        for sha, row in sorted(self.textures.items()):
+            if sha in trusted_shas:
+                continue
+            example = self.texture_examples.get(sha, (None, None, None))
+            unknown.append({
+                "texture_sha256": sha,
+                "label_status": "unknown",
+                "example_mod_id": example[0],
+                "example_file": example[1],
+                "occurrence_count": self.texture_occurrence_counts[sha],
+                "dds_format": row.get("dds_format"),
+                "dds_width": row.get("dds_width"),
+                "dds_height": row.get("dds_height"),
+                "baseline_texture_class": row.get("baseline_texture_class"),
+                "baseline_role": row.get("baseline_role"),
+                "baseline_confidence": row.get("baseline_confidence"),
+            })
+        _write_csv(self.output_dir / "unknown_candidates.csv", unknown,
+                   UNKNOWN_FIELDS)
+        _write_csv(self.output_dir / "manual_labels.csv", [], MANUAL_FIELDS)
+        _write_csv(self.output_dir / "component_labels.csv",
+                   sorted(self.component_labels,
+                          key=lambda row: tuple(row.get(key) or ""
+                                                for key in COMPONENT_LABEL_FIELDS)),
+                   COMPONENT_LABEL_FIELDS)
+
+        label_counts = Counter(row["label"] for row in self.trusted_labels)
+        source_counts = Counter(row["label_source"] for row in self.trusted_labels)
+        format_counts = Counter(
+            str(row.get("dds_format") or "invalid")
+            for row in self.textures.values())
+        parse_counts = Counter(row["parse_status"] for row in self.mods)
+        game_counts = Counter(row["game"] for row in self.mods)
+        pixel_decoded_total = sum(
+            row.get("decode_status") == "decoded"
+            for row in self.textures.values())
+        pixel_skipped_total = sum(
+            row.get("decode_status") == "skipped_budget"
+            for row in self.textures.values())
+        summary = {
+            "schema_version": SCHEMA_VERSION,
+            "feature_schema_version": FEATURE_SCHEMA_VERSION,
+            "mods_discovered": len(self.mods),
+            "mods_total_discovered": self._mods_total_discovered,
+            "mods_scan_limit": self.max_mods,
+            "scan_truncated": (self.max_mods is not None
+                                and self.max_mods < self._mods_total_discovered),
+            "mods_in_dataset": sum(
+                1 for row in self.mods
+                if not self.wuwa_only or row["game"] == "wuwa"),
+            "mods_by_game": dict(sorted(game_counts.items())),
+            "parse_status": dict(sorted(parse_counts.items())),
+            "textures_unique": len(self.textures),
+            "texture_occurrences": len(self.occurrences),
+            "trusted_label_rows": len(self.trusted_labels),
+            "trusted_labels_by_label": dict(sorted(label_counts.items())),
+            "trusted_labels_by_source": dict(sorted(source_counts.items())),
+            "unknown_candidates": len(unknown),
+            "component_label_rows": len(self.component_labels),
+            "format_distribution": dict(sorted(format_counts.items())),
+            "archives_found": len(archive_paths),
+            "archives_skipped": len(archive_paths),
+            "feature_extractions": self.feature_extractions,
+            "feature_cache_hits": self.feature_cache_hits,
+            "pixel_decoded": pixel_decoded_total,
+            "pixel_decoded_this_run": self.pixel_decoded,
+            "pixel_skipped_budget": pixel_skipped_total,
+            "pixel_skipped_budget_this_run": self.pixel_skipped_budget,
+            "pixel_decode_limit": self.pixel_limit,
+            "errors": len(self.errors),
+            "error_details": self.errors[:100],
+        }
+        manifest = {
+            "schema_version": SCHEMA_VERSION,
+            "scanner_version": SCANNER_VERSION,
+            "feature_schema_version": FEATURE_SCHEMA_VERSION,
+            "input_root_name": Path(self.mods_root).name,
+            "wuwa_only": self.wuwa_only,
+            "pixel_decode_limit": self.pixel_limit,
+            "mods_scan_limit": self.max_mods,
+            "files": [
+                "manifest.json", "summary.json", "mods.csv", "textures.csv",
+                "occurrences.csv", "trusted_labels.csv",
+                "unknown_candidates.csv", "manual_labels.csv",
+                "component_labels.csv", "feature_cache.json",
+            ],
+            "label_policy": {
+                "primary_sources": sorted(_PRIMARY_SOURCES),
+                "secondary_sources": sorted(_SECONDARY_SOURCES),
+                "unknown_is_not_negative": True,
+                "excluded_as_labels": [
+                    "current_dds_classifier", "Components_filename",
+                    "filename_t_tag", "original_texture_hash",
+                    "WWMI_TextureUsage", "Asset_JSON", "material_guess",
+                    "runtime_fallback",
+                ],
+            },
+            "model_feature_columns": model_feature_columns(
+                {key for row in self.textures.values() for key in row}),
+            "diagnostic_feature_columns": sorted({
+                key for row in self.textures.values() for key in row
+                if key.startswith("baseline_")
+            }),
+        }
+        _write_json(self.output_dir / "manifest.json", manifest)
+        _write_json(self.output_dir / "summary.json", summary)
+        _write_json(self.output_dir / "feature_cache.json", {
+            "feature_schema_version": FEATURE_SCHEMA_VERSION,
+            "entries": {
+                sha: {key: value for key, value in row.items()
+                      if key not in {"example_mod_id", "example_relative_file"}}
+                for sha, row in sorted(self.textures.items())
+            },
+        })
+        self._write_report(summary, unknown)
+        return summary
+
+    def _write_report(self, summary, unknown):
+        reports = self.output_dir / "reports"
+        _write_json(reports / "scan_report.json", summary)
+        rows = "".join(
+            f"<tr><td>{html.escape(str(row.get('label') or ''))}</td>"
+            f"<td>{html.escape(str(row.get('count') or ''))}</td></tr>"
+            for row in [
+                {"label": key, "count": value}
+                for key, value in summary["trusted_labels_by_label"].items()
+            ])
+        page = """<!doctype html><meta charset='utf-8'>
+<title>WuWa texture corpus report</title>
+<h1>WuWa texture corpus</h1>
+<p>Scanner-only checkpoint. Unknown candidates are not negative labels.</p>
+<table><tr><th>Metric</th><th>Value</th></tr>
+{metrics}</table>
+<h2>Trusted labels</h2><table><tr><th>Label</th><th>Rows</th></tr>
+{labels}</table>
+""".format(
+            metrics="".join(
+                f"<tr><td>{html.escape(str(key))}</td><td>{html.escape(str(value))}</td></tr>"
+                for key, value in summary.items()
+                if key not in {"error_details", "trusted_labels_by_label",
+                               "trusted_labels_by_source"}),
+            labels=rows,
+        )
+        (reports / "summary.html").write_text(page, encoding="utf-8")
+
+
+def scan_corpus(mods_root, output_dir, *, wuwa_only=True, progress=False,
+                pixel_limit=None, max_mods=None):
+    return CorpusBuilder(
+        mods_root, output_dir, wuwa_only=wuwa_only, progress=progress,
+        pixel_limit=pixel_limit, max_mods=max_mods).scan()
+
+
+def read_summary(corpus_dir):
+    path = Path(corpus_dir) / "summary.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _safe_review_path(mods_root, mod_id, relative_file):
+    root = Path(mods_root).resolve()
+    candidate = (root / Path(mod_id) / Path(relative_file)).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
+def review_corpus(corpus_dir, mods_root, *, limit=12):
+    """Create deterministic contact sheets for a small unknown sample."""
+    corpus_dir = Path(corpus_dir)
+    review_dir = corpus_dir / "review"
+    review_dir.mkdir(parents=True, exist_ok=True)
+    with (corpus_dir / "unknown_candidates.csv").open(
+            encoding="utf-8", newline="") as stream:
+        unknown = list(csv.DictReader(stream))
+    selected = unknown[:max(0, int(limit))]
+    items = []
+    for row in selected:
+        path = _safe_review_path(mods_root, row.get("example_mod_id", ""),
+                                 row.get("example_file", ""))
+        image = load_texture_image(path, max_size=160, preserve_alpha=True) \
+            if path and path.is_file() else None
+        if image is None:
+            continue
+        items.append((row, image.convert("RGB")))
+
+    sheets = []
+    if items:
+        from PIL import Image, ImageDraw
+
+        columns = 4
+        cell_width, cell_height = 220, 200
+        for start in range(0, len(items), columns * 3):
+            chunk = items[start:start + columns * 3]
+            sheet = Image.new("RGB", (columns * cell_width, 3 * cell_height),
+                              "white")
+            draw = ImageDraw.Draw(sheet)
+            for index, (row, image) in enumerate(chunk):
+                x = (index % columns) * cell_width
+                y = (index // columns) * cell_height
+                image.thumbnail((200, 160))
+                sheet.paste(image, (x + 10, y + 8))
+                draw.text((x + 10, y + 172), row["texture_sha256"][:12],
+                          fill="black")
+            name = f"contact-sheet-{len(sheets) + 1:02d}.png"
+            sheet.save(review_dir / name)
+            sheets.append(name)
+
+    _write_csv(review_dir / "items.csv", [
+        {"texture_sha256": row["texture_sha256"],
+         "example_mod_id": row.get("example_mod_id"),
+         "example_file": row.get("example_file"),
+         "image_available": bool(_safe_review_path(
+             mods_root, row.get("example_mod_id", ""), row.get("example_file", ""))) }
+        for row in selected
+    ], ["texture_sha256", "example_mod_id", "example_file", "image_available"])
+    html_rows = "".join(
+        f"<li>{html.escape(name)}</li>" for name in sheets)
+    (review_dir / "index.html").write_text(
+        "<!doctype html><meta charset='utf-8'><title>Unknown review</title>"
+        "<h1>Unknown candidates</h1><ul>" + html_rows + "</ul>",
+        encoding="utf-8")
+    return {"selected": len(selected), "decoded": len(items), "sheets": sheets}
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    scan = commands.add_parser("scan", help="scan an extracted mod root")
+    scan.add_argument("mods_root", type=Path)
+    scan.add_argument("--output", required=True, type=Path)
+    scan.add_argument("--include-non-wuwa", action="store_true")
+    scan.add_argument(
+        "--pixel-limit", type=int, default=None,
+        help="decode at most this many unique DDS previews; headers still scan fully")
+    scan.add_argument(
+        "--max-mods", type=int, default=None,
+        help="scan only the first N discovered mod directories")
+    summary = commands.add_parser("summary", help="print corpus summary")
+    summary.add_argument("corpus", type=Path)
+    review = commands.add_parser("review", help="make unknown contact sheets")
+    review.add_argument("corpus", type=Path)
+    review.add_argument("--mods-root", required=True, type=Path)
+    review.add_argument("--limit", default=12, type=int)
+    return parser
+
+
+def main(argv=None):
+    args = _build_parser().parse_args(argv)
+    if args.command == "scan":
+        result = scan_corpus(
+            args.mods_root, args.output, wuwa_only=not args.include_non_wuwa,
+            progress=True, pixel_limit=args.pixel_limit,
+            max_mods=args.max_mods)
+    elif args.command == "summary":
+        result = read_summary(args.corpus)
+    else:
+        result = review_corpus(args.corpus, args.mods_root, limit=args.limit)
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/wuwa_texture_corpus.py
+++ b/tools/wuwa_texture_corpus.py
@@ -43,6 +43,7 @@ from core.texture_features import (  # noqa: E402
     model_feature_columns,
 )
 from core.textures import load_texture_image  # noqa: E402
+from tools.wuwa_texture_labels import MANUAL_LABELS, NEGATIVE_LABELS  # noqa: E402
 
 
 SCHEMA_VERSION = "wuwa-texture-corpus-v1"
@@ -94,11 +95,8 @@ UNKNOWN_FIELDS = [
 MANUAL_FIELDS = [
     "texture_sha256", "label", "notes", "reviewer", "source",
 ]
-MANUAL_LABELS = frozenset({
-    "", "unknown", "diffuse", "normal_map", "light_map", "material_map",
-})
 DECODE_TARGET_LABELS = frozenset({
-    "diffuse", "normal_map", "light_map", "material_map", "not_diffuse",
+    "diffuse", *NEGATIVE_LABELS,
 })
 COMPONENT_LABEL_FIELDS = [
     "texture_sha256", "component", "label", "label_source", "label_tier",
@@ -389,6 +387,7 @@ class CorpusBuilder:
                 for row in rows:
                     normalized = {field: (row.get(field) or "")
                                   for field in MANUAL_FIELDS}
+                    normalized["label"] = normalized["label"].strip().lower()
                     if normalized["label"] not in MANUAL_LABELS:
                         self.manual_label_errors.append({
                             "kind": "manual_label",

--- a/tools/wuwa_texture_corpus.py
+++ b/tools/wuwa_texture_corpus.py
@@ -94,6 +94,9 @@ UNKNOWN_FIELDS = [
 MANUAL_FIELDS = [
     "texture_sha256", "label", "notes", "reviewer", "source",
 ]
+MANUAL_LABELS = frozenset({
+    "", "unknown", "diffuse", "normal_map", "light_map", "material_map",
+})
 COMPONENT_LABEL_FIELDS = [
     "texture_sha256", "component", "label", "label_source", "label_tier",
     "mod_id", "relative_file", "role",
@@ -342,7 +345,10 @@ class CorpusBuilder:
         self.feature_extractions = 0
         self.pixel_decoded = 0
         self.pixel_skipped_budget = 0
+        self.manual_labels = []
+        self.manual_label_errors = []
         self._load_feature_cache()
+        self._load_manual_labels()
 
     def _load_feature_cache(self):
         path = self.output_dir / "feature_cache.json"
@@ -366,6 +372,35 @@ class CorpusBuilder:
                 for sha, row in sorted(self.textures.items())
             },
         })
+
+    def _load_manual_labels(self):
+        path = self.output_dir / "manual_labels.csv"
+        try:
+            with path.open(encoding="utf-8", newline="") as stream:
+                rows = csv.DictReader(stream)
+                for row in rows:
+                    normalized = {field: (row.get(field) or "")
+                                  for field in MANUAL_FIELDS}
+                    if normalized["label"] not in MANUAL_LABELS:
+                        self.manual_label_errors.append({
+                            "kind": "manual_label",
+                            "sha256": normalized["texture_sha256"],
+                            "error": f"unsupported label: {normalized['label']}",
+                        })
+                        continue
+                    if not normalized["texture_sha256"]:
+                        self.manual_label_errors.append({
+                            "kind": "manual_label",
+                            "error": "missing texture_sha256",
+                        })
+                        continue
+                    self.manual_labels.append(normalized)
+        except FileNotFoundError:
+            return
+        except (OSError, UnicodeError, csv.Error) as exc:
+            self.manual_label_errors.append({
+                "kind": "manual_label", "error": str(exc),
+            })
 
     def _ensure_texture(self, path, mod_id, relative_file):
         try:
@@ -735,7 +770,8 @@ class CorpusBuilder:
             })
         _write_csv(self.output_dir / "unknown_candidates.csv", unknown,
                    UNKNOWN_FIELDS)
-        _write_csv(self.output_dir / "manual_labels.csv", [], MANUAL_FIELDS)
+        _write_csv(self.output_dir / "manual_labels.csv", self.manual_labels,
+                   MANUAL_FIELDS)
         _write_csv(self.output_dir / "component_labels.csv",
                    sorted(self.component_labels,
                           key=lambda row: tuple(row.get(key) or ""
@@ -774,6 +810,8 @@ class CorpusBuilder:
             "trusted_labels_by_label": dict(sorted(label_counts.items())),
             "trusted_labels_by_source": dict(sorted(source_counts.items())),
             "unknown_candidates": len(unknown),
+            "manual_label_rows": len(self.manual_labels),
+            "manual_label_errors": len(self.manual_label_errors),
             "component_label_rows": len(self.component_labels),
             "format_distribution": dict(sorted(format_counts.items())),
             "archives_found": len(archive_paths),
@@ -884,15 +922,18 @@ def _safe_review_path(mods_root, mod_id, relative_file):
     return candidate
 
 
-def review_corpus(corpus_dir, mods_root, *, limit=12):
+def review_corpus(corpus_dir, mods_root, *, limit=12, offset=0):
     """Create deterministic contact sheets for a small unknown sample."""
     corpus_dir = Path(corpus_dir)
+    offset = max(0, int(offset))
     review_dir = corpus_dir / "review"
+    if offset:
+        review_dir = review_dir / f"batch-{offset:04d}"
     review_dir.mkdir(parents=True, exist_ok=True)
     with (corpus_dir / "unknown_candidates.csv").open(
             encoding="utf-8", newline="") as stream:
         unknown = list(csv.DictReader(stream))
-    selected = unknown[:max(0, int(limit))]
+    selected = unknown[offset:offset + max(0, int(limit))]
     items = []
     for row in selected:
         path = _safe_review_path(mods_root, row.get("example_mod_id", ""),
@@ -939,7 +980,13 @@ def review_corpus(corpus_dir, mods_root, *, limit=12):
         "<!doctype html><meta charset='utf-8'><title>Unknown review</title>"
         "<h1>Unknown candidates</h1><ul>" + html_rows + "</ul>",
         encoding="utf-8")
-    return {"selected": len(selected), "decoded": len(items), "sheets": sheets}
+    return {
+        "offset": offset,
+        "selected": len(selected),
+        "decoded": len(items),
+        "sheets": sheets,
+        "review_dir": str(review_dir),
+    }
 
 
 def _build_parser():
@@ -961,6 +1008,7 @@ def _build_parser():
     review.add_argument("corpus", type=Path)
     review.add_argument("--mods-root", required=True, type=Path)
     review.add_argument("--limit", default=12, type=int)
+    review.add_argument("--offset", default=0, type=int)
     return parser
 
 
@@ -974,7 +1022,8 @@ def main(argv=None):
     elif args.command == "summary":
         result = read_summary(args.corpus)
     else:
-        result = review_corpus(args.corpus, args.mods_root, limit=args.limit)
+        result = review_corpus(
+            args.corpus, args.mods_root, limit=args.limit, offset=args.offset)
     print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
     return 0
 

--- a/tools/wuwa_texture_labels.py
+++ b/tools/wuwa_texture_labels.py
@@ -1,0 +1,25 @@
+"""Shared labels for the offline WuWa texture corpus and trainer."""
+
+from __future__ import annotations
+
+
+POSITIVE_LABELS = frozenset({"diffuse"})
+NEGATIVE_LABELS = frozenset({
+    "light_map", "material_map", "normal_map", "not_diffuse",
+})
+IGNORED_LABELS = frozenset({"", "skip", "unknown"})
+MANUAL_LABELS = frozenset({
+    *POSITIVE_LABELS, *NEGATIVE_LABELS, *IGNORED_LABELS,
+})
+
+
+def canonical_label(label):
+    """Return ``(canonical_label, target)`` or ``None`` when ignored."""
+    normalized = (label or "").strip().lower()
+    if normalized in POSITIVE_LABELS:
+        return "diffuse", 1
+    if normalized in NEGATIVE_LABELS:
+        return "not_diffuse", 0
+    if normalized in IGNORED_LABELS:
+        return None
+    raise ValueError(f"unsupported texture label: {normalized}")


### PR DESCRIPTION
## Summary
- add a read-only CLI for scanning extracted WuWa mod directories with the existing pre-enrichment parser
- record authoritative semantic labels separately from filename, classifier, and runtime diagnostics
- add SHA-deduplicated DDS metadata and generic pixel features with resumable cache and bounded decode controls
- add unknown-candidate, component-label, manual-label, report, and contact-sheet outputs

## Validation
- adds regression coverage for discovery boundaries, parser provenance, label policy, SHA deduplication, cache reuse, and filename association tiers
- keeps the experiment separate from runtime texture resolution and model training