### PR TITLE
Simplify WuWa texture discovery

### DIFF
--- a/context.md
+++ b/context.md
@@ -147,6 +147,8 @@ machine-specific paths or facts that are obvious from the source.
   `normal_map`, `normal_data`, `light_map` and `material_map`. Diffuse is sRGB;
   auxiliary roles are non-color data. A legacy path-only key is normalized
   using the caller's known role, never guessed in the browser.
+- Heuristic texture candidate discovery populates viewer choices only; it must
+  not infer or mutate semantic texture bindings.
 - `core.resource_paths.safe_resource_path()` is the single sandbox for
   mod-authored geometry, manual texture selection and diagnostics. Reject
   absolute/drive paths and excessive parent traversal. The server's separate

--- a/src/app/mod_loader.py
+++ b/src/app/mod_loader.py
@@ -528,8 +528,7 @@ def _apply_texture_enrichment(parsed, context, bindings, complete_index):
         dds_classification_cache=context.dds_classification_cache)
     if str(getattr(parsed.game, "game", "")).casefold() == "wuwa":
         wuwa_texture_fallback.apply(
-            parsed.groups, context.mod_dir,
-            dds_classification_cache=context.dds_classification_cache)
+            parsed.groups, context.mod_dir)
 
 
 def _assign_material_profiles(meshes, game):

--- a/src/app/wuwa_texture_fallback.py
+++ b/src/app/wuwa_texture_fallback.py
@@ -18,18 +18,9 @@ _SLOT_SOURCE = "wuwa_ps_slot"
 
 
 @dataclass(frozen=True, slots=True)
-class _FilenameReplacement:
-    replacement: object
-    components: tuple[int, ...]
-
-
-@dataclass(frozen=True, slots=True)
 class _Candidate:
     file: str
     source: str
-    association: str | None = None
-    slot: int | None = None
-    resource: str | None = None
 
 
 def _component_ordinal(group):
@@ -48,48 +39,28 @@ def _file_key(path):
     return os.path.normcase(os.path.normpath(path))
 
 
-def _parse_filename_replacement(replacement):
+def _filename_matches_component(replacement, ordinal):
     filename = replacement.file
     if not isinstance(filename, str):
-        return None
+        return False
     match = _WUWA_COMPONENT_TEXTURE_RE.fullmatch(_basename(filename))
     if not match:
-        return None
-    components = tuple(
-        int(value) for value in match.group("components").split("-"))
-    if not components:
-        return None
-    return _FilenameReplacement(
-        replacement=replacement,
-        components=components,
-    )
-
-
-def _component_association(components, ordinal):
-    if ordinal not in components:
-        return None
-    if components == (ordinal,):
-        return "exact"
-    if components[0] == ordinal:
-        return "leading"
-    return "contains"
+        return False
+    return ordinal in {
+        int(value) for value in match.group("components").split("-")
+    }
 
 
 def _filename_candidates(ordinal, texture_index):
     result = []
     for replacements in (texture_index.replacements_by_hash or {}).values():
         for replacement in replacements:
-            parsed = _parse_filename_replacement(replacement)
-            if parsed is None:
-                continue
-            association = _component_association(
-                parsed.components, ordinal)
-            if association is None or not parsed.replacement.file:
+            if (not replacement.file
+                    or not _filename_matches_component(replacement, ordinal)):
                 continue
             result.append(_Candidate(
-                file=parsed.replacement.file,
+                file=replacement.file,
                 source=_FILENAME_SOURCE,
-                association=association,
             ))
     return result
 
@@ -104,8 +75,6 @@ def _slot_candidates(group):
             result.append(_Candidate(
                 file=filename,
                 source=_SLOT_SOURCE,
-                slot=binding.slot,
-                resource=binding.resource,
             ))
     return result
 
@@ -118,24 +87,10 @@ def _record_discovered(group, candidates, mod_dir):
         if path is None or not os.path.isfile(path):
             continue
         key = _file_key(path)
-        record = discovered.get(key)
-        if record is None:
-            record = {
-                "file": candidate.file,
-                "source": candidate.source,
-            }
-            if candidate.association is not None:
-                record["association"] = candidate.association
-            if candidate.slot is not None:
-                record["slot"] = candidate.slot
-            if candidate.resource is not None:
-                record["resource"] = candidate.resource
-            discovered[key] = record
-            continue
-
-        sources = record.setdefault("sources", [record["source"]])
-        if candidate.source not in sources:
-            sources.append(candidate.source)
+        discovered.setdefault(key, {
+            "file": candidate.file,
+            "source": candidate.source,
+        })
 
     group["discovered_textures"] = list(discovered.values())
 

--- a/src/app/wuwa_texture_fallback.py
+++ b/src/app/wuwa_texture_fallback.py
@@ -1,62 +1,41 @@
-"""Contextual WuWa texture analysis and candidate discovery."""
+"""WuWa component texture candidate discovery."""
 
 from dataclasses import dataclass
 import os
 import re
 
-from core.dds_classifier import DDSClassification, is_color_candidate
 from core.ini_parser import TextureOverrideIndex
 from core.resource_paths import safe_resource_path
-
-from .asset_enrichment import (
-    TextureSemanticEvidence,
-    _apply_hash_replacements,
-    _cached_dds_classification,
-    _has_mod_texture,
-)
 
 
 _COMPONENT_RE = re.compile(
     r"^Component(?P<ordinal>\d+)(?:_\d+)?$", re.I)
 _WUWA_COMPONENT_TEXTURE_RE = re.compile(
     r"^Components-(?P<components>\d+(?:-\d+)*)"
-    r"\s+t=(?P<tag>.+?)\.dds$",
-    re.I,
-)
-_INFERRED_ROLES = frozenset(("diffuse", "normal_map"))
-_DIRECT_SOURCE = "wuwa_direct_analysis"
-_FILENAME_SOURCE = "wuwa_filename_analysis"
+    r"\s+t=(?P<tag>.+?)\.dds$", re.I)
+_FILENAME_SOURCE = "wuwa_filename"
+_SLOT_SOURCE = "wuwa_ps_slot"
 
 
 @dataclass(frozen=True, slots=True)
 class _FilenameReplacement:
     replacement: object
     components: tuple[int, ...]
-    filename_tag: str
 
 
 @dataclass(frozen=True, slots=True)
 class _Candidate:
-    original_hash: str | None
-    role: str
-    priority: tuple[int, ...]
-    classification: DDSClassification
-    file: str | None = None
-    association_source: str = _FILENAME_SOURCE
+    file: str
+    source: str
+    association: str | None = None
+    slot: int | None = None
+    resource: str | None = None
 
 
 def _component_ordinal(group):
     name = group.get("display_name") or group.get("name")
     match = _COMPONENT_RE.fullmatch(str(name or ""))
     return int(match.group("ordinal")) if match else None
-
-
-def _uses_slotfix(group):
-    return any(
-        item.role_hint_source == "mod_slot_mapping"
-        for draw in group.get("draws", [])
-        for item in draw.slot_textures
-    )
 
 
 def _basename(filename):
@@ -67,53 +46,6 @@ def _basename(filename):
 
 def _file_key(path):
     return os.path.normcase(os.path.normpath(path))
