### PR TITLE
Add explicit missing Asset part loading

### DIFF
--- a/context.md
+++ b/context.md
@@ -174,8 +174,9 @@ machine-specific paths or facts that are obvious from the source.
   composition.
 - Mod/Asset coverage is determined from authored geometry override identities
   across every discovered INI, including staged documents and
-  `handling=skip`, not from rendered draw output. A hash-only override
-  conservatively covers every Asset range under that hash.
+  `handling=skip`, not from rendered draw output. A hash-only geometry-bearing
+  override conservatively covers every Asset range under that hash; a
+  texture-only hash binding identifies an Asset but does not claim geometry.
 - Automatic original-part filling requires one uniquely resolved original
   Asset. Ambiguous identity never triggers composition. Filled geometry is
   viewer-session state, retains Asset provenance, and is removed on mod reload

--- a/context.md
+++ b/context.md
@@ -297,6 +297,10 @@ machine-specific paths or facts that are obvious from the source.
 - Viewport camera actions (Reset, Turn and Tilt) belong in the compact viewport
   toolbar with the render and navigation tools. Do not restore a separate
   Orientation panel when changing camera behavior.
+- Model orientation is persistent display state: auto-upright, game/base-facing
+  rotation and manual Turn/Tilt are applied in that order to late-adopted
+  meshes. Reset View retains the original base transform, and removed meshes
+  must be removed from that reset baseline.
 
 ## Feature flags and test strategy
 

--- a/context.md
+++ b/context.md
@@ -169,6 +169,17 @@ machine-specific paths or facts that are obvious from the source.
   `.mod_viewer.json` inside an Asset folder. Asset texture choices are
   session-only, and ambiguous texture discovery may populate candidates but
   must not create semantic role bindings.
+- Missing original Asset parts are loaded only through an explicit viewer
+  action; normal mod loading must not read heavy Asset geometry solely for
+  composition.
+- Mod/Asset coverage is determined from authored geometry override identities
+  across every discovered INI, including staged documents and
+  `handling=skip`, not from rendered draw output. A hash-only override
+  conservatively covers every Asset range under that hash.
+- Automatic original-part filling requires one uniquely resolved original
+  Asset. Ambiguous identity never triggers composition. Filled geometry is
+  viewer-session state, retains Asset provenance, and is removed on mod reload
+  or switch without modifying the mod or Asset.
 - Direct Asset geometry retains Asset/component/range provenance so later
   mod/Asset composition can compare coverage without reparsing viewer labels.
 - Direct Asset UVs are canonical viewer-space Float32 UVs (V is flipped exactly

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -112,12 +112,11 @@ class ModViewerAPI:
         index_versions = []
         for asset_type, root, _enabled in entries:
             try:
-                index = asset_index.load_index(asset_type, root)
-            except asset_index.AssetIndexError:
-                index = None
-            index_versions.append((asset_type, root,
-                                   index.get("version") if index else None,
-                                   index.get("builtAt") if index else None))
+                stat = os.stat(asset_index.index_path(asset_type, root))
+                stamp = (stat.st_mtime_ns, stat.st_size)
+            except OSError:
+                stamp = None
+            index_versions.append((asset_type, root, stamp))
         key = (os.path.normcase(os.path.abspath(folder_path)), revision,
                entries, tuple(index_versions))
         cached = self._asset_fill_plan_cache.get(key)
@@ -126,6 +125,10 @@ class ModViewerAPI:
         plan = plan_missing_asset_parts(context, overrides)
         self._asset_fill_plan_cache[key] = plan
         return plan
+
+    def _invalidate_asset_fill_plan_cache(self):
+        """Drop plans whose Asset index or enabled-root state may have changed."""
+        self._asset_fill_plan_cache.clear()
 
     def select_folder(self):
         """Open a native folder-picker dialog. Returns None if cancelled."""
@@ -267,6 +270,7 @@ class ModViewerAPI:
         except asset_catalog.AssetCatalogError as error:
             return {"error": str(error)}
         self._refresh_authorized_asset_roots(entries)
+        self._invalidate_asset_fill_plan_cache()
         self._authorized_asset_folders.add(folder_path)
         return {"folders": self._asset_folder_entries(entries)}
 
@@ -281,6 +285,7 @@ class ModViewerAPI:
         except asset_catalog.AssetCatalogError as error:
             return {"error": str(error)}
         self._refresh_authorized_asset_roots(entries)
+        self._invalidate_asset_fill_plan_cache()
         self._authorized_asset_folders.add(folder_path)
         return {"folders": self._asset_folder_entries(entries)}
 
@@ -291,6 +296,7 @@ class ModViewerAPI:
         except asset_catalog.AssetCatalogError as error:
             return {"error": str(error)}
         self._refresh_authorized_asset_roots(entries)
+        self._invalidate_asset_fill_plan_cache()
         return {"folders": self._asset_folder_entries(entries)}
 
     def set_asset_folder_enabled(self, folder_path, enabled):
@@ -300,6 +306,7 @@ class ModViewerAPI:
         except asset_catalog.AssetCatalogError as error:
             return {"error": str(error)}
         self._refresh_authorized_asset_roots(entries)
+        self._invalidate_asset_fill_plan_cache()
         return {"folders": self._asset_folder_entries(entries)}
 
     def rebuild_asset_index(self, folder_path):
@@ -312,6 +319,7 @@ class ModViewerAPI:
                 "indexPreserved": error.index_preserved,
             }
         self._refresh_authorized_asset_roots(entries)
+        self._invalidate_asset_fill_plan_cache()
         return {"folders": self._asset_folder_entries(entries)}
 
     def list_asset_subfolders(self, folder_path):
@@ -538,15 +546,13 @@ class ModViewerAPI:
                 "GIMI": "genshin", "ZZMI": "zzz", "WWMI": "wuwa",
             }[plan.asset_type])
             try:
-                loaded = asset_loader.load_asset(
+                loaded = asset_loader.load_asset_parts(
                     plan.asset_type, plan.root, plan.asset,
-                    geometry=geometry,
                     texture_source=publication.register,
                     part_filter=set(plan.missing_parts))
                 payload = build_asset_fill_payload(
                     plan.asset_type, plan.root, plan.asset, loaded.parts,
-                    geometry=geometry, warnings=loaded.payload[
-                        "metadata"]["asset"].get("warnings", ()))
+                    geometry=geometry, warnings=loaded.warnings)
                 server.publish_payload_geometry(
                     payload, geometry, replace=False)
                 publication.commit(replace=False)

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -19,6 +19,8 @@ from core.texture_profiles import texture_profile_for
 from . import (asset_catalog, asset_folders, asset_index, edit_session, ini_api,
                asset_loader, asset_paths, metadata, mod_folders, mod_loader, present_api, server,
                toggle_api)
+from .asset_composition import plan_missing_asset_parts
+from .asset_loader.models import build_asset_fill_payload
 
 
 class ModViewerAPI:
@@ -35,6 +37,8 @@ class ModViewerAPI:
         self._authorized_asset_roots = set()
         self._active_mesh_keys = {}
         self._dds_classification_caches = {}
+        self._asset_fill_sessions = {}
+        self._asset_fill_plan_cache = {}
         try:
             self._authorized_roots = mod_folders.registered_paths(
                 mod_folders.load_registry())
@@ -86,6 +90,42 @@ class ModViewerAPI:
                 path, role, validate=True, transform=transform)
 
         return register
+
+    def _clear_asset_fill(self, folder_path=None):
+        """Release session-only Asset-fill resources before a model change."""
+        keys = list(self._asset_fill_sessions)
+        if folder_path is not None:
+            requested = os.path.normcase(os.path.abspath(folder_path))
+            keys = [key for key in keys if key == requested]
+        for key in keys:
+            state = self._asset_fill_sessions.pop(key, None) or {}
+            server.release_texture_publication(state.get("publication"))
+            server.release_geometry(state.get("geometry_url"))
+
+    def _asset_fill_plan(self, folder_path, context, overrides):
+        revision = edit_session.current_revision(folder_path)
+        entries = tuple(sorted(
+            (item.get("type"), item.get("path"),
+             bool(item.get("enabled", True)))
+            for item in context.asset_folders
+            if isinstance(item, dict)))
+        index_versions = []
+        for asset_type, root, _enabled in entries:
+            try:
+                index = asset_index.load_index(asset_type, root)
+            except asset_index.AssetIndexError:
+                index = None
+            index_versions.append((asset_type, root,
+                                   index.get("version") if index else None,
+                                   index.get("builtAt") if index else None))
+        key = (os.path.normcase(os.path.abspath(folder_path)), revision,
+               entries, tuple(index_versions))
+        cached = self._asset_fill_plan_cache.get(key)
+        if cached is not None:
+            return cached
+        plan = plan_missing_asset_parts(context, overrides)
+        self._asset_fill_plan_cache[key] = plan
+        return plan
 
     def select_folder(self):
         """Open a native folder-picker dialog. Returns None if cancelled."""
@@ -440,6 +480,7 @@ class ModViewerAPI:
         return {"error": "Unexpected backend error. See the application log for details."}
 
     def load_mod(self, folder_path):
+        self._clear_asset_fill()
         folder_path, overrides, pending_new_sections, context = \
             self._authoritative_context(folder_path)
         ini_paths = context.ini_paths
@@ -475,6 +516,72 @@ class ModViewerAPI:
             publication.discard()
             self._active_mesh_keys.pop(folder_path, None)
             raise
+
+    def load_missing_asset_parts(self, folder_path):
+        """Append original Asset parts not covered by the current mod INIs."""
+        try:
+            folder_path, overrides, _pending, context = \
+                self._authoritative_context(folder_path)
+            key = os.path.normcase(os.path.abspath(folder_path))
+            existing = self._asset_fill_sessions.get(key)
+            if existing is not None:
+                return {**existing["summary"], "status": "loaded",
+                        "already_loaded": True}
+            plan = self._asset_fill_plan(folder_path, context, overrides)
+            summary = plan.to_dict()
+            if plan.status != "ready":
+                return summary
+
+            geometry = GeometryBlob()
+            publication = server.begin_texture_publication(folder_path)
+            publication.set_game_profile({
+                "GIMI": "genshin", "ZZMI": "zzz", "WWMI": "wuwa",
+            }[plan.asset_type])
+            try:
+                loaded = asset_loader.load_asset(
+                    plan.asset_type, plan.root, plan.asset,
+                    geometry=geometry,
+                    texture_source=publication.register,
+                    part_filter=set(plan.missing_parts))
+                payload = build_asset_fill_payload(
+                    plan.asset_type, plan.root, plan.asset, loaded.parts,
+                    geometry=geometry, warnings=loaded.payload[
+                        "metadata"]["asset"].get("warnings", ()))
+                server.publish_payload_geometry(
+                    payload, geometry, replace=False)
+                publication.commit(replace=False)
+            except Exception:
+                publication.discard()
+                raise
+            summary["payload"] = payload
+            self._asset_fill_sessions[key] = {
+                "publication": publication,
+                "geometry_url": payload.get("geometry", {}).get("url")
+                if payload.get("geometry") else None,
+                "summary": summary,
+            }
+            return {**summary, "status": "loaded"}
+        except (PermissionError, asset_folders.AssetFolderError,
+                asset_index.AssetIndexError, asset_loader.AssetLoadError) as error:
+            return {"status": "error", "error": str(error)}
+        except Exception:
+            traceback.print_exc()
+            return {"status": "error",
+                    "error": "Could not load missing Asset parts. See the application log for details."}
+
+    def remove_missing_asset_parts(self, folder_path):
+        """Remove the current session-only original Asset fill."""
+        try:
+            folder_path = self._folder(folder_path)
+            key = os.path.normcase(os.path.abspath(folder_path))
+            state = self._asset_fill_sessions.pop(key, None)
+            if state is None:
+                return {"status": "removed", "removed": False}
+            server.release_texture_publication(state.get("publication"))
+            server.release_geometry(state.get("geometry_url"))
+            return {"status": "removed", "removed": True}
+        except (PermissionError, mod_folders.ModFolderError) as error:
+            return {"status": "error", "error": str(error)}
 
     def get_present_state(self, folder_path):
         """Return staged PRESENT state without loading geometry or textures."""

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -375,6 +375,7 @@ class ModViewerAPI:
 
     def load_asset(self, folder_path):
         """Load one exact indexed Asset without creating or editing an INI."""
+        self._clear_asset_fill()
         try:
             selected, entry, _index, record = self._asset_selection(folder_path)
             geometry = GeometryBlob()

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -7,6 +7,7 @@ belongs in mod_loader instead.
 
 import os
 import traceback
+import uuid
 
 import webview
 
@@ -535,7 +536,8 @@ class ModViewerAPI:
             existing = self._asset_fill_sessions.get(key)
             if existing is not None:
                 return {**existing["summary"], "status": "loaded",
-                        "already_loaded": True}
+                        "already_loaded": True,
+                        "fill_id": existing.get("fill_id")}
             plan = self._asset_fill_plan(folder_path, context, overrides)
             summary = plan.to_dict()
             if plan.status != "ready":
@@ -561,13 +563,15 @@ class ModViewerAPI:
                 publication.discard()
                 raise
             summary["payload"] = payload
+            fill_id = uuid.uuid4().hex
             self._asset_fill_sessions[key] = {
+                "fill_id": fill_id,
                 "publication": publication,
                 "geometry_url": payload.get("geometry", {}).get("url")
                 if payload.get("geometry") else None,
                 "summary": summary,
             }
-            return {**summary, "status": "loaded"}
+            return {**summary, "status": "loaded", "fill_id": fill_id}
         except (PermissionError, asset_folders.AssetFolderError,
                 asset_index.AssetIndexError, asset_loader.AssetLoadError) as error:
             return {"status": "error", "error": str(error)}
@@ -576,14 +580,17 @@ class ModViewerAPI:
             return {"status": "error",
                     "error": "Could not load missing Asset parts. See the application log for details."}
 
-    def remove_missing_asset_parts(self, folder_path):
+    def remove_missing_asset_parts(self, folder_path, fill_id=None):
         """Remove the current session-only original Asset fill."""
         try:
             folder_path = self._folder(folder_path)
             key = os.path.normcase(os.path.abspath(folder_path))
-            state = self._asset_fill_sessions.pop(key, None)
+            state = self._asset_fill_sessions.get(key)
             if state is None:
                 return {"status": "removed", "removed": False}
+            if fill_id is not None and state.get("fill_id") != fill_id:
+                return {"status": "removed", "removed": False, "stale": True}
+            self._asset_fill_sessions.pop(key, None)
             server.release_texture_publication(state.get("publication"))
             server.release_geometry(state.get("geometry_url"))
             return {"status": "removed", "removed": True}

--- a/src/app/asset_composition.py
+++ b/src/app/asset_composition.py
@@ -135,6 +135,8 @@ def _asset_parts(asset_type, root, asset):
 def _part_is_covered(part, override, hash_range_count):
     if part.geometry_hash != override.geometry_hash:
         return False
+    if not override.handling_skip and not override.geometry_evidence:
+        return False
     if hash_range_count <= 1:
         return True
     if override.first_index is None:

--- a/src/app/asset_composition.py
+++ b/src/app/asset_composition.py
@@ -143,11 +143,10 @@ def _part_is_covered(part, override, hash_range_count):
         # A hash-only override is intentionally conservative, including when
         # it also contains a count but no match_first_index.
         return True
-    if part.first_index != override.first_index:
-        return False
-    return (override.index_count is None
-            or part.index_count is None
-            or part.index_count == override.index_count)
+    # The range start is the stable component identity. Authored
+    # match_index_count values can differ from the indexed count after a mod
+    # changes the draw while retaining the same original range.
+    return part.first_index == override.first_index
 
 
 def _coverage_for_asset(parts, evidence):
@@ -165,6 +164,18 @@ def _coverage_for_asset(parts, evidence):
     return covered, missing
 
 
+def _enabled_asset_entries(asset_type, asset_entries):
+    if asset_type is not None:
+        return asset_folders.enabled_entries_for_type(
+            asset_entries, asset_type)
+    return [
+        entry
+        for candidate_type in _GAME_ASSET_TYPES.values()
+        for entry in asset_folders.enabled_entries_for_type(
+            asset_entries, candidate_type)
+    ]
+
+
 def _candidate_assets(asset_type, evidence, asset_entries):
     """Return the Asset identities with the strongest authored support.
 
@@ -175,25 +186,23 @@ def _candidate_assets(asset_type, evidence, asset_entries):
     """
     candidates = {}
     support = {}
-    if asset_type is None:
-        entries = [
-            entry
-            for candidate_type in _GAME_ASSET_TYPES.values()
-            for entry in asset_folders.enabled_entries_for_type(
-                asset_entries, candidate_type)
-        ]
-    else:
-        entries = asset_folders.enabled_entries_for_type(
-            asset_entries, asset_type)
-    for item in evidence:
-        if not item.asset_identity_evidence:
+    entries = _enabled_asset_entries(asset_type, asset_entries)
+    indexes = []
+    for entry in entries:
+        try:
+            index = asset_index.load_index(entry["type"], entry["path"])
+        except asset_index.AssetIndexError:
             continue
+        if index:
+            indexes.append((entry, index))
+
+    unique_evidence = {}
+    for item in evidence:
+        if item.asset_identity_evidence:
+            unique_evidence.setdefault(item.geometry_hash, item)
+    for item in unique_evidence.values():
         matches = {}
-        for entry in entries:
-            try:
-                index = asset_index.load_index(entry["type"], entry["path"])
-            except asset_index.AssetIndexError:
-                continue
+        for entry, index in indexes:
             for lookup in asset_index.lookup_geometry(index, item.geometry_hash):
                 try:
                     asset = index["assets"][lookup["asset"]]
@@ -243,16 +252,7 @@ def plan_missing_asset_parts(context, overrides=None):
         game_evidence, runtime_evidence, texture_api_evidence)
     asset_type = _asset_type(detection)
 