-
-
-def _is_strong_normal_candidate(classification):
-    return (classification.role == "normal_map"
-            and classification.confidence == "high")
-
-
-def _direct_analysis_roles(classification):
-    """Map direct draw evidence to roles the contextual resolver may use."""
-    roles = []
-    if _is_strong_normal_candidate(classification):
-        roles.append("normal_map")
-    if is_color_candidate(classification):
-        roles.append("diffuse")
-    return tuple(roles)
-
-
-def _filename_analysis_roles(classification):
-    """Filename association is allowed to produce Diffuse candidates only."""
-    return ("diffuse",) if is_color_candidate(classification) else ()
-
-
-def _direct_dds_candidates(draw, mod_dir, cache):
-    """Collect viable direct candidates for one effective draw state."""
-    candidates = {}
-    for binding in draw.slot_textures:
-        if binding.role_hint is not None:
-            continue
-        filename = binding.file
-        if (not isinstance(filename, str)
-                or not filename.casefold().endswith(".dds")):
-            continue
-        path = safe_resource_path(mod_dir, filename)
-        if path is None:
-            continue
-        classification = _cached_dds_classification(path, cache)
-        for role in _direct_analysis_roles(classification):
-            key = (role, _file_key(path))
-            candidates.setdefault(key, _Candidate(
-                original_hash=None,
-                role=role,
-                priority=(0, 0, 0),
-                classification=classification,
-                file=filename,
-                association_source=_DIRECT_SOURCE,
-            ))
-    return list(candidates.values())
 
 
 def _parse_filename_replacement(replacement):
@@ -130,245 +62,93 @@ def _parse_filename_replacement(replacement):
     return _FilenameReplacement(
         replacement=replacement,
         components=components,
-        # This value is deliberately opaque. It is diagnostic metadata only;
-        # it is never compared with the INI original hash or normalized.
-        filename_tag=match.group("tag"),
     )
 
 
-def _component_priority(components, ordinal):
+def _component_association(components, ordinal):
     if ordinal not in components:
         return None
     if components == (ordinal,):
-        tier = 0
-    elif components[0] == ordinal:
-        tier = 1
-    else:
-        tier = 2
-    return tier, len(components)
+        return "exact"
+    if components[0] == ordinal:
+        return "leading"
+    return "contains"
 
 
-def _filename_priority(components, ordinal):
-    priority = _component_priority(components, ordinal)
-    return (1, *priority) if priority is not None else None
-
-
-def _index_metadata(texture_index):
-    """Parse replacement filename metadata once for one INI index."""
-    result = {}
-    for original_hash, replacements in (
-            texture_index.replacements_by_hash or {}).items():
-        items = []
-        for replacement in replacements:
-            if not replacement.file:
-                continue
-            items.append(_parse_filename_replacement(replacement))
-        result[original_hash] = tuple(items)
-    return result
-
-
-def _classify_items(items, ordinal, mod_dir, cache):
-    """Classify one hash family after verifying component membership."""
-    if not items or any(item is None for item in items):
-        return None
-    if any(_component_priority(item.components, ordinal) is None
-           for item in items):
-        return None
-    classified = []
-    for item in items:
-        path = safe_resource_path(mod_dir, item.replacement.file)
-        if path is None:
-            return None
-        classified.append(_cached_dds_classification(path, cache))
-    return list(zip(items, classified))
-
-
-def _classify_candidate_family(original_hash, items, ordinal, mod_dir, cache):
-    """Return one automatic candidate for an unambiguous hash family."""
-    classified = _classify_items(items, ordinal, mod_dir, cache)
-    if not classified:
-        return None
-    role_items = [
-        (item, classification, role)
-        for item, classification in classified
-        for role in _filename_analysis_roles(classification)
-    ]
-    roles = {role for _item, _classification, role in role_items}
-    if len(roles) != 1:
-        return None
-    role = next(iter(roles))
-    role_items = [item for item in role_items if item[2] == role]
-    _strongest_item, strongest_classification, _role = min(
-        role_items,
-        key=lambda item: _filename_priority(item[0].components, ordinal),
-    )
-    return _Candidate(
-        # The filename tag and replacement object cannot define identity.
-        original_hash=original_hash,
-        role=role,
-        priority=min(
-            _filename_priority(item.components, ordinal)
-            for item, _classification, _role in role_items),
-        classification=strongest_classification,
-        association_source=_FILENAME_SOURCE,
-    )
-
-
-def _filename_inventory(ordinal, mod_dir, cache, parsed_index):
-    """Return every viable filename-associated candidate for the pool."""
+def _filename_candidates(ordinal, texture_index):
     result = []
-    for original_hash, items in parsed_index.items():
-        classified = _classify_items(items, ordinal, mod_dir, cache)
-        if not classified:
-            continue
-        for item, classification in classified:
-            priority = _filename_priority(item.components, ordinal)
-            for role in _filename_analysis_roles(classification):
-                result.append(_Candidate(
-                    original_hash=original_hash,
-                    role=role,
-                    priority=priority,
-                    classification=classification,
-                    file=item.replacement.file,
-                    association_source=_FILENAME_SOURCE,
-                ))
+    for replacements in (texture_index.replacements_by_hash or {}).values():
+        for replacement in replacements:
+            parsed = _parse_filename_replacement(replacement)
+            if parsed is None:
+                continue
+            association = _component_association(
+                parsed.components, ordinal)
+            if association is None or not parsed.replacement.file:
+                continue
+            result.append(_Candidate(
+                file=parsed.replacement.file,
+                source=_FILENAME_SOURCE,
+                association=association,
+            ))
     return result
 
 
-def _candidate_identity(candidate, mod_dir):
-    if candidate.file:
-        path = safe_resource_path(mod_dir, candidate.file)
-        if path is not None:
-            return ("file", _file_key(path))
-        return ("file", candidate.file.casefold())
-    return ("hash", candidate.original_hash)
-
-
-def _select_role_candidate(candidates, role, mod_dir):
-    role_candidates = [item for item in candidates if item.role == role]
-    if not role_candidates:
-        return None
-    priority = min(item.priority for item in role_candidates)
-    strongest = [
-        item for item in role_candidates if item.priority == priority
-    ]
-    identities = {
-        _candidate_identity(item, mod_dir) for item in strongest
-    }
-    if len(identities) != 1:
-        # Equal-strength direct files or hash families are ambiguous. A
-        # weaker candidate must not silently resolve that ambiguity.
-        return None
-    return strongest[0]
-
-
-def _select_candidates(ordinal, mod_dir, cache, parsed_index):
-    candidates = []
-    for original_hash, items in parsed_index.items():
-        candidate = _classify_candidate_family(
-            original_hash, items, ordinal, mod_dir, cache)
-        if candidate is not None:
-            candidates.append(candidate)
-    return {
-        role: selected
-        for role in _INFERRED_ROLES
-        if (selected := _select_role_candidate(candidates, role, mod_dir))
-    }
+def _slot_candidates(group):
+    result = []
+    for draw in group.get("draws", []) or []:
+        for binding in getattr(draw, "slot_textures", ()) or ():
+            filename = binding.file
+            if not isinstance(filename, str) or not filename:
+                continue
+            result.append(_Candidate(
+                file=filename,
+                source=_SLOT_SOURCE,
+                slot=binding.slot,
+                resource=binding.resource,
+            ))
+    return result
 
 
 def _record_discovered(group, candidates, mod_dir):
-    """Store viable candidates as enrichment-owned, temporary group state."""
+    """Store safe, associated files for the viewer's manual texture pool."""
     discovered = {}
     for candidate in candidates:
-        if not candidate.file:
-            continue
         path = safe_resource_path(mod_dir, candidate.file)
-        if path is None:
+        if path is None or not os.path.isfile(path):
             continue
-        key = (candidate.role, _file_key(path))
-        record = {
-            "file": candidate.file,
-            "role": candidate.role,
-            "semantic_candidate": candidate.role,
-            "source": candidate.association_source,
-            "priority": candidate.priority,
-            "texture_class": candidate.classification.texture_class,
-            "confidence": candidate.classification.confidence,
-            "evidence": candidate.classification.evidence,
-        }
-        existing = discovered.get(key)
-        if existing is None or record["priority"] < existing["priority"]:
+        key = _file_key(path)
+        record = discovered.get(key)
+        if record is None:
+            record = {
+                "file": candidate.file,
+                "source": candidate.source,
+            }
+            if candidate.association is not None:
+                record["association"] = candidate.association
+            if candidate.slot is not None:
+                record["slot"] = candidate.slot
+            if candidate.resource is not None:
+                record["resource"] = candidate.resource
             discovered[key] = record
+            continue
+
+        sources = record.setdefault("sources", [record["source"]])
+        if candidate.source not in sources:
+            sources.append(candidate.source)
+
     group["discovered_textures"] = list(discovered.values())
 
 
-def _apply_candidate(draw, candidate, texture_index):
-    if _has_mod_texture(draw, candidate.role):
-        return
-    if candidate.file:
-        draw.set_texture_default(candidate.role, candidate.file)
-        draw.texture_provenance.setdefault(
-            candidate.role, candidate.association_source)
-        return
-    draw.texture_provenance.setdefault(
-        candidate.role, candidate.association_source)
-    _apply_hash_replacements(
-        draw,
-        [TextureSemanticEvidence(
-            role=candidate.role,
-            texture_hash=candidate.original_hash,
-            source=candidate.association_source,
-            texture_class=candidate.classification.texture_class,
-            confidence=candidate.classification.confidence,
-            evidence=candidate.classification.evidence,
-        )],
-        texture_index,
-    )
-
-
-def apply(groups, mod_dir, *, dds_classification_cache=None):
-    """Resolve WuWa roles and expose viable candidates to texture pools.
-
-    Direct bindings are stronger than generated filename associations. The
-    parser-owned diffuse pool is not mutated; discovered candidates are kept
-    in enrichment-owned group state for the mesh builder to merge later.
-    """
-    cache = (dds_classification_cache
-             if dds_classification_cache is not None else {})
-    parsed_indexes = {}
+def apply(groups, mod_dir):
+    """Discover WuWa texture files without assigning semantic texture roles."""
     for group in groups or ():
+        candidates = _slot_candidates(group)
+
         ordinal = _component_ordinal(group)
-        if ordinal is None or _uses_slotfix(group):
-            continue
-
-        direct_by_draw = []
-        all_candidates = []
-        for draw in group.get("draws", []):
-            direct = _direct_dds_candidates(draw, mod_dir, cache)
-            direct_by_draw.append(direct)
-            all_candidates.extend(direct)
-
         texture_index = group.get("_texture_override_index")
-        filename_selected = {}
-        filename_inventory = []
-        if isinstance(texture_index, TextureOverrideIndex):
-            index_key = id(texture_index)
-            parsed_index = parsed_indexes.get(index_key)
-            if parsed_index is None:
-                parsed_index = _index_metadata(texture_index)
-                parsed_indexes[index_key] = parsed_index
-            filename_selected = _select_candidates(
-                ordinal, mod_dir, cache, parsed_index)
-            filename_inventory = _filename_inventory(
-                ordinal, mod_dir, cache, parsed_index)
-            all_candidates.extend(filename_inventory)
+        if ordinal is not None and isinstance(
+                texture_index, TextureOverrideIndex):
+            candidates.extend(_filename_candidates(ordinal, texture_index))
 
-        _record_discovered(group, all_candidates, mod_dir)
-
-        for draw, direct_candidates in zip(
-                group.get("draws", []), direct_by_draw):
-            candidates = direct_candidates + list(filename_selected.values())
-            for role in _INFERRED_ROLES:
-                selected = _select_role_candidate(candidates, role, mod_dir)
-                if selected is not None:
-                    _apply_candidate(draw, selected, texture_index)
+        _record_discovered(group, candidates, mod_dir)

--- a/src/core/mesh_builder.py
+++ b/src/core/mesh_builder.py
@@ -469,7 +469,7 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
     the diffuse at this exact point, is a list of {conditions, tex_key}
     alternatives (same DNF shape as `conditions`) for the UI to pick between
     as toggle state changes. `texture_options`, present when the component's
-    section references one or more distinct, resolved diffuses anywhere
+    parser or candidate discovery references one or more distinct files
     (regardless of position/condition), is the full deduplicated pool as
     {tex_key, file, label} for a manual per-mesh override picker -- same list
     object shared by every draw in the component, so it also serves as the
@@ -579,11 +579,11 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 tex_uris[key] = value or ""
             return key
 
-        # Every parser-derived or enrichment-discovered diffuse this
-        # component references, resolved once and shared by every draw in the
-        # group -- the UI's per-mesh texture picker list. The parser-owned
-        # diffuse pool remains separate from WuWa discovery; both use the same
-        # role-aware registry so duplicate files produce one option.
+        # Every parser-derived or discovered texture this component exposes,
+        # resolved once and shared by every draw in the group -- the UI's
+        # per-mesh texture picker list. The parser-owned diffuse pool remains
+        # separate from WuWa discovery; both use the same role-aware registry
+        # so duplicate files produce one option.
         texture_options = []
         texture_option_keys = set()
 
@@ -602,39 +602,19 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 label = res_name[8:] if res_name.startswith("Resource") else res_name
                 _append_texture_option(key, pool_entry["file"], label)
 
-        discovered_normals = {}
-        normal_role = texture_profile.normal_transport_role
         for candidate in grp.get("discovered_textures") or []:
             filename = candidate.get("file")
-            role = candidate.get("role") or candidate.get(
-                "semantic_candidate")
             path = safe_resource_path(mod_dir, filename)
             if path is None:
                 continue
-            if role == "diffuse":
-                key = _tex_key(path)
-                label = os.path.splitext(
-                    str(filename).replace("\\", "/").rsplit("/", 1)[-1]
-                )[0]
-                _append_texture_option(
-                    key, filename, label,
-                    candidate_source=candidate.get("source"),
-                    candidate_priority=candidate.get("priority"),
-                )
-            elif (role == "normal_map"
-                  and candidate.get("source") == "wuwa_direct_analysis"):
-                key = _tex_key(path, normal_role)
-                if key:
-                    discovered_normals[key] = key
-
-        # A unique discovered normal is safe to pair with every diffuse pool
-        # option. Ambiguous normals remain available only as analysis data;
-        # guessing a color/normal Cartesian product would create false pairs.
-        if len(discovered_normals) == 1:
-            normal_key = next(iter(discovered_normals.values()))
-            for option in texture_options:
-                if not option.get("normal_map") and not option.get("normal_data"):
-                    option[normal_role] = normal_key
+            key = _tex_key(path)
+            label = os.path.splitext(
+                str(filename).replace("\\", "/").rsplit("/", 1)[-1]
+            )[0]
+            _append_texture_option(
+                key, filename, label,
+                candidate_source=candidate.get("source"),
+            )
 
         for draw in unique:
             lbl = draw.label

--- a/src/tests/test_load_pipeline.py
+++ b/src/tests/test_load_pipeline.py
@@ -16,6 +16,7 @@ from app.asset_resolver import AssetComponentBinding
 from app.api import ModViewerAPI
 from core.ini_analysis import analyze_ini
 from core.ini_document import IniDocument