-    if asset_type is None:
-        roots = [
-            entry
-            for candidate_type in _GAME_ASSET_TYPES.values()
-            for entry in asset_folders.enabled_entries_for_type(
-                context.asset_folders, candidate_type)
-        ]
-    else:
-        roots = asset_folders.enabled_entries_for_type(
-            context.asset_folders, asset_type)
+    roots = _enabled_asset_entries(asset_type, context.asset_folders)
     if not roots:
         return AssetFillPlan(
             "asset_not_found", asset_type=asset_type,

--- a/src/app/asset_composition.py
+++ b/src/app/asset_composition.py
@@ -166,9 +166,17 @@ def _coverage_for_asset(parts, evidence):
 
 
 def _candidate_assets(asset_type, evidence, asset_entries):
+    """Return the Asset identities with the strongest authored support.
+
+    A mod can contain auxiliary vertex-buffer hashes and optional components
+    from a related variant. Those hashes must not veto the Asset supported by
+    the main indexed geometry. Equal support remains ambiguous.
+    """
     candidates = {}
-    relevant = []
+    support = {}
     for item in evidence:
+        if not item.asset_identity_evidence:
+            continue
         matches = {}
         for entry in asset_folders.enabled_entries_for_type(
                 asset_entries, asset_type):
@@ -183,13 +191,17 @@ def _candidate_assets(asset_type, evidence, asset_entries):
                     continue
                 identity = (asset_type, entry["path"], asset.get("path"))
                 matches[identity] = (entry["path"], index, asset)
-        if matches:
-            relevant.append(set(matches))
-            candidates.update(matches)
-    if not relevant:
+        if not matches:
+            continue
+        for identity, value in matches.items():
+            candidates[identity] = value
+            support[identity] = support.get(identity, 0) + 1
+    if not support:
         return (), candidates
-    common = set.intersection(*relevant)
-    return tuple(sorted(common, key=lambda value: (
+    best_score = max(support.values())
+    best = [identity for identity, score in support.items()
+            if score == best_score]
+    return tuple(sorted(best, key=lambda value: (
         value[1].casefold(), value[1], value[2].casefold(), value[2]))), candidates
 
 

--- a/src/app/asset_composition.py
+++ b/src/app/asset_composition.py
@@ -170,18 +170,28 @@ def _candidate_assets(asset_type, evidence, asset_entries):
 
     A mod can contain auxiliary vertex-buffer hashes and optional components
     from a related variant. Those hashes must not veto the Asset supported by
-    the main indexed geometry. Equal support remains ambiguous.
+    the main indexed geometry. When game detection is unknown, all enabled
+    Asset types are searched and the same equal-support ambiguity rule applies.
     """
     candidates = {}
     support = {}
+    if asset_type is None:
+        entries = [
+            entry
+            for candidate_type in _GAME_ASSET_TYPES.values()
+            for entry in asset_folders.enabled_entries_for_type(
+                asset_entries, candidate_type)
+        ]
+    else:
+        entries = asset_folders.enabled_entries_for_type(
+            asset_entries, asset_type)
     for item in evidence:
         if not item.asset_identity_evidence:
             continue
         matches = {}
-        for entry in asset_folders.enabled_entries_for_type(
-                asset_entries, asset_type):
+        for entry in entries:
             try:
-                index = asset_index.load_index(asset_type, entry["path"])
+                index = asset_index.load_index(entry["type"], entry["path"])
             except asset_index.AssetIndexError:
                 continue
             for lookup in asset_index.lookup_geometry(index, item.geometry_hash):
@@ -189,7 +199,7 @@ def _candidate_assets(asset_type, evidence, asset_entries):
                     asset = index["assets"][lookup["asset"]]
                 except (KeyError, IndexError, TypeError):
                     continue
-                identity = (asset_type, entry["path"], asset.get("path"))
+                identity = (entry["type"], entry["path"], asset.get("path"))
                 matches[identity] = (entry["path"], index, asset)
         if not matches:
             continue
@@ -232,11 +242,17 @@ def plan_missing_asset_parts(context, overrides=None):
     detection = resolve_game_detection(
         game_evidence, runtime_evidence, texture_api_evidence)
     asset_type = _asset_type(detection)
-    if asset_type is None:
-        return AssetFillPlan("asset_not_found", evidence=tuple(authored))
 
-    roots = asset_folders.enabled_entries_for_type(
-        context.asset_folders, asset_type)
+    if asset_type is None:
+        roots = [
+            entry
+            for candidate_type in _GAME_ASSET_TYPES.values()
+            for entry in asset_folders.enabled_entries_for_type(
+                context.asset_folders, candidate_type)
+        ]
+    else:
+        roots = asset_folders.enabled_entries_for_type(
+            context.asset_folders, asset_type)
     if not roots:
         return AssetFillPlan(
             "asset_not_found", asset_type=asset_type,
@@ -254,11 +270,12 @@ def plan_missing_asset_parts(context, overrides=None):
 
     identity = identities[0]
     root, _index, asset = candidates[identity]
-    parts = _asset_parts(asset_type, root, asset)
+    resolved_asset_type = identity[0]
+    parts = _asset_parts(resolved_asset_type, root, asset)
     covered, missing = _coverage_for_asset(parts, authored)
     status = "nothing_missing" if not missing else "ready"
     return AssetFillPlan(
-        status=status, asset_type=asset_type, root=root, asset=asset,
+        status=status, asset_type=resolved_asset_type, root=root, asset=asset,
         asset_parts=parts, covered_parts=covered, missing_parts=missing,
         evidence=tuple(authored), index_status="ready")
 

--- a/src/app/asset_composition.py
+++ b/src/app/asset_composition.py
@@ -1,0 +1,254 @@
+"""Plan explicit, session-only filling of missing original Asset parts."""
+
+from dataclasses import dataclass
+import os
+
+from core.component_coverage import (
+    AuthoredComponentOverride, ComponentCoverageKey,
+    collect_component_overrides,
+)
+from core.game_profile import collect_game_evidence, resolve_game_detection
+from core.ini_sections import extract_resources, merge_sections
+
+from . import asset_folders, asset_index
+
+
+_GAME_ASSET_TYPES = {
+    "genshin": "GIMI",
+    "zzz": "ZZMI",
+    "wuwa": "WWMI",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class AssetCoveragePart:
+    """One metadata-only original Asset geometry range."""
+
+    asset_type: str
+    root: str
+    asset_path: str
+    geometry_hash: str
+    first_index: int | None
+    index_count: int | None
+    component_name: str | None = None
+    classification: str | None = None
+    component_ordinal: int | None = None
+    metadata: str | None = None
+
+    @property
+    def key(self):
+        return ComponentCoverageKey(
+            self.geometry_hash, self.first_index, self.index_count)
+
+    def to_dict(self):
+        return {
+            "geometry_hash": self.geometry_hash,
+            "first_index": self.first_index,
+            "index_count": self.index_count,
+            "component_name": self.component_name,
+            "classification": self.classification,
+            "component_ordinal": self.component_ordinal,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AssetFillPlan:
+    """Decision output kept separate from the expensive Asset load."""
+
+    status: str
+    asset_type: str | None = None
+    root: str | None = None
+    asset: dict | None = None
+    asset_parts: tuple[AssetCoveragePart, ...] = ()
+    covered_parts: tuple[AssetCoveragePart, ...] = ()
+    missing_parts: tuple[AssetCoveragePart, ...] = ()
+    evidence: tuple[AuthoredComponentOverride, ...] = ()
+    index_status: str = "not_configured"
+
+    @property
+    def skipped_parts(self):
+        skipped_evidence = tuple(
+            item for item in self.evidence if item.handling_skip)
+        range_counts = {}
+        for part in self.asset_parts:
+            range_counts[part.geometry_hash] = (
+                range_counts.get(part.geometry_hash, 0) + 1)
+        return tuple(
+            part for part in self.covered_parts
+            if any(_part_is_covered(
+                part, item, range_counts.get(part.geometry_hash, 0))
+                for item in skipped_evidence))
+
+    def to_dict(self):
+        asset = None
+        if self.asset is not None:
+            asset = {"type": self.asset_type, "path": self.asset.get("path")}
+        return {
+            "status": self.status,
+            "asset": asset,
+            "coverage": {
+                "asset_parts": len(self.asset_parts),
+                "handled_parts": len(self.covered_parts),
+                "missing_parts": len(self.missing_parts),
+                "skipped_parts": len(self.skipped_parts),
+            },
+            "index_status": self.index_status,
+        }
+
+
+def _asset_type(game):
+    value = getattr(game, "game", game)
+    return _GAME_ASSET_TYPES.get(value.casefold()) if isinstance(value, str) else None
+
+
+def _asset_parts(asset_type, root, asset):
+    result = []
+    for geometry in asset.get("geometry", ()):
+        if not isinstance(geometry, dict):
+            continue
+        geometry_hash = geometry.get("hash")
+        if not geometry_hash:
+            continue
+        ranges = geometry.get("ranges")
+        if not isinstance(ranges, list) or not ranges:
+            ranges = [{}]
+        for item in ranges:
+            if not isinstance(item, dict):
+                continue
+            result.append(AssetCoveragePart(
+                asset_type=asset_type,
+                root=root,
+                asset_path=asset.get("path", ""),
+                geometry_hash=geometry_hash,
+                first_index=item.get("firstIndex"),
+                index_count=item.get("indexCount"),
+                component_name=geometry.get("componentName"),
+                classification=item.get("classification"),
+                component_ordinal=item.get(
+                    "componentOrdinal", geometry.get("componentOrdinal")),
+                metadata=geometry.get("metadata"),
+            ))
+    return tuple(result)
+
+
+def _part_is_covered(part, override, hash_range_count):
+    if part.geometry_hash != override.geometry_hash:
+        return False
+    if hash_range_count <= 1:
+        return True
+    if override.first_index is None:
+        # A hash-only override is intentionally conservative, including when
+        # it also contains a count but no match_first_index.
+        return True
+    if part.first_index != override.first_index:
+        return False
+    return (override.index_count is None
+            or part.index_count is None
+            or part.index_count == override.index_count)
+
+
+def _coverage_for_asset(parts, evidence):
+    range_counts = {}
+    for part in parts:
+        range_counts[part.geometry_hash] = (
+            range_counts.get(part.geometry_hash, 0) + 1)
+    covered = tuple(
+        part for part in parts
+        if any(_part_is_covered(
+            part, item, range_counts.get(part.geometry_hash, 0))
+            for item in evidence))
+    covered_keys = {part.key for part in covered}
+    missing = tuple(part for part in parts if part.key not in covered_keys)
+    return covered, missing
+
+
+def _candidate_assets(asset_type, evidence, asset_entries):
+    candidates = {}
+    relevant = []
+    for item in evidence:
+        matches = {}
+        for entry in asset_folders.enabled_entries_for_type(
+                asset_entries, asset_type):
+            try:
+                index = asset_index.load_index(asset_type, entry["path"])
+            except asset_index.AssetIndexError:
+                continue
+            for lookup in asset_index.lookup_geometry(index, item.geometry_hash):
+                try:
+                    asset = index["assets"][lookup["asset"]]
+                except (KeyError, IndexError, TypeError):
+                    continue
+                identity = (asset_type, entry["path"], asset.get("path"))
+                matches[identity] = (entry["path"], index, asset)
+        if matches:
+            relevant.append(set(matches))
+            candidates.update(matches)
+    if not relevant:
+        return (), candidates
+    common = set.intersection(*relevant)
+    return tuple(sorted(common, key=lambda value: (
+        value[1].casefold(), value[1], value[2].casefold(), value[2]))), candidates
+
+
+def _mod_sections(context, overrides):
+    result = []
+    for ini_path in context.ini_paths:
+        sections = merge_sections(
+            [ini_path], overrides=overrides, documents=context.docs)
+        result.append((ini_path, sections))
+    return result
+
+
+def plan_missing_asset_parts(context, overrides=None):
+    """Resolve one Asset and subtract all authored component coverage."""
+    overrides = overrides or {}
+    sections_by_ini = _mod_sections(context, overrides)
+    game_evidence = []
+    runtime_evidence = []
+    texture_api_evidence = []
+    authored = []
+    for ini_path, sections in sections_by_ini:
+        resources = extract_resources(sections)
+        game, runtime, texture_api = collect_game_evidence(sections, resources)
+        game_evidence.extend(game)
+        runtime_evidence.extend(runtime)
+        texture_api_evidence.extend(texture_api)
+        authored.extend(collect_component_overrides(sections, ini_path))
+    detection = resolve_game_detection(
+        game_evidence, runtime_evidence, texture_api_evidence)
+    asset_type = _asset_type(detection)
+    if asset_type is None:
+        return AssetFillPlan("asset_not_found", evidence=tuple(authored))
+
+    roots = asset_folders.enabled_entries_for_type(
+        context.asset_folders, asset_type)
+    if not roots:
+        return AssetFillPlan(
+            "asset_not_found", asset_type=asset_type,
+            evidence=tuple(authored), index_status="not_configured")
+    identities, candidates = _candidate_assets(
+        asset_type, authored, context.asset_folders)
+    if not identities:
+        return AssetFillPlan(
+            "asset_not_found", asset_type=asset_type,
+            evidence=tuple(authored), index_status="ready")
+    if len(identities) != 1:
+        return AssetFillPlan(
+            "asset_ambiguous", asset_type=asset_type,
+            evidence=tuple(authored), index_status="ready")
+
+    identity = identities[0]
+    root, _index, asset = candidates[identity]
+    parts = _asset_parts(asset_type, root, asset)
+    covered, missing = _coverage_for_asset(parts, authored)
+    status = "nothing_missing" if not missing else "ready"
+    return AssetFillPlan(
+        status=status, asset_type=asset_type, root=root, asset=asset,
+        asset_parts=parts, covered_parts=covered, missing_parts=missing,
+        evidence=tuple(authored), index_status="ready")
+
+
+__all__ = [
+    "AssetCoveragePart", "AssetFillPlan", "plan_missing_asset_parts",
+]

--- a/src/app/asset_loader/__init__.py
+++ b/src/app/asset_loader/__init__.py
@@ -13,6 +13,24 @@ def load_asset(asset_type, root, record, *, geometry, texture_source=None,
                part_filter=None):
     """Load one exact index record into the application's normalized payload."""
     started = time.perf_counter()
+    adapted = load_asset_parts(
+        asset_type, root, record, texture_source=texture_source,
+        part_filter=part_filter)
+    result = AssetLoadResult.from_parts(
+        asset_type, root, record, adapted.parts, geometry=geometry,
+        warnings=adapted.warnings)
+    _LOGGER.info(
+        "Asset type: %s; Asset: %s; Mesh parts: %d; Textures resolved: %d; "
+        "Load time: %.3fs",
+        asset_type, record.get("path"), len(adapted.parts),
+        sum(len(part.textures) for part in adapted.parts),
+        time.perf_counter() - started)
+    return result
+
+
+def load_asset_parts(asset_type, root, record, *, texture_source=None,
+                     part_filter=None):
+    """Adapt one exact index record without packing its geometry payload."""
     if asset_type in ("GIMI", "ZZMI"):
         from .hash_asset import load_hash_asset
         adapted = load_hash_asset(
@@ -29,19 +47,11 @@ def load_asset(asset_type, root, record, *, geometry, texture_source=None,
         adapted = AssetAdapterResult(tuple(adapted))
     if not adapted.parts:
         raise AssetLoadError("Asset contains no renderable geometry parts.")
-    result = AssetLoadResult.from_parts(
-        asset_type, root, record, adapted.parts, geometry=geometry,
-        warnings=adapted.warnings)
-    _LOGGER.info(
-        "Asset type: %s; Asset: %s; Mesh parts: %d; Textures resolved: %d; "
-        "Load time: %.3fs",
-        asset_type, record.get("path"), len(adapted.parts),
-        sum(len(part.textures) for part in adapted.parts),
-        time.perf_counter() - started)
-    return result
+    return adapted
 
 
 __all__ = [
     "AssetAdapterResult", "AssetLoadError", "AssetLoadResult",
     "AssetMeshPart", "AssetTexture", "load_asset",
+    "load_asset_parts",
 ]

--- a/src/app/asset_loader/__init__.py
+++ b/src/app/asset_loader/__init__.py
@@ -9,17 +9,20 @@ import time
 _LOGGER = logging.getLogger(__name__)
 
 
-def load_asset(asset_type, root, record, *, geometry, texture_source=None):
+def load_asset(asset_type, root, record, *, geometry, texture_source=None,
+               part_filter=None):
     """Load one exact index record into the application's normalized payload."""
     started = time.perf_counter()
     if asset_type in ("GIMI", "ZZMI"):
         from .hash_asset import load_hash_asset
         adapted = load_hash_asset(
-            asset_type, root, record, texture_source=texture_source)
+            asset_type, root, record, texture_source=texture_source,
+            part_filter=part_filter)
     elif asset_type == "WWMI":
         from .wwmi import load_wwmi_asset
         adapted = load_wwmi_asset(
-            root, record, texture_source=texture_source)
+            root, record, texture_source=texture_source,
+            part_filter=part_filter)
     else:
         raise AssetLoadError(f"Unsupported Asset type: {asset_type}.")
     if not isinstance(adapted, AssetAdapterResult):

--- a/src/app/asset_loader/hash_asset.py
+++ b/src/app/asset_loader/hash_asset.py
@@ -345,7 +345,29 @@ def _cached_index_dump(path, vertex_count, cache):
     return cache[path]
 
 
-def load_hash_asset(asset_type, root, record, *, texture_source=None):
+def _filter_matches(part_filter, geometry_hash, first, count, ordinal=None):
+    if part_filter is None:
+        return True
+    for item in part_filter:
+        if getattr(item, "geometry_hash", None) != geometry_hash:
+            continue
+        expected_first = getattr(item, "first_index", None)
+        expected_count = getattr(item, "index_count", None)
+        expected_ordinal = getattr(item, "component_ordinal", None)
+        if expected_first is not None and expected_first != first:
+            continue
+        if (expected_count is not None and count is not None
+                and expected_count != count):
+            continue
+        if (expected_ordinal is not None and ordinal is not None
+                and expected_ordinal != ordinal):
+            continue
+        return True
+    return False
+
+
+def load_hash_asset(asset_type, root, record, *, texture_source=None,
+                    part_filter=None):
     asset_path = record.get("path") if isinstance(record, dict) else None
     geometries = record.get("geometry", ()) if isinstance(record, dict) else ()
     asset_dir = asset_paths.safe_asset_dir(root, asset_path)
@@ -404,6 +426,13 @@ def load_hash_asset(asset_type, root, record, *, texture_source=None):
                     component, None, "geometry_hash_missing",
                     f"{component or 'Component'} has no usable index-buffer hash."))
                 continue
+            ranges = _ranges(entry)
+            selected_ranges = [
+                item for item in ranges
+                if _filter_matches(part_filter, geometry_hash,
+                                   item[1], item[2], item[0])]
+            if not selected_ranges:
+                continue
             vb_hash = _entry_hash(entry, (
                 "vb0", "vb0_hash", "vertex_buffer", "vertexBuffer",
                 "position_vb", "positionVB", "draw_vb", "drawVB"))
@@ -428,8 +457,7 @@ def load_hash_asset(asset_type, root, record, *, texture_source=None):
                     component, None, "vertex_dump_invalid",
                     f"{component or geometry_hash} vertex dump skipped: {error}"))
                 continue
-            ranges = _ranges(entry)
-            for ordinal, first, count, classification in ranges:
+            for ordinal, first, count, classification in selected_ranges:
                 resolved, had_invalid, had_valid = _resolve_ib_dump(
                     ib_files, first, count, vertex_dump.layout.vertex_count,
                     ib_cache)

--- a/src/app/asset_loader/models.py
+++ b/src/app/asset_loader/models.py
@@ -77,118 +77,142 @@ class AssetLoadResult:
     @classmethod
     def from_parts(cls, asset_type, root, record, parts, *, geometry,
                    warnings=()):
-        game = {"GIMI": "genshin", "ZZMI": "zzz", "WWMI": "wuwa"}[asset_type]
-        root_id = os.path.normcase(os.path.abspath(root))
-        source = record.get("path", "") if isinstance(record, dict) else ""
-        profile = material_profile_for(game)
-        profiles = {profile.id: profile.to_metadata()}
-        meshes = {}
-        textures = {}
-        pools = {}
-        pool_ids = {}
-        component_hashes = {}
-        for part in parts:
-            base = part.component_name or part.label
-            component_hashes.setdefault(base, set()).add(part.geometry_hash)
-        component_labels = {}
-        for base, hashes in component_hashes.items():
-            if len(hashes) <= 1:
-                continue
-            for geometry_hash in hashes:
-                component_labels[(base, geometry_hash)] = (
-                    f"{base} [{geometry_hash or 'unknown'}]")
-        for ordinal, part in enumerate(parts):
-            for candidate in part.texture_candidates:
-                # Candidate textures are published and selectable, but their
-                # presence must not infer a semantic material role.
-                textures[candidate.key] = candidate.uri or candidate.key
-            base_component = part.component_name or part.label
-            component = component_labels.get(
-                (base_component, part.geometry_hash), base_component)
-            entry = {
-                "pos": geometry.add(part.positions),
-                "idx": geometry.add(part.indices),
-                "uv": geometry.add(part.uvs) if part.uvs else None,
-                "normal": geometry.add(part.normals) if part.normals else None,
-                "component": component,
-                "display_name": part.label,
-                "source": source,
-                "conditions": [],
-                "sources": [{"asset": part.asset_source}],
-                "drawindexed": [part.index_count or 0, part.first_index or 0, 0],
-                "tex_key": None,
-                "normal_map_key": None,
-                "normal_data_key": None,
-                "light_map_key": None,
-                "material_map_key": None,
-                "texture_variants": [],
-                "normal_map_variants": [],
-                "normal_data_variants": [],
-                "light_map_variants": [],
-                "material_map_variants": [],
-                "material_kind": "unknown",
-                "material_kind_reliable": False,
-                "material_kind_reason": "Asset preview has no mod material override.",
-                "material_profile_id": profile.id,
-                "asset_source": part.asset_source,
-            }
-            for role, texture in part.textures.items():
-                textures[texture.key] = texture.uri or texture.key
-                field = {
-                    "diffuse": "tex_key", "normal_map": "normal_map_key",
-                    "normal_data": "normal_data_key", "light_map": "light_map_key",
-                    "material_map": "material_map_key",
-                }.get(role)
-                if field:
-                    entry[field] = texture.key
-            pool = []
-            if part.texture_candidates:
-                pool = [candidate.as_candidate()
-                        for candidate in part.texture_candidates]
-            pool.extend(texture.as_candidate() for texture in part.textures.values()
-                        if texture.role == "diffuse")
-            if pool:
-                component = entry["component"]
-                pool_id = pool_ids.get(component)
-                if pool_id is None:
-                    pool_id = f"asset-pool-{len(pool_ids)}"
-                    pool_ids[component] = pool_id
-                    pools[pool_id] = []
-                seen = {item.get("tex_key") for item in pools[pool_id]}
-                for item in pool:
-                    key = item.get("tex_key")
-                    if key in seen:
-                        continue
-                    pools[pool_id].append(item)
-                    seen.add(key)
-                entry["texture_pool_id"] = pool_id
-            meshes[part.key] = entry
+        payload = _build_asset_payload(
+            asset_type, root, record, parts, geometry=geometry,
+            warnings=warnings, asset_fill=False)
+        return cls(payload, tuple(parts))
 
-        payload = {
+
+def _build_asset_payload(asset_type, root, record, parts, *, geometry,
+                         warnings=(), asset_fill=False):
+    game = {"GIMI": "genshin", "ZZMI": "zzz", "WWMI": "wuwa"}[asset_type]
+    root_id = os.path.normcase(os.path.abspath(root))
+    source = record.get("path", "") if isinstance(record, dict) else ""
+    profile = material_profile_for(game)
+    profiles = {profile.id: profile.to_metadata()}
+    meshes = {}
+    textures = {}
+    pools = {}
+    pool_ids = {}
+    component_hashes = {}
+    for part in parts:
+        base = part.component_name or part.label
+        component_hashes.setdefault(base, set()).add(part.geometry_hash)
+    component_labels = {}
+    for base, hashes in component_hashes.items():
+        if len(hashes) <= 1:
+            continue
+        for geometry_hash in hashes:
+            component_labels[(base, geometry_hash)] = (
+                f"{base} [{geometry_hash or 'unknown'}]")
+    for ordinal, part in enumerate(parts):
+        mesh_key = (f"asset-fill::{part.key}" if asset_fill else part.key)
+        for candidate in part.texture_candidates:
+            # Candidate textures are published and selectable, but their
+            # presence must not infer a semantic material role.
+            textures[candidate.key] = candidate.uri or candidate.key
+        base_component = part.component_name or part.label
+        component = component_labels.get(
+            (base_component, part.geometry_hash), base_component)
+        entry = {
+            "pos": geometry.add(part.positions),
+            "idx": geometry.add(part.indices),
+            "uv": geometry.add(part.uvs) if part.uvs else None,
+            "normal": geometry.add(part.normals) if part.normals else None,
+            "component": component,
+            "display_name": part.label,
+            "source": "ORIGINAL ASSET" if asset_fill else source,
+            "conditions": [],
+            "sources": [{"asset": part.asset_source}],
+            "drawindexed": [part.index_count or 0, part.first_index or 0, 0],
+            "tex_key": None,
+            "normal_map_key": None,
+            "normal_data_key": None,
+            "light_map_key": None,
+            "material_map_key": None,
+            "texture_variants": [],
+            "normal_map_variants": [],
+            "normal_data_variants": [],
+            "light_map_variants": [],
+            "material_map_variants": [],
+            "material_kind": "unknown",
+            "material_kind_reliable": False,
+            "material_kind_reason": "Asset preview has no mod material override.",
+            "material_profile_id": profile.id,
+            "asset_source": part.asset_source,
+            "asset_fill": asset_fill,
+            "fill_reason": ("missing_mod_coverage" if asset_fill
+                            else None),
+        }
+        for role, texture in part.textures.items():
+            textures[texture.key] = texture.uri or texture.key
+            field = {
+                "diffuse": "tex_key", "normal_map": "normal_map_key",
+                "normal_data": "normal_data_key", "light_map": "light_map_key",
+                "material_map": "material_map_key",
+            }.get(role)
+            if field:
+                entry[field] = texture.key
+        pool = []
+        if part.texture_candidates:
+            pool = [candidate.as_candidate()
+                    for candidate in part.texture_candidates]
+        pool.extend(texture.as_candidate() for texture in part.textures.values()
+                    if texture.role == "diffuse")
+        if pool:
+            component = entry["component"]
+            pool_id = pool_ids.get(component)
+            if pool_id is None:
+                pool_id = f"asset-pool-{len(pool_ids)}"
+                pool_ids[component] = pool_id
+                pools[pool_id] = []
+            seen = {item.get("tex_key") for item in pools[pool_id]}
+            for item in pool:
+                key = item.get("tex_key")
+                if key in seen:
+                    continue
+                pools[pool_id].append(item)
+                seen.add(key)
+            entry["texture_pool_id"] = pool_id
+        meshes[mesh_key] = entry
+
+    asset_metadata = {
+        "source_kind": "asset-fill" if asset_fill else "asset",
+        "game": {"id": game, "runtime": "asset",
+                 "texture_api": asset_type.lower(),
+                 "confidence": "authoritative"},
+        "asset": {"type": asset_type, "path": source,
+                  "root": root_id, "warnings": list(warnings)},
+        "material_profiles": profiles,
+    }
+    if asset_fill:
+        return {
             "meshes": meshes,
             "textures": textures,
             "texture_pools": pools,
-            "controls": {"toggles": {}, "menu": {},
-                         "present": {"target_inis": [], "item": None}},
-            "state": {"rules": [], "defaults": {}},
             "geometry": None,
-            "metadata": {
-                "source_kind": "asset",
-                "game": {"id": game, "runtime": "asset",
-                         "texture_api": asset_type.lower(),
-                         "confidence": "authoritative"},
-                "asset": {"type": asset_type, "path": source,
-                          "root": root_id, "warnings": list(warnings)},
-                "mesh_names": {},
-                "material_profiles": profiles,
-            },
-            "health": None,
-            "asset_resolution": None,
+            "metadata": asset_metadata,
         }
-        # TexturePublication returns opaque URLs.  Resolve the registry after
-        # the mesh map has been assembled so the payload never contains a
-        # filesystem path as a browser texture source.
-        return cls(payload, tuple(parts))
+    return {
+        "meshes": meshes,
+        "textures": textures,
+        "texture_pools": pools,
+        "controls": {"toggles": {}, "menu": {},
+                     "present": {"target_inis": [], "item": None}},
+        "state": {"rules": [], "defaults": {}},
+        "geometry": None,
+        "metadata": {**asset_metadata, "mesh_names": {}},
+        "health": None,
+        "asset_resolution": None,
+    }
+
+
+def build_asset_fill_payload(asset_type, root, record, parts, *, geometry,
+                             warnings=()):
+    """Build only the mesh data needed to append missing Asset parts."""
+    return _build_asset_payload(
+        asset_type, root, record, parts, geometry=geometry,
+        warnings=warnings, asset_fill=True)
 
 
 def make_texture(root, path, role, *, texture_source=None, source="explicit"):
@@ -203,5 +227,6 @@ def make_texture(root, path, role, *, texture_source=None, source="explicit"):
 
 __all__ = [
     "AssetAdapterResult", "AssetLoadError", "AssetLoadResult",
-    "AssetMeshPart", "AssetTexture", "make_texture",
+    "AssetMeshPart", "AssetTexture", "build_asset_fill_payload",
+    "make_texture",
 ]

--- a/src/app/asset_loader/wwmi.py
+++ b/src/app/asset_loader/wwmi.py
@@ -230,7 +230,28 @@ def _warning(component, ordinal, reason, message):
             "reason": reason, "message": message}
 
 