+from core.ini_parser import TextureOverrideIndex, TextureReplacement
 from core.ini_sections import (extract_resources, sections_from_document)
 from core.draw_call import DrawCall
 from core.mesh_builder import (GeometryBlob, MeshBuildResult,
@@ -106,6 +107,62 @@ def test_geometry_blob_bypasses_base64_intermediate():
                 and loaded_entry["material_kind_reliable"] is False
                 and loaded_entry["material_profile_id"] == "none"), ("mesh material identity is assigned conservatively")
         assert set(loaded["metadata"]["material_profiles"]) == {"none"}, ("profile metadata is deduplicated at payload scope")
+
+
+def test_wuwa_candidates_reach_texture_pool_without_changing_draw_default(
+        tmp_path):
+    (tmp_path / "Components-0 t=candidate.dds").write_bytes(
+        b"synthetic texture")
+    (tmp_path / "existing.dds").write_bytes(b"synthetic texture")
+    (tmp_path / "p.buf").write_bytes(struct.pack(
+        "<9f", 0, 0, 0, 1, 0, 0, 0, 1, 0))
+    (tmp_path / "t.buf").write_bytes(struct.pack(
+        "<6f", 0, 0, 1, 0, 0, 0))
+    (tmp_path / "i.buf").write_bytes(struct.pack("<3I", 0, 1, 2))
+
+    replacement = TextureReplacement(
+        "aaaaaaaa", "ResourceCandidate", (),
+        "TextureOverrideGenerated", "Components-0 t=candidate.dds")
+    draw = DrawCall(
+        label="Component0-1", count=3, start=0, base=0,
+        ib_file="i.buf", index_size=4,
+        position_file="p.buf", position_stride=12,
+        texcoord_file="t.buf", texcoord_stride=8,
+        texture_default_file="existing.dds")
+    group = {
+        "name": "Component0", "display_name": "Component0",
+        "position_file": "p.buf", "position_stride": 12,
+        "texcoord_file": "t.buf", "texcoord_stride": 8,
+        "ib_file": "i.buf", "index_size": 4,
+        "diffuse_pool_files": [{"res": "ResourceExisting",
+                                 "file": "existing.dds"}],
+        "draws": [draw],
+        "_texture_override_index": TextureOverrideIndex(
+            replacements_by_hash={"aaaaaaaa": (replacement,)}),
+    }
+    parsed = mod_loader.ParsedModAnalysis(
+        groups=[group], toggles={}, menu={}, defaults={}, state_rules=[],
+        present={}, game=SimpleNamespace(game="wuwa"))
+    context = mod_loader.ModLoadContext(str(tmp_path), [], {}, {})
+
+    mod_loader._apply_texture_enrichment(
+        parsed, context, [[]], complete_index=False)
+
+    def register(path, role, transform=None):
+        return f"/texture/{role}/{os.path.basename(path)}"
+
+    built = build_mesh_result(
+        parsed.groups, str(tmp_path), geometry=GeometryBlob(),
+        texture_source=register, game_profile="wuwa")
+    payload = {"meshes": built.meshes, "textures": built.textures}
+    metadata.hydrate_textures(
+        str(tmp_path), payload, texture_profile="wuwa")
+
+    entry = payload["meshes"]["Component0-1"]
+    pool = payload["texture_pools"][entry["texture_pool_id"]]
+    assert entry["tex_key"] == "diffuse::existing.dds"
+    assert [item["file"] for item in pool] == [
+        "existing.dds", "Components-0 t=candidate.dds"]
 
 
 def test_mesh_semantics_include_conditional_texture_roles_without_geometry(

--- a/src/tests/test_wuwa_texture_candidates.py
+++ b/src/tests/test_wuwa_texture_candidates.py
@@ -13,8 +13,8 @@ def _write_geometry(root):
     (root / "i.buf").write_bytes(struct.pack("<3I", 0, 1, 2))
 
 
-def _group(root, *, normals=("normal.dds",)):
-    for filename in ("A.dds", "B.dds", *normals):
+def _group(root, *, discovered=("B.dds", "normal.dds")):
+    for filename in ("A.dds", *discovered):
         (root / filename).write_bytes(b"synthetic dds")
     return [{
         "name": "Component4", "display_name": "Component4",
@@ -23,29 +23,23 @@ def _group(root, *, normals=("normal.dds",)):
         "ib_file": "i.buf", "index_size": 4,
         "diffuse_pool_files": [{"res": "ResourceA", "file": "A.dds"}],
         "discovered_textures": [
-            {"file": "A.dds", "role": "diffuse",
-             "source": "wuwa_direct_analysis", "priority": (0, 0, 0)},
-            {"file": "B.dds", "role": "diffuse",
-             "source": "wuwa_filename_analysis", "priority": (1, 1, 2)},
-            *[
-                {"file": filename, "role": "normal_map",
-                 "source": "wuwa_direct_analysis", "priority": (0, 0, 0)}
-                for filename in normals
-            ],
+            {"file": "A.dds", "source": "wuwa_ps_slot"},
+            *[{"file": filename, "source": "wuwa_filename"}
+              for filename in discovered],
         ],
         "draws": [{"label": "Component4-1", "count": 3,
                    "start": 0, "base": 0}],
     }]
 
 
-def _build(root, *, normals=("normal.dds",)):
+def _build(root, *, discovered=("B.dds", "normal.dds")):
     _write_geometry(root)
 
     def register(path, role, transform=None):
         return f"/texture/{role}/{os.path.basename(path)}"
 
     return build_mesh_result(
-        _group(root, normals=normals), str(root), geometry=GeometryBlob(),
+        _group(root, discovered=discovered), str(root), geometry=GeometryBlob(),
         texture_source=register, game_profile="wuwa")
 
 
@@ -55,23 +49,27 @@ def test_manage_texture_pool_deduplicates_parser_and_discovered_files(
     entry = built.meshes["Component4-1"]
 
     assert [item["file"] for item in entry["texture_options"]] == [
-        "A.dds", "B.dds"]
-    assert all(item["normal_data"] == "normal_data::normal.dds"
-               for item in entry["texture_options"])
+        "A.dds", "B.dds", "normal.dds"]
+    assert all("normal_map" not in item for item in entry["texture_options"])
+    assert all("normal_data" not in item for item in entry["texture_options"])
 
     payload = {"meshes": built.meshes, "textures": {}}
     metadata.hydrate_textures(
         str(tmp_path), payload, texture_profile="wuwa")
 
     pool = payload["texture_pools"]["p0"]
-    assert [item["file"] for item in pool] == ["A.dds", "B.dds"]
-    assert all(item["normal_data"] == "normal_data::normal.dds"
-               for item in pool)
+    assert [item["file"] for item in pool] == [
+        "A.dds", "B.dds", "normal.dds"]
+    assert all("normal_map" not in item for item in pool)
+    assert all("normal_data" not in item for item in pool)
 
 
-def test_manage_texture_pool_does_not_pair_ambiguous_normals(tmp_path):
-    built = _build(tmp_path, normals=("normal-a.dds", "normal-b.dds"))
+def test_manage_texture_pool_keeps_all_candidates_independent(tmp_path):
+    built = _build(tmp_path, discovered=(
+        "B.dds", "normal-a.dds", "normal-b.dds"))
     options = built.meshes["Component4-1"]["texture_options"]
 
-    assert [item["file"] for item in options] == ["A.dds", "B.dds"]
+    assert [item["file"] for item in options] == [
+        "A.dds", "B.dds", "normal-a.dds", "normal-b.dds"]
+    assert all("normal_map" not in item for item in options)
     assert all("normal_data" not in item for item in options)

--- a/src/tests/test_wuwa_texture_fallback.py
+++ b/src/tests/test_wuwa_texture_fallback.py
@@ -36,7 +36,6 @@ def test_filename_exact_association_discovers_without_mutating_draw(tmp_path):
     apply([group], str(tmp_path))
 
     assert _files(group) == [replacement.file]
-    assert group["discovered_textures"][0]["association"] == "exact"
     assert draw.texture_default("diffuse") is None
     assert draw.texture_provenance == {}
 
@@ -50,7 +49,6 @@ def test_filename_shared_association_is_included(tmp_path):
     apply([group], str(tmp_path))
 
     assert _files(group) == [replacement.file]
-    assert group["discovered_textures"][0]["association"] == "contains"
 
 
 def test_all_matching_filenames_are_retained(tmp_path):
@@ -155,9 +153,10 @@ def test_filename_and_slot_duplicate_is_recorded_once(tmp_path):
 
     apply([group], str(tmp_path))
 
-    assert _files(group) == [replacement.file]
-    assert group["discovered_textures"][0]["sources"] == [
-        "wuwa_ps_slot", "wuwa_filename"]
+    assert group["discovered_textures"] == [{
+        "file": replacement.file,
+        "source": "wuwa_ps_slot",
+    }]
 
 
 def test_slotfix_bindings_are_discovered_without_role_assignment(tmp_path):

--- a/src/tests/test_wuwa_texture_fallback.py
+++ b/src/tests/test_wuwa_texture_fallback.py
@@ -1,515 +1,210 @@
-import os
-from types import SimpleNamespace
-
-from app import mod_loader
-from app.asset_resolver import AssetComponentBinding
 from app.wuwa_texture_fallback import apply
-from core import dds_classifier
 from core.draw_call import DrawCall, SlotTextureBinding
 from core.ini_parser import TextureOverrideIndex, TextureReplacement
 
 
-def _replacement(tmp_path, original_hash, filename, *, conditions=()):
-    path = tmp_path / filename
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(b"synthetic dds")
+def _replacement(tmp_path, original_hash, filename, *, create=True):
+    if create:
+        path = tmp_path / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"synthetic texture")
     return TextureReplacement(
-        original_hash, f"Resource{original_hash}", conditions,
+        original_hash, f"Resource{original_hash}", (),
         "TextureOverrideGenerated", filename)
 
 
-def _direct_file(tmp_path, filename):
-    path = tmp_path / filename
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(b"synthetic dds")
-    return filename
-
-
-def _group(name, index, draw=None):
+def _group(name, index=None, draws=None):
     return {
         "name": name,
         "display_name": name,
-        "draws": [draw or DrawCall()],
+        "draws": list(draws or [DrawCall()]),
         "_texture_override_index": index,
     }
 
 
-def _classify(monkeypatch, roles, calls=None):
-    def classify(path):
-        filename = os.path.basename(path)
-        if calls is not None:
-            calls.append(filename)
-        role = roles[filename]
-        return dds_classifier.DDSClassification(
-            role, "packed_normal" if role == "normal_map" else "color",
-            "high", (f"synthetic_{role}",))
-
-    monkeypatch.setattr("app.asset_enrichment.classify_dds", classify)
+def _files(group):
+    return [item["file"] for item in group["discovered_textures"]]
 
 
-def test_no_asset_component_fallback_prefers_exact_filename_candidate(
-        tmp_path, monkeypatch):
-    shared = _replacement(
-        tmp_path, "aaaaaaaa", "Components-0-1-2-3 t=randomA.dds")
-    exact = _replacement(
-        tmp_path, "bbbbbbbb", "Components-2 t=randomB.dds")
-    index = TextureOverrideIndex(replacements_by_hash={
-        "aaaaaaaa": (shared,), "bbbbbbbb": (exact,),
-    })
-    _classify(monkeypatch, {
-        shared.file: "diffuse", exact.file: "diffuse",
-    })
+def test_filename_exact_association_discovers_without_mutating_draw(tmp_path):
+    replacement = _replacement(
+        tmp_path, "aaaaaaaa", "Components-2 t=A.dds")
     draw = DrawCall()
-
-    apply([_group("Component2", index, draw)], str(tmp_path))
-
-    assert draw.texture_default("diffuse") == exact.file
-    assert draw.texture_provenance == {"diffuse": "wuwa_filename_analysis"}
-    assert draw.asset_binding is None
-
-
-def test_color_candidate_without_diffuse_role_is_contextually_selected(
-        tmp_path, monkeypatch):
-    candidate = _replacement(
-        tmp_path, "aaaaaaaa", "Components-1-2 t=color-candidate.dds")
-    _classify(monkeypatch, {candidate.file: "color"})
-    draw = DrawCall()
-
-    apply([_group("Component1", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (candidate,)}), draw)],
-        str(tmp_path))
-
-    assert draw.texture_default("diffuse") == candidate.file
-    assert draw.texture_provenance == {"diffuse": "wuwa_filename_analysis"}
-
-
-def test_component_priority_prefers_leading_target_over_shorter_shared_list(
-        tmp_path, monkeypatch):
-    shared = _replacement(
-        tmp_path, "aaaaaaaa", "Components-0-1-2-3 t=shared.dds")
-    leading = _replacement(
-        tmp_path, "bbbbbbbb", "Components-1-2-4-5-7 t=leading.dds")
-    _classify(monkeypatch, {
-        shared.file: "diffuse", leading.file: "diffuse",
-    })
-    draw = DrawCall()
-
-    apply([_group("Component1", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (shared,),
-                              "bbbbbbbb": (leading,)}), draw)],
-        str(tmp_path))
-
-    assert draw.texture_default("diffuse") == leading.file
-
-
-def test_direct_dds_binding_works_without_index_or_filename_convention(
-        tmp_path, monkeypatch):
-    filename = _direct_file(tmp_path, "Textures/completely-opaque-name.dds")
-    _classify(monkeypatch, {"completely-opaque-name.dds": "diffuse"})
-    draw = DrawCall(slot_textures=[SlotTextureBinding(
-        0, "ResourceMystery", file=filename)])
-
-    apply([_group("Component4", None, draw)], str(tmp_path))
-
-    assert draw.texture_default("diffuse") == filename
-    assert draw.texture_provenance == {"diffuse": "wuwa_direct_analysis"}
-
-
-def test_direct_dds_bindings_are_resolved_per_draw(tmp_path, monkeypatch):
-    first = _direct_file(tmp_path, "first.dds")
-    second = _direct_file(tmp_path, "second.dds")
-    _classify(monkeypatch, {"first.dds": "diffuse", "second.dds": "diffuse"})
-    first_draw = DrawCall(slot_textures=[SlotTextureBinding(
-        0, "ResourceFirst", file=first)])
-    second_draw = DrawCall(slot_textures=[SlotTextureBinding(
-        0, "ResourceSecond", file=second)])
-    group = _group("Component4", None, first_draw)
-    group["draws"] = [first_draw, second_draw]
+    group = _group("Component2", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (replacement,)}), [draw])
 
     apply([group], str(tmp_path))
 