-def load_wwmi_asset(root, record, *, texture_source=None):
+def _filter_matches(part_filter, geometry_hash, first, count, ordinal=None):
+    if part_filter is None:
+        return True
+    for item in part_filter:
+        if getattr(item, "geometry_hash", None) != geometry_hash:
+            continue
+        expected_first = getattr(item, "first_index", None)
+        expected_count = getattr(item, "index_count", None)
+        expected_ordinal = getattr(item, "component_ordinal", None)
+        if expected_first is not None and expected_first != first:
+            continue
+        if (expected_count is not None and count is not None
+                and expected_count != count):
+            continue
+        if (expected_ordinal is not None and ordinal is not None
+                and expected_ordinal != ordinal):
+            continue
+        return True
+    return False
+
+
+def load_wwmi_asset(root, record, *, texture_source=None, part_filter=None):
     parts = []
     warnings = []
     convention = geometry_convention_for("wuwa")
@@ -274,6 +295,12 @@ def load_wwmi_asset(root, record, *, texture_source=None):
             name = component.get("component_name") or component.get(
                 "componentName") or component.get("name")
             name = str(name) if name else None
+            first_index = _integer(component.get("index_offset"), 0)
+            declared_index_count = _integer(component.get("index_count"))
+            if not _filter_matches(
+                    part_filter, geometry_hash, first_index,
+                    declared_index_count, ordinal):
+                continue
             files = _component_files(root, metadata_directory, ordinal)
             missing = next((key for key, path in files.items() if not path), None)
             if missing:
@@ -325,7 +352,6 @@ def load_wwmi_asset(root, record, *, texture_source=None):
                     f"{name or f'Component {ordinal}'} skipped: {error}"))
                 continue
 
-            first_index = _integer(component.get("index_offset"), 0)
             index_count = _integer(component.get("index_count"), len(indices))
             label = name or f"Part {ordinal + 1}"
             source_path = record.get("path")

--- a/src/app/server.py
+++ b/src/app/server.py
@@ -138,16 +138,30 @@ class TexturePublication:
                 self._sources[source_id] = source
             return _texture_url(self.token, source_id, source)
 
-    def commit(self):
-        """Make this publication active and retire every older publication."""
+    def commit(self, *, replace=True):
+        """Commit a publication, optionally retaining the active one."""
         global _active_texture_publication
         with _texture_lock:
             if self._state == "discarded":
                 return False
-            _texture_publications.clear()
+            if replace:
+                _texture_publications.clear()
             _texture_publications[self.token] = self
-            _active_texture_publication = self
+            if replace:
+                _active_texture_publication = self
             self._state = "committed"
+            return True
+
+    def release(self):
+        """Retire a committed auxiliary publication after session removal."""
+        global _active_texture_publication
+        with _texture_lock:
+            _texture_publications.pop(self.token, None)
+            if _active_texture_publication is self:
+                _active_texture_publication = None
+            self._sources.clear()
+            self._dedupe.clear()
+            self._state = "discarded"
             return True
 
     def discard(self):
@@ -222,18 +236,19 @@ def _render_texture_request(token, source_id, source):
         )
 
 
-def publish_geometry(blob):
-    """Publish one load's packed geometry and discard every older load."""
+def publish_geometry(blob, *, replace=True):
+    """Publish packed geometry, optionally retaining prior load blobs."""
     if len(blob) > _MAX_GEOMETRY_BYTES:
         raise ValueError("Generated geometry exceeds the 512 MiB safety limit.")
     token = uuid.uuid4().hex
     with _geometry_lock:
-        _geometry_blobs.clear()
+        if replace:
+            _geometry_blobs.clear()
         _geometry_blobs[token] = bytes(blob)
     return f"{_GEOMETRY_PREFIX}{token}"
 
 
-def publish_payload_geometry(payload, geometry=None):
+def publish_payload_geometry(payload, geometry=None, *, replace=True):
     """Publish the structured payload's packed geometry and its references.
 
     Normal loads pass the builder's append-only blob, so no encoded geometry
@@ -247,7 +262,7 @@ def publish_payload_geometry(payload, geometry=None):
                 else bytes(geometry))
         if blob:
             payload["geometry"] = {
-                "url": publish_geometry(blob),
+                "url": publish_geometry(blob, replace=replace),
                 "length": len(blob),
             }
         else:
@@ -277,11 +292,29 @@ def publish_payload_geometry(payload, geometry=None):
                 target[field] = {"offset": offset, "length": len(raw)}
     if blob:
         payload["geometry"] = {
-            "url": publish_geometry(blob),
+            "url": publish_geometry(blob, replace=replace),
             "length": len(blob),
         }
     else:
         payload["geometry"] = None
+
+
+def release_texture_publication(publication):
+    """Retire one auxiliary texture publication without touching the active one."""
+    if publication is None:
+        return False
+    return publication.release()
+
+
+def release_geometry(url):
+    """Release an unpublished geometry blob by its opaque URL."""
+    if not isinstance(url, str) or not url.startswith(_GEOMETRY_PREFIX):
+        return False
+    token = url[len(_GEOMETRY_PREFIX):]
+    if not token or "/" in token:
+        return False
+    with _geometry_lock:
+        return _geometry_blobs.pop(token, None) is not None
 
 
 class _Handler(http.server.SimpleHTTPRequestHandler):

--- a/src/core/component_coverage.py
+++ b/src/core/component_coverage.py
@@ -32,6 +32,7 @@ class AuthoredComponentOverride:
     section: str
     handling_skip: bool
     geometry_evidence: bool = False
+    asset_identity_evidence: bool = True
 
     @property
     def key(self):
@@ -45,6 +46,12 @@ _COUNT_RE = re.compile(r"^match_index_count\s*=\s*(\d+)$", re.I)
 _SKIP_RE = re.compile(r"^handling\s*=\s*skip\b", re.I)
 _GEOMETRY_RE = re.compile(
     r"^(?:drawindexed|draw|ib|vb\d+)\s*=\s*(?!null\b)\S+", re.I)
+_IB_RE = re.compile(r"^ib\s*=\s*(?!null\b)\S+", re.I)
+_DRAW_INDEXED_RE = re.compile(r"^drawindexed\s*=\s*\S+", re.I)
+_AUXILIARY_RE = re.compile(
+    r"^(?:draw|vb\d+|override_vertex_count|override_byte_stride)\s*=\s*\S+",
+    re.I,
+)
 
 
 def collect_component_overrides(sections, ini_path):
@@ -65,6 +72,8 @@ def collect_component_overrides(sections, ini_path):
         index_count = None
         handling_skip = False
         geometry_evidence = False
+        explicit_asset_identity = False
+        auxiliary_geometry = False
         for raw in lines or ():
             line = str(raw).split(";", 1)[0].strip()
             if not line:
@@ -85,8 +94,14 @@ def collect_component_overrides(sections, ini_path):
                 continue
             if _SKIP_RE.match(line):
                 handling_skip = True
+            if _IB_RE.match(line) or _DRAW_INDEXED_RE.match(line):
+                explicit_asset_identity = True
+            if _AUXILIARY_RE.match(line):
+                auxiliary_geometry = True
             if _GEOMETRY_RE.match(line):
                 geometry_evidence = True
+        asset_identity_evidence = (
+            explicit_asset_identity or not auxiliary_geometry)
         for geometry_hash in dict.fromkeys(hashes):
             result.append(AuthoredComponentOverride(
                 geometry_hash=geometry_hash,
@@ -96,6 +111,7 @@ def collect_component_overrides(sections, ini_path):
                 section=str(section),
                 handling_skip=handling_skip,
                 geometry_evidence=geometry_evidence,
+                asset_identity_evidence=asset_identity_evidence,
             ))
     return tuple(result)
 

--- a/src/core/component_coverage.py
+++ b/src/core/component_coverage.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 import re
 
 from .geometry_identity import normalize_geometry_hash
+from .ini_parser import (_reachable_execution_sections,
+                          _scan_sections_for_draws)
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,20 +63,29 @@ def collect_component_overrides(sections, ini_path):
     only binds textures. The composition planner uses ``geometry_evidence``
     to avoid treating those texture-only bindings as rendered geometry.
     Explicit ``handling = skip`` remains a coverage claim because it suppresses
-    the corresponding original draw.
+    the corresponding original draw. Execution follows the same command-list
+    closure as the normal INI scanner so declarations in nested ``run``
+    sections retain their component coverage semantics.
     """
+    sections = sections or {}
+    section_lookup = {str(name).casefold(): name for name in sections}
+    scanned = _scan_sections_for_draws(sections)
     result = []
-    for section, lines in (sections or {}).items():
+    for section in sections:
         if not str(section).casefold().startswith("textureoverride"):
             continue
+        scope_sections = _reachable_execution_sections(
+            sections, section, section_lookup)
+        scope_lines = [raw for name in scope_sections
+                       for raw in sections[name]]
         hashes = []
-        first_index = None
-        index_count = None
         handling_skip = False
         geometry_evidence = False
         explicit_asset_identity = False
         auxiliary_geometry = False
-        for raw in lines or ():
+        last_first_index = None
+        last_index_count = None
+        for raw in scope_lines:
             line = str(raw).split(";", 1)[0].strip()
             if not line:
                 continue
@@ -86,11 +97,11 @@ def collect_component_overrides(sections, ini_path):
                 continue
             match = _FIRST_RE.match(line)
             if match:
-                first_index = int(match.group(1))
+                last_first_index = int(match.group(1))
                 continue
             match = _COUNT_RE.match(line)
             if match:
-                index_count = int(match.group(1))
+                last_index_count = int(match.group(1))
                 continue
             if _SKIP_RE.match(line):
                 handling_skip = True
@@ -100,9 +111,59 @@ def collect_component_overrides(sections, ini_path):
                 auxiliary_geometry = True
             if _GEOMETRY_RE.match(line):
                 geometry_evidence = True
-        asset_identity_evidence = (
-            explicit_asset_identity or not auxiliary_geometry)
+        info = scanned.get(section, {})
+        draw_matches = [
+            item.geometry_match
+            for item in info.get("draws", ())
+            if item.geometry_match is not None
+        ]
+        end_match = info.get("geometry_match_at_end")
+        if end_match is not None and end_match.first_index is not None:
+            # A few generated INIs place match_first_index after their
+            # drawindexed line. The scanner records the draw's state before
+            # that assignment; the section's final match is the authoritative
+            # range for the coverage declaration in that shape.
+            draw_matches = [
+                match for match in draw_matches
+                if not (match.hash == end_match.hash
+                        and match.first_index is None)
+            ]
+
+        declarations = []
+        seen_declarations = set()
+        for match in draw_matches:
+            key = (match.hash, match.first_index, match.index_count)
+            if key in seen_declarations:
+                continue
+            seen_declarations.add(key)
+            declarations.append((match.hash, match.first_index,
+                                 match.index_count, True, True))
+
+        if end_match is not None:
+            key = (end_match.hash, end_match.first_index,
+                   end_match.index_count)
+            if key not in seen_declarations:
+                declarations.append((
+                    end_match.hash, end_match.first_index,
+                    end_match.index_count, geometry_evidence,
+                    explicit_asset_identity or not auxiliary_geometry))
+                seen_declarations.add(key)
+
+        fallback_first = (end_match.first_index if end_match is not None
+                          else last_first_index)
+        fallback_count = (end_match.index_count if end_match is not None
+                          else last_index_count)
+        explicit_scope_geometry = explicit_asset_identity
         for geometry_hash in dict.fromkeys(hashes):
+            if any(item[0] == geometry_hash for item in declarations):
+                continue
+            declarations.append((
+                geometry_hash, fallback_first, fallback_count,
+                geometry_evidence, explicit_scope_geometry
+                or not auxiliary_geometry))
+
+        for (geometry_hash, first_index, index_count, item_geometry,
+             item_identity) in declarations:
             result.append(AuthoredComponentOverride(
                 geometry_hash=geometry_hash,
                 first_index=first_index,
@@ -110,8 +171,8 @@ def collect_component_overrides(sections, ini_path):
                 ini=ini_path,
                 section=str(section),
                 handling_skip=handling_skip,
-                geometry_evidence=geometry_evidence,
-                asset_identity_evidence=asset_identity_evidence,
+                geometry_evidence=item_geometry,
+                asset_identity_evidence=item_identity,
             ))
     return tuple(result)
 

--- a/src/core/component_coverage.py
+++ b/src/core/component_coverage.py
@@ -23,7 +23,7 @@ class ComponentCoverageKey:
 
 @dataclass(frozen=True, slots=True)
 class AuthoredComponentOverride:
-    """One authored TextureOverride claim, including its source section."""
+    """One authored TextureOverride claim, including geometry evidence."""
 
     geometry_hash: str
     first_index: int | None
@@ -31,6 +31,7 @@ class AuthoredComponentOverride:
     ini: str
     section: str
     handling_skip: bool
+    geometry_evidence: bool = False
 
     @property
     def key(self):
@@ -42,15 +43,18 @@ _HASH_RE = re.compile(r"^hash\s*=\s*(\S+)$", re.I)
 _FIRST_RE = re.compile(r"^match_first_index\s*=\s*(\d+)$", re.I)
 _COUNT_RE = re.compile(r"^match_index_count\s*=\s*(\d+)$", re.I)
 _SKIP_RE = re.compile(r"^handling\s*=\s*skip\b", re.I)
+_GEOMETRY_RE = re.compile(
+    r"^(?:drawindexed|draw|ib|vb\d+)\s*=\s*(?!null\b)\S+", re.I)
 
 
 def collect_component_overrides(sections, ini_path):
     """Return geometry ownership declared by TextureOverride sections.
 
-    This extractor intentionally does not inspect draw rows or conditions.
-    A hash-only or skipped override is still an authored claim, and the
-    composition planner later decides whether the hash belongs to the
-    resolved Asset.
+    Hashes remain available as Asset identity evidence even when a section
+    only binds textures. The composition planner uses ``geometry_evidence``
+    to avoid treating those texture-only bindings as rendered geometry.
+    Explicit ``handling = skip`` remains a coverage claim because it suppresses
+    the corresponding original draw.
     """
     result = []
     for section, lines in (sections or {}).items():
@@ -60,6 +64,7 @@ def collect_component_overrides(sections, ini_path):
         first_index = None
         index_count = None
         handling_skip = False
+        geometry_evidence = False
         for raw in lines or ():
             line = str(raw).split(";", 1)[0].strip()
             if not line:
@@ -80,6 +85,8 @@ def collect_component_overrides(sections, ini_path):
                 continue
             if _SKIP_RE.match(line):
                 handling_skip = True
+            if _GEOMETRY_RE.match(line):
+                geometry_evidence = True
         for geometry_hash in dict.fromkeys(hashes):
             result.append(AuthoredComponentOverride(
                 geometry_hash=geometry_hash,
@@ -88,6 +95,7 @@ def collect_component_overrides(sections, ini_path):
                 ini=ini_path,
                 section=str(section),
                 handling_skip=handling_skip,
+                geometry_evidence=geometry_evidence,
             ))
     return tuple(result)
 

--- a/src/core/component_coverage.py
+++ b/src/core/component_coverage.py
@@ -1,0 +1,98 @@
+"""Authored geometry ownership extracted independently from render draws."""
+
+from dataclasses import dataclass
+import re
+
+from .geometry_identity import normalize_geometry_hash
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentCoverageKey:
+    """The smallest identity needed to compare authored and Asset ranges."""
+
+    geometry_hash: str
+    first_index: int | None = None
+    index_count: int | None = None
+
+    def __post_init__(self):
+        normalized = normalize_geometry_hash(self.geometry_hash)
+        if normalized is None:
+            raise ValueError("Component coverage requires a valid geometry hash.")
+        object.__setattr__(self, "geometry_hash", normalized)
+
+
+@dataclass(frozen=True, slots=True)
+class AuthoredComponentOverride:
+    """One authored TextureOverride claim, including its source section."""
+
+    geometry_hash: str
+    first_index: int | None
+    index_count: int | None
+    ini: str
+    section: str
+    handling_skip: bool
+
+    @property
+    def key(self):
+        return ComponentCoverageKey(
+            self.geometry_hash, self.first_index, self.index_count)
+
+
+_HASH_RE = re.compile(r"^hash\s*=\s*(\S+)$", re.I)
+_FIRST_RE = re.compile(r"^match_first_index\s*=\s*(\d+)$", re.I)
+_COUNT_RE = re.compile(r"^match_index_count\s*=\s*(\d+)$", re.I)
+_SKIP_RE = re.compile(r"^handling\s*=\s*skip\b", re.I)
+
+
+def collect_component_overrides(sections, ini_path):
+    """Return geometry ownership declared by TextureOverride sections.
+
+    This extractor intentionally does not inspect draw rows or conditions.
+    A hash-only or skipped override is still an authored claim, and the
+    composition planner later decides whether the hash belongs to the
+    resolved Asset.
+    """
+    result = []
+    for section, lines in (sections or {}).items():
+        if not str(section).casefold().startswith("textureoverride"):
+            continue
+        hashes = []
+        first_index = None
+        index_count = None
+        handling_skip = False
+        for raw in lines or ():
+            line = str(raw).split(";", 1)[0].strip()
+            if not line:
+                continue
+            match = _HASH_RE.match(line)
+            if match:
+                geometry_hash = normalize_geometry_hash(match.group(1))
+                if geometry_hash:
+                    hashes.append(geometry_hash)
+                continue
+            match = _FIRST_RE.match(line)
+            if match:
+                first_index = int(match.group(1))
+                continue
+            match = _COUNT_RE.match(line)
+            if match:
+                index_count = int(match.group(1))
+                continue
+            if _SKIP_RE.match(line):
+                handling_skip = True
+        for geometry_hash in dict.fromkeys(hashes):
+            result.append(AuthoredComponentOverride(
+                geometry_hash=geometry_hash,
+                first_index=first_index,
+                index_count=index_count,
+                ini=ini_path,
+                section=str(section),
+                handling_skip=handling_skip,
+            ))
+    return tuple(result)
+
+
+__all__ = [
+    "AuthoredComponentOverride", "ComponentCoverageKey",
+    "collect_component_overrides",
+]

--- a/src/tests/test_asset_composition.py
+++ b/src/tests/test_asset_composition.py
@@ -70,6 +70,21 @@ def test_collect_component_overrides_includes_skip_and_range():
     assert result[0].index_count == 12
     assert result[0].handling_skip is True
     assert result[0].geometry_evidence is False