-    assert first_draw.texture_default("diffuse") == first
-    assert second_draw.texture_default("diffuse") == second
-
-
-def test_direct_dds_binding_beats_filename_fallback(
-        tmp_path, monkeypatch):
-    direct = _direct_file(tmp_path, "direct.dds")
-    fallback = _replacement(
-        tmp_path, "aaaaaaaa", "Components-4 t=fallback.dds")
-    _classify(monkeypatch, {
-        "direct.dds": "diffuse", fallback.file: "diffuse",
-    })
-    draw = DrawCall(slot_textures=[SlotTextureBinding(
-        0, "ResourceDirect", file=direct)])
-    group = _group("Component4", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (fallback,)}), draw)
-
-    apply([group], str(tmp_path))
-
-    assert draw.texture_default("diffuse") == direct
-    assert draw.texture_provenance == {"diffuse": "wuwa_direct_analysis"}
-    assert {item["file"] for item in group["discovered_textures"]} == {
-        direct, fallback.file}
-
-
-def test_filename_normal_is_ignored_even_when_direct_diffuse_exists(
-        tmp_path, monkeypatch):
-    direct = _direct_file(tmp_path, "direct.dds")
-    normal = _replacement(
-        tmp_path, "aaaaaaaa", "Components-4 t=normal.dds")
-    _classify(monkeypatch, {
-        "direct.dds": "diffuse", normal.file: "normal_map",
-    })
-    draw = DrawCall(slot_textures=[SlotTextureBinding(
-        0, "ResourceDirect", file=direct)])
-    group = _group("Component4", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (normal,)}), draw)
-
-    apply([group], str(tmp_path))
-
-    assert draw.texture_default("diffuse") == direct
-    assert draw.texture_default("normal_map") is None
-    assert draw.texture_provenance == {"diffuse": "wuwa_direct_analysis"}
-    assert [item["file"] for item in group["discovered_textures"]] == [direct]
-
-
-def test_direct_strong_normal_still_resolves_and_is_discovered(
-        tmp_path, monkeypatch):
-    normal = _direct_file(tmp_path, "direct-normal.dds")
-    _classify(monkeypatch, {"direct-normal.dds": "normal_map"})
-    draw = DrawCall(slot_textures=[SlotTextureBinding(
-        0, "ResourceNormal", file=normal)])
-    group = _group("Component4", None, draw)
-
-    apply([group], str(tmp_path))
-
-    assert draw.texture_default("normal_map") == normal
-    assert draw.texture_provenance == {"normal_map": "wuwa_direct_analysis"}
-    assert group["discovered_textures"][0]["file"] == normal
-
-
-def test_multiple_direct_files_with_one_role_are_ambiguous(
-        tmp_path, monkeypatch):
-    first = _direct_file(tmp_path, "first.dds")
-    second = _direct_file(tmp_path, "second.dds")
-    _classify(monkeypatch, {"first.dds": "diffuse", "second.dds": "diffuse"})
-    draw = DrawCall(slot_textures=[
-        SlotTextureBinding(0, "ResourceFirst", file=first),
-        SlotTextureBinding(3, "ResourceSecond", file=second),
-    ])
-
-    apply([_group("Component4", None, draw)], str(tmp_path))
-
+    assert _files(group) == [replacement.file]
+    assert group["discovered_textures"][0]["association"] == "exact"
     assert draw.texture_default("diffuse") is None
     assert draw.texture_provenance == {}
 
 
-def test_same_direct_file_in_multiple_slots_is_one_candidate(
-        tmp_path, monkeypatch):
-    filename = _direct_file(tmp_path, "shared.dds")
-    _classify(monkeypatch, {"shared.dds": "diffuse"})
-    draw = DrawCall(slot_textures=[
-        SlotTextureBinding(0, "ResourceShared", file=filename),
-        SlotTextureBinding(3, "ResourceShared", file=filename),
-    ])
-
-    apply([_group("Component4", None, draw)], str(tmp_path))
-
-    assert draw.texture_default("diffuse") == filename
-
-
-def test_unknown_direct_dds_does_not_block_filename_fallback(
-        tmp_path, monkeypatch):
-    unknown = _direct_file(tmp_path, "unknown.dds")
-    fallback = _replacement(
-        tmp_path, "aaaaaaaa", "Components-4 t=fallback.dds")
-
-    def classify(path):
-        if os.path.basename(path) == "unknown.dds":
-            return dds_classifier.DDSClassification(
-                None, "packed_data", "medium", ("synthetic_unknown",))
-        return dds_classifier.DDSClassification(
-            "diffuse", "color", "high", ("synthetic_diffuse",))
-
-    monkeypatch.setattr("app.asset_enrichment.classify_dds", classify)
-    draw = DrawCall(slot_textures=[SlotTextureBinding(
-        0, "ResourceUnknown", file=unknown)])
-
-    apply([_group("Component4", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (fallback,)}), draw)],
-        str(tmp_path))
-
-    assert draw.texture_default("diffuse") == fallback.file
-    assert draw.texture_provenance == {"diffuse": "wuwa_filename_analysis"}
-
-
-def test_non_dds_direct_binding_is_skipped(tmp_path, monkeypatch):
-    calls = []
-
-    def classify(path):
-        calls.append(path)
-        raise AssertionError("non-DDS bindings must not be classified")
-
-    monkeypatch.setattr("app.asset_enrichment.classify_dds", classify)
-    draw = DrawCall(slot_textures=[SlotTextureBinding(
-        2, "ResourceImage", file="image.jpg")])
-
-    apply([_group("Component4", None, draw)], str(tmp_path))
-
-    assert calls == []
-    assert draw.texture_provenance == {}
-
-
-def test_filename_tag_is_opaque_and_does_not_need_to_match_ini_hash(
-        tmp_path, monkeypatch):
-    first = _replacement(
-        tmp_path, "aaaaaaaa", "Components-2 t=bbbbbbbb.dds")
-    _classify(monkeypatch, {first.file: "diffuse"})
-    first_draw = DrawCall()
-    apply([_group("Component2", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (first,)}), first_draw)],
-        str(tmp_path))
-
-    second = _replacement(
-        tmp_path, "aaaaaaaa", "Components-2 t=completely-different-tag.dds")
-    _classify(monkeypatch, {second.file: "diffuse"})
-    second_draw = DrawCall()
-    apply([_group("Component2", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (second,)}), second_draw)],
-        str(tmp_path))
-
-    assert first_draw.texture_default("diffuse") == first.file
-    assert second_draw.texture_default("diffuse") == second.file
-
-
-def test_equal_specificity_distinct_hashes_are_ambiguous(tmp_path, monkeypatch):
-    first = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=A.dds")
-    second = _replacement(tmp_path, "bbbbbbbb", "Components-0 t=B.dds")
-    _classify(monkeypatch, {first.file: "diffuse", second.file: "diffuse"})
-    draw = DrawCall()
-
-    apply([_group("Component0", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (first,), "bbbbbbbb": (second,)}),
-        draw)], str(tmp_path))
-
-    assert draw.texture_default("diffuse") is None
-
-
-def test_ambiguous_filename_candidates_remain_discovered(tmp_path, monkeypatch):
-    first = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=A.dds")
-    second = _replacement(tmp_path, "bbbbbbbb", "Components-0 t=B.dds")
-    _classify(monkeypatch, {first.file: "diffuse", second.file: "diffuse"})
-    draw = DrawCall()
-    group = _group("Component0", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (first,), "bbbbbbbb": (second,)}),
-        draw)
-    group["diffuse_pool_files"] = []
+def test_filename_shared_association_is_included(tmp_path):
+    replacement = _replacement(
+        tmp_path, "aaaaaaaa", "Components-0-1-2-3 t=A.dds")
+    group = _group("Component2", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (replacement,)}))
 
     apply([group], str(tmp_path))
 