+    assert result[0].asset_identity_evidence is True
+
+
+def test_auxiliary_buffer_hash_does_not_identify_another_asset():
+    result = collect_component_overrides({
+        "TextureOverrideBodyBlend": [
+            "hash = 0xAAAAAAAA",
+            "handling = skip",
+            "vb1 = ResourceBodyTexcoord",
+            "Draw = 3, 0",
+        ],
+    }, "mod.ini")
+
+    assert result[0].geometry_evidence is True
+    assert result[0].asset_identity_evidence is False
 
 
 def test_texture_only_hash_identifies_asset_without_covering_geometry(
@@ -115,6 +130,36 @@ def test_plan_unions_nested_inis_and_ignores_non_asset_hashes(
     assert len(plan.covered_parts) == 2
     assert not plan.missing_parts
     assert len(plan.skipped_parts) == 1
+
+
+def test_plan_ignores_auxiliary_hash_that_matches_another_asset(
+        tmp_path, monkeypatch):
+    index = _index(_geometry("aaaaaaaa", (0, 12)), asset_path="Remielle")
+    index["assets"].append({
+        "path": "Other",
+        "geometry": [_geometry("bbbbbbbb", (0, 6))],
+    })
+    index["byGeometryHash"]["bbbbbbbb"] = [{"asset": 1, "geometry": 0}]
+    monkeypatch.setattr(asset_index, "load_index",
+                        lambda _type, _root: index)
+    context = _context(tmp_path, {
+        "mod.ini": (
+            "[TextureOverrideBodyBlend]\n"
+            "hash = bbbbbbbb\n"
+            "handling = skip\n"
+            "vb1 = ResourceBodyTexcoord\n"
+            "Draw = 3, 0\n"
+            "[TextureOverrideBody]\n"
+            "hash = aaaaaaaa\n"
+            "drawindexed = 3, 0, 0\n"
+            "run = CommandList\\ZZMI\\SetTextures\n"
+        ),
+    })
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "nothing_missing"
+    assert plan.asset["path"] == "Remielle"
 
 
 def test_plan_matches_requested_range_only(tmp_path, monkeypatch):
@@ -181,3 +226,30 @@ def test_plan_refuses_duplicate_original_assets(tmp_path, monkeypatch):
 
     assert plan.status == "asset_ambiguous"
     assert not plan.missing_parts
+
+
+def test_plan_refuses_equal_support_for_different_original_assets(
+        tmp_path, monkeypatch):
+    indexes = {
+        "one": _index(_geometry("aaaaaaaa", (0, 12)), asset_path="One"),
+        "two": _index(_geometry("bbbbbbbb", (0, 12)), asset_path="Two"),
+    }
+    monkeypatch.setattr(
+        asset_index, "load_index",
+        lambda _type, root: indexes[root])
+    context = _context(tmp_path, {
+        "mod.ini": (
+            "[TextureOverrideBody]\n"
+            "hash = aaaaaaaa\n"
+            "drawindexed = 3, 0, 0\n"
+            "run = CommandList\\ZZMI\\SetTextures\n"
+            "[TextureOverrideFace]\n"
+            "hash = bbbbbbbb\n"
+            "drawindexed = 3, 0, 0\n"
+            "run = CommandList\\ZZMI\\SetTextures\n"
+        ),
+    }, roots=("one", "two"))
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "asset_ambiguous"

--- a/src/tests/test_asset_composition.py
+++ b/src/tests/test_asset_composition.py
@@ -162,6 +162,65 @@ def test_plan_ignores_auxiliary_hash_that_matches_another_asset(
     assert plan.asset["path"] == "Remielle"
 
 
+def test_unknown_game_fallback_searches_all_asset_types(
+        tmp_path, monkeypatch):
+    indexes = {
+        "GIMI": _index(_geometry("bbbbbbbb", (0, 12)),
+                        asset_path="Other"),
+        "ZZMI": _index(_geometry("aaaaaaaa", (0, 12)),
+                        asset_path="Evelyn"),
+    }
+    monkeypatch.setattr(
+        asset_index, "load_index",
+        lambda asset_type, _root: indexes[asset_type])
+    context = _context(tmp_path, {
+        "mod.ini": (
+            "[TextureOverrideBody]\n"
+            "hash = aaaaaaaa\n"
+            "drawindexed = 3, 0, 0\n"
+        ),
+    })
+    context.asset_folders = [
+        {"type": "GIMI", "path": "gimi-root", "enabled": True},
+        {"type": "ZZMI", "path": "zzmi-root", "enabled": True},
+    ]
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "nothing_missing"
+    assert plan.asset_type == "ZZMI"
+    assert plan.asset["path"] == "Evelyn"
+
+
+def test_unknown_game_fallback_keeps_cross_type_asset_ambiguity(
+        tmp_path, monkeypatch):
+    indexes = {
+        "GIMI": _index(_geometry("aaaaaaaa", (0, 12)),
+                        asset_path="GenshinAsset"),
+        "ZZMI": _index(_geometry("aaaaaaaa", (0, 12)),
+                        asset_path="ZZZAsset"),
+    }
+    monkeypatch.setattr(
+        asset_index, "load_index",
+        lambda asset_type, _root: indexes[asset_type])
+    context = _context(tmp_path, {
+        "mod.ini": (
+            "[TextureOverrideBody]\n"
+            "hash = aaaaaaaa\n"
+            "drawindexed = 3, 0, 0\n"
+        ),
+    })
+    context.asset_folders = [
+        {"type": "GIMI", "path": "gimi-root", "enabled": True},
+        {"type": "ZZMI", "path": "zzmi-root", "enabled": True},
+    ]
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "asset_ambiguous"
+    assert not plan.missing_parts
+
+
 def test_plan_matches_requested_range_only(tmp_path, monkeypatch):
     index = _index(_geometry(
         "aaaaaaaa", (0, 12), (300, 24), (600, 18)))

--- a/src/tests/test_asset_composition.py
+++ b/src/tests/test_asset_composition.py
@@ -1,0 +1,159 @@
+"""Coverage planning regressions for explicit original Asset filling."""
+
+from types import SimpleNamespace
+
+from app import asset_composition, asset_index
+from core.component_coverage import collect_component_overrides
+from core.ini_document import IniDocument
+
+
+def _index(*geometries, asset_path="Character"):
+    return {
+        "type": "ZZMI",
+        "assets": [{"path": asset_path, "geometry": list(geometries)}],
+        "byGeometryHash": {
+            geometry["hash"]: [{"asset": 0, "geometry": ordinal}]
+            for ordinal, geometry in enumerate(geometries)
+        },
+    }
+
+
+def _geometry(hash_value, *ranges):
+    return {
+        "hash": hash_value,
+        "ranges": [
+            {"firstIndex": first, "indexCount": count}
+            for first, count in ranges
+        ],
+        "metadata": "Character/hash.json",
+        "componentName": hash_value,
+    }
+
+
+def _context(tmp_path, texts, roots=("asset-root",)):
+    paths = []
+    for name, text in texts.items():
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        paths.append(str(path))
+    return SimpleNamespace(
+        mod_dir=str(tmp_path), ini_paths=paths, docs={},
+        asset_folders=[{"type": "ZZMI", "path": root, "enabled": True}
+                       for root in roots],
+    )
+
+
+def _zzmi(hash_value, extra=""):
+    return (
+        "[TextureOverrideBody]\n"
+        f"hash = {hash_value}\n"
+        "run = CommandList\\ZZMI\\SetTextures\n"
+        f"{extra}"
+    )
+
+
+def test_collect_component_overrides_includes_skip_and_range():
+    result = collect_component_overrides({
+        "TextureOverrideFace": [
+            "hash = 0xAAAAAAAA",
+            "match_first_index = 300",
+            "match_index_count = 12",
+            "handling = skip",
+        ],
+    }, "nested/face.ini")
+
+    assert len(result) == 1
+    assert result[0].key.geometry_hash == "aaaaaaaa"
+    assert result[0].first_index == 300
+    assert result[0].index_count == 12
+    assert result[0].handling_skip is True
+
+
+def test_plan_unions_nested_inis_and_ignores_non_asset_hashes(
+        tmp_path, monkeypatch):
+    index = _index(
+        _geometry("aaaaaaaa", (0, 12)),
+        _geometry("bbbbbbbb", (0, 6)),
+    )
+    monkeypatch.setattr(asset_index, "load_index",
+                        lambda _type, _root: index)
+    context = _context(tmp_path, {
+        "mod.ini": _zzmi("aaaaaaaa"),
+        "nested/face.ini": _zzmi(
+            "bbbbbbbb", "handling = skip\nhash = deadbeef\n"),
+    })
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "nothing_missing"
+    assert len(plan.asset_parts) == 2
+    assert len(plan.covered_parts) == 2
+    assert not plan.missing_parts
+    assert len(plan.skipped_parts) == 1
+
+
+def test_plan_matches_requested_range_only(tmp_path, monkeypatch):
+    index = _index(_geometry(
+        "aaaaaaaa", (0, 12), (300, 24), (600, 18)))
+    monkeypatch.setattr(asset_index, "load_index",
+                        lambda _type, _root: index)
+    context = _context(tmp_path, {
+        "mod.ini": _zzmi(
+            "aaaaaaaa", "match_first_index = 300\n"),
+    })
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "ready"
+    assert [part.first_index for part in plan.covered_parts] == [300]
+    assert [part.first_index for part in plan.missing_parts] == [0, 600]
+
+
+def test_hash_only_skip_covers_all_ranges(tmp_path, monkeypatch):
+    index = _index(_geometry("aaaaaaaa", (0, 12), (300, 24)))
+    monkeypatch.setattr(asset_index, "load_index",
+                        lambda _type, _root: index)
+    context = _context(tmp_path, {
+        "mod.ini": _zzmi("aaaaaaaa", "handling = skip\n"),
+    })
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "nothing_missing"
+    assert len(plan.skipped_parts) == 2
+
+
+def test_plan_reads_staged_document_projection(tmp_path, monkeypatch):
+    index = _index(_geometry("aaaaaaaa", (0, 12)))
+    monkeypatch.setattr(asset_index, "load_index",
+                        lambda _type, _root: index)
+    path = str(tmp_path / "mod.ini")
+    document = IniDocument.from_string(
+        _zzmi("aaaaaaaa"), path=path)
+    context = SimpleNamespace(
+        mod_dir=str(tmp_path), ini_paths=[path], docs={path: document},
+        asset_folders=[{"type": "ZZMI", "path": "asset-root",
+                        "enabled": True}],
+    )
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "nothing_missing"
+
+
+def test_plan_refuses_duplicate_original_assets(tmp_path, monkeypatch):
+    indexes = {
+        "one": _index(_geometry("aaaaaaaa", (0, 12)), asset_path="One"),
+        "two": _index(_geometry("aaaaaaaa", (0, 12)), asset_path="Two"),
+    }
+    monkeypatch.setattr(
+        asset_index, "load_index",
+        lambda _type, root: indexes[root])
+    context = _context(tmp_path, {"mod.ini": _zzmi("aaaaaaaa")},
+                       roots=("one", "two"))
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "asset_ambiguous"
+    assert not plan.missing_parts

--- a/src/tests/test_asset_composition.py
+++ b/src/tests/test_asset_composition.py
@@ -48,6 +48,7 @@ def _zzmi(hash_value, extra=""):
     return (
         "[TextureOverrideBody]\n"
         f"hash = {hash_value}\n"
+        "drawindexed = 3, 0, 0\n"
         "run = CommandList\\ZZMI\\SetTextures\n"
         f"{extra}"
     )
@@ -68,6 +69,29 @@ def test_collect_component_overrides_includes_skip_and_range():
     assert result[0].first_index == 300
     assert result[0].index_count == 12
     assert result[0].handling_skip is True
+    assert result[0].geometry_evidence is False
+
+
+def test_texture_only_hash_identifies_asset_without_covering_geometry(
+        tmp_path, monkeypatch):
+    index = _index(_geometry("aaaaaaaa", (0, 12)))
+    monkeypatch.setattr(asset_index, "load_index",
+                        lambda _type, _root: index)
+    context = _context(tmp_path, {
+        "mod.ini": (
+            "[TextureOverrideFaceIB]\n"
+            "hash = aaaaaaaa\n"
+            "run = CommandList\\ZZMI\\SetTextures\n"),
+    })
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "ready"
+    assert plan.asset == {"path": "Character", "geometry": [
+        _geometry("aaaaaaaa", (0, 12))]}
+    assert plan.evidence[0].geometry_evidence is False
+    assert not plan.covered_parts
+    assert [part.first_index for part in plan.missing_parts] == [0]
 
 
 def test_plan_unions_nested_inis_and_ignores_non_asset_hashes(

--- a/src/tests/test_asset_composition.py
+++ b/src/tests/test_asset_composition.py
@@ -87,6 +87,31 @@ def test_auxiliary_buffer_hash_does_not_identify_another_asset():
     assert result[0].asset_identity_evidence is False
 
 
+def test_collect_component_overrides_follows_nested_command_lists():
+    result = collect_component_overrides({
+        "TextureOverrideBody": [
+            "hash = 0xAAAAAAAA",
+            "match_first_index = 300",
+            "run = CommandListBody",
+        ],
+        "CommandListBody": [
+            "handling = skip",
+            "run = CommandListBodyDraw",
+        ],
+        "CommandListBodyDraw": [
+            "ib = ResourceBodyIB",
+            "drawindexed = 12000, 300, 0",
+        ],
+    }, "mod.ini")
+
+    assert len(result) == 1
+    assert result[0].geometry_hash == "aaaaaaaa"
+    assert result[0].first_index == 300
+    assert result[0].handling_skip is True
+    assert result[0].geometry_evidence is True
+    assert result[0].asset_identity_evidence is True
+
+
 def test_texture_only_hash_identifies_asset_without_covering_geometry(
         tmp_path, monkeypatch):
     index = _index(_geometry("aaaaaaaa", (0, 12)))
@@ -221,6 +246,37 @@ def test_unknown_game_fallback_keeps_cross_type_asset_ambiguity(
     assert not plan.missing_parts
 
 
+def test_candidate_matching_reuses_indexes_and_unique_hash_support(
+        tmp_path, monkeypatch):
+    index = _index(_geometry("aaaaaaaa", (0, 12)), asset_path="AssetA")
+    index["assets"].append({
+        "path": "AssetB",
+        "geometry": [_geometry("bbbbbbbb", (0, 12))],
+    })
+    index["byGeometryHash"]["bbbbbbbb"] = [{"asset": 1, "geometry": 0}]
+    calls = []
+
+    def load_index(asset_type, root):
+        calls.append((asset_type, root))
+        return index
+
+    monkeypatch.setattr(asset_index, "load_index", load_index)
+    context = _context(tmp_path, {
+        "mod.ini": (
+            _zzmi("aaaaaaaa")
+            + _zzmi("aaaaaaaa").replace(
+                "TextureOverrideBody", "TextureOverrideFace")
+            + _zzmi("bbbbbbbb").replace(
+                "TextureOverrideBody", "TextureOverrideHair")
+        ),
+    })
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert plan.status == "asset_ambiguous"
+    assert calls == [("ZZMI", "asset-root")]
+
+
 def test_plan_matches_requested_range_only(tmp_path, monkeypatch):
     index = _index(_geometry(
         "aaaaaaaa", (0, 12), (300, 24), (600, 18)))
@@ -236,6 +292,25 @@ def test_plan_matches_requested_range_only(tmp_path, monkeypatch):
     assert plan.status == "ready"
     assert [part.first_index for part in plan.covered_parts] == [300]
     assert [part.first_index for part in plan.missing_parts] == [0, 600]
+
+
+def test_plan_matches_range_start_when_index_count_differs(
+        tmp_path, monkeypatch):
+    index = _index(_geometry(
+        "aaaaaaaa", (0, 12), (300, 24)))
+    monkeypatch.setattr(asset_index, "load_index",
+                        lambda _type, _root: index)
+    context = _context(tmp_path, {
+        "mod.ini": _zzmi(
+            "aaaaaaaa",
+            "match_first_index = 300\n"
+            "match_index_count = 12\n"),
+    })
+
+    plan = asset_composition.plan_missing_asset_parts(context)
+
+    assert [part.first_index for part in plan.covered_parts] == [300]
+    assert [part.first_index for part in plan.missing_parts] == [0]
 
 
 def test_hash_only_skip_covers_all_ranges(tmp_path, monkeypatch):

--- a/src/tests/test_asset_loader.py
+++ b/src/tests/test_asset_loader.py
@@ -808,8 +808,11 @@ def test_api_load_missing_asset_parts_is_incremental_and_reversible(
     assert entry["conditions"] == []
     assert result["payload"]["metadata"]["source_kind"] == "asset-fill"
 
+    preview = api.load_asset(str(asset))
+    assert preview["metadata"]["source_kind"] == "asset"
+
     removed = api.remove_missing_asset_parts(str(mod))
-    assert removed == {"status": "removed", "removed": True}
+    assert removed == {"status": "removed", "removed": False}
 
 
 def test_api_rejects_category_and_keeps_disabled_root_browsable(tmp_path, monkeypatch):

--- a/src/tests/test_asset_loader.py
+++ b/src/tests/test_asset_loader.py
@@ -785,6 +785,7 @@ def test_api_load_missing_asset_parts_is_incremental_and_reversible(
     (mod / "mod.ini").write_text(
         "[TextureOverrideBody]\n"
         "hash = aaaaaaaa\n"
+        "drawindexed = 3, 0, 0\n"
         "run = CommandList\\ZZMI\\SetTextures\n", encoding="utf-8")
     config = tmp_path / "config.json"
     config.write_text(json.dumps({

--- a/src/tests/test_asset_loader.py
+++ b/src/tests/test_asset_loader.py
@@ -6,12 +6,13 @@ import struct
 
 import pytest
 
-from app import asset_folders, asset_textures, paths, server
+from app import asset_folders, asset_index, asset_textures, paths, server
 from app.asset_index import build_index
 from app.asset_loader import hash_asset, load_asset
 from app.asset_loader.wwmi import _component_texture_candidates
 from app.asset_loader.models import AssetLoadResult, AssetMeshPart
 from app.api import ModViewerAPI
+from core.component_coverage import ComponentCoverageKey
 from core.geometry_transport import GeometryBlob
 from core.migoto_dump import parse_index_dump, parse_vertex_dump
 
@@ -261,6 +262,45 @@ def test_hash_asset_preserves_duplicate_position_vertices_and_authored_normals(
     assert result.payload["textures"]
     assert all(value.startswith("uri:diffuse:")
                for value in result.payload["textures"].values())
+
+
+def test_hash_asset_part_filter_skips_unrequested_ranges(tmp_path, monkeypatch):
+    root = tmp_path / "assets"
+    asset = root / "Character"
+    asset.mkdir(parents=True)
+    _write_json(asset / "hash.json", [{
+        "ib": "87654321", "vb0": "12345678", "component_name": "Body",
+        "object_indexes": [0, 3], "object_index_counts": [3, 3],
+    }])
+    _text_vb(asset / "Body-vb0=12345678.txt", 92, [
+        ((0, 0, 0), (0, 0, 1), (0, 0)),
+        ((1, 0, 0), (0, 0, 1), (1, 0)),
+        ((0, 1, 0), (0, 0, 1), (0, 1)),
+        ((0, 0, 0), (0, 0, 1), (0, 0)),
+        ((1, 0, 0), (0, 0, 1), (1, 0)),
+        ((0, 1, 0), (0, 0, 1), (0, 1)),
+    ])
+    for name, first in (("BodyA", 0), ("BodyB", 3)):
+        (asset / f"{name}-ib=87654321.txt").write_text(
+            f"first index: {first}\nindex count: 3\n"
+            "topology: trianglelist\n0 1 2\n", encoding="utf-8")
+
+    index = build_index("ZZMI", str(root))
+    parsed_vbs = []
+    original_parse = hash_asset.parse_vertex_dump
+
+    def count_vertex_dump(path):
+        parsed_vbs.append(path)
+        return original_parse(path)
+
+    monkeypatch.setattr(hash_asset, "parse_vertex_dump", count_vertex_dump)
+    result = load_asset(
+        "ZZMI", str(root), index["assets"][0], geometry=GeometryBlob(),
+        part_filter={ComponentCoverageKey("87654321", 3, 3)})
+
+    assert len(result.parts) == 1
+    assert result.parts[0].first_index == 3
+    assert len(parsed_vbs) == 1
 
 
 def test_asset_parts_with_same_component_share_one_texture_pool(tmp_path):
@@ -713,6 +753,62 @@ def test_api_load_asset_publishes_shared_payload_without_ini(tmp_path, monkeypat
         "toggles": {}, "menu": {}, "present": {"target_inis": [], "item": None}}
     assert result["geometry"]["url"].startswith("/geometry/")
     assert server.active_texture_publication(str(asset)) is not None
+
+
+def test_api_load_missing_asset_parts_is_incremental_and_reversible(
+        tmp_path, monkeypatch):
+    asset_root = tmp_path / "assets"
+    asset = asset_root / "Character"
+    asset.mkdir(parents=True)
+    _write_json(asset / "hash.json", [
+        {"ib": "aaaaaaaa", "vb0": "11111111", "component_name": "Body",
+         "object_indexes": [0], "object_index_counts": [3]},
+        {"ib": "bbbbbbbb", "vb0": "22222222", "component_name": "Hair",
+         "object_indexes": [0], "object_index_counts": [3]},
+    ])
+    rows = [
+        ((0, 0, 0), (0, 0, 1), (0, 0)),
+        ((1, 0, 0), (0, 0, 1), (1, 0)),
+        ((0, 1, 0), (0, 0, 1), (0, 1)),
+    ]
+    _text_vb(asset / "Body-vb0=11111111.txt", 92, rows)
+    _text_vb(asset / "Hair-vb0=22222222.txt", 92, rows)
+    for name, hash_value in (("Body", "aaaaaaaa"), ("Hair", "bbbbbbbb")):
+        (asset / f"{name}-ib={hash_value}.txt").write_text(
+            "first index: 0\nindex count: 3\ntopology: trianglelist\n"
+            "0 1 2\n", encoding="utf-8")
+    index = build_index("ZZMI", str(asset_root))
+    monkeypatch.setattr(asset_index, "load_index", lambda _type, _root: index)
+
+    mod = tmp_path / "mod"
+    mod.mkdir()
+    (mod / "mod.ini").write_text(
+        "[TextureOverrideBody]\n"
+        "hash = aaaaaaaa\n"
+        "run = CommandList\\ZZMI\\SetTextures\n", encoding="utf-8")
+    config = tmp_path / "config.json"
+    config.write_text(json.dumps({
+        "version": 1,
+        "modFolders": [{"name": "Test", "path": str(mod)}],
+        "assetFolders": [{"type": "ZZMI", "path": str(asset_root),
+                           "enabled": True}],
+    }), encoding="utf-8")
+    monkeypatch.setattr(paths, "config_path", lambda: str(config))
+
+    api = ModViewerAPI()
+    result = api.load_missing_asset_parts(str(mod))
+
+    assert result["status"] == "loaded"
+    assert result["coverage"]["handled_parts"] == 1
+    assert result["coverage"]["missing_parts"] == 1
+    assert len(result["payload"]["meshes"]) == 1
+    entry = next(iter(result["payload"]["meshes"].values()))
+    assert entry["asset_fill"] is True
+    assert entry["conditions"] == []
+    assert result["payload"]["metadata"]["source_kind"] == "asset-fill"
+
+    removed = api.remove_missing_asset_parts(str(mod))
+    assert removed == {"status": "removed", "removed": True}
 
 
 def test_api_rejects_category_and_keeps_disabled_root_browsable(tmp_path, monkeypatch):

--- a/src/tests/test_asset_loader.py
+++ b/src/tests/test_asset_loader.py
@@ -800,6 +800,7 @@ def test_api_load_missing_asset_parts_is_incremental_and_reversible(
     result = api.load_missing_asset_parts(str(mod))
 
     assert result["status"] == "loaded"
+    old_fill_id = result["fill_id"]
     assert result["coverage"]["handled_parts"] == 1
     assert result["coverage"]["missing_parts"] == 1
     assert len(result["payload"]["meshes"]) == 1
@@ -807,6 +808,19 @@ def test_api_load_missing_asset_parts_is_incremental_and_reversible(
     assert entry["asset_fill"] is True
     assert entry["conditions"] == []
     assert result["payload"]["metadata"]["source_kind"] == "asset-fill"
+
+    preview = api.load_asset(str(asset))
+    assert preview["metadata"]["source_kind"] == "asset"
+
+    replacement = api.load_missing_asset_parts(str(mod))
+    assert replacement["status"] == "loaded"
+    new_fill_id = replacement["fill_id"]
+    assert new_fill_id != old_fill_id
+
+    stale = api.remove_missing_asset_parts(str(mod), old_fill_id)
+    assert stale == {"status": "removed", "removed": False, "stale": True}
+    key = os.path.normcase(os.path.abspath(str(mod)))
+    assert api._asset_fill_sessions[key]["fill_id"] == new_fill_id
 
     preview = api.load_asset(str(asset))
     assert preview["metadata"]["source_kind"] == "asset"

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -788,13 +788,18 @@ def test_assets_panel_uses_badges_and_lazy_browse_only_children(
     child = root + r"\Character"
     context, page = _page(
         edge_browser, frontend_url, {},
-        asset_folders=[{"type": "GIMI", "path": root, "exists": True}],
+        asset_folders=[{
+            "type": "GIMI", "path": root, "exists": True, "enabled": False,
+        }],
         asset_subfolders={root: [{"name": "Character", "path": child}]},
     )
     try:
         page.locator("#assets-tab").click()
         page.locator("#asset-folder-list .asset-folder-select").first.wait_for()
         assert "GIMI" in page.locator("#asset-folder-list").first.inner_text()
+        assert page.locator(".asset-folder-status").count() == 0
+        assert page.locator(
+            ".asset-folder-row.asset-folder-disabled .asset-folder-label").count() == 1
         page.locator("#asset-folder-list .asset-folder-expand").first.click()
         page.locator(".asset-folder-select", has_text="Character").wait_for()
         assert page.evaluate("window.__fakeApi.calls.listAssetSubfolders") == [root]
@@ -805,18 +810,26 @@ def test_assets_panel_uses_badges_and_lazy_browse_only_children(
             "document.querySelector('.asset-folder-row.active')?.dataset.assetFolderPath"
         ) == child
         switch = page.locator(".asset-folder-switch").first
-        assert switch.get_attribute("aria-checked") == "true"
+        assert switch.get_attribute("aria-checked") == "false"
         switch.click()
-        page.wait_for_function("window.__fakeApi.assetFolders[0].enabled === false")
-        page.locator(".asset-folder-switch[aria-checked='false']").wait_for()
+        page.wait_for_function("window.__fakeApi.assetFolders[0].enabled === true")
+        page.locator(".asset-folder-switch[aria-checked='true']").wait_for()
         child_select.wait_for()
         assert page.locator(".asset-folder-expand.expanded").count() == 1
         assert page.evaluate(
             "document.querySelector('.asset-folder-row.active')?.dataset.assetFolderPath"
         ) == child
+        root_arrow = page.locator(
+            "#asset-folder-list > .asset-folder-node > .asset-folder-row .asset-folder-expand")
+        root_children = page.locator(
+            "#asset-folder-list > .asset-folder-node > .asset-folder-children")
+        root_arrow.click()
+        assert root_children.is_hidden()
+        root_arrow.click()
+        assert not root_children.is_hidden()
         page.locator(".asset-folder-switch").first.click()
-        page.wait_for_function("window.__fakeApi.assetFolders[0].enabled === true")
-        page.locator(".asset-folder-switch[aria-checked='true']").wait_for()
+        page.wait_for_function("window.__fakeApi.assetFolders[0].enabled === false")
+        page.locator(".asset-folder-switch[aria-checked='false']").wait_for()
         child_select.wait_for()
         assert page.locator(".asset-folder-expand.expanded").count() == 1
         assert page.evaluate(
@@ -835,7 +848,7 @@ def test_assets_panel_uses_badges_and_lazy_browse_only_children(
         page.locator(".asset-folder-switch").first.click()
         page.locator("#asset-folder-error.show").wait_for()
         assert page.locator(".asset-folder-switch").first.get_attribute(
-            "aria-checked") == "true"
+            "aria-checked") == "false"
         page.evaluate("""() => {
           window.pywebview.api.set_asset_folder_enabled = async (path, enabled) => {
             const item = window.__fakeApi.assetFolders.find(folder => folder.path === path);
@@ -846,6 +859,7 @@ def test_assets_panel_uses_badges_and_lazy_browse_only_children(
         page.locator(".asset-folder-switch").first.click()
         page.wait_for_function(
             "!document.querySelector('#asset-folder-error').classList.contains('show')")
+        page.locator(".asset-folder-switch[aria-checked='true']").wait_for()
         page.locator("#asset-folder-add").click()
         assert page.locator("#afm-type option").all_inner_texts() == ["ZZMI", "GIMI", "WWMI"]
         page.evaluate("window.__fakeApi.nextPath = 'picked-asset-folder'")
@@ -928,12 +942,19 @@ def test_missing_asset_parts_append_and_remove_without_reloading_mod(
         page.locator(".draw-item").wait_for()
         button = page.locator("#asset-fill-btn")
         assert not button.is_disabled()
-        assert button.inner_text() == "Load Missing Parts"
+        assert button.inner_text() == ""
+        assert button.get_attribute("data-state") == "load"
+        assert button.get_attribute("aria-label") == "Load missing parts"
+        assert button.get_attribute("aria-pressed") == "false"
+        assert button.locator("use").get_attribute("href") == "#icon-mesh-add"
 
         button.click()
         page.wait_for_function(
             "window.__fakeApi.calls.loadMissingAssetParts.length === 1")
-        page.locator("#asset-fill-btn", has_text="Remove Missing Parts").wait_for()
+        page.locator("#asset-fill-btn[data-state='remove']").wait_for()
+        assert button.get_attribute("aria-label") == "Remove missing parts"
+        assert button.get_attribute("aria-pressed") == "true"
+        assert button.locator("use").get_attribute("href") == "#icon-close"
         assert page.evaluate("window.modViewer.activeMeshes.length") == 2
         appended = page.evaluate("""() => window.modViewer.activeMeshes.map(mesh => ({
           position: mesh.position.toArray(), quaternion: mesh.quaternion.toArray(),
@@ -947,15 +968,15 @@ def test_missing_asset_parts_append_and_remove_without_reloading_mod(
         button.click()
         page.wait_for_function(
             "window.__fakeApi.calls.removeMissingAssetParts.length === 1")
-        page.locator("#asset-fill-btn", has_text="Load Missing Parts").wait_for()
+        page.locator("#asset-fill-btn[data-state='load']").wait_for()
         assert page.evaluate("window.modViewer.activeMeshes.length") == 1
         assert page.locator(".mesh-src-hdr", has_text="ORIGINAL ASSET").count() == 0
         assert page.evaluate("window.__fakeApi.calls.loadMod") == ["FillMod"]
 
         page.locator("#camera-flip-btn").click()
         page.locator("#camera-flip-horizontal-btn").click()
-        page.locator("#asset-fill-btn", has_text="Load Missing Parts").click()
-        page.locator("#asset-fill-btn", has_text="Remove Missing Parts").wait_for()
+        page.locator("#asset-fill-btn[data-state='load']").click()
+        page.locator("#asset-fill-btn[data-state='remove']").wait_for()
         turned = page.evaluate("""() => window.modViewer.activeMeshes.map(mesh => ({
           position: mesh.position.toArray(), quaternion: mesh.quaternion.toArray(),
         }))""")
@@ -970,7 +991,7 @@ def test_missing_asset_parts_append_and_remove_without_reloading_mod(
 
         page.evaluate("window.modViewer.reloadCurrentMod()")
         page.wait_for_function("window.__fakeApi.calls.loadMod.length === 2")
-        assert page.locator("#asset-fill-btn").inner_text() == "Load Missing Parts"
+        assert page.locator("#asset-fill-btn").get_attribute("data-state") == "load"
         assert page.evaluate("window.modViewer.activeMeshes.length") == 1
     finally:
         context.close()
@@ -1033,7 +1054,7 @@ def test_missing_asset_parts_inherit_auto_upright_and_wuwa_facing(
         assert initial == pytest.approx(
             [-2 ** -0.5, 0, 0, 2 ** -0.5])
         page.locator("#asset-fill-btn").click()
-        page.locator("#asset-fill-btn", has_text="Remove Missing Parts").wait_for()
+        page.locator("#asset-fill-btn[data-state='remove']").wait_for()
         upright_states = page.evaluate("""() => window.modViewer.activeMeshes.map(
           mesh => mesh.quaternion.toArray())""")
         assert upright_states[1] == pytest.approx(upright_states[0])
@@ -1046,7 +1067,7 @@ def test_missing_asset_parts_inherit_auto_upright_and_wuwa_facing(
             "window.modViewer.activeMeshes[0].quaternion.toArray()")
         assert wuwa_initial == pytest.approx([0, 1, 0, 0])
         page.locator("#asset-fill-btn").click()
-        page.locator("#asset-fill-btn", has_text="Remove Missing Parts").wait_for()
+        page.locator("#asset-fill-btn[data-state='remove']").wait_for()
         wuwa_states = page.evaluate("""() => window.modViewer.activeMeshes.map(
           mesh => mesh.quaternion.toArray())""")
         assert wuwa_states[1] == pytest.approx(wuwa_states[0])
@@ -1095,6 +1116,14 @@ def test_asset_rebuild_preserves_tree_and_disables_only_one_root(
         assert page.evaluate(
             "document.querySelector('.asset-folder-row.active')?.dataset.assetFolderPath"
         ) == child
+        root_arrow = page.locator(
+            "#asset-folder-list > .asset-folder-node > .asset-folder-row .asset-folder-expand")
+        root_children = page.locator(
+            "#asset-folder-list > .asset-folder-node > .asset-folder-children")
+        root_arrow.click()
+        assert root_children.is_hidden()
+        root_arrow.click()
+        assert not root_children.is_hidden()
         page.evaluate("""() => {
           window.pywebview.api.rebuild_asset_index = async () => ({
             error: 'rebuild failed', indexPreserved: true});
@@ -3956,7 +3985,21 @@ def test_inspector_follows_component_and_mesh_selection(
         assert page.locator("#sidebar > .panel-hdr #reset-state-btn").count() == 1
         assert page.locator("#sidebar > .panel-hdr > *").evaluate_all(
             "nodes => nodes.map(node => node.id || node.tagName)") == [
-                "BUTTON", "H3", "asset-fill-btn", "reset-state-btn"]
+                "BUTTON", "H3", "DIV"]
+        assert page.locator("#sidebar > .panel-hdr > .panel-hdr-actions > *").evaluate_all(
+            "nodes => nodes.map(node => node.id)") == [
+                "asset-fill-btn", "reset-state-btn"]
+        assert page.locator("#asset-fill-btn").get_attribute("aria-label") == (
+            "Load missing parts")
+        assert page.locator("#asset-fill-btn").get_attribute("aria-pressed") == "false"
+        assert page.locator("#asset-fill-btn").get_attribute("data-state") == "load"
+        assert page.locator("#asset-fill-btn .ui-icon use").get_attribute("href") == (
+            "#icon-mesh-add")
+        for panel_id, action_id in (("mod-folder-panel", "mod-folder-add"),
+                                    ("asset-folder-panel", "asset-folder-add")):
+            actions = page.locator(f"#{panel_id} > .panel-hdr .panel-hdr-actions")
+            assert actions.count() == 1
+            assert actions.locator(f"#{action_id}").get_attribute("aria-label")
         assert page.locator("#sidebar > .panel-hdr .group-toggle").get_attribute(
             "aria-expanded") == "true"
         assert page.locator("#sidebar").is_visible()

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -929,6 +929,7 @@ def test_missing_asset_parts_append_and_remove_without_reloading_mod(
     }
     mod_payload["assetFillResponse"] = {
         "status": "loaded",
+        "fill_id": "fill-FillAsset",
         "coverage": {
             "asset_parts": 2, "handled_parts": 1,
             "missing_parts": 1, "skipped_parts": 0,
@@ -1079,6 +1080,77 @@ def test_stale_missing_asset_response_preserves_new_mod_fill(
         context.close()
 
 
+def test_stale_same_path_fill_response_preserves_replacement_session(
+        edge_browser, frontend_url):
+    payload = _payload("FillSamePath")
+    _add_asset_fill_response(payload, "FillSamePathAsset")
+    context, page = _page(
+        edge_browser, frontend_url, {"FillSamePath": payload})
+    try:
+        _open(page, "FillSamePath")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""() => {
+          const api = window.pywebview.api;
+          const originalLoadMod = api.load_mod;
+          const originalLoadFill = api.load_missing_asset_parts;
+          const originalRemove = api.remove_missing_asset_parts;
+          let loadCount = 0;
+          window.__backendFillId = null;
+          window.__removeFillIds = [];
+          window.__releaseFill = null;
+          api.load_mod = async path => {
+            window.__backendFillId = null;
+            return originalLoadMod(path);
+          };
+          api.load_missing_asset_parts = async path => {
+            const result = await originalLoadFill(path);
+            const fillId = `same-path-fill-${++loadCount}`;
+            window.__backendFillId = fillId;
+            const enriched = {...result, fill_id: fillId};
+            if (loadCount === 1) {
+              await new Promise(resolve => window.__releaseFill = resolve);
+            }
+            return enriched;
+          };
+          api.remove_missing_asset_parts = async (path, fillId) => {
+            window.__removeFillIds.push(fillId);
+            const result = await originalRemove(path, fillId);
+            if (fillId !== window.__backendFillId) {
+              return {status: 'removed', removed: false, stale: true};
+            }
+            window.__backendFillId = null;
+            return result;
+          };
+          document.getElementById('asset-fill-btn').click();
+        }""")
+        page.wait_for_function("window.__releaseFill !== null")
+
+        page.evaluate("window.modViewer.reloadCurrentMod()")
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadMod.length === 2"
+            " && window.modViewer.activeMeshes.length === 1")
+        page.locator("#asset-fill-btn").click()
+        page.locator("#asset-fill-btn[data-state='remove']").wait_for()
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 2
+        assert page.evaluate("window.__backendFillId") == "same-path-fill-2"
+
+        page.evaluate("window.__releaseFill()")
+        page.wait_for_function(
+            "window.__fakeApi.calls.removeMissingAssetParts.length === 1")
+        assert page.evaluate("window.__backendFillId") == "same-path-fill-2"
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 2
+        assert page.locator("#asset-fill-btn").get_attribute("data-state") == "remove"
+
+        page.locator("#asset-fill-btn").click()
+        page.locator("#asset-fill-btn[data-state='load']").wait_for()
+        assert page.evaluate("window.__removeFillIds") == [
+            "same-path-fill-1", "same-path-fill-2"]
+        assert page.evaluate("window.__backendFillId") is None
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 1
+    finally:
+        context.close()
+
+
 def test_stale_missing_asset_remove_preserves_new_mod_fill(
         edge_browser, frontend_url):
     first = _payload("FillRemoveA")
@@ -1145,6 +1217,7 @@ def _add_asset_fill_response(payload, label, position=None):
     }
     payload["assetFillResponse"] = {
         "status": "loaded",
+        "fill_id": f"fill-{label}",
         "coverage": {
             "asset_parts": 2, "handled_parts": 1,
             "missing_parts": 1, "skipped_parts": 0,

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -324,6 +324,8 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                    "listAssetSubfolders": [],
                    "selectAssetFolder": [],
                    "rebuildAssetIndex": [],
+                   "loadMissingAssetParts": [],
+                   "removeMissingAssetParts": [],
                    "discardChanges": [], "switches": [], "diagnostics": [],
                    "panelOpacity": [], "presentState": [],
                    "controlState": [], "meshSemantics": [],
@@ -365,6 +367,16 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
             load_asset: async path => {
               state.calls.loadAsset.push(path);
               return copy(state.responses[path]);
+            },
+            load_missing_asset_parts: async path => {
+              state.calls.loadMissingAssetParts.push(path);
+              return copy(state.responses[path]?.assetFillResponse || {
+                status: 'nothing_missing',
+              });
+            },
+            remove_missing_asset_parts: async path => {
+              state.calls.removeMissingAssetParts.push(path);
+              return {status: 'removed', removed: true};
             },
             get_present_state: async path => {
               state.calls.presentState.push(path);
@@ -879,6 +891,65 @@ def test_indexed_asset_row_loads_read_only_preview(edge_browser, frontend_url):
         assert page.locator("#export-btn").is_hidden()
         assert page.evaluate("window.__fakeApi.calls.loadMod") == []
         assert page.evaluate("window.modViewer.getCurrentSource().kind") == "asset"
+    finally:
+        context.close()
+
+
+def test_missing_asset_parts_append_and_remove_without_reloading_mod(
+        edge_browser, frontend_url):
+    mod_payload = _payload("FillMod")
+    mod_payload["asset_resolution"] = {"configured_roots": 1}
+    fill_payload = _payload("FillAsset")
+    fill_entry = next(iter(fill_payload["meshes"].values()))
+    fill_entry["source"] = "ORIGINAL ASSET"
+    fill_entry["component"] = "Original Hair"
+    fill_entry["asset_fill"] = True
+    fill_entry["fill_reason"] = "missing_mod_coverage"
+    fill_entry["sources"] = [{"asset": {
+        "type": "ZZMI", "asset": "Character", "geometry_hash": "bbbbbbbb",
+        "component_name": "Hair", "first_index": 0, "index_count": 3,
+    }}]
+    fill_payload["metadata"] = {
+        "source_kind": "asset-fill",
+        "material_profiles": {},
+    }
+    mod_payload["assetFillResponse"] = {
+        "status": "loaded",
+        "coverage": {
+            "asset_parts": 2, "handled_parts": 1,
+            "missing_parts": 1, "skipped_parts": 0,
+        },
+        "payload": fill_payload,
+    }
+    context, page = _page(
+        edge_browser, frontend_url, {"FillMod": mod_payload})
+    try:
+        _open(page, "FillMod")
+        page.locator(".draw-item").wait_for()
+        button = page.locator("#asset-fill-btn")
+        assert not button.is_disabled()
+        assert button.inner_text() == "Load Missing Parts"
+
+        button.click()
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadMissingAssetParts.length === 1")
+        page.locator("#asset-fill-btn", has_text="Remove Missing Parts").wait_for()
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 2
+        assert page.locator(".mesh-src-hdr", has_text="ORIGINAL ASSET").count() == 1
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["FillMod"]
+
+        button.click()
+        page.wait_for_function(
+            "window.__fakeApi.calls.removeMissingAssetParts.length === 1")
+        page.locator("#asset-fill-btn", has_text="Load Missing Parts").wait_for()
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 1
+        assert page.locator(".mesh-src-hdr", has_text="ORIGINAL ASSET").count() == 0
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["FillMod"]
+
+        page.evaluate("window.modViewer.reloadCurrentMod()")
+        page.wait_for_function("window.__fakeApi.calls.loadMod.length === 2")
+        assert page.locator("#asset-fill-btn").inner_text() == "Load Missing Parts"
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 1
     finally:
         context.close()
 
@@ -3789,7 +3860,7 @@ def test_inspector_follows_component_and_mesh_selection(
         assert page.locator("#sidebar > .panel-hdr #reset-state-btn").count() == 1
         assert page.locator("#sidebar > .panel-hdr > *").evaluate_all(
             "nodes => nodes.map(node => node.id || node.tagName)") == [
-                "BUTTON", "H3", "reset-state-btn"]
+                "BUTTON", "H3", "asset-fill-btn", "reset-state-btn"]
         assert page.locator("#sidebar > .panel-hdr .group-toggle").get_attribute(
             "aria-expanded") == "true"
         assert page.locator("#sidebar").is_visible()

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -1038,6 +1038,92 @@ def test_stale_missing_asset_response_is_rolled_back_after_mod_switch(
         context.close()
 
 
+def test_stale_missing_asset_response_preserves_new_mod_fill(
+        edge_browser, frontend_url):
+    first = _payload("FillRaceA")
+    _add_asset_fill_response(first, "FillRaceAssetA")
+    second = _payload("FillRaceB")
+    _add_asset_fill_response(second, "FillRaceAssetB")
+    context, page = _page(
+        edge_browser, frontend_url, {"FillRaceA": first, "FillRaceB": second})
+    try:
+        _open(page, "FillRaceA")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""() => {
+          const original = window.pywebview.api.load_missing_asset_parts;
+          window.__releaseFill = null;
+          window.pywebview.api.load_missing_asset_parts = async path => {
+            const result = await original(path);
+            if (path === 'FillRaceA') {
+              await new Promise(resolve => window.__releaseFill = resolve);
+            }
+            return result;
+          };
+          document.getElementById('asset-fill-btn').click();
+        }""")
+        page.wait_for_function("window.__releaseFill !== null")
+
+        _open(page, "FillRaceB")
+        page.locator(".draw-item").wait_for()
+        page.locator("#asset-fill-btn").click()
+        page.locator("#asset-fill-btn[data-state='remove']").wait_for()
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 2
+
+        page.evaluate("window.__releaseFill()")
+        page.wait_for_function(
+            "window.__fakeApi.calls.removeMissingAssetParts.includes('FillRaceA')")
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 2
+        assert page.locator("#asset-fill-btn").get_attribute("data-state") == "remove"
+        assert page.locator("#asset-fill-btn").get_attribute("aria-pressed") == "true"
+    finally:
+        context.close()
+
+
+def test_stale_missing_asset_remove_preserves_new_mod_fill(
+        edge_browser, frontend_url):
+    first = _payload("FillRemoveA")
+    _add_asset_fill_response(first, "FillRemoveAssetA")
+    second = _payload("FillRemoveB")
+    _add_asset_fill_response(second, "FillRemoveAssetB")
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"FillRemoveA": first, "FillRemoveB": second})
+    try:
+        _open(page, "FillRemoveA")
+        page.locator(".draw-item").wait_for()
+        page.locator("#asset-fill-btn").click()
+        page.locator("#asset-fill-btn[data-state='remove']").wait_for()
+
+        page.evaluate("""() => {
+          const original = window.pywebview.api.remove_missing_asset_parts;
+          window.__releaseRemove = null;
+          window.pywebview.api.remove_missing_asset_parts = async path => {
+            const result = await original(path);
+            if (path === 'FillRemoveA') {
+              await new Promise(resolve => window.__releaseRemove = resolve);
+            }
+            return result;
+          };
+          document.getElementById('asset-fill-btn').click();
+        }""")
+        page.wait_for_function("window.__releaseRemove !== null")
+
+        _open(page, "FillRemoveB")
+        page.locator(".draw-item").wait_for()
+        page.locator("#asset-fill-btn").click()
+        page.locator("#asset-fill-btn[data-state='remove']").wait_for()
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 2
+
+        page.evaluate("window.__releaseRemove()")
+        page.wait_for_function(
+            "window.__fakeApi.calls.removeMissingAssetParts.includes('FillRemoveA')")
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 2
+        assert page.locator("#asset-fill-btn").get_attribute("data-state") == "remove"
+        assert page.locator("#asset-fill-btn").get_attribute("aria-pressed") == "true"
+    finally:
+        context.close()
+
+
 def _add_asset_fill_response(payload, label, position=None):
     payload["asset_resolution"] = {"configured_roots": 1}
     fill_payload = _payload(label)

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -956,6 +956,8 @@ def test_missing_asset_parts_append_and_remove_without_reloading_mod(
         assert button.get_attribute("aria-pressed") == "true"
         assert button.locator("use").get_attribute("href") == "#icon-close"
         assert page.evaluate("window.modViewer.activeMeshes.length") == 2
+        assert page.evaluate("window.modViewer.refreshMeshSemantics()") is True
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 2
         appended = page.evaluate("""() => window.modViewer.activeMeshes.map(mesh => ({
           position: mesh.position.toArray(), quaternion: mesh.quaternion.toArray(),
         }))""")
@@ -999,6 +1001,41 @@ def test_missing_asset_parts_append_and_remove_without_reloading_mod(
 
 
 
+
+
+def test_stale_missing_asset_response_is_rolled_back_after_mod_switch(
+        edge_browser, frontend_url):
+    first = _payload("FillRaceA")
+    first["asset_resolution"] = {"configured_roots": 1}
+    _add_asset_fill_response(first, "FillRaceAsset")
+    second = _payload("FillRaceB")
+    context, page = _page(
+        edge_browser, frontend_url, {"FillRaceA": first, "FillRaceB": second})
+    try:
+        _open(page, "FillRaceA")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""() => {
+          const original = window.pywebview.api.load_missing_asset_parts;
+          window.__releaseFill = null;
+          window.pywebview.api.load_missing_asset_parts = async path => {
+            const result = await original(path);
+            await new Promise(resolve => window.__releaseFill = resolve);
+            return result;
+          };
+          document.getElementById('asset-fill-btn').click();
+        }""")
+        page.wait_for_function("window.__releaseFill !== null")
+
+        _open(page, "FillRaceB")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("window.__releaseFill()")
+
+        page.wait_for_function(
+            "window.__fakeApi.calls.removeMissingAssetParts.length === 1")
+        assert page.evaluate("window.modViewer.getCurrentSource().path") == "FillRaceB"
+        assert page.evaluate("window.modViewer.activeMeshes.length") == 1
+    finally:
+        context.close()
 
 
 def _add_asset_fill_response(payload, label, position=None):

--- a/src/tests/test_frontend.py
+++ b/src/tests/test_frontend.py
@@ -935,6 +935,12 @@ def test_missing_asset_parts_append_and_remove_without_reloading_mod(
             "window.__fakeApi.calls.loadMissingAssetParts.length === 1")
         page.locator("#asset-fill-btn", has_text="Remove Missing Parts").wait_for()
         assert page.evaluate("window.modViewer.activeMeshes.length") == 2
+        appended = page.evaluate("""() => window.modViewer.activeMeshes.map(mesh => ({
+          position: mesh.position.toArray(), quaternion: mesh.quaternion.toArray(),
+        }))""")
+        assert appended[1]["position"] == pytest.approx(appended[0]["position"])
+        assert appended[1]["quaternion"] == pytest.approx(
+            appended[0]["quaternion"])
         assert page.locator(".mesh-src-hdr", has_text="ORIGINAL ASSET").count() == 1
         assert page.evaluate("window.__fakeApi.calls.loadMod") == ["FillMod"]
 
@@ -946,6 +952,22 @@ def test_missing_asset_parts_append_and_remove_without_reloading_mod(
         assert page.locator(".mesh-src-hdr", has_text="ORIGINAL ASSET").count() == 0
         assert page.evaluate("window.__fakeApi.calls.loadMod") == ["FillMod"]
 
+        page.locator("#camera-flip-btn").click()
+        page.locator("#camera-flip-horizontal-btn").click()
+        page.locator("#asset-fill-btn", has_text="Load Missing Parts").click()
+        page.locator("#asset-fill-btn", has_text="Remove Missing Parts").wait_for()
+        turned = page.evaluate("""() => window.modViewer.activeMeshes.map(mesh => ({
+          position: mesh.position.toArray(), quaternion: mesh.quaternion.toArray(),
+        }))""")
+        assert turned[1]["position"] == pytest.approx(turned[0]["position"])
+        assert turned[1]["quaternion"] == pytest.approx(turned[0]["quaternion"])
+        page.locator("#camera-reset-view-btn").click()
+        reset = page.evaluate("""() => window.modViewer.activeMeshes.map(mesh => ({
+          position: mesh.position.toArray(), quaternion: mesh.quaternion.toArray(),
+        }))""")
+        assert reset[1]["position"] == pytest.approx(reset[0]["position"])
+        assert reset[1]["quaternion"] == pytest.approx(reset[0]["quaternion"])
+
         page.evaluate("window.modViewer.reloadCurrentMod()")
         page.wait_for_function("window.__fakeApi.calls.loadMod.length === 2")
         assert page.locator("#asset-fill-btn").inner_text() == "Load Missing Parts"
@@ -956,6 +978,80 @@ def test_missing_asset_parts_append_and_remove_without_reloading_mod(
 
 
 
+
+
+def _add_asset_fill_response(payload, label, position=None):
+    payload["asset_resolution"] = {"configured_roots": 1}
+    fill_payload = _payload(label)
+    fill_entry = next(iter(fill_payload["meshes"].values()))
+    if position is not None:
+        fill_entry["pos"] = position
+    fill_entry.update({
+        "source": "ORIGINAL ASSET",
+        "component": "Original Hair",
+        "asset_fill": True,
+        "fill_reason": "missing_mod_coverage",
+        "sources": [{"asset": {
+            "type": "ZZMI", "asset": "Character", "geometry_hash": "bbbbbbbb",
+            "component_name": "Hair", "first_index": 0, "index_count": 3,
+        }}],
+    })
+    fill_payload["metadata"] = {
+        "source_kind": "asset-fill", "material_profiles": {},
+    }
+    payload["assetFillResponse"] = {
+        "status": "loaded",
+        "coverage": {
+            "asset_parts": 2, "handled_parts": 1,
+            "missing_parts": 1, "skipped_parts": 0,
+        },
+        "payload": fill_payload,
+    }
+
+
+def test_missing_asset_parts_inherit_auto_upright_and_wuwa_facing(
+        edge_browser, frontend_url):
+    upright = _payload("Upright")
+    upright_position = _f32(0, 0, 0, 1, 0, 0, 0, 0, 2)
+    upright["meshes"]["Body-Upright-0"]["pos"] = upright_position
+    _add_asset_fill_response(upright, "UprightAsset", upright_position)
+
+    wuwa = _payload("WuWaFill")
+    wuwa["metadata"]["game"] = {
+        "id": "wuwa", "runtime": "wwmi", "texture_api": "raw",
+        "confidence": "high",
+    }
+    _add_asset_fill_response(wuwa, "WuWaAsset")
+
+    context, page = _page(
+        edge_browser, frontend_url, {"Upright": upright, "WuWa": wuwa})
+    try:
+        _open(page, "Upright")
+        page.locator(".draw-item").wait_for()
+        initial = page.evaluate(
+            "window.modViewer.activeMeshes[0].quaternion.toArray()")
+        assert initial == pytest.approx(
+            [-2 ** -0.5, 0, 0, 2 ** -0.5])
+        page.locator("#asset-fill-btn").click()
+        page.locator("#asset-fill-btn", has_text="Remove Missing Parts").wait_for()
+        upright_states = page.evaluate("""() => window.modViewer.activeMeshes.map(
+          mesh => mesh.quaternion.toArray())""")
+        assert upright_states[1] == pytest.approx(upright_states[0])
+
+        page.evaluate("async () => await window.modViewer.switchMod('WuWa')")
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadMod.length === 2"
+            " && window.modViewer.activeMeshes.length === 1")
+        wuwa_initial = page.evaluate(
+            "window.modViewer.activeMeshes[0].quaternion.toArray()")
+        assert wuwa_initial == pytest.approx([0, 1, 0, 0])
+        page.locator("#asset-fill-btn").click()
+        page.locator("#asset-fill-btn", has_text="Remove Missing Parts").wait_for()
+        wuwa_states = page.evaluate("""() => window.modViewer.activeMeshes.map(
+          mesh => mesh.quaternion.toArray())""")
+        assert wuwa_states[1] == pytest.approx(wuwa_states[0])
+    finally:
+        context.close()
 
 
 def test_asset_rebuild_preserves_tree_and_disables_only_one_root(

--- a/src/tests/test_texture_transport.py
+++ b/src/tests/test_texture_transport.py
@@ -173,6 +173,27 @@ def test_publication_deduplicates_by_role_and_invalidates_old_load(tmp_path):
     assert server._lookup_texture(replacement.token, "0").path == str(path)
 
 
+def test_auxiliary_publication_retains_active_mod_publication(tmp_path):
+    path = tmp_path / "shared.png"
+    Image.new("RGB", (1, 1), (128, 128, 32)).save(path)
+
+    mod = server.begin_texture_publication(str(tmp_path))
+    mod.register(str(path), "diffuse")
+    mod.commit()
+    fill = server.begin_texture_publication(str(tmp_path))
+    fill.register(str(path), "normal_map")
+    fill.commit(replace=False)
+
+    assert server.active_texture_publication(str(tmp_path)) is mod
+    assert server._lookup_texture(mod.token, "0") is not None
+    assert server._lookup_texture(fill.token, "0") is not None
+
+    fill.release()
+    assert server.active_texture_publication(str(tmp_path)) is mod
+    assert server._lookup_texture(mod.token, "0") is not None
+    assert server._lookup_texture(fill.token, "0") is None
+
+
 
 
 

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -344,6 +344,7 @@ body.asset-preview-mode #toolbar-overflow [data-toolbar-target="export-btn"] {
   letter-spacing: .1em; margin: 0; flex: 1;
 }
 #sidebar > .panel-hdr h3 { flex: 0 0 auto; }
+.asset-fill-btn { min-height: 24px; padding: 3px 7px; font-size: 10px; }
 
 /* ── toolbox (wireframe / grid) ───────────────────────────────────────────── */
 #tool-panel {

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -344,7 +344,7 @@ body.asset-preview-mode #toolbar-overflow [data-toolbar-target="export-btn"] {
   letter-spacing: .1em; margin: 0; flex: 1;
 }
 #sidebar > .panel-hdr h3 { flex: 0 0 auto; }
-.asset-fill-btn { min-height: 24px; padding: 3px 7px; font-size: 10px; }
+.icon-btn.asset-fill-btn { width: 28px; height: 28px; min-height: 28px; }
 
 /* ── toolbox (wireframe / grid) ───────────────────────────────────────────── */
 #tool-panel {
@@ -419,6 +419,7 @@ body.asset-preview-mode #toolbar-overflow [data-toolbar-target="export-btn"] {
 .environment-icon [data-environment-icon="outdoor"] circle { fill: #ffd866; stroke: #fff0a8; }
 body.right-dock-mounted #view-gizmo { top: 52px; right: 338px; }
 .panel-hdr { display: flex; align-items: center; gap: 7px; margin-bottom: 8px; cursor: pointer; }
+.panel-hdr-actions { display: inline-flex; align-items: center; gap: 4px; margin-left: auto; flex: 0 0 auto; }
 #mesh-list.collapsed, #present-list.collapsed, #toggle-list.collapsed, #menu-list.collapsed { display: none; }
 .icon-btn {
   background: #21262d; border: 1px solid #30363d; color: #e6edf3; border-radius: 4px;
@@ -1255,8 +1256,6 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 .asset-folder-name {
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.asset-folder-status { flex: 0 0 auto; color: var(--text-muted); font-size: 9px; font-weight: 700;
-  letter-spacing: .04em; text-transform: uppercase; }
 .asset-folder-row.asset-folder-disabled .asset-folder-label { opacity: .72; }
 .asset-folder-expand, .asset-folder-actions button { min-height: 0; }
 .asset-folder-tools { display: inline-flex; align-items: center; gap: 3px; flex: 0 0 auto; }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -178,6 +178,8 @@
       <div class="panel-hdr">
         <button type="button" class="group-toggle" aria-expanded="true" aria-controls="mesh-list"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
         <h3>Meshes</h3>
+        <button id="asset-fill-btn" class="ui-button asset-fill-btn" type="button" disabled
+                title="Add original Asset components not handled by this mod.">Load Missing Parts</button>
         <button id="reset-state-btn" class="icon-btn" title="Reset mesh visibility" aria-label="Reset mesh visibility"><svg class="ui-icon" aria-hidden="true"><use href="#icon-reset"></use></svg></button>
       </div>
       <div id="mesh-list"></div>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -13,6 +13,7 @@
 <svg id="ui-icon-sprite" aria-hidden="true" focusable="false">
   <symbol id="icon-library" viewBox="0 0 24 24"><path d="M4 6h6l2 2h8v11H4z"/><path d="M4 9h16"/></symbol>
   <symbol id="icon-mesh" viewBox="0 0 24 24"><path d="m12 3 8 4.5v9L12 21l-8-4.5v-9L12 3Z"/><path d="m4 7.5 8 4.5 8-4.5M12 12v9"/></symbol>
+  <symbol id="icon-mesh-add" viewBox="0 0 24 24"><path d="m8 3 6 3.5v7L8 17l-6-3.5v-7L8 3Z"/><path d="m2 6.5 6 3.5 6-3.5M8 10v7M18 14v7M14.5 17.5h7"/></symbol>
   <symbol id="icon-assets" viewBox="0 0 24 24"><path d="M4 7h5l2 2h9v11H4z"/><path d="M4 7V4h7l2 3M8 13h8M8 17h5"/></symbol>
   <symbol id="icon-inspector" viewBox="0 0 24 24"><path d="M5 4h14v16H5zM8 8h8M8 12h5M8 16h8"/></symbol>
   <symbol id="icon-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></symbol>
@@ -145,8 +146,10 @@
     <section id="mod-folder-panel" class="left-dock-panel" role="tabpanel" aria-labelledby="mod-library-tab" aria-label="Mod Library" hidden>
       <div class="panel-hdr">
         <h3>Mod Library</h3>
-        <button id="mod-folder-add" class="icon-btn" type="button"
-                title="Add Mod Folder"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
+        <div class="panel-hdr-actions">
+          <button id="mod-folder-add" class="icon-btn" type="button"
+                  title="Add Mod Folder" aria-label="Add Mod Folder"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
+        </div>
       </div>
       <div id="mod-folder-error" class="mod-folder-error" role="alert"></div>
       <div id="mod-folder-list" class="mod-folder-list folder-registry-list"></div>
@@ -161,8 +164,10 @@
     <section id="asset-folder-panel" class="left-dock-panel" role="tabpanel" aria-labelledby="assets-tab" aria-label="Assets" hidden>
       <div class="panel-hdr">
         <h3>Assets</h3>
-        <button id="asset-folder-add" class="icon-btn" type="button"
-                title="Add Asset Folder" aria-label="Add Asset Folder"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
+        <div class="panel-hdr-actions">
+          <button id="asset-folder-add" class="icon-btn" type="button"
+                  title="Add Asset Folder" aria-label="Add Asset Folder"><svg class="ui-icon" aria-hidden="true"><use href="#icon-plus"></use></svg></button>
+        </div>
       </div>
       <div id="asset-folder-error" class="asset-folder-error" role="alert"></div>
       <div id="asset-folder-list" class="asset-folder-list folder-registry-list"></div>
@@ -178,9 +183,12 @@
       <div class="panel-hdr">
         <button type="button" class="group-toggle" aria-expanded="true" aria-controls="mesh-list"><svg class="ui-icon" aria-hidden="true"><use href="#icon-chevron-down"></use></svg></button>
         <h3>Meshes</h3>
-        <button id="asset-fill-btn" class="ui-button asset-fill-btn" type="button" disabled
-                title="Add original Asset components not handled by this mod.">Load Missing Parts</button>
-        <button id="reset-state-btn" class="icon-btn" title="Reset mesh visibility" aria-label="Reset mesh visibility"><svg class="ui-icon" aria-hidden="true"><use href="#icon-reset"></use></svg></button>
+        <div class="panel-hdr-actions">
+          <button id="asset-fill-btn" class="icon-btn asset-fill-btn" type="button" disabled
+                  title="Add original Asset components not handled by this mod."
+                  aria-label="Load missing parts" aria-pressed="false" data-state="load"><svg class="ui-icon" aria-hidden="true"><use href="#icon-mesh-add"></use></svg></button>
+          <button id="reset-state-btn" class="icon-btn" title="Reset mesh visibility" aria-label="Reset mesh visibility"><svg class="ui-icon" aria-hidden="true"><use href="#icon-reset"></use></svg></button>
+        </div>
       </div>
       <div id="mesh-list"></div>
     </section>

--- a/src/web/js/asset-folder-panel.js
+++ b/src/web/js/asset-folder-panel.js
@@ -166,12 +166,6 @@ export function initAssetFolderPanel({ switchAsset = null } = {}) {
       name.className = 'asset-folder-name';
       name.textContent = baseName(entry.path);
       wrapper.append(badge, name);
-      if (entry.enabled === false) {
-        const status = document.createElement('span');
-        status.className = 'asset-folder-status';
-        status.textContent = 'Disabled';
-        wrapper.appendChild(status);
-      }
       return wrapper;
     },
     classPrefix: 'asset-folder',

--- a/src/web/js/camera-frame.js
+++ b/src/web/js/camera-frame.js
@@ -27,7 +27,9 @@ export function createCameraFrame({
   let homeView = null;
   let clipNear = camera.near;
   let clipFar = camera.far;
-  let uprightApplied = false;
+  let orientationInitialized = false;
+  const uprightRotation = new THREE.Quaternion();
+  const baseFacingRotation = new THREE.Quaternion();
   const modelRotation = new THREE.Quaternion();
   let modelPivot = null;
 
@@ -153,8 +155,39 @@ export function createCameraFrame({
     modelRotation.premultiply(rotation);
   }
 
+  function applyCurrentModelOrientation(meshes = [], { includeUserRotation = true } = {}) {
+    if (!orientationInitialized || !modelPivot || !meshes.length) return;
+    meshes.forEach(mesh => mesh.quaternion.copy(uprightRotation));
+    rotateMeshesAroundCenter(meshes, baseFacingRotation);
+    if (includeUserRotation) rotateMeshesAroundCenter(meshes, modelRotation);
+  }
+
+  function adoptModelMeshes(meshes = []) {
+    if (!orientationInitialized || !homeView || !meshes.length) return [];
+    const known = new Set(homeView.meshes.map(item => item.mesh));
+    const added = meshes.filter(mesh => mesh && !known.has(mesh));
+    if (!added.length) return [];
+    applyCurrentModelOrientation(added, {includeUserRotation: false});
+    const homeTransforms = added.map(mesh => ({
+      mesh,
+      quaternion: mesh.quaternion.clone(),
+      position: mesh.position.clone(),
+    }));
+    rotateMeshesAroundCenter(added, modelRotation);
+    homeView.meshes.push(...homeTransforms);
+    return added;
+  }
+
+  function forgetModelMeshes(meshes = []) {
+    if (!homeView || !meshes.length) return;
+    const removed = new Set(meshes);
+    homeView.meshes = homeView.meshes.filter(item => !removed.has(item.mesh));
+  }
+
   function resetModelOrientation({ preserveRotation = false } = {}) {
-    uprightApplied = false;
+    orientationInitialized = false;
+    uprightRotation.identity();
+    baseFacingRotation.identity();
     if (!preserveRotation) modelRotation.identity();
     modelPivot = null;
     homeView = null;
@@ -182,6 +215,7 @@ export function createCameraFrame({
 
   function fitTo(meshes, {
     preserveCamera = false,
+    preserveHomeView = false,
     initialRotationY = 0,
   } = {}) {
     const preservedView = preserveCamera ? {
@@ -192,26 +226,27 @@ export function createCameraFrame({
       zoom: camera.zoom,
     } : null;
     let homeMeshTransforms = null;
-    if (!uprightApplied && meshes.length) {
+    if (!orientationInitialized && meshes.length) {
       const rawBox = new THREE.Box3();
       meshes.forEach(mesh => expandByBaseMesh(rawBox, mesh));
       const rawSize = rawBox.getSize(new THREE.Vector3());
+      uprightRotation.identity();
       if (rawSize.z > rawSize.y * 1.5 && rawSize.z > rawSize.x * 1.15) {
-        meshes.forEach(mesh => {
-          mesh.quaternion.copy(new THREE.Quaternion().setFromAxisAngle(
-            new THREE.Vector3(1, 0, 0), -Math.PI / 2));
-        });
+        uprightRotation.setFromAxisAngle(
+          new THREE.Vector3(1, 0, 0), -Math.PI / 2);
       }
+      meshes.forEach(mesh => mesh.quaternion.copy(uprightRotation));
       const uprightBox = new THREE.Box3();
       meshes.forEach(mesh => expandByBaseMesh(uprightBox, mesh));
+      baseFacingRotation.identity();
       if (!uprightBox.isEmpty()) {
         modelPivot = uprightBox.getCenter(new THREE.Vector3());
         if (Number.isFinite(initialRotationY) && initialRotationY !== 0) {
-          const initialRotation = new THREE.Quaternion().setFromAxisAngle(
+          baseFacingRotation.setFromAxisAngle(
             new THREE.Vector3(0, 1, 0), initialRotationY);
           // Capture the base game orientation in homeView.  Manual turns are
           // tracked separately in modelRotation and can still be reset.
-          rotateMeshesAroundCenter(meshes, initialRotation);
+          rotateMeshesAroundCenter(meshes, baseFacingRotation);
         }
       }
       homeMeshTransforms = meshes.map(mesh => ({
@@ -220,7 +255,7 @@ export function createCameraFrame({
         position: mesh.position.clone(),
       }));
       rotateMeshesAroundCenter(meshes, modelRotation);
-      uprightApplied = true;
+      orientationInitialized = true;
     }
     const box = new THREE.Box3();
     meshes.forEach(mesh => expandByBaseMesh(box, mesh));
@@ -244,17 +279,19 @@ export function createCameraFrame({
     camera.up.copy(INITIAL_CAMERA_UP);
     frameView(meshes, INITIAL_CAMERA_DIRECTION, boxSize.y * 0.08);
     onModelFit?.(size);
-    homeView = {
-      position: camera.position.clone(),
-      target: controls.target.clone(),
-      near: camera.near,
-      far: camera.far,
-      meshes: homeMeshTransforms || meshes.map(mesh => ({
-        mesh,
-        quaternion: mesh.quaternion.clone(),
-        position: mesh.position.clone(),
-      })),
-    };
+    if (!preserveHomeView) {
+      homeView = {
+        position: camera.position.clone(),
+        target: controls.target.clone(),
+        near: camera.near,
+        far: camera.far,
+        meshes: homeMeshTransforms || meshes.map(mesh => ({
+          mesh,
+          quaternion: mesh.quaternion.clone(),
+          position: mesh.position.clone(),
+        })),
+      };
+    }
     if (preservedView) {
       camera.position.copy(preservedView.position);
       camera.up.copy(preservedView.up);
@@ -276,8 +313,10 @@ export function createCameraFrame({
   }
 
   return {
+    adoptModelMeshes,
     fitTo,
     frameView,
+    forgetModelMeshes,
     resetModelOrientation,
     resetView,
     resize,

--- a/src/web/js/folder-registry-panel.js
+++ b/src/web/js/folder-registry-panel.js
@@ -259,36 +259,28 @@ export function createFolderRegistryPanel({
     });
     if (!currentNode) return false;
 
-    const currentRow = currentNode.querySelector(`:scope > ${selector('row')}`);
     const currentChildren = currentNode.querySelector(
       `:scope > ${selector('children')}`);
-    const currentMeta = currentNode.querySelector(
-      `:scope > ${selector('meta')}`);
-    const currentMissing = currentNode.querySelector(
-      `:scope > ${selector('missing')}`);
     const expanded = currentNode.classList.contains('expanded');
     const replacement = createNode(entry, true);
-    const replacementRow = replacement.querySelector(`:scope > ${selector('row')}`);
     const replacementArrow = replacement.querySelector(
       `:scope > ${selector('row')} ${selector('expand')}`);
-    const replacementMissing = replacement.querySelector(
-      `:scope > ${selector('missing')}`);
-    const replacementMeta = replacement.querySelector(
-      `:scope > ${selector('meta')}`);
+    const replacementChildren = replacement.querySelector(
+      `:scope > ${selector('children')}`);
+    if (currentChildren && replacementChildren) {
+      replacementChildren.replaceWith(currentChildren);
+    }
+    const preservedChildren = currentChildren || replacementChildren;
     if (expanded) {
+      replacement.classList.add('expanded');
+      preservedChildren.hidden = false;
       replacementArrow.classList.remove('leaf');
       replacementArrow.classList.add('expanded');
       replacementArrow.setAttribute('aria-expanded', 'true');
       replacementArrow.setAttribute(
         'aria-label', `Collapse ${replacementArrow.dataset.folderName}`);
     }
-    currentRow.replaceWith(replacementRow);
-    if (currentMeta && replacementMeta) currentMeta.replaceWith(replacementMeta);
-    else if (currentMeta) currentMeta.remove();
-    else if (replacementMeta) currentNode.insertBefore(replacementMeta, currentChildren);
-    if (currentMissing && replacementMissing) currentMissing.replaceWith(replacementMissing);
-    else if (currentMissing) currentMissing.remove();
-    else if (replacementMissing) currentNode.insertBefore(replacementMissing, currentChildren);
+    currentNode.replaceWith(replacement);
     roots[index] = entry;
     setActivePath(activePath);
     return true;

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -262,6 +262,7 @@ let assetFillAvailable = false;
 let assetFillLoaded = false;
 let assetFillLoading = false;
 let assetFillTextureKeys = new Set();
+let assetFillId = null;
 let assetFillEpoch = 0;
 
 // The last-loaded payload's controls.toggles model, kept
@@ -337,6 +338,7 @@ function clearScene({ preserveModelOrientation = false } = {}) {
   setTextures(null);
   removeTextures(assetFillTextureKeys);
   assetFillTextureKeys = new Set();
+  assetFillId = null;
   assetFillAvailable = false;
   assetFillLoaded = false;
   assetFillLoading = false;
@@ -510,11 +512,13 @@ function rollbackAssetFillFrontend(addedMeshes, textureKeys) {
   removeTextures(keys);
   keys.forEach(key => assetFillTextureKeys.delete(key));
   assetFillLoaded = false;
+  assetFillId = null;
 }
 
-async function releaseBackendAssetFill(path) {
+async function releaseBackendAssetFill(path, fillId = null) {
   try {
-    const result = await window.pywebview.api.remove_missing_asset_parts(path);
+    const result = await window.pywebview.api.remove_missing_asset_parts(
+      path, fillId);
     if (result?.status === 'error') {
       console.warn('Could not roll back missing Asset parts:', result.error);
     }
@@ -523,7 +527,8 @@ async function releaseBackendAssetFill(path) {
   }
 }
 
-async function rollbackAssetFill(path, operation, addedMeshes, textureKeys) {
+async function rollbackAssetFill(
+    path, operation, fillId, addedMeshes, textureKeys) {
   if (assetFillOperationIsCurrent(operation, path)) {
     rollbackAssetFillFrontend(addedMeshes, textureKeys);
   } else {
@@ -533,7 +538,7 @@ async function rollbackAssetFill(path, operation, addedMeshes, textureKeys) {
     removeTextures(keys);
     keys.forEach(key => assetFillTextureKeys.delete(key));
   }
-  await releaseBackendAssetFill(path);
+  await releaseBackendAssetFill(path, fillId);
 }
 
 async function loadMissingAssetParts() {
@@ -544,6 +549,7 @@ async function loadMissingAssetParts() {
   const operation = ++assetFillEpoch;
   let backendLoaded = false;
   let rolledBack = false;
+  let transactionFillId = null;
   let addedMeshes = [];
   const transactionTextureKeys = new Set();
   const rollback = async () => {
@@ -551,7 +557,8 @@ async function loadMissingAssetParts() {
     rolledBack = true;
     if (backendLoaded) {
       await rollbackAssetFill(
-        path, operation, addedMeshes, transactionTextureKeys);
+        path, operation, transactionFillId,
+        addedMeshes, transactionTextureKeys);
     }
   };
   assetFillLoading = true;
@@ -559,7 +566,10 @@ async function loadMissingAssetParts() {
   try {
     const result = await window.pywebview.api.load_missing_asset_parts(path);
     if (!assetFillOperationIsCurrent(operation, path)) {
-      if (result?.status === 'loaded') backendLoaded = true;
+      if (result?.status === 'loaded') {
+        backendLoaded = true;
+        transactionFillId = result.fill_id || null;
+      }
       await rollback();
       return false;
     }
@@ -574,6 +584,7 @@ async function loadMissingAssetParts() {
       return false;
     }
     backendLoaded = true;
+    transactionFillId = result.fill_id || null;
     if (!assetFillOperationIsCurrent(operation, path)) {
       await rollback();
       return false;
@@ -621,6 +632,7 @@ async function loadMissingAssetParts() {
       return false;
     }
     assetFillLoaded = true;
+    assetFillId = transactionFillId;
     fitTo(activeMeshes, {
       preserveCamera: true,
       preserveHomeView: true,
@@ -647,14 +659,17 @@ async function removeMissingAssetParts() {
   assetFillLoading = true;
   updateAssetFillButton();
   try {
-    const result = await window.pywebview.api.remove_missing_asset_parts(path);
+    const result = await window.pywebview.api.remove_missing_asset_parts(
+      path, assetFillId);
     if (!assetFillOperationIsCurrent(operation, path)) return false;
     if (result?.status === 'error') throw new Error(result.error);
+    if (result?.stale) return false;
     const removedMeshes = removeAssetFillMeshPanel();
     forgetModelMeshes(removedMeshes);
     removeTextures(assetFillTextureKeys);
     assetFillTextureKeys = new Set();
     assetFillLoaded = false;
+    assetFillId = null;
     requestRender();
     return true;
   } catch (error) {

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -5,12 +5,15 @@ import { fitTo, resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterT
          getEnvironmentPreset, getLightMode, isRendererAvailable, rendererReady,
          setEnvironmentPreset, setLightMode, getRenderCount } from './scene.js';
 import { ENVIRONMENT_PRESETS } from './environment.js';
-import { refreshMeshTexture, setTextures } from './mesh-factory.js';
+import { addTexture, refreshMeshTexture, removeTextures, setTextures } from './mesh-factory.js';
 import { activeMeshes, refreshAll, reset, resetMeshState, setStateRules,
          toggleWireframe, toggleSmoothShading, toggleGlossy,
          updateMeshSemantics } from './visibility.js';
 import { initSelection, clearSelection } from './selection.js';
-import { buildMeshPanel, refreshMeshAssetDiagnostics } from './mesh-panel.js';
+import {
+  appendMeshPanel, buildMeshPanel, refreshMeshAssetDiagnostics,
+  removeAssetFillMeshPanel,
+} from './mesh-panel.js';
 import { buildTogglePanel } from './toggle-panel.js';
 import { buildMenuPanel } from './menu-panel.js';
 import { buildPresentPanel } from './present-panel.js';
@@ -253,6 +256,10 @@ let displayedModPath = null;
 let displayedSource = null;
 let modTransitionInFlight = false;
 let rightDockEnabled = false;
+let assetFillAvailable = false;
+let assetFillLoaded = false;
+let assetFillLoading = false;
+let assetFillTextureKeys = new Set();
 
 // The last-loaded payload's controls.toggles model, kept
 // around purely so refreshPendingState() can check for a still-unwired
@@ -262,6 +269,19 @@ let lastToggles = {};
 function showLoading(on, message) {
   if (message) $('status-text').textContent = message;
   $('loading').classList.toggle('show', on);
+}
+
+function updateAssetFillButton() {
+  const button = $('asset-fill-btn');
+  if (!button) return;
+  const available = assetFillAvailable
+    && currentSource?.kind === 'mod' && !!currentModPath;
+  button.disabled = !available || assetFillLoading;
+  button.textContent = assetFillLoading ? 'Loading…'
+    : assetFillLoaded ? 'Remove Missing Parts' : 'Load Missing Parts';
+  button.title = assetFillLoaded
+    ? 'Remove original Asset components added for this session.'
+    : 'Add original Asset components not handled by this mod.';
 }
 
 /** Normalizes a Windows path for a same-folder comparison: slash direction,
@@ -304,6 +324,11 @@ function clearScene({ preserveModelOrientation = false } = {}) {
   // the next mod's normal materials.
   setOutlineSuppressedByDebug(false);
   setTextures(null);
+  removeTextures(assetFillTextureKeys);
+  assetFillTextureKeys = new Set();
+  assetFillAvailable = false;
+  assetFillLoaded = false;
+  assetFillLoading = false;
   setGeometryBlob(null);
   lastToggles = {};
   $('mesh-list').innerHTML = '';
@@ -317,6 +342,7 @@ function clearScene({ preserveModelOrientation = false } = {}) {
   setMeshesAvailable(false);
   setRightDockEnabled(false);
   syncViewportControlPlacement();
+  updateAssetFillButton();
 }
 
 function clearPendingState() {
@@ -336,6 +362,7 @@ function setSourceUi(kind) {
   $('pending-indicator').classList.toggle('show', false);
   $('pending-indicator').setAttribute('aria-hidden', String(asset));
   if (asset) $('export-btn').disabled = true;
+  updateAssetFillButton();
 }
 
 /** Commit the UI to a new folder before asking the backend to load it. This
@@ -400,6 +427,8 @@ async function displayMeshPayload(payload, { preserveCamera = false } = {}) {
   const meshes = payload.meshes || {};
   const assetMode = currentSource?.kind === 'asset'
     || payload.metadata?.source_kind === 'asset';
+  assetFillAvailable = !assetMode
+    && Number(payload.asset_resolution?.configured_roots || 0) > 0;
   if (assetMode && currentSource?.kind !== 'asset') {
     currentSource = {
       kind: 'asset', path: payload.metadata?.asset?.path || '',
@@ -443,7 +472,87 @@ async function displayMeshPayload(payload, { preserveCamera = false } = {}) {
     initialRotationY: payload.metadata?.game?.id === 'wuwa' ? Math.PI : 0,
   });
 
+  updateAssetFillButton();
   showLoading(false);
+}
+
+async function loadMissingAssetParts() {
+  if (!currentModPath || currentSource?.kind !== 'mod' || assetFillLoading) {
+    return false;
+  }
+  assetFillLoading = true;
+  updateAssetFillButton();
+  try {
+    const result = await window.pywebview.api.load_missing_asset_parts(currentModPath);
+    if (result?.status !== 'loaded') {
+      const messages = {
+        nothing_missing: 'No missing original Asset parts found.',
+        asset_ambiguous: 'Could not uniquely determine the original Asset.',
+        asset_not_found: 'No matching original Asset was found.',
+      };
+      if (result?.error) throw new Error(result.error);
+      await alertDialog(messages[result?.status] || 'No original Asset parts were loaded.');
+      return false;
+    }
+    const payload = result.payload || {};
+    const geometry = payload.geometry;
+    if (geometry) {
+      const response = await fetch(geometry.url, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`Geometry download failed (${response.status}).`);
+      const blob = await response.arrayBuffer();
+      if (blob.byteLength !== geometry.length) {
+        throw new Error('Geometry download was incomplete.');
+      }
+      setGeometryBlob(blob);
+    }
+    for (const [key, uri] of Object.entries(payload.textures || {})) {
+      if (addTexture(key, uri)) assetFillTextureKeys.add(key);
+    }
+    appendMeshPanel(
+      payload.meshes || {}, null,
+      {}, payload.metadata?.material_profiles || {}, {
+        replace: false,
+        texturePools: payload.texture_pools || {},
+        readOnlySource: true,
+      });
+    assetFillLoaded = true;
+    fitTo(activeMeshes, { preserveCamera: true });
+    requestRender();
+    return true;
+  } catch (error) {
+    await alertDialog('Could not load missing Asset parts:\n\n' + error.message);
+    return false;
+  } finally {
+    assetFillLoading = false;
+    updateAssetFillButton();
+  }
+}
+
+async function removeMissingAssetParts() {
+  if (!currentModPath || !assetFillLoaded || assetFillLoading) return false;
+  assetFillLoading = true;
+  updateAssetFillButton();
+  try {
+    const result = await window.pywebview.api.remove_missing_asset_parts(currentModPath);
+    if (result?.status === 'error') throw new Error(result.error);
+    removeAssetFillMeshPanel();
+    removeTextures(assetFillTextureKeys);
+    assetFillTextureKeys = new Set();
+    assetFillLoaded = false;
+    requestRender();
+    return true;
+  } catch (error) {
+    await alertDialog('Could not remove missing Asset parts:\n\n' + error.message);
+    return false;
+  } finally {
+    assetFillLoading = false;
+    updateAssetFillButton();
+  }
+}
+
+async function toggleMissingAssetParts() {
+  return assetFillLoaded
+    ? removeMissingAssetParts() : loadMissingAssetParts();
 }
 
 function beginSemanticRefresh() {
@@ -825,6 +934,10 @@ rendererReady.then(ready => {
 
   $('open-btn').addEventListener('click', openMod);
   $('export-btn').addEventListener('click', exportChanges);
+  $('asset-fill-btn').addEventListener('click', event => {
+    event.stopPropagation();
+    void toggleMissingAssetParts();
+  });
   $('wire-btn').addEventListener('click', toggleWireframe);
   $('outline-btn').addEventListener('click', () => {
     const enabled = setOutlinesEnabled();
@@ -855,6 +968,7 @@ rendererReady.then(ready => {
   if (viewportCameraButtons && cameraButtons) viewportCameraButtons.append(cameraButtons);
   syncViewportControlPlacement();
   initPanelCollapse($('sidebar'), 'mesh-list');
+  updateAssetFillButton();
   initPanelCollapse($('present-panel'), 'present-list');
   initPanelCollapse($('toggle-panel'), 'toggle-list');
   initPanelCollapse($('menu-panel'), 'menu-list');

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -8,8 +8,8 @@ import { adoptModelMeshes, fitTo, forgetModelMeshes, resetView,
 import { ENVIRONMENT_PRESETS } from './environment.js';
 import { addTexture, refreshMeshTexture, removeTextures, setTextures } from './mesh-factory.js';
 import { activeMeshes, refreshAll, reset, resetMeshState, setStateRules,
-         toggleWireframe, toggleSmoothShading, toggleGlossy,
-         updateMeshSemantics, removeAssetFillMeshes } from './visibility.js';
+         toggleWireframe, toggleSmoothShading, toggleGlossy, removeMesh,
+         updateMeshSemantics } from './visibility.js';
 import { initSelection, clearSelection } from './selection.js';
 import {
   appendMeshPanel, buildMeshPanel, refreshMeshAssetDiagnostics,
@@ -495,22 +495,24 @@ function assetFillOperationIsCurrent(operation, path) {
     && samePath(currentModPath, path);
 }
 
-async function rollbackAssetFill(path, textureKeys) {
-  const fillMeshes = activeMeshes.filter(
-    mesh => mesh.userData.assetFill === true);
-  const removedFromPanel = removeAssetFillMeshPanel();
-  const remaining = activeMeshes.filter(
-    mesh => mesh.userData.assetFill === true);
-  removeAssetFillMeshes();
-  const removed = [...new Set([
-    ...fillMeshes, ...removedFromPanel, ...remaining,
-  ])];
-  forgetModelMeshes(removed);
+function rollbackAssetFillFrontend(addedMeshes, textureKeys) {
+  const targetMeshes = [...new Set(addedMeshes || [])];
+  const removedFromPanel = removeAssetFillMeshPanel(targetMeshes);
+  const remaining = targetMeshes.filter(mesh => activeMeshes.includes(mesh));
+  remaining.forEach(removeMesh);
+  const removed = [...new Set([...removedFromPanel, ...remaining])];
+  if (removed.length) {
+    forgetModelMeshes(removed);
+    requestRender();
+  }
 
   const keys = new Set(textureKeys || []);
   removeTextures(keys);
   keys.forEach(key => assetFillTextureKeys.delete(key));
   assetFillLoaded = false;
+}
+
+async function releaseBackendAssetFill(path) {
   try {
     const result = await window.pywebview.api.remove_missing_asset_parts(path);
     if (result?.status === 'error') {
@@ -521,6 +523,19 @@ async function rollbackAssetFill(path, textureKeys) {
   }
 }
 
+async function rollbackAssetFill(path, operation, addedMeshes, textureKeys) {
+  if (assetFillOperationIsCurrent(operation, path)) {
+    rollbackAssetFillFrontend(addedMeshes, textureKeys);
+  } else {
+    // A stale operation must not touch the scene or global fill state. Texture
+    // entries are still owned by this transaction, so release only those.
+    const keys = new Set(textureKeys || []);
+    removeTextures(keys);
+    keys.forEach(key => assetFillTextureKeys.delete(key));
+  }
+  await releaseBackendAssetFill(path);
+}
+
 async function loadMissingAssetParts() {
   if (!currentModPath || currentSource?.kind !== 'mod' || assetFillLoading) {
     return false;
@@ -529,11 +544,15 @@ async function loadMissingAssetParts() {
   const operation = ++assetFillEpoch;
   let backendLoaded = false;
   let rolledBack = false;
+  let addedMeshes = [];
   const transactionTextureKeys = new Set();
   const rollback = async () => {
     if (rolledBack) return;
     rolledBack = true;
-    if (backendLoaded) await rollbackAssetFill(path, transactionTextureKeys);
+    if (backendLoaded) {
+      await rollbackAssetFill(
+        path, operation, addedMeshes, transactionTextureKeys);
+    }
   };
   assetFillLoading = true;
   updateAssetFillButton();
@@ -585,14 +604,17 @@ async function loadMissingAssetParts() {
       return false;
     }
     const before = new Set(activeMeshes);
-    appendMeshPanel(
-      payload.meshes || {}, null,
-      {}, payload.metadata?.material_profiles || {}, {
-        replace: false,
-        texturePools: payload.texture_pools || {},
-        readOnlySource: true,
-      });
-    const addedMeshes = activeMeshes.filter(mesh => !before.has(mesh));
+    try {
+      appendMeshPanel(
+        payload.meshes || {}, null,
+        {}, payload.metadata?.material_profiles || {}, {
+          replace: false,
+          texturePools: payload.texture_pools || {},
+          readOnlySource: true,
+        });
+    } finally {
+      addedMeshes = activeMeshes.filter(mesh => !before.has(mesh));
+    }
     adoptModelMeshes(addedMeshes);
     if (!assetFillOperationIsCurrent(operation, path)) {
       await rollback();
@@ -620,10 +642,13 @@ async function loadMissingAssetParts() {
 
 async function removeMissingAssetParts() {
   if (!currentModPath || !assetFillLoaded || assetFillLoading) return false;
+  const path = currentModPath;
+  const operation = ++assetFillEpoch;
   assetFillLoading = true;
   updateAssetFillButton();
   try {
-    const result = await window.pywebview.api.remove_missing_asset_parts(currentModPath);
+    const result = await window.pywebview.api.remove_missing_asset_parts(path);
+    if (!assetFillOperationIsCurrent(operation, path)) return false;
     if (result?.status === 'error') throw new Error(result.error);
     const removedMeshes = removeAssetFillMeshPanel();
     forgetModelMeshes(removedMeshes);
@@ -633,11 +658,14 @@ async function removeMissingAssetParts() {
     requestRender();
     return true;
   } catch (error) {
+    if (!assetFillOperationIsCurrent(operation, path)) return false;
     await alertDialog('Could not remove missing Asset parts:\n\n' + error.message);
     return false;
   } finally {
-    assetFillLoading = false;
-    updateAssetFillButton();
+    if (operation === assetFillEpoch) {
+      assetFillLoading = false;
+      updateAssetFillButton();
+    }
   }
 }
 

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -32,6 +32,7 @@ import { setTextureDisplayMode } from './render-modes.js';
 import { clearInspector, initInspectorPanel } from './inspector-panel.js';
 import { initRightDock, setRightDockEnabled } from './right-dock.js';
 import { initPanelOpacityControl } from './appearance.js';
+import { createIcon } from './ui-icons.js';
 import {
   getOutlineState as getMeshOutlineState,
   setOutlineSuppressedByDebug,
@@ -277,9 +278,17 @@ function updateAssetFillButton() {
   if (!button) return;
   const available = assetFillAvailable
     && currentSource?.kind === 'mod' && !!currentModPath;
+  const state = assetFillLoading ? 'loading' : assetFillLoaded ? 'remove' : 'load';
+  const label = state === 'remove'
+    ? 'Remove missing parts'
+    : state === 'loading'
+      ? assetFillLoaded ? 'Removing missing parts' : 'Loading missing parts'
+      : 'Load missing parts';
   button.disabled = !available || assetFillLoading;
-  button.textContent = assetFillLoading ? 'Loading…'
-    : assetFillLoaded ? 'Remove Missing Parts' : 'Load Missing Parts';
+  button.dataset.state = state;
+  button.setAttribute('aria-label', label);
+  button.setAttribute('aria-pressed', String(assetFillLoaded));
+  button.replaceChildren(createIcon(state === 'remove' ? 'close' : 'mesh-add'));
   button.title = assetFillLoaded
     ? 'Remove original Asset components added for this session.'
     : 'Add original Asset components not handled by this mod.';
@@ -923,12 +932,12 @@ function initPanelCollapse(panel, contentId) {
   chevron.setAttribute('aria-controls', contentId);
   setCollapsed(initiallyCollapsed, false);
   const toggle = (e) => {
-    if (e?.target?.closest?.('.icon-btn, .panel-actions, .panel-action-menu')) return;
+    if (e?.target?.closest?.('.icon-btn, .panel-hdr-actions, .panel-actions, .panel-action-menu')) return;
     e?.stopPropagation?.();
     setCollapsed(!content.classList.contains('collapsed'));
   };
   hdr.addEventListener('click', e => {
-    if (e.target.closest('.icon-btn, .group-toggle, .panel-actions, .panel-action-menu')) return;
+    if (e.target.closest('.icon-btn, .group-toggle, .panel-hdr-actions, .panel-actions, .panel-action-menu')) return;
     setCollapsed(!content.classList.contains('collapsed'));
   });
   chevron.addEventListener('click', toggle);

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -9,7 +9,7 @@ import { ENVIRONMENT_PRESETS } from './environment.js';
 import { addTexture, refreshMeshTexture, removeTextures, setTextures } from './mesh-factory.js';
 import { activeMeshes, refreshAll, reset, resetMeshState, setStateRules,
          toggleWireframe, toggleSmoothShading, toggleGlossy,
-         updateMeshSemantics } from './visibility.js';
+         updateMeshSemantics, removeAssetFillMeshes } from './visibility.js';
 import { initSelection, clearSelection } from './selection.js';
 import {
   appendMeshPanel, buildMeshPanel, refreshMeshAssetDiagnostics,
@@ -262,6 +262,7 @@ let assetFillAvailable = false;
 let assetFillLoaded = false;
 let assetFillLoading = false;
 let assetFillTextureKeys = new Set();
+let assetFillEpoch = 0;
 
 // The last-loaded payload's controls.toggles model, kept
 // around purely so refreshPendingState() can check for a still-unwired
@@ -380,6 +381,7 @@ function setSourceUi(kind) {
  * state one transition: a failed replacement can never leave the previous
  * mod visible under the new folder's toolbar state. */
 function beginModLoad(path, message, { preserveModelOrientation = false } = {}) {
+  assetFillEpoch += 1;
   currentModPath = path;
   currentSource = { kind: 'mod', path };
   setSourceUi('mod');
@@ -401,6 +403,7 @@ function beginModLoad(path, message, { preserveModelOrientation = false } = {}) 
 
 function beginAssetLoad(path, entry, message = 'Loading Asset…',
                         { preserveModelOrientation = false } = {}) {
+  assetFillEpoch += 1;
   currentModPath = null;
   currentSource = {
     kind: 'asset', path, assetType: entry?.asset_type || null,
@@ -486,14 +489,61 @@ async function displayMeshPayload(payload, { preserveCamera = false } = {}) {
   showLoading(false);
 }
 
+function assetFillOperationIsCurrent(operation, path) {
+  return operation === assetFillEpoch
+    && currentSource?.kind === 'mod'
+    && samePath(currentModPath, path);
+}
+
+async function rollbackAssetFill(path, textureKeys) {
+  const fillMeshes = activeMeshes.filter(
+    mesh => mesh.userData.assetFill === true);
+  const removedFromPanel = removeAssetFillMeshPanel();
+  const remaining = activeMeshes.filter(
+    mesh => mesh.userData.assetFill === true);
+  removeAssetFillMeshes();
+  const removed = [...new Set([
+    ...fillMeshes, ...removedFromPanel, ...remaining,
+  ])];
+  forgetModelMeshes(removed);
+
+  const keys = new Set(textureKeys || []);
+  removeTextures(keys);
+  keys.forEach(key => assetFillTextureKeys.delete(key));
+  assetFillLoaded = false;
+  try {
+    const result = await window.pywebview.api.remove_missing_asset_parts(path);
+    if (result?.status === 'error') {
+      console.warn('Could not roll back missing Asset parts:', result.error);
+    }
+  } catch (error) {
+    console.warn('Could not roll back missing Asset parts:', error);
+  }
+}
+
 async function loadMissingAssetParts() {
   if (!currentModPath || currentSource?.kind !== 'mod' || assetFillLoading) {
     return false;
   }
+  const path = currentModPath;
+  const operation = ++assetFillEpoch;
+  let backendLoaded = false;
+  let rolledBack = false;
+  const transactionTextureKeys = new Set();
+  const rollback = async () => {
+    if (rolledBack) return;
+    rolledBack = true;
+    if (backendLoaded) await rollbackAssetFill(path, transactionTextureKeys);
+  };
   assetFillLoading = true;
   updateAssetFillButton();
   try {
-    const result = await window.pywebview.api.load_missing_asset_parts(currentModPath);
+    const result = await window.pywebview.api.load_missing_asset_parts(path);
+    if (!assetFillOperationIsCurrent(operation, path)) {
+      if (result?.status === 'loaded') backendLoaded = true;
+      await rollback();
+      return false;
+    }
     if (result?.status !== 'loaded') {
       const messages = {
         nothing_missing: 'No missing original Asset parts found.',
@@ -502,6 +552,11 @@ async function loadMissingAssetParts() {
       };
       if (result?.error) throw new Error(result.error);
       await alertDialog(messages[result?.status] || 'No original Asset parts were loaded.');
+      return false;
+    }
+    backendLoaded = true;
+    if (!assetFillOperationIsCurrent(operation, path)) {
+      await rollback();
       return false;
     }
     const payload = result.payload || {};
@@ -513,10 +568,21 @@ async function loadMissingAssetParts() {
       if (blob.byteLength !== geometry.length) {
         throw new Error('Geometry download was incomplete.');
       }
+      if (!assetFillOperationIsCurrent(operation, path)) {
+        await rollback();
+        return false;
+      }
       setGeometryBlob(blob);
     }
     for (const [key, uri] of Object.entries(payload.textures || {})) {
-      if (addTexture(key, uri)) assetFillTextureKeys.add(key);
+      if (addTexture(key, uri)) {
+        assetFillTextureKeys.add(key);
+        transactionTextureKeys.add(key);
+      }
+    }
+    if (!assetFillOperationIsCurrent(operation, path)) {
+      await rollback();
+      return false;
     }
     const before = new Set(activeMeshes);
     appendMeshPanel(
@@ -528,6 +594,10 @@ async function loadMissingAssetParts() {
       });
     const addedMeshes = activeMeshes.filter(mesh => !before.has(mesh));
     adoptModelMeshes(addedMeshes);
+    if (!assetFillOperationIsCurrent(operation, path)) {
+      await rollback();
+      return false;
+    }
     assetFillLoaded = true;
     fitTo(activeMeshes, {
       preserveCamera: true,
@@ -536,11 +606,15 @@ async function loadMissingAssetParts() {
     requestRender();
     return true;
   } catch (error) {
+    await rollback();
+    if (!assetFillOperationIsCurrent(operation, path)) return false;
     await alertDialog('Could not load missing Asset parts:\n\n' + error.message);
     return false;
   } finally {
-    assetFillLoading = false;
-    updateAssetFillButton();
+    if (operation === assetFillEpoch) {
+      assetFillLoading = false;
+      updateAssetFillButton();
+    }
   }
 }
 

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -1,6 +1,7 @@
 // Entry point: wires the toolbar and orchestrates model loading.
 
-import { fitTo, resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
+import { adoptModelMeshes, fitTo, forgetModelMeshes, resetView,
+         rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
          toggleGrid, toggleTrackballGizmo,
          getEnvironmentPreset, getLightMode, isRendererAvailable, rendererReady,
          setEnvironmentPreset, setLightMode, getRenderCount } from './scene.js';
@@ -508,6 +509,7 @@ async function loadMissingAssetParts() {
     for (const [key, uri] of Object.entries(payload.textures || {})) {
       if (addTexture(key, uri)) assetFillTextureKeys.add(key);
     }
+    const before = new Set(activeMeshes);
     appendMeshPanel(
       payload.meshes || {}, null,
       {}, payload.metadata?.material_profiles || {}, {
@@ -515,8 +517,13 @@ async function loadMissingAssetParts() {
         texturePools: payload.texture_pools || {},
         readOnlySource: true,
       });
+    const addedMeshes = activeMeshes.filter(mesh => !before.has(mesh));
+    adoptModelMeshes(addedMeshes);
     assetFillLoaded = true;
-    fitTo(activeMeshes, { preserveCamera: true });
+    fitTo(activeMeshes, {
+      preserveCamera: true,
+      preserveHomeView: true,
+    });
     requestRender();
     return true;
   } catch (error) {
@@ -535,7 +542,8 @@ async function removeMissingAssetParts() {
   try {
     const result = await window.pywebview.api.remove_missing_asset_parts(currentModPath);
     if (result?.status === 'error') throw new Error(result.error);
-    removeAssetFillMeshPanel();
+    const removedMeshes = removeAssetFillMeshPanel();
+    forgetModelMeshes(removedMeshes);
     removeTextures(assetFillTextureKeys);
     assetFillTextureKeys = new Set();
     assetFillLoaded = false;

--- a/src/web/js/mesh-factory.js
+++ b/src/web/js/mesh-factory.js
@@ -58,6 +58,22 @@ export function addTexture(key, uri) {
   return true;
 }
 
+export function removeTextures(keys) {
+  let removed = 0;
+  for (const key of keys || []) {
+    if (!Object.hasOwn(registry, key)) continue;
+    delete registry[key];
+    disposeTexture(loaders[key]);
+    delete loaders[key];
+    readyTextures.delete(key);
+    failedTextures.delete(key);
+    nativeDDSFallbacks.delete(key);
+    textureUsers.delete(key);
+    removed += 1;
+  }
+  return removed;
+}
+
 export function hasTexture(key) {
   return !!(splitTextureKey(key) && registry[key]
     && !failedTextures.has(key));

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -4,7 +4,7 @@
 
 import { buildMesh, hasTexture } from './mesh-factory.js';
 import {
-  activeMeshes, addMesh, applyMeshVisibility, conditionsSatisfied,
+  activeMeshes, addMesh, applyMeshVisibility, conditionsSatisfied, removeMesh,
   setManualTexOverride,
 } from './mesh-state.js';
 import {
@@ -13,7 +13,7 @@ import {
 import { bindMeshView, getMeshView } from './mesh-view-bindings.js';
 import { registerViewSync } from './view-sync.js';
 import { buildSourceSection, groupKeysBySource, usesSourceSections } from './panel-utils.js';
-import { selectMesh } from './selection.js';
+import { clearSelection, selectMesh } from './selection.js';
 import { openTextureModal } from './texture-modal.js';
 import { registerInspectorMesh } from './inspector-panel.js';
 import { createIcon } from './ui-icons.js';
@@ -285,9 +285,18 @@ function buildDrawRow(name, groupName, entry, mesh, itemCbs, masterCb) {
  * open the native file picker rooted at the mod folder. */
 export function buildMeshPanel(meshes, modPath, meshNames = {},
                                materialProfiles = {}, options = {}) {
+  return appendMeshPanel(meshes, modPath, meshNames, materialProfiles,
+    {...options, replace: true});
+}
+
+export function appendMeshPanel(meshes, modPath, meshNames = {},
+                                materialProfiles = {}, options = {}) {
   const list = document.getElementById('mesh-list');
-  list.innerHTML = '';
-  groupsUI = [];
+  const replace = options.replace !== false;
+  if (replace) {
+    list.innerHTML = '';
+    groupsUI = [];
+  }
   registerViewSync('mesh-panel', syncMeshPanel);
   const texturePools = options.texturePools || {};
   const readOnlySource = options.readOnlySource === true;
@@ -302,6 +311,8 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
     const container = (multiSource && src) ? buildSourceSection(src, list, {
       headerClass: 'mesh-src-hdr', itemsClass: 'mesh-src-items',
     }) : list;
+    const sourceHeader = container === list
+      ? null : container.previousElementSibling;
 
     for (const [groupName, names] of Object.entries(groupByComponent(bySource[src], meshes))) {
       const itemsWrap = document.createElement('div');
@@ -409,6 +420,7 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
           || entry.display_name || null;
         mesh.userData.meshNames = meshNames;
         mesh.userData.modPath = modPath;
+        mesh.userData.assetFill = entry.asset_fill === true;
         // Diagnostic-only projection. Operational identity remains the
         // existing semantic key and component grouping.
         mesh.userData.assetEntry = meshes[name];
@@ -468,6 +480,11 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
       groupsUI.push({
         masterCb, itemCbs, itemObjs,
         componentDescriptor,
+        header: componentDescriptor.header,
+        itemsWrap,
+        sourceContainer: container === list ? null : container,
+        sourceHeader,
+        assetFill: names.every(name => meshes[name]?.asset_fill === true),
         assetResolution: options.assetResolution || null,
         applyTextureRuns: () => recomputeTextureRuns(itemObjs),
       });
@@ -476,6 +493,31 @@ export function buildMeshPanel(meshes, modPath, meshNames = {},
 
   document.getElementById('camera-panel').style.display = 'none';
   return activeMeshes;
+}
+
+export function removeAssetFillMeshPanel() {
+  const groups = groupsUI.filter(group => group.assetFill);
+  if (!groups.length) return 0;
+  clearSelection();
+  let removed = 0;
+  for (const group of groups) {
+    group.itemObjs.forEach(mesh => {
+      if (removeMesh(mesh)) removed += 1;
+    });
+    group.header?.remove();
+    group.itemsWrap?.remove();
+  }
+  groupsUI = groupsUI.filter(group => !group.assetFill);
+  for (const source of new Set(groups.map(group => group.sourceContainer).filter(Boolean))) {
+    if (!source.children.length) {
+      source.previousElementSibling?.remove();
+      source.remove();
+    }
+  }
+  window.dispatchEvent(new CustomEvent('mod-viewer-inspector-refresh', {
+    detail: { component: null, reason: 'asset-fill-removed' },
+  }));
+  return removed;
 }
 
 export function refreshMeshAssetDiagnostics(assetResolution = undefined) {

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -522,6 +522,7 @@ export function removeAssetFillMeshPanel() {
 
 export function refreshMeshAssetDiagnostics(assetResolution = undefined) {
   for (const group of groupsUI) {
+    if (group.assetFill) continue;
     if (assetResolution !== undefined) {
       group.assetResolution = assetResolution;
       group.componentDescriptor.assetResolution = assetResolution;

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -497,12 +497,12 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
 
 export function removeAssetFillMeshPanel() {
   const groups = groupsUI.filter(group => group.assetFill);
-  if (!groups.length) return 0;
+  if (!groups.length) return [];
   clearSelection();
-  let removed = 0;
+  const removed = [];
   for (const group of groups) {
     group.itemObjs.forEach(mesh => {
-      if (removeMesh(mesh)) removed += 1;
+      if (removeMesh(mesh)) removed.push(mesh);
     });
     group.header?.remove();
     group.itemsWrap?.remove();

--- a/src/web/js/mesh-panel.js
+++ b/src/web/js/mesh-panel.js
@@ -495,19 +495,34 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
   return activeMeshes;
 }
 
-export function removeAssetFillMeshPanel() {
-  const groups = groupsUI.filter(group => group.assetFill);
+export function removeAssetFillMeshPanel(targetMeshes = null) {
+  const target = targetMeshes === null ? null : new Set(targetMeshes);
+  const groups = groupsUI.filter(group => group.assetFill
+    && (!target || group.itemObjs.some(mesh => target.has(mesh))));
   if (!groups.length) return [];
   clearSelection();
   const removed = [];
   for (const group of groups) {
-    group.itemObjs.forEach(mesh => {
+    const members = target
+      ? group.itemObjs.filter(mesh => target.has(mesh))
+      : [...group.itemObjs];
+    members.forEach(mesh => {
+      mesh.userData.assetRow?.closest('.draw-item-wrap')?.remove();
       if (removeMesh(mesh)) removed.push(mesh);
+      const index = group.itemObjs.indexOf(mesh);
+      if (index >= 0) {
+        group.itemObjs.splice(index, 1);
+        group.itemCbs.splice(index, 1);
+      }
     });
-    group.header?.remove();
-    group.itemsWrap?.remove();
+    if (!group.itemObjs.length) {
+      group.header?.remove();
+      group.itemsWrap?.remove();
+    } else {
+      group.applyTextureRuns?.();
+    }
   }
-  groupsUI = groupsUI.filter(group => !group.assetFill);
+  groupsUI = groupsUI.filter(group => !group.assetFill || group.itemObjs.length);
   for (const source of new Set(groups.map(group => group.sourceContainer).filter(Boolean))) {
     if (!source.children.length) {
       source.previousElementSibling?.remove();

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -50,6 +50,31 @@ export function addMesh(mesh, conditions, sources, textureVariants, materialVari
   applyTextureVariant(mesh);
 }
 
+export function removeMesh(mesh) {
+  if (!mesh) return false;
+  const index = activeMeshes.indexOf(mesh);
+  if (index < 0) return false;
+  detachOutline(mesh);
+  scene.remove(mesh);
+  mesh.geometry?.dispose?.();
+  const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+  materials.forEach(material => {
+    disposeGameMaterial(material);
+    material?.dispose?.();
+  });
+  activeMeshes.splice(index, 1);
+  return true;
+}
+
+export function removeAssetFillMeshes() {
+  const removed = activeMeshes
+    .filter(mesh => mesh.userData.assetFill === true)
+    .slice();
+  removed.forEach(removeMesh);
+  if (removed.length) requestRender();
+  return removed.length;
+}
+
 export function resetMeshVisibility() {
   activeMeshes.forEach(mesh => {
     mesh.userData.manualVisible = mesh.userData.loadedVisible !== false;

--- a/src/web/js/mesh-state.js
+++ b/src/web/js/mesh-state.js
@@ -88,10 +88,12 @@ export function resetMeshVisibility() {
 /** Replace draw visibility and texture semantics on the existing meshes. */
 export function updateMeshSemantics(semantics) {
   const next = semantics || {};
-  const keys = activeMeshes.map(mesh => mesh.userData.semanticKey);
+  const semanticMeshes = activeMeshes.filter(
+    mesh => mesh.userData.assetFill !== true);
+  const keys = semanticMeshes.map(mesh => mesh.userData.semanticKey);
   if (keys.some(key => !next[key])
       || Object.keys(next).length !== keys.length) return false;
-  activeMeshes.forEach(mesh => {
+  semanticMeshes.forEach(mesh => {
     const semantic = next[mesh.userData.semanticKey];
     mesh.userData.conditions = semantic.conditions || [];
     mesh.userData.sources = semantic.sources || [];

--- a/src/web/js/scene.js
+++ b/src/web/js/scene.js
@@ -233,8 +233,19 @@ export function resetView() {
   requestRender();
 }
 
+export function adoptModelMeshes(meshes = []) {
+  const adopted = cameraFrame.adoptModelMeshes(meshes);
+  requestRender();
+  return adopted;
+}
+
 export function fitTo(meshes, options) {
   cameraFrame.fitTo(meshes, options);
+  requestRender();
+}
+
+export function forgetModelMeshes(meshes = []) {
+  cameraFrame.forgetModelMeshes(meshes);
   requestRender();
 }
 

--- a/src/web/js/visibility.js
+++ b/src/web/js/visibility.js
@@ -15,7 +15,8 @@ import { clearViewSyncs, syncView, syncViews } from './view-sync.js';
 
 export {
   activeMeshes, addMesh, applyMeshVisibility, conditionsSatisfied,
-  setManualTexOverride, updateMeshSemantics,
+  removeAssetFillMeshes, removeMesh, setManualTexOverride,
+  updateMeshSemantics,
 } from './mesh-state.js';
 
 export const setToggleValue = setControlValue;


### PR DESCRIPTION
## Summary
- Add an explicit MESHES-panel action to load Asset parts not covered by the active mod.
- Derive coverage from all authored INI documents and resolve only unique indexed Asset candidates.
- Append selectively loaded geometry and textures with a session-only remove action.
- Add backend, loader, transport, and browser regression coverage.