-    assert draw.texture_default("diffuse") is None
-    assert {item["file"] for item in group["discovered_textures"]} == {
-        first.file, second.file}
-    assert group["diffuse_pool_files"] == []
+    assert _files(group) == [replacement.file]
+    assert group["discovered_textures"][0]["association"] == "contains"
 
 
-def test_different_roles_compete_per_role(tmp_path, monkeypatch):
-    normal = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=normal.dds")
-    diffuse = _replacement(
-        tmp_path, "bbbbbbbb", "Components-0-1-2 t=diffuse.dds")
-    _classify(monkeypatch, {
-        normal.file: "normal_map", diffuse.file: "diffuse",
-    })
-    draw = DrawCall()
+def test_all_matching_filenames_are_retained(tmp_path):
+    replacements = [
+        _replacement(tmp_path, "aaaaaaaa", "Components-2 t=A.dds"),
+        _replacement(tmp_path, "bbbbbbbb", "Components-2-3 t=B.dds"),
+        _replacement(tmp_path, "cccccccc", "Components-0-1-2 t=C.dds"),
+    ]
+    group = _group("Component2", TextureOverrideIndex(
+        replacements_by_hash={
+            "aaaaaaaa": (replacements[0],),
+            "bbbbbbbb": (replacements[1],),
+            "cccccccc": (replacements[2],),
+        }))
 
-    apply([_group("Component0", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (normal,), "bbbbbbbb": (diffuse,)}),
-        draw)], str(tmp_path))
+    apply([group], str(tmp_path))
 
-    assert draw.texture_default("normal_map") is None
-    assert draw.texture_default("diffuse") == diffuse.file
+    assert _files(group) == [item.file for item in replacements]
 
 
-def test_unknown_dds_does_not_create_a_render_role(tmp_path, monkeypatch):
-    unknown = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=unknown.dds")
+def test_nonmatching_filename_is_excluded(tmp_path):
+    replacement = _replacement(
+        tmp_path, "aaaaaaaa", "Components-3-4 t=A.dds")
+    group = _group("Component2", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (replacement,)}))
+
+    apply([group], str(tmp_path))
+
+    assert group["discovered_textures"] == []
+
+
+def test_matching_replacement_survives_mixed_hash_family(tmp_path):
+    matching = _replacement(
+        tmp_path, "aaaaaaaa", "Components-2 t=A.dds")
+    other = _replacement(
+        tmp_path, "aaaaaaaa", "Components-5 t=B.dds")
+    group = _group("Component2", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (matching, other)}))
+
+    apply([group], str(tmp_path))
+
+    assert _files(group) == [matching.file]
+
+
+def test_dds_classifier_is_not_called_by_discovery(tmp_path, monkeypatch):
+    replacement = _replacement(
+        tmp_path, "aaaaaaaa", "Components-2 t=A.dds")
 
     def classify(_path):
-        return dds_classifier.DDSClassification(
-            None, "packed_data", "medium", ("synthetic_unknown",))
+        raise AssertionError("classifier must not be called")
 
     monkeypatch.setattr("app.asset_enrichment.classify_dds", classify)
-    draw = DrawCall()
-    apply([_group("Component0", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (unknown,)}), draw)], str(tmp_path))
+    group = _group("Component2", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (replacement,)}))
 
-    assert draw.texture_default("diffuse") is None
-    assert draw.texture_default("normal_map") is None
+    apply([group], str(tmp_path))
+
+    assert _files(group) == [replacement.file]
 
 
-def test_slotfix_skips_filename_inference_and_dds_classification(
-        tmp_path, monkeypatch):
-    direct = _direct_file(tmp_path, "slotfix-direct.dds")
+def test_slot_candidates_union_effective_bindings_across_draws(tmp_path):
+    for filename in ("A.dds", "B.dds", "C.dds"):
+        (tmp_path / filename).write_bytes(b"synthetic texture")
+    draws = [
+        DrawCall(slot_textures=[
+            SlotTextureBinding(0, "ResourceA", file="A.dds"),
+            SlotTextureBinding(1, "ResourceB", file="B.dds"),
+        ]),
+        DrawCall(slot_textures=[
+            SlotTextureBinding(0, "ResourceC", file="C.dds"),
+            SlotTextureBinding(2, "ResourceB", file="B.dds"),
+        ]),
+    ]
+    group = _group("Component2", draws=draws)
+
+    apply([group], str(tmp_path))
+
+    assert set(_files(group)) == {"A.dds", "B.dds", "C.dds"}
+
+
+def test_duplicate_slot_files_are_recorded_once(tmp_path):
+    (tmp_path / "A.dds").write_bytes(b"synthetic texture")
+    draw = DrawCall(slot_textures=[
+        SlotTextureBinding(0, "ResourceA", file="A.dds"),
+        SlotTextureBinding(3, "ResourceA", file="A.dds"),
+    ])
+    group = _group("Component2", draws=[draw])
+
+    apply([group], str(tmp_path))
+
+    assert _files(group) == ["A.dds"]
+
+
+def test_filename_and_slot_duplicate_is_recorded_once(tmp_path):
     replacement = _replacement(
-        tmp_path, "aaaaaaaa", "Components-0 t=slotfix.dds")
-    calls = []
-    _classify(monkeypatch, {
-        "slotfix-direct.dds": "diffuse", replacement.file: "diffuse",
-    }, calls)
+        tmp_path, "aaaaaaaa", "Components-2 t=A.dds")
+    draw = DrawCall(slot_textures=[
+        SlotTextureBinding(0, "ResourceA", file=replacement.file),
+    ])
+    group = _group("Component2", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (replacement,)}), [draw])
+
+    apply([group], str(tmp_path))
+
+    assert _files(group) == [replacement.file]
+    assert group["discovered_textures"][0]["sources"] == [
+        "wuwa_ps_slot", "wuwa_filename"]
+
+
+def test_slotfix_bindings_are_discovered_without_role_assignment(tmp_path):
+    (tmp_path / "A.dds").write_bytes(b"synthetic texture")
     draw = DrawCall(slot_textures=[SlotTextureBinding(
-        0, "ResourceSlot", file=direct, role_hint="diffuse",
+        0, "ResourceA", file="A.dds", role_hint="diffuse",
         role_hint_source="mod_slot_mapping")])
+    group = _group("Component2", draws=[draw])
 
-    apply([_group("Component0", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (replacement,)}), draw)],
-        str(tmp_path))
+    apply([group], str(tmp_path))
 
-    assert calls == []
+    assert _files(group) == ["A.dds"]
     assert draw.texture_default("diffuse") is None
-
-
-def test_existing_role_is_preserved_while_missing_role_is_filled(
-        tmp_path, monkeypatch):
-    existing = "existing.dds"
-    diffuse = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=other.dds")
-    normal = _replacement(tmp_path, "bbbbbbbb", "Components-0 t=normal.dds")
-    _classify(monkeypatch, {
-        diffuse.file: "diffuse", normal.file: "normal_map",
-    })
-    draw = DrawCall(texture_default_file=existing)
-
-    apply([_group("Component0", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (diffuse,), "bbbbbbbb": (normal,)}),
-        draw)], str(tmp_path))
-
-    assert draw.texture_default("diffuse") == existing
-    assert draw.texture_default("normal_map") is None
     assert draw.texture_provenance == {}
 
 
-def test_conditional_same_hash_family_keeps_all_variants(
-        tmp_path, monkeypatch):
-    first = _replacement(
-        tmp_path, "aaaaaaaa", "Components-0 t=A.dds", conditions=(
-            (("style", "0", False),),))
-    second = _replacement(
-        tmp_path, "aaaaaaaa", "Components-0 t=B.dds", conditions=(
-            (("style", "1", False),),))
-    _classify(monkeypatch, {first.file: "diffuse", second.file: "diffuse"})
-    draw = DrawCall()
-
-    apply([_group("Component0", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (first, second)}), draw)],
-        str(tmp_path))
-
-    assert [item["file"] for item in draw.texture_rules("diffuse")] == [
-        first.file, second.file,
-    ]
-
-
-def test_cross_component_variants_do_not_promote_a_hash_family(
-        tmp_path, monkeypatch):
-    first = _replacement(tmp_path, "aaaaaaaa", "Components-0 t=A.dds")
-    second = _replacement(tmp_path, "aaaaaaaa", "Components-1 t=B.dds")
-    calls = []
-    _classify(monkeypatch, {first.file: "diffuse", second.file: "diffuse"},
-              calls)
-    draw = DrawCall()
-
-    apply([_group("Component0", TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (first, second)}), draw)],
-        str(tmp_path))
-
-    assert calls == []
-    assert draw.texture_default("diffuse") is None
-
-
-def test_loader_runs_wuwa_fallback_without_asset_configuration(
-        tmp_path, monkeypatch):
+def test_existing_texture_defaults_are_untouched(tmp_path):
+    for filename in ("A.dds", "existing.dds", "existing-normal.dds"):
+        (tmp_path / filename).write_bytes(b"synthetic texture")
     replacement = _replacement(
-        tmp_path, "aaaaaaaa", "Components-0 t=no-asset.dds")
-    _classify(monkeypatch, {replacement.file: "diffuse"})
-    draw = DrawCall()
-    parsed = mod_loader.ParsedModAnalysis(
-        groups=[_group("Component0", TextureOverrideIndex(
-            replacements_by_hash={"aaaaaaaa": (replacement,)}), draw)],
-        toggles={}, menu={}, defaults={}, state_rules=[], present={},
-        game=SimpleNamespace(game="wuwa"),
-    )
-    context = mod_loader.ModLoadContext(str(tmp_path), [], {}, {})
-    binding = AssetComponentBinding(status="not_found")
+        tmp_path, "aaaaaaaa", "Components-2 t=A.dds", create=False)
+    draw = DrawCall(
+        texture_default_file="existing.dds",
+        normal_map_default_file="existing-normal.dds")
+    group = _group("Component2", TextureOverrideIndex(
+        replacements_by_hash={"aaaaaaaa": (replacement,)}), [draw])
 
-    mod_loader._apply_texture_enrichment(
-        parsed, context, [[binding]], complete_index=False)
+    apply([group], str(tmp_path))
 
-    assert draw.texture_default("diffuse") == replacement.file
-    assert draw.texture_provenance == {"diffuse": "wuwa_filename_analysis"}
+    assert draw.texture_default("diffuse") == "existing.dds"
+    assert draw.texture_default("normal_map") == "existing-normal.dds"
+    assert draw.texture_default("light_map") is None
+    assert draw.texture_default("material_map") is None
+    assert draw.texture_provenance == {}
 
 
-def test_wuwa_fallback_reuses_cache_across_semantic_refresh(
-        tmp_path, monkeypatch):
-    replacement = _replacement(
-        tmp_path, "aaaaaaaa", "Components-0 t=cache.dds")
-    calls = []
-    _classify(monkeypatch, {replacement.file: "diffuse"}, calls)
-    index = TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (replacement,)})
-    context = mod_loader.ModLoadContext(str(tmp_path), [], {}, {})
+def test_empty_unsafe_and_missing_slot_files_are_ignored(tmp_path):
+    (tmp_path / "safe.dds").write_bytes(b"synthetic texture")
+    draw = DrawCall(slot_textures=[
+        SlotTextureBinding(0, "ResourceSafe", file="safe.dds"),
+        SlotTextureBinding(1, "ResourceNull", file=None),
+        SlotTextureBinding(2, "ResourceMissing", file="missing.dds"),
+        SlotTextureBinding(3, "ResourceUnsafe", file="../../outside.dds"),
+        SlotTextureBinding(4, "ResourceEmpty", file=""),
+    ])
+    group = _group("ComponentWithoutFilename", draws=[draw])
 
-    def parsed(draw):
-        return mod_loader.ParsedModAnalysis(
-            groups=[_group("Component0", index, draw)],
-            toggles={}, menu={}, defaults={}, state_rules=[], present={},
-            game=SimpleNamespace(game="wuwa"),
-        )
+    apply([group], str(tmp_path))
 
-    first = DrawCall()
-    second = DrawCall()
-    binding = [AssetComponentBinding(status="not_found")]
-    mod_loader._apply_texture_enrichment(
-        parsed(first), context, [binding], complete_index=False)
-    mod_loader._apply_texture_enrichment(
-        parsed(second), context, [binding], complete_index=False)
-
-    assert calls == ["Components-0 t=cache.dds"]
-    assert first.texture_default("diffuse") == replacement.file
-    assert second.texture_default("diffuse") == replacement.file
-
-
-def test_wwmi_asset_json_does_not_change_filename_texture_result(
-        tmp_path, monkeypatch):
-    replacement = _replacement(
-        tmp_path, "aaaaaaaa", "Components-0 t=filename-authority.dds")
-    _classify(monkeypatch, {replacement.file: "diffuse"})
-    index = TextureOverrideIndex(
-        replacements_by_hash={"aaaaaaaa": (replacement,)})
-
-    def parsed(draw):
-        return mod_loader.ParsedModAnalysis(
-            groups=[_group("Component0", index, draw)],
-            toggles={}, menu={}, defaults={}, state_rules=[], present={},
-            game=SimpleNamespace(game="wuwa"),
-        )
-
-    without_asset = DrawCall()
-    context = mod_loader.ModLoadContext(str(tmp_path), [], {}, {})
-    mod_loader._apply_texture_enrichment(
-        parsed(without_asset), context,
-        [[AssetComponentBinding(status="not_found")]], False)
-
-    asset_root = tmp_path / "assets"
-    asset_dir = asset_root / "Alice"
-    asset_dir.mkdir(parents=True)
-    (asset_dir / "TextureUsage.json").write_text(
-        '{"Component 1": {"ps-t0": '
-        '["bbbbbbbb-vs=aaaa-ps=bbbb"]}}', encoding="utf-8")
-    with_asset = DrawCall()
-    binding = AssetComponentBinding(
-        status="exact", component_status="exact", range_status="exact",
-        asset_type="WWMI", asset="Alice", root=str(asset_root),
-        component_ordinal=1, detail_metadata="Alice/TextureUsage.json")
-    mod_loader._apply_texture_enrichment(
-        parsed(with_asset), context, [[binding]], True)
-
-    assert with_asset.texture_default("diffuse") == \
-        without_asset.texture_default("diffuse") == replacement.file
+    assert _files(group) == ["safe.dds"]

--- a/src/web/js/asset-diagnostics.js
+++ b/src/web/js/asset-diagnostics.js
@@ -14,8 +14,6 @@ const PROVENANCE_LABELS = Object.freeze({
   mod_slot_semantic: 'Mod slot mapping',
   mod_slot_legacy: 'Legacy slot mapping',
   mod_texture_hash: 'Mod hash match',
-  wuwa_direct_analysis: 'WuWa direct binding + texture analysis',
-  wuwa_filename_analysis: 'WuWa filename association + texture analysis',
   asset_original_fallback: 'Asset fallback',
   unresolved: 'Not resolved',
 });


### PR DESCRIPTION
## Summary
- Replace WuWa texture role inference with safe candidate discovery.
- Collect effective `ps-tN` bindings and matching `Components-X-Y` filename associations into the existing texture pool.
- Preserve authoritative draw texture resolution while removing classifier, ranking, auto-assignment, and unique-normal pairing paths.
- Add discovery-focused and load-pipeline regression coverage.

## Testing
- Repository pytest suite