### PR TITLE
Align GIMI face Asset geometry

### DIFF
--- a/context.md
+++ b/context.md
@@ -183,6 +183,14 @@ machine-specific paths or facts that are obvious from the source.
   or switch without modifying the mod or Asset.
 - Direct Asset geometry retains Asset/component/range provenance so later
   mod/Asset composition can compare coverage without reparsing viewer labels.
+- GIMI face geometry may be head-local. When native full-body Eyes and a
+  usable Face/FaceEye anchor are available, the Asset adapter may derive one
+  geometry-based rigid face-to-character transform and apply it to local face
+  components before payload construction; native Eyes remain untransformed.
+  Alignment transforms positions and authored normals together, preserve UVs
+  and triangle winding, and use no character-specific offsets. Selective Asset
+  loading may read Eyes and FaceEye as alignment dependencies without emitting
+  them unless independently selected.
 - Direct Asset UVs are canonical viewer-space Float32 UVs (V is flipped exactly
   once). GIMI/ZZMI index ranges resolve against parsed IB header identity;
   WWMI metadata offsets remain provenance while `Component N.fmt/.vb/.ib`

--- a/src/app/asset_loader/gimi_face_alignment.py
+++ b/src/app/asset_loader/gimi_face_alignment.py
@@ -325,20 +325,9 @@ def _sample_points(points, limit=256):
                  for index in range(limit))
 
 
-def _split_near_eye(points, centers, radius):
-    groups = [[], []]
-    for point in points:
-        distances = [_length(_sub(point, center)) for center in centers]
-        side = 0 if distances[0] <= distances[1] else 1
-        if distances[side] <= radius:
-            groups[side].append(point)
-    return tuple(_sample_points(group) for group in groups)
-
-
-def _cluster_extent(groups, centers):
-    return max((_length(_sub(point, centers[index]))
-                for index, group in enumerate(groups) for point in group),
-               default=0.0)
+def _projected_half_span(points, center, axis):
+    values = [_dot(_sub(point, center), axis) for point in points]
+    return ((max(values) - min(values)) * 0.5) if values else 0.0
 
 
 def _trimmed_surface_error(face_groups, body_groups, matrix):
@@ -358,37 +347,46 @@ def _trimmed_surface_error(face_groups, body_groups, matrix):
 
 
 def _fit_eye_surface_offset(face_points, body_points, matrix,
-                            target_v, target_f, separation, *,
-                            face_centers=None, body_centers=None,
-                            body_groups=None):
+                            target_h, target_v, target_f, separation, *,
+                            body_centers=None, body_groups=None):
     """Fit corresponding eye surfaces with bounded up/forward translations."""
     if (not face_points or len(body_points) < 2
             or separation <= _EPSILON):
         return matrix, 0.0
-    if face_centers is None or body_centers is None or body_groups is None:
-        face_groups = (tuple(face_points),)
-        reference_groups = (tuple(body_points),)
-    else:
-        face_radius = max(separation * 0.45, _EPSILON)
-        face_groups = _split_near_eye(
-            face_points, face_centers, face_radius)
-        reference_groups = tuple(_sample_points(group) for group in body_groups)
-        if any(not group for group in face_groups + reference_groups):
+    if body_centers is None or body_groups is None:
+        return matrix, 0.0
+    scales = []
+    for center, group in zip(body_centers, body_groups):
+        if not group:
             return matrix, 0.0
+        half_h = _projected_half_span(group, center, target_h)
+        half_v = _projected_half_span(group, center, target_v)
+        scales.append((half_h + half_v) * 0.5)
+    if not scales:
+        return matrix, 0.0
+    eye_scale = sum(scales) / len(scales)
+    if eye_scale <= _EPSILON:
+        return matrix, 0.0
+
+    selection_radius = eye_scale * 2.0
+    selected = [[], []]
+    for point in face_points:
+        aligned = transform_point(matrix, point)
+        distances = [_length(_sub(aligned, center))
+                     for center in body_centers]
+        side = 0 if distances[0] <= distances[1] else 1
+        if distances[side] <= selection_radius:
+            selected[side].append(point)
+    if min(len(group) for group in selected) < 24:
+        return matrix, 0.0
+
+    face_groups = tuple(_sample_points(group) for group in selected)
+    reference_groups = tuple(_sample_points(group) for group in body_groups)
     baseline = _trimmed_surface_error(face_groups, reference_groups, matrix)
     if baseline is None or baseline <= _EPSILON:
         return matrix, 0.0
-    if face_centers is None or body_centers is None:
-        eye_scale = separation * 0.05
-    else:
-        eye_scale = max(
-            _cluster_extent(face_groups, face_centers),
-            _cluster_extent(reference_groups, body_centers),
-            separation * 0.04)
-    up_range = min(max(eye_scale * 1.5, separation * 0.05),
-                   separation * 0.30)
-    forward_range = min(max(eye_scale, separation * 0.05),
-                         separation * 0.30)
+    up_range = 1.5 * eye_scale
+    forward_range = 0.75 * eye_scale
     base_translation = (matrix[0][3], matrix[1][3], matrix[2][3])
     best_error = baseline
     best_matrix = matrix
@@ -503,9 +501,9 @@ def solve(body_eyes, face_anchor, landmark=None, *, landmark_kind=None,
     face_points = _clean_points(face_anchor.positions)
     if refine:
         matrix, refinement = _fit_eye_surface_offset(
-            face_points, body_points, matrix, target_v, target_f,
-            body_separation, face_centers=(left_center, right_center),
-            body_centers=body_centers, body_groups=body_groups)
+            face_points, body_points, matrix, target_h, target_v, target_f,
+            body_separation, body_centers=body_centers,
+            body_groups=body_groups)
     return GimiFaceAlignment(matrix, {
         "body_eye_separation": body_separation,
         "face_eye_separation": _length(_sub(right_center, left_center)),

--- a/src/app/asset_loader/gimi_face_alignment.py
+++ b/src/app/asset_loader/gimi_face_alignment.py
@@ -1,0 +1,482 @@
+"""Geometry-only alignment for GIMI face parts.
+
+GIMI exports can contain face parts in a head-local frame while the exported
+Eyes mesh is already in character space.  This module deliberately knows
+nothing about Asset records or rendering; it only derives and applies a rigid
+transform from the two pieces of geometry.
+"""
+
+from dataclasses import dataclass
+import math
+import struct
+
+
+Vec3 = tuple[float, float, float]
+Matrix4 = tuple[
+    tuple[float, float, float, float],
+    tuple[float, float, float, float],
+    tuple[float, float, float, float],
+    tuple[float, float, float, float],
+]
+
+_EPSILON = 1e-8
+_MIN_LOOP_VERTICES = 8
+_MAX_SEPARATION_ERROR = 0.25
+_MIN_AXIS_DOMINANCE = 0.90
+
+
+@dataclass(frozen=True, slots=True)
+class AlignmentMesh:
+    name: str
+    positions: tuple[Vec3, ...]
+    indices: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class GimiFaceAlignment:
+    matrix: Matrix4
+    diagnostics: dict
+
+
+def _finite_vec(value):
+    try:
+        return (len(value) == 3 and
+                all(isinstance(item, (int, float)) and math.isfinite(item)
+                    for item in value))
+    except TypeError:
+        return False
+
+
+def _sub(left, right):
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def _add(left, right):
+    return (left[0] + right[0], left[1] + right[1], left[2] + right[2])
+
+
+def _scale(value, factor):
+    return (value[0] * factor, value[1] * factor, value[2] * factor)
+
+
+def _dot(left, right):
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def _cross(left, right):
+    return (left[1] * right[2] - left[2] * right[1],
+            left[2] * right[0] - left[0] * right[2],
+            left[0] * right[1] - left[1] * right[0])
+
+
+def _length(value):
+    return math.sqrt(_dot(value, value))
+
+
+def _normalize(value):
+    length = _length(value)
+    if length <= _EPSILON or not math.isfinite(length):
+        return None
+    return _scale(value, 1.0 / length)
+
+
+def _mean(points):
+    if not points:
+        return None
+    total = (0.0, 0.0, 0.0)
+    for point in points:
+        total = _add(total, point)
+    return _scale(total, 1.0 / len(points))
+
+
+def _clean_points(positions):
+    result = []
+    for point in positions or ():
+        if _finite_vec(point):
+            result.append(tuple(float(item) for item in point))
+    return result
+
+
+def _initial_eye_centers(points):
+    """Choose deterministic far-apart initial centers without O(n squared)."""
+    candidates = []
+    for axis in range(3):
+        low = min(range(len(points)), key=lambda index: points[index][axis])
+        high = max(range(len(points)), key=lambda index: points[index][axis])
+        candidates.extend((low, high))
+    pair = max(
+        ((left, right) for left in set(candidates)
+         for right in set(candidates) if left != right),
+        key=lambda item: _length(_sub(points[item[0]], points[item[1]])),
+        default=None,
+    )
+    if pair is None:
+        return None
+    return points[pair[0]], points[pair[1]]
+
+
+def find_two_eye_centers(positions):
+    """Return the consistently ordered centers of two point clusters.
+
+    The largest geometric span seeds a deterministic two-means fit.  Centers
+    are ordered along their dominant separation axis, which gives callers a
+    stable left-to-right bilateral axis without relying on vertex order.
+    """
+    points = _clean_points(positions)
+    if len(points) < 4:
+        return None
+    centers = _initial_eye_centers(points)
+    if centers is None:
+        return None
+    centers = [centers[0], centers[1]]
+    groups = ((), ())
+    for _ in range(32):
+        grouped = [[], []]
+        for point in points:
+            distances = [_dot(_sub(point, center), _sub(point, center))
+                         for center in centers]
+            grouped[0 if distances[0] <= distances[1] else 1].append(point)
+        if not all(grouped):
+            return None
+        updated = [_mean(group) for group in grouped]
+        if updated == centers:
+            groups = (tuple(grouped[0]), tuple(grouped[1]))
+            break
+        centers = updated
+        groups = (tuple(grouped[0]), tuple(grouped[1]))
+    else:
+        groups = (tuple(grouped[0]), tuple(grouped[1]))
+    if min(len(group) for group in groups) < 2:
+        return None
+    separation = _sub(centers[1], centers[0])
+    if _length(separation) <= _EPSILON:
+        return None
+    axis = max(range(3), key=lambda index: abs(separation[index]))
+    ordered = sorted(centers, key=lambda value: value[axis])
+    return tuple(ordered)
+
+
+def _boundary_components(mesh):
+    """Return closed triangle-boundary components as vertex-index tuples."""
+    positions = mesh.positions
+    edge_counts = {}
+    for offset in range(0, len(mesh.indices) - 2, 3):
+        triangle = mesh.indices[offset:offset + 3]
+        if (len(triangle) != 3 or any(
+                not isinstance(item, int) or item < 0 or item >= len(positions)
+                for item in triangle) or len(set(triangle)) != 3):
+            continue
+        for left, right in ((triangle[0], triangle[1]),
+                            (triangle[1], triangle[2]),
+                            (triangle[2], triangle[0])):
+            edge = (min(left, right), max(left, right))
+            edge_counts[edge] = edge_counts.get(edge, 0) + 1
+    adjacency = {}
+    for (left, right), count in edge_counts.items():
+        if count != 1:
+            continue
+        adjacency.setdefault(left, set()).add(right)
+        adjacency.setdefault(right, set()).add(left)
+    components = []
+    remaining = set(adjacency)
+    while remaining:
+        start = min(remaining)
+        stack = [start]
+        component = set()
+        while stack:
+            current = stack.pop()
+            if current in component:
+                continue
+            component.add(current)
+            remaining.discard(current)
+            stack.extend(adjacency.get(current, ()) - component)
+        if (len(component) >= _MIN_LOOP_VERTICES and
+                all(len(adjacency.get(item, ())) == 2 for item in component)):
+            components.append(tuple(sorted(component)))
+    return tuple(components)
+
+
+def _component_centroid(mesh, component):
+    return _mean([mesh.positions[index] for index in component])
+
+
+def _dominant_axis(value):
+    length = _length(value)
+    if length <= _EPSILON:
+        return None, 0.0
+    axis = max(range(3), key=lambda index: abs(value[index]))
+    return axis, abs(value[axis]) / length
+
+
+def _select_eye_loop_pair(mesh, body_separation=None):
+    components = _boundary_components(mesh)
+    centers = [(component, _component_centroid(mesh, component))
+               for component in components]
+    candidates = []
+    for left_index, (left_component, left_center) in enumerate(centers):
+        for right_component, right_center in centers[left_index + 1:]:
+            separation = _sub(right_center, left_center)
+            distance = _length(separation)
+            axis, dominance = _dominant_axis(separation)
+            if axis is None or dominance < _MIN_AXIS_DOMINANCE:
+                continue
+            error = (abs(distance - body_separation) / body_separation
+                     if body_separation and body_separation > _EPSILON else 0.0)
+            if body_separation and error > _MAX_SEPARATION_ERROR:
+                continue
+            candidates.append((error, -distance, left_component,
+                               right_component, left_center, right_center))
+    if not candidates:
+        return None
+    _, _, first_component, second_component, first_center, second_center = min(
+        candidates, key=lambda item: item[:2])
+    axis, _ = _dominant_axis(_sub(second_center, first_center))
+    if first_center[axis] <= second_center[axis]:
+        return ((first_component, first_center),
+                (second_component, second_center))
+    return ((second_component, second_center),
+            (first_component, first_center))
+
+
+def _area_weighted_normal(mesh):
+    total = (0.0, 0.0, 0.0)
+    valid = 0
+    for offset in range(0, len(mesh.indices) - 2, 3):
+        triangle = mesh.indices[offset:offset + 3]
+        if (len(triangle) != 3 or any(
+                not isinstance(item, int) or item < 0 or item >= len(mesh.positions)
+                for item in triangle)):
+            continue
+        first, second, third = (mesh.positions[item] for item in triangle)
+        cross = _cross(_sub(second, first), _sub(third, first))
+        if _length(cross) <= _EPSILON:
+            continue
+        total = _add(total, cross)
+        valid += 1
+    return _normalize(total) if valid else None
+
+
+def _basis_rotation(source_basis, target_basis):
+    """Return R = target_basis @ transpose(source_basis)."""
+    rotation = tuple(
+        tuple(sum(target_basis[basis][row] * source_basis[basis][column]
+                  for basis in range(3)) for column in range(3))
+        for row in range(3))
+    return rotation
+
+
+def _determinant(rotation):
+    a, b, c = rotation
+    return (a[0] * (b[1] * c[2] - b[2] * c[1])
+            - a[1] * (b[0] * c[2] - b[2] * c[0])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]))
+
+
+def _rotation_point(rotation, point):
+    return tuple(sum(rotation[row][column] * point[column]
+                     for column in range(3)) for row in range(3))
+
+
+def _matrix(rotation, translation):
+    return (
+        (rotation[0][0], rotation[0][1], rotation[0][2], translation[0]),
+        (rotation[1][0], rotation[1][1], rotation[1][2], translation[1]),
+        (rotation[2][0], rotation[2][1], rotation[2][2], translation[2]),
+        (0.0, 0.0, 0.0, 1.0),
+    )
+
+
+def transform_point(matrix, point):
+    """Apply a row-major homogeneous matrix to one point."""
+    return (
+        matrix[0][0] * point[0] + matrix[0][1] * point[1]
+        + matrix[0][2] * point[2] + matrix[0][3],
+        matrix[1][0] * point[0] + matrix[1][1] * point[1]
+        + matrix[1][2] * point[2] + matrix[1][3],
+        matrix[2][0] * point[0] + matrix[2][1] * point[1]
+        + matrix[2][2] * point[2] + matrix[2][3],
+    )
+
+
+def _with_translation(matrix, translation):
+    return (matrix[0][:3] + (translation[0],),
+            matrix[1][:3] + (translation[1],),
+            matrix[2][:3] + (translation[2],),
+            matrix[3])
+
+
+def _trimmed_surface_error(face_points, body_points, matrix):
+    distances = []
+    for point in face_points:
+        transformed = transform_point(matrix, point)
+        nearest = min((_length(_sub(transformed, candidate))
+                       for candidate in body_points), default=None)
+        if nearest is not None and math.isfinite(nearest):
+            distances.append(nearest * nearest)
+    if not distances:
+        return None
+    distances.sort()
+    keep = max(1, int(math.ceil(len(distances) * 0.8)))
+    return sum(distances[:keep]) / keep
+
+
+def _fit_eye_surface_offset(face_points, body_points, matrix,
+                            target_v, target_f, separation):
+    """Try a bounded up/forward-only refinement and return its diagnostics."""
+    if not face_points or len(body_points) < 2 or separation <= _EPSILON:
+        return matrix, 0.0
+    baseline = _trimmed_surface_error(face_points, body_points, matrix)
+    if baseline is None or baseline <= _EPSILON:
+        return matrix, 0.0
+    extent = max(separation * 0.15, 1e-5)
+    candidates = []
+    for up_step in (-1.0, -0.5, 0.0, 0.5, 1.0):
+        for forward_step in (-1.0, -0.5, 0.0, 0.5, 1.0):
+            offset = _add(_scale(target_v, up_step * extent),
+                          _scale(target_f, forward_step * extent))
+            candidate = _with_translation(
+                matrix, _add((matrix[0][3], matrix[1][3], matrix[2][3]),
+                             offset))
+            error = _trimmed_surface_error(face_points, body_points, candidate)
+            if error is not None:
+                candidates.append((error, candidate))
+    if not candidates:
+        return matrix, 0.0
+    best_error, best_matrix = min(candidates, key=lambda item: item[0])
+    improvement = (baseline - best_error) / baseline
+    return (best_matrix if improvement >= 0.02 else matrix), improvement
+
+
+def solve(body_eyes, face_anchor, landmark=None, *, refine=True):
+    """Derive one conservative rigid face-to-character alignment.
+
+    ``body_eyes`` supplies the target eye centers and ``face_anchor`` supplies
+    the source eye boundary loops and authored winding.  ``landmark`` is
+    preferably Brow/Eyebrow and otherwise Mouth; it is only used to resolve
+    the source frame's 180-degree roll ambiguity.
+    """
+    body_points = _clean_points(body_eyes.positions if body_eyes else ())
+    if not body_points or not face_anchor:
+        return None
+    if not all(_finite_vec(point) for point in face_anchor.positions):
+        return None
+    body_centers = find_two_eye_centers(body_points)
+    if body_centers is None:
+        return None
+    body_separation_vector = _sub(body_centers[1], body_centers[0])
+    body_separation = _length(body_separation_vector)
+    if body_separation <= _EPSILON:
+        return None
+    pair = _select_eye_loop_pair(face_anchor, body_separation)
+    if pair is None:
+        return None
+    (left_loop, left_center), (right_loop, right_center) = pair
+    source_h = _normalize(_sub(right_center, left_center))
+    if source_h is None:
+        return None
+    source_f = _area_weighted_normal(face_anchor)
+    if source_f is None:
+        return None
+    source_f = _normalize(_sub(source_f, _scale(source_h,
+                                                _dot(source_f, source_h))))
+    if source_f is None:
+        return None
+    source_v = _normalize(_cross(source_f, source_h))
+    if source_v is None:
+        return None
+
+    landmark_points = _clean_points(landmark.positions if landmark else ())
+    eye_midpoint = _scale(_add(left_center, right_center), 0.5)
+    if landmark_points:
+        landmark_relative = _sub(_mean(landmark_points), eye_midpoint)
+        landmark_height = _dot(landmark_relative, source_v)
+        is_brow = "brow" in str(getattr(landmark, "name", "")).casefold()
+        if ((is_brow and landmark_height < -_EPSILON)
+                or (not is_brow and landmark_height > _EPSILON)):
+            source_h = _scale(source_h, -1.0)
+            source_v = _scale(source_v, -1.0)
+
+    target_h = _normalize(body_separation_vector)
+    target_v = (0.0, 1.0, 0.0)
+    target_f = _normalize(_cross(target_h, target_v))
+    if target_f is None:
+        return None
+    source_basis = (source_h, source_v, source_f)
+    target_basis = (target_h, target_v, target_f)
+    rotation = _basis_rotation(source_basis, target_basis)
+    determinant = _determinant(rotation)
+    if not math.isfinite(determinant) or abs(determinant - 1.0) > 1e-4:
+        return None
+    rotated_midpoint = _rotation_point(rotation, eye_midpoint)
+    body_midpoint = _scale(_add(body_centers[0], body_centers[1]), 0.5)
+    matrix = _matrix(rotation, _sub(body_midpoint, rotated_midpoint))
+
+    refinement = 0.0
+    loop_points = [face_anchor.positions[index]
+                   for index in (*left_loop, *right_loop)]
+    if refine:
+        matrix, refinement = _fit_eye_surface_offset(
+            loop_points, body_points, matrix, target_v, target_f,
+            body_separation)
+    return GimiFaceAlignment(matrix, {
+        "body_eye_separation": body_separation,
+        "face_eye_separation": _length(_sub(right_center, left_center)),
+        "rotation_determinant": determinant,
+        "surface_fit_improvement": refinement,
+    })
+
+
+def solve_face_alignment(body_eyes, face_anchor, landmark=None, *, refine=True):
+    """Descriptive alias for callers outside the geometry module."""
+    return solve(body_eyes, face_anchor, landmark, refine=refine)
+
+
+def unpack_f32x3(data):
+    """Unpack canonical packed Float32 XYZ data."""
+    if data is None or len(data) % 12:
+        raise ValueError("Packed XYZ data must contain complete Float32 triples.")
+    points = tuple(item for item in struct.iter_unpack("<3f", bytes(data)))
+    if any(not _finite_vec(point) for point in points):
+        raise ValueError("Packed XYZ data contains a non-finite value.")
+    return points
+
+
+def _transform_vectors(data, matrix, *, normalize=False):
+    if data is None:
+        return None
+    points = unpack_f32x3(data)
+    result = bytearray(len(points) * 12)
+    for index, point in enumerate(points):
+        transformed = _rotation_point((
+            matrix[0][:3], matrix[1][:3], matrix[2][:3]), point)
+        if normalize:
+            length = _length(transformed)
+            if length > _EPSILON:
+                transformed = _scale(transformed, 1.0 / length)
+        struct.pack_into("<3f", result, index * 12, *transformed)
+    return bytes(result)
+
+
+def transform_position_bytes(data, matrix):
+    """Transform packed canonical positions, including translation."""
+    if data is None:
+        return None
+    points = unpack_f32x3(data)
+    result = bytearray(len(points) * 12)
+    for index, point in enumerate(points):
+        struct.pack_into("<3f", result, index * 12,
+                         *transform_point(matrix, point))
+    return bytes(result)
+
+
+def transform_normal_bytes(data, matrix):
+    """Rotate packed canonical authored normals without applying translation."""
+    return _transform_vectors(data, matrix, normalize=True)
+
+
+__all__ = [
+    "AlignmentMesh", "GimiFaceAlignment", "Matrix4", "Vec3",
+    "find_two_eye_centers", "solve", "solve_face_alignment",
+    "transform_normal_bytes", "transform_point", "transform_position_bytes",
+    "unpack_f32x3",
+]

--- a/src/app/asset_loader/gimi_face_alignment.py
+++ b/src/app/asset_loader/gimi_face_alignment.py
@@ -115,19 +115,14 @@ def _initial_eye_centers(points):
     return points[pair[0]], points[pair[1]]
 
 
-def find_two_eye_centers(positions):
-    """Return the consistently ordered centers of two point clusters.
-
-    The largest geometric span seeds a deterministic two-means fit.  Centers
-    are ordered along their dominant separation axis, which gives callers a
-    stable left-to-right bilateral axis without relying on vertex order.
-    """
+def _cluster_two_means(positions):
+    """Return ordered two-means centers and their point groups."""
     points = _clean_points(positions)
     if len(points) < 4:
-        return None
+        return None, None
     centers = _initial_eye_centers(points)
     if centers is None:
-        return None
+        return None, None
     centers = [centers[0], centers[1]]
     groups = ((), ())
     for _ in range(32):
@@ -137,7 +132,7 @@ def find_two_eye_centers(positions):
                          for center in centers]
             grouped[0 if distances[0] <= distances[1] else 1].append(point)
         if not all(grouped):
-            return None
+            return None, None
         updated = [_mean(group) for group in grouped]
         if updated == centers:
             groups = (tuple(grouped[0]), tuple(grouped[1]))
@@ -147,13 +142,25 @@ def find_two_eye_centers(positions):
     else:
         groups = (tuple(grouped[0]), tuple(grouped[1]))
     if min(len(group) for group in groups) < 2:
-        return None
+        return None, None
     separation = _sub(centers[1], centers[0])
     if _length(separation) <= _EPSILON:
-        return None
+        return None, None
     axis = max(range(3), key=lambda index: abs(separation[index]))
-    ordered = sorted(centers, key=lambda value: value[axis])
-    return tuple(ordered)
+    order = sorted(range(2), key=lambda index: centers[index][axis])
+    return (tuple(centers[index] for index in order),
+            tuple(groups[index] for index in order))
+
+
+def find_two_eye_centers(positions):
+    """Return the consistently ordered centers of two point clusters.
+
+    The largest geometric span seeds a deterministic two-means fit.  Centers
+    are ordered along their dominant separation axis, which gives callers a
+    stable left-to-right bilateral axis without relying on vertex order.
+    """
+    centers, _groups = _cluster_two_means(positions)
+    return centers
 
 
 def _boundary_components(mesh):
@@ -224,12 +231,18 @@ def _select_eye_loop_pair(mesh, body_separation=None):
                      if body_separation and body_separation > _EPSILON else 0.0)
             if body_separation and error > _MAX_SEPARATION_ERROR:
                 continue
-            candidates.append((error, -distance, left_component,
+            topology_penalty = (abs(len(left_component) - len(right_component))
+                                / max(len(left_component),
+                                      len(right_component)))
+            if topology_penalty > 0.05:
+                continue
+            candidates.append((error + topology_penalty, topology_penalty,
+                               -distance, left_component,
                                right_component, left_center, right_center))
     if not candidates:
         return None
-    _, _, first_component, second_component, first_center, second_center = min(
-        candidates, key=lambda item: item[:2])
+    _, _, _, first_component, second_component, first_center, second_center = min(
+        candidates, key=lambda item: item[:3])
     axis, _ = _dominant_axis(_sub(second_center, first_center))
     if first_center[axis] <= second_center[axis]:
         return ((first_component, first_center),
@@ -305,49 +318,116 @@ def _with_translation(matrix, translation):
             matrix[3])
 
 
-def _trimmed_surface_error(face_points, body_points, matrix):
+def _sample_points(points, limit=256):
+    if len(points) <= limit:
+        return tuple(points)
+    return tuple(points[round(index * (len(points) - 1) / (limit - 1))]
+                 for index in range(limit))
+
+
+def _split_near_eye(points, centers, radius):
+    groups = [[], []]
+    for point in points:
+        distances = [_length(_sub(point, center)) for center in centers]
+        side = 0 if distances[0] <= distances[1] else 1
+        if distances[side] <= radius:
+            groups[side].append(point)
+    return tuple(_sample_points(group) for group in groups)
+
+
+def _cluster_extent(groups, centers):
+    return max((_length(_sub(point, centers[index]))
+                for index, group in enumerate(groups) for point in group),
+               default=0.0)
+
+
+def _trimmed_surface_error(face_groups, body_groups, matrix):
     distances = []
-    for point in face_points:
-        transformed = transform_point(matrix, point)
-        nearest = min((_length(_sub(transformed, candidate))
-                       for candidate in body_points), default=None)
-        if nearest is not None and math.isfinite(nearest):
-            distances.append(nearest * nearest)
+    for face_points, body_points in zip(face_groups, body_groups):
+        for point in face_points:
+            transformed = transform_point(matrix, point)
+            nearest = min((_length(_sub(transformed, candidate))
+                           for candidate in body_points), default=None)
+            if nearest is not None and math.isfinite(nearest):
+                distances.append(nearest * nearest)
     if not distances:
         return None
     distances.sort()
-    keep = max(1, int(math.ceil(len(distances) * 0.8)))
+    keep = max(1, int(math.ceil(len(distances) * 0.7)))
     return sum(distances[:keep]) / keep
 
 
 def _fit_eye_surface_offset(face_points, body_points, matrix,
-                            target_v, target_f, separation):
-    """Try a bounded up/forward-only refinement and return its diagnostics."""
-    if not face_points or len(body_points) < 2 or separation <= _EPSILON:
+                            target_v, target_f, separation, *,
+                            face_centers=None, body_centers=None,
+                            body_groups=None):
+    """Fit corresponding eye surfaces with bounded up/forward translations."""
+    if (not face_points or len(body_points) < 2
+            or separation <= _EPSILON):
         return matrix, 0.0
-    baseline = _trimmed_surface_error(face_points, body_points, matrix)
+    if face_centers is None or body_centers is None or body_groups is None:
+        face_groups = (tuple(face_points),)
+        reference_groups = (tuple(body_points),)
+    else:
+        face_radius = max(separation * 0.45, _EPSILON)
+        face_groups = _split_near_eye(
+            face_points, face_centers, face_radius)
+        reference_groups = tuple(_sample_points(group) for group in body_groups)
+        if any(not group for group in face_groups + reference_groups):
+            return matrix, 0.0
+    baseline = _trimmed_surface_error(face_groups, reference_groups, matrix)
     if baseline is None or baseline <= _EPSILON:
         return matrix, 0.0
-    extent = max(separation * 0.15, 1e-5)
-    candidates = []
-    for up_step in (-1.0, -0.5, 0.0, 0.5, 1.0):
-        for forward_step in (-1.0, -0.5, 0.0, 0.5, 1.0):
-            offset = _add(_scale(target_v, up_step * extent),
-                          _scale(target_f, forward_step * extent))
-            candidate = _with_translation(
-                matrix, _add((matrix[0][3], matrix[1][3], matrix[2][3]),
-                             offset))
-            error = _trimmed_surface_error(face_points, body_points, candidate)
-            if error is not None:
-                candidates.append((error, candidate))
-    if not candidates:
-        return matrix, 0.0
-    best_error, best_matrix = min(candidates, key=lambda item: item[0])
+    if face_centers is None or body_centers is None:
+        eye_scale = separation * 0.05
+    else:
+        eye_scale = max(
+            _cluster_extent(face_groups, face_centers),
+            _cluster_extent(reference_groups, body_centers),
+            separation * 0.04)
+    up_range = min(max(eye_scale * 1.5, separation * 0.05),
+                   separation * 0.30)
+    forward_range = min(max(eye_scale, separation * 0.05),
+                         separation * 0.30)
+    base_translation = (matrix[0][3], matrix[1][3], matrix[2][3])
+    best_error = baseline
+    best_matrix = matrix
+    best_up = 0.0
+    best_forward = 0.0
+
+    def evaluate(up, forward):
+        nonlocal best_error, best_matrix, best_up, best_forward
+        offset = _add(_scale(target_v, up), _scale(target_f, forward))
+        candidate = _with_translation(matrix, _add(base_translation, offset))
+        error = _trimmed_surface_error(face_groups, reference_groups, candidate)
+        if error is not None and error < best_error:
+            best_error = error
+            best_matrix = candidate
+            best_up = up
+            best_forward = forward
+
+    for up_step in range(9):
+        up = (up_step / 4.0 - 1.0) * up_range
+        for forward_step in range(9):
+            forward = (forward_step / 4.0 - 1.0) * forward_range
+            evaluate(up, forward)
+    local_up_range = up_range / 4.0
+    local_forward_range = forward_range / 4.0
+    for _ in range(4):
+        local_up_range /= 2.0
+        local_forward_range /= 2.0
+        for up_step in range(5):
+            up = best_up + (up_step / 2.0 - 1.0) * local_up_range
+            for forward_step in range(5):
+                forward = (best_forward
+                           + (forward_step / 2.0 - 1.0) * local_forward_range)
+                evaluate(up, forward)
     improvement = (baseline - best_error) / baseline
     return (best_matrix if improvement >= 0.02 else matrix), improvement
 
 
-def solve(body_eyes, face_anchor, landmark=None, *, refine=True):
+def solve(body_eyes, face_anchor, landmark=None, *, landmark_kind=None,
+          refine=True):
     """Derive one conservative rigid face-to-character alignment.
 
     ``body_eyes`` supplies the target eye centers and ``face_anchor`` supplies
@@ -360,7 +440,7 @@ def solve(body_eyes, face_anchor, landmark=None, *, refine=True):
         return None
     if not all(_finite_vec(point) for point in face_anchor.positions):
         return None
-    body_centers = find_two_eye_centers(body_points)
+    body_centers, body_groups = _cluster_two_means(body_points)
     if body_centers is None:
         return None
     body_separation_vector = _sub(body_centers[1], body_centers[0])
@@ -390,14 +470,22 @@ def solve(body_eyes, face_anchor, landmark=None, *, refine=True):
     if landmark_points:
         landmark_relative = _sub(_mean(landmark_points), eye_midpoint)
         landmark_height = _dot(landmark_relative, source_v)
-        is_brow = "brow" in str(getattr(landmark, "name", "")).casefold()
+        is_brow = (landmark_kind == "brow" or
+                   (landmark_kind is None and
+                    "brow" in str(getattr(landmark, "name", "")).casefold()))
         if ((is_brow and landmark_height < -_EPSILON)
                 or (not is_brow and landmark_height > _EPSILON)):
             source_h = _scale(source_h, -1.0)
             source_v = _scale(source_v, -1.0)
 
-    target_h = _normalize(body_separation_vector)
     target_v = (0.0, 1.0, 0.0)
+    target_h = _normalize(body_separation_vector)
+    if target_h is None:
+        return None
+    target_h = _normalize(_sub(
+        target_h, _scale(target_v, _dot(target_h, target_v))))
+    if target_h is None:
+        return None
     target_f = _normalize(_cross(target_h, target_v))
     if target_f is None:
         return None
@@ -412,12 +500,12 @@ def solve(body_eyes, face_anchor, landmark=None, *, refine=True):
     matrix = _matrix(rotation, _sub(body_midpoint, rotated_midpoint))
 
     refinement = 0.0
-    loop_points = [face_anchor.positions[index]
-                   for index in (*left_loop, *right_loop)]
+    face_points = _clean_points(face_anchor.positions)
     if refine:
         matrix, refinement = _fit_eye_surface_offset(
-            loop_points, body_points, matrix, target_v, target_f,
-            body_separation)
+            face_points, body_points, matrix, target_v, target_f,
+            body_separation, face_centers=(left_center, right_center),
+            body_centers=body_centers, body_groups=body_groups)
     return GimiFaceAlignment(matrix, {
         "body_eye_separation": body_separation,
         "face_eye_separation": _length(_sub(right_center, left_center)),
@@ -426,9 +514,11 @@ def solve(body_eyes, face_anchor, landmark=None, *, refine=True):
     })
 
 
-def solve_face_alignment(body_eyes, face_anchor, landmark=None, *, refine=True):
+def solve_face_alignment(body_eyes, face_anchor, landmark=None, *,
+                         landmark_kind=None, refine=True):
     """Descriptive alias for callers outside the geometry module."""
-    return solve(body_eyes, face_anchor, landmark, refine=refine)
+    return solve(body_eyes, face_anchor, landmark,
+                 landmark_kind=landmark_kind, refine=refine)
 
 
 def unpack_f32x3(data):

--- a/src/app/asset_loader/hash_asset.py
+++ b/src/app/asset_loader/hash_asset.py
@@ -30,9 +30,6 @@ _TEXTURE_SUFFIXES = (
     ("light_map", "lightmap"),
     ("material_map", "materialmap"),
 )
-_FACE_COMPONENT_NAMES = frozenset({
-    "face", "eye", "mouth", "nose", "brow", "eyebrows",
-})
 
 
 @dataclass(frozen=True, slots=True)
@@ -396,44 +393,65 @@ def _record_name(record):
         f"{record.component_name or ''}{_record_prefix(record)}")
 
 
+def _component_face_kind(value):
+    component = _compact_name(value)
+    exact = {
+        "face": "face", "facemesh": "face", "facehead": "face",
+        "eye": "eye", "eyes": "eyes", "mouth": "mouth",
+        "nose": "nose", "brow": "brow", "eyebrows": "brow",
+    }
+    if component in exact:
+        return exact[component]
+    for prefix, kind in (
+        ("faceeyebrow", "brow"), ("facebrow", "brow"),
+        ("faceeye", "eye"), ("facemouth", "mouth"),
+        ("facenose", "nose"),
+    ):
+        if component.startswith(prefix):
+            return kind
+    return None
+
+
+def _filename_face_kind(record):
+    prefix = _record_prefix(record)
+    for token, kind in (
+        ("faceeyebrow", "brow"), ("facebrow", "brow"),
+        ("faceeye", "eye"), ("facemouth", "mouth"),
+        ("facenose", "nose"),
+    ):
+        if token in prefix:
+            return kind
+    return "face" if "face" in prefix else None
+
+
 def _is_native_eyes_record(record):
-    name = _record_name(record)
-    if "face" in name:
-        return False
     component = _compact_name(record.component_name)
-    return "eyes" in name or component == "eyes"
+    if component:
+        return component == "eyes"
+    return "eyes" in _record_prefix(record)
 
 
 def _is_face_local_record(record):
-    if _is_native_eyes_record(record):
-        return False
     component = _compact_name(record.component_name)
-    name = _record_name(record)
-    return (component in _FACE_COMPONENT_NAMES
-            or any(token in component for token in _FACE_COMPONENT_NAMES)
-            or any(token in name for token in _FACE_COMPONENT_NAMES))
+    if component:
+        return _component_face_kind(component) in {
+            "face", "eye", "mouth", "nose", "brow"
+        }
+    return _filename_face_kind(record) is not None
 
 
 def _is_face_anchor_record(record):
     component = _compact_name(record.component_name)
-    prefix = _record_prefix(record)
-    return ("faceeye" in component or "faceeye" in prefix
-            or component in {"face", "facemesh"}
-            or ("face" in prefix
-                and not any(token in prefix
-                            for token in ("mouth", "brow", "eyebrow", "nose"))))
+    if component:
+        return _component_face_kind(component) in {"face", "eye"}
+    return _filename_face_kind(record) in {"face", "eye"}
 
 
 def _landmark_kind(record):
     component = _compact_name(record.component_name)
-    name = _record_name(record)
-    if "brow" in component or "eyebrow" in component:
-        return "brow"
-    if "brow" in name or "eyebrow" in name:
-        return "brow"
-    if "mouth" in component or "mouth" in name:
-        return "mouth"
-    return None
+    kind = (_component_face_kind(component) if component
+            else _filename_face_kind(record))
+    return kind if kind in {"brow", "mouth"} else None
 
 
 def _reference_score(record):
@@ -462,7 +480,8 @@ def _alignment_vertex(record, vertex_cache):
     return vertex_cache[record.vb_file]
 
 
-def _alignment_mesh(record, vertex_cache, ib_cache, *, with_indices):
+def _alignment_mesh(record, vertex_cache, ib_cache, *, with_indices,
+                    name_override=None):
     vertex_dump = _alignment_vertex(record, vertex_cache)
     if vertex_dump is None:
         return None
@@ -481,7 +500,7 @@ def _alignment_mesh(record, vertex_cache, ib_cache, *, with_indices):
     except ValueError:
         return None
     return gimi_face_alignment.AlignmentMesh(
-        record.component_name or "GIMI alignment", positions,
+        name_override or record.component_name or "GIMI alignment", positions,
         tuple(indices))
 
 
@@ -513,16 +532,19 @@ def _solve_face_alignment(records, vertex_cache, ib_cache):
             if face_mesh is None:
                 continue
             landmark_mesh = None
+            landmark_kind = None
             for kind in ("brow", "mouth"):
                 if not landmarks[kind]:
                     continue
                 landmark_mesh = _alignment_mesh(
                     landmarks[kind][0], vertex_cache, ib_cache,
-                    with_indices=False)
+                    with_indices=False, name_override=kind)
                 if landmark_mesh is not None:
+                    landmark_kind = kind
                     break
             alignment = gimi_face_alignment.solve(
-                body_mesh, face_mesh, landmark_mesh)
+                body_mesh, face_mesh, landmark_mesh,
+                landmark_kind=landmark_kind)
             if alignment is not None:
                 return alignment
     return None

--- a/src/app/asset_loader/hash_asset.py
+++ b/src/app/asset_loader/hash_asset.py
@@ -3,6 +3,7 @@
 import json
 import os
 import re
+from dataclasses import dataclass
 
 from core.geometry_identity import normalize_geometry_hash
 from core.migoto_dump import (MigotoDumpError, pack_indices,
@@ -10,6 +11,7 @@ from core.migoto_dump import (MigotoDumpError, pack_indices,
 from core.textures import normalize_texture_role
 
 from .. import asset_paths
+from . import gimi_face_alignment
 from .models import (AssetAdapterResult, AssetLoadError, AssetMeshPart,
                      make_texture)
 
@@ -28,6 +30,21 @@ _TEXTURE_SUFFIXES = (
     ("light_map", "lightmap"),
     ("material_map", "materialmap"),
 )
+_FACE_COMPONENT_NAMES = frozenset({
+    "face", "eye", "mouth", "nose", "brow", "eyebrows",
+})
+
+
+@dataclass(frozen=True, slots=True)
+class _HashAssetRecord:
+    metadata_path: str
+    entry: dict
+    component_name: str | None
+    geometry_hash: str
+    vb_hash: str | None
+    ranges: tuple
+    vb_file: str | None
+    ib_files: tuple[str, ...]
 
 
 def _entries(value):
@@ -366,6 +383,151 @@ def _filter_matches(part_filter, geometry_hash, first, count, ordinal=None):
     return False
 
 
+def _compact_name(value):
+    return re.sub(r"[^a-z0-9]", "", str(value or "").casefold())
+
+
+def _record_prefix(record):
+    return _compact_name(_dump_prefix(record.vb_file) if record.vb_file else "")
+
+
+def _record_name(record):
+    return _compact_name(
+        f"{record.component_name or ''}{_record_prefix(record)}")
+
+
+def _is_native_eyes_record(record):
+    name = _record_name(record)
+    if "face" in name:
+        return False
+    component = _compact_name(record.component_name)
+    return "eyes" in name or component == "eyes"
+
+
+def _is_face_local_record(record):
+    if _is_native_eyes_record(record):
+        return False
+    component = _compact_name(record.component_name)
+    name = _record_name(record)
+    return (component in _FACE_COMPONENT_NAMES
+            or any(token in component for token in _FACE_COMPONENT_NAMES)
+            or any(token in name for token in _FACE_COMPONENT_NAMES))
+
+
+def _is_face_anchor_record(record):
+    component = _compact_name(record.component_name)
+    prefix = _record_prefix(record)
+    return ("faceeye" in component or "faceeye" in prefix
+            or component in {"face", "facemesh"}
+            or ("face" in prefix
+                and not any(token in prefix
+                            for token in ("mouth", "brow", "eyebrow", "nose"))))
+
+
+def _landmark_kind(record):
+    component = _compact_name(record.component_name)
+    name = _record_name(record)
+    if "brow" in component or "eyebrow" in component:
+        return "brow"
+    if "brow" in name or "eyebrow" in name:
+        return "brow"
+    if "mouth" in component or "mouth" in name:
+        return "mouth"
+    return None
+
+
+def _reference_score(record):
+    name = _record_name(record)
+    component = _compact_name(record.component_name)
+    return (0 if "eyesa" in name else 1,
+            0 if component in {"eye", "eyes"} else 1,
+            name)
+
+
+def _anchor_score(record):
+    name = _record_name(record)
+    component = _compact_name(record.component_name)
+    return (0 if "faceeye" in name else 1 if component == "face" else 2,
+            name)
+
+
+def _alignment_vertex(record, vertex_cache):
+    if not record.vb_file:
+        return None
+    if record.vb_file not in vertex_cache:
+        try:
+            vertex_cache[record.vb_file] = parse_vertex_dump(record.vb_file)
+        except MigotoDumpError:
+            vertex_cache[record.vb_file] = None
+    return vertex_cache[record.vb_file]
+
+
+def _alignment_mesh(record, vertex_cache, ib_cache, *, with_indices):
+    vertex_dump = _alignment_vertex(record, vertex_cache)
+    if vertex_dump is None:
+        return None
+    indices = []
+    if with_indices:
+        for _ordinal, first, count, _classification in record.ranges:
+            resolved, _had_invalid, _had_valid = _resolve_ib_dump(
+                record.ib_files, first, count,
+                vertex_dump.layout.vertex_count, ib_cache)
+            if resolved is not None:
+                indices.extend(resolved[1].indices)
+        if len(indices) < 3:
+            return None
+    try:
+        positions = gimi_face_alignment.unpack_f32x3(vertex_dump.positions)
+    except ValueError:
+        return None
+    return gimi_face_alignment.AlignmentMesh(
+        record.component_name or "GIMI alignment", positions,
+        tuple(indices))
+
+
+def _solve_face_alignment(records, vertex_cache, ib_cache):
+    references = sorted(
+        (record for record in records if _is_native_eyes_record(record)),
+        key=_reference_score)
+    anchors = sorted(
+        (record for record in records if _is_face_anchor_record(record)),
+        key=_anchor_score)
+    if not references or not anchors:
+        return None
+    landmarks = {"brow": [], "mouth": []}
+    for record in records:
+        kind = _landmark_kind(record)
+        if kind:
+            landmarks[kind].append(record)
+    for kind in landmarks:
+        landmarks[kind].sort(key=_anchor_score)
+
+    for reference in references:
+        body_mesh = _alignment_mesh(
+            reference, vertex_cache, ib_cache, with_indices=False)
+        if body_mesh is None:
+            continue
+        for anchor in anchors:
+            face_mesh = _alignment_mesh(
+                anchor, vertex_cache, ib_cache, with_indices=True)
+            if face_mesh is None:
+                continue
+            landmark_mesh = None
+            for kind in ("brow", "mouth"):
+                if not landmarks[kind]:
+                    continue
+                landmark_mesh = _alignment_mesh(
+                    landmarks[kind][0], vertex_cache, ib_cache,
+                    with_indices=False)
+                if landmark_mesh is not None:
+                    break
+            alignment = gimi_face_alignment.solve(
+                body_mesh, face_mesh, landmark_mesh)
+            if alignment is not None:
+                return alignment
+    return None
+
+
 def load_hash_asset(asset_type, root, record, *, texture_source=None,
                     part_filter=None):
     asset_path = record.get("path") if isinstance(record, dict) else None
@@ -386,13 +548,13 @@ def load_hash_asset(asset_type, root, record, *, texture_source=None,
     if not metadata_paths:
         raise AssetLoadError("The indexed hash.json is missing from this Asset.")
     metadata_paths.sort(key=lambda value: (
-        os.path.dirname(value).casefold() != asset_path.casefold(),
+        os.path.dirname(value).casefold() != str(asset_path or "").casefold(),
         value.casefold(), value))
     files = _file_list(asset_dir)
     vb_cache = {}
     ib_cache = {}
-    parts = []
     warnings = []
+    records = []
     for metadata_path in metadata_paths:
         metadata_file = asset_paths.safe_asset_path(root, metadata_path)
         if not metadata_file:
@@ -427,88 +589,138 @@ def load_hash_asset(asset_type, root, record, *, texture_source=None,
                     f"{component or 'Component'} has no usable index-buffer hash."))
                 continue
             ranges = _ranges(entry)
-            selected_ranges = [
-                item for item in ranges
-                if _filter_matches(part_filter, geometry_hash,
-                                   item[1], item[2], item[0])]
-            if not selected_ranges:
-                continue
             vb_hash = _entry_hash(entry, (
                 "vb0", "vb0_hash", "vertex_buffer", "vertexBuffer",
                 "position_vb", "positionVB", "draw_vb", "drawVB"))
-            vb_file = _find_dump(files, "vb", vb_hash, component)
-            if not vb_file:
+            records.append(_HashAssetRecord(
+                metadata_path=metadata_path, entry=entry,
+                component_name=component, geometry_hash=geometry_hash,
+                vb_hash=vb_hash, ranges=tuple(ranges),
+                vb_file=_find_dump(files, "vb", vb_hash, component),
+                ib_files=tuple(_find_dumps(
+                    files, "ib", geometry_hash, component))))
+
+    selected_records = []
+    for item in records:
+        selected_ranges = tuple(
+            value for value in item.ranges
+            if _filter_matches(part_filter, item.geometry_hash,
+                               value[1], value[2], value[0]))
+        if selected_ranges:
+            selected_records.append((item, selected_ranges))
+
+    face_alignment = None
+    face_alignment_warning = False
+    if (asset_type == "GIMI"
+            and any(_is_face_local_record(item)
+                    for item, _ranges_for_output in selected_records)):
+        try:
+            face_alignment = _solve_face_alignment(
+                records, vb_cache, ib_cache)
+        except Exception:
+            # Alignment is an optional compatibility improvement.  A malformed
+            # dependency must not make an otherwise renderable Asset unloadable.
+            face_alignment = None
+        if face_alignment is None:
+            warnings.append(_warning(
+                "Face", None, "face_alignment_unavailable",
+                "GIMI face geometry could not be aligned to the native Eyes component."))
+            face_alignment_warning = True
+
+    parts = []
+    for item, selected_ranges in selected_records:
+        component = item.component_name
+        geometry_hash = item.geometry_hash
+        vb_file = item.vb_file
+        ib_files = item.ib_files
+        if not vb_file:
+            warnings.append(_warning(
+                component, None, "vertex_dump_missing",
+                f"{component or geometry_hash} has no source vertex dump."))
+            continue
+        if not ib_files:
+            warnings.append(_warning(
+                component, None, "index_dump_missing",
+                f"{component or geometry_hash} has no source index dump."))
+            continue
+        try:
+            if vb_file not in vb_cache or vb_cache[vb_file] is None:
+                vb_cache[vb_file] = parse_vertex_dump(vb_file)
+            vertex_dump = vb_cache[vb_file]
+        except MigotoDumpError as error:
+            warnings.append(_warning(
+                component, None, "vertex_dump_invalid",
+                f"{component or geometry_hash} vertex dump skipped: {error}"))
+            continue
+        for ordinal, first, count, classification in selected_ranges:
+            resolved, had_invalid, had_valid = _resolve_ib_dump(
+                ib_files, first, count, vertex_dump.layout.vertex_count,
+                ib_cache)
+            if resolved is None:
+                reason = "index_dump_invalid" if had_invalid and not had_valid \
+                    else "index_range_missing"
+                message = (f"{component or geometry_hash} index dump skipped"
+                           if reason == "index_dump_invalid" else
+                           f"{component or geometry_hash} range {first} has "
+                           "no matching index dump.")
                 warnings.append(_warning(
-                    component, None, "vertex_dump_missing",
-                    f"{component or geometry_hash} has no source vertex dump."))
+                    component, classification, reason, message))
                 continue
-            ib_files = _find_dumps(files, "ib", geometry_hash, component)
-            if not ib_files:
+            _ib_file, ib_dump = resolved
+            selected = ib_dump.indices
+            if len(selected) < 3:
                 warnings.append(_warning(
-                    component, None, "index_dump_missing",
-                    f"{component or geometry_hash} has no source index dump."))
+                    component, classification, "index_range_empty",
+                    f"{component or geometry_hash} range {first} has no complete triangles."))
                 continue
             try:
-                if vb_file not in vb_cache:
-                    vb_cache[vb_file] = parse_vertex_dump(vb_file)
-                vertex_dump = vb_cache[vb_file]
-            except MigotoDumpError as error:
+                positions, normals, uvs, indices = _remap(vertex_dump, selected)
+            except (AssetLoadError, MigotoDumpError) as error:
                 warnings.append(_warning(
-                    component, None, "vertex_dump_invalid",
-                    f"{component or geometry_hash} vertex dump skipped: {error}"))
+                    component, classification, "part_invalid",
+                    f"{component or geometry_hash} part skipped: {error}"))
                 continue
-            for ordinal, first, count, classification in selected_ranges:
-                resolved, had_invalid, had_valid = _resolve_ib_dump(
-                    ib_files, first, count, vertex_dump.layout.vertex_count,
-                    ib_cache)
-                if resolved is None:
-                    reason = "index_dump_invalid" if had_invalid and not had_valid \
-                        else "index_range_missing"
-                    message = (f"{component or geometry_hash} index dump skipped"
-                               if reason == "index_dump_invalid" else
-                               f"{component or geometry_hash} range {first} has "
-                               "no matching index dump.")
-                    warnings.append(_warning(
-                        component, classification, reason, message))
-                    continue
-                _ib_file, ib_dump = resolved
-                selected = ib_dump.indices
-                if len(selected) < 3:
-                    warnings.append(_warning(
-                        component, classification, "index_range_empty",
-                        f"{component or geometry_hash} range {first} has no complete triangles."))
-                    continue
+            if (face_alignment is not None
+                    and _is_face_local_record(item)):
                 try:
-                    positions, normals, uvs, indices = _remap(vertex_dump, selected)
-                except (AssetLoadError, MigotoDumpError) as error:
-                    warnings.append(_warning(
-                        component, classification, "part_invalid",
-                        f"{component or geometry_hash} part skipped: {error}"))
-                    continue
-                effective_count = (
-                    count if count is not None
-                    else ib_dump.index_count or len(ib_dump.indices))
-                textures = _texture_records(
-                    entry, ordinal, files, root, component, classification,
-                    texture_source, ib_candidates=ib_files, first=first,
-                    count=effective_count,
-                    vertex_count=vertex_dump.layout.vertex_count,
-                    ib_cache=ib_cache)
-                label = component or os.path.basename(asset_path)
-                if classification:
-                    label = f"{label} {classification}"
-                if len(ranges) > 1:
-                    label = f"{label} {ordinal + 1}"
-                key = (f"{asset_path}::{metadata_path}::"
-                       f"{component or 'part'}::{geometry_hash}::{ordinal}")
-                parts.append(AssetMeshPart(
-                    key=key, label=label, asset_type=asset_type,
-                    asset_path=asset_path, geometry_hash=geometry_hash,
-                    component_name=component, classification=classification,
-                    component_ordinal=ordinal, first_index=first,
-                    index_count=effective_count, positions=positions,
-                    indices=indices,
-                    uvs=uvs, normals=normals, textures=textures))
+                    aligned_positions = (
+                        gimi_face_alignment.transform_position_bytes(
+                            positions, face_alignment.matrix))
+                    aligned_normals = (
+                        gimi_face_alignment.transform_normal_bytes(
+                            normals, face_alignment.matrix))
+                    positions, normals = aligned_positions, aligned_normals
+                except Exception as error:
+                    if not face_alignment_warning:
+                        warnings.append(_warning(
+                            component, classification,
+                            "face_alignment_failed",
+                            f"GIMI face alignment was skipped: {error}"))
+                        face_alignment_warning = True
+            effective_count = (
+                count if count is not None
+                else ib_dump.index_count or len(ib_dump.indices))
+            textures = _texture_records(
+                item.entry, ordinal, files, root, component, classification,
+                texture_source, ib_candidates=ib_files, first=first,
+                count=effective_count,
+                vertex_count=vertex_dump.layout.vertex_count,
+                ib_cache=ib_cache)
+            label = component or os.path.basename(asset_path)
+            if classification:
+                label = f"{label} {classification}"
+            if len(item.ranges) > 1:
+                label = f"{label} {ordinal + 1}"
+            key = (f"{asset_path}::{item.metadata_path}::"
+                   f"{component or 'part'}::{geometry_hash}::{ordinal}")
+            parts.append(AssetMeshPart(
+                key=key, label=label, asset_type=asset_type,
+                asset_path=asset_path, geometry_hash=geometry_hash,
+                component_name=component, classification=classification,
+                component_ordinal=ordinal, first_index=first,
+                index_count=effective_count, positions=positions,
+                indices=indices,
+                uvs=uvs, normals=normals, textures=textures))
     if not parts:
         raise AssetLoadError("Asset contains no complete renderable parts.")
     return AssetAdapterResult(tuple(parts), tuple(warnings))

--- a/src/app/asset_resolver.py
+++ b/src/app/asset_resolver.py
@@ -413,6 +413,26 @@ def _exact_asset_identity(binding):
     return binding.asset_type, binding.root, binding.asset
 
 
+def _group_resolution_scope(group, group_index):
+    ini_paths = set()
+    for draw in group.get("draws", []):
+        for source in getattr(draw, "sources", []) or []:
+            if not isinstance(source, dict):
+                continue
+            ini_path = source.get("ini_path")
+            if isinstance(ini_path, str) and ini_path:
+                ini_paths.add(ini_path.casefold())
+    if ini_paths:
+        return "ini", frozenset(ini_paths)
+    return "group", group_index
+
+
+def _scopes_overlap(left, right):
+    if left[0] != "ini" or right[0] != "ini":
+        return left == right
+    return bool(left[1] & right[1])
+
+
 def resolve_component(geometry_match, game, asset_entries):
     """Resolve one draw's geometry evidence without using texture evidence."""
     asset_type, indexes = _indexes_for_game(game, asset_entries)
@@ -429,6 +449,7 @@ def resolve_component(geometry_match, game, asset_entries):
 
 def resolve_groups(groups, game, asset_entries, *, availability=None):
     """Return per-draw bindings with conservative shared-Asset narrowing."""
+    groups = list(groups or [])
     if availability is not None:
         availability.clear()
     detected_asset_type = _asset_type(game)
@@ -456,29 +477,35 @@ def resolve_groups(groups, game, asset_entries, *, availability=None):
                 geometry_match, asset_type, indexes,
                 require_range=asset_type is None))
         resolved.append(group_bindings)
-    exact_identities = {
-        identity
-        for group_bindings in resolved
-        for identity in (_exact_asset_identity(binding)
-                         for binding in group_bindings)
-        if identity is not None
-    }
-    if detected_asset_type is not None and len(exact_identities) == 1:
+    scopes = [
+        _group_resolution_scope(group, group_index)
+        for group_index, group in enumerate(groups)
+    ]
+    for group_index, (group, group_bindings) in enumerate(
+            zip(groups, resolved)):
+        exact_identities = set()
+        for evidence_index, evidence_bindings in enumerate(resolved):
+            if not _scopes_overlap(scopes[group_index], scopes[evidence_index]):
+                continue
+            for binding in evidence_bindings:
+                identity = _exact_asset_identity(binding)
+                if identity is not None:
+                    exact_identities.add(identity)
+        if detected_asset_type is None or len(exact_identities) != 1:
+            continue
         preferred_identity = next(iter(exact_identities))
-        for group_index, group in enumerate(groups):
-            for draw_index, draw in enumerate(group.get("draws", [])):
-                if resolved[group_index][draw_index].status != "ambiguous":
-                    continue
-                geometry_match = (
-                    draw if isinstance(draw, GeometryMatch)
-                    else getattr(draw, "geometry_match", None))
-                narrowed = _resolve_component_from_indexes(
-                    geometry_match, asset_type, indexes,
-                    require_range=asset_type is None,
-                    asset_identity=preferred_identity)
-                if (_exact_asset_identity(narrowed)
-                        == preferred_identity):
-                    resolved[group_index][draw_index] = narrowed
+        for draw_index, draw in enumerate(group.get("draws", [])):
+            if group_bindings[draw_index].status != "ambiguous":
+                continue
+            geometry_match = (
+                draw if isinstance(draw, GeometryMatch)
+                else getattr(draw, "geometry_match", None))
+            narrowed = _resolve_component_from_indexes(
+                geometry_match, asset_type, indexes,
+                require_range=asset_type is None,
+                asset_identity=preferred_identity)
+            if _exact_asset_identity(narrowed) == preferred_identity:
+                group_bindings[draw_index] = narrowed
     return resolved
 
 

--- a/src/app/asset_resolver.py
+++ b/src/app/asset_resolver.py
@@ -255,7 +255,8 @@ def _equivalent_matches(range_matches):
 
 
 def _resolve_component_from_indexes(geometry_match, asset_type, indexes,
-                                    *, require_range=False):
+                                    *, require_range=False,
+                                    asset_identity=None):
     if not isinstance(geometry_match, GeometryMatch):
         return _not_found(asset_type)
     if asset_type is None and not indexes:
@@ -270,13 +271,18 @@ def _resolve_component_from_indexes(geometry_match, asset_type, indexes,
             if candidate_key in seen:
                 continue
             try:
-                geometry = index["assets"][lookup["asset"]]["geometry"][
-                    lookup["geometry"]]
+                asset = index["assets"][lookup["asset"]]
+                geometry = asset["geometry"][lookup["geometry"]]
                 ranges = geometry.get("ranges", [])
                 if not isinstance(ranges, list):
                     continue
             except (IndexError, KeyError, TypeError):
                 continue
+            if asset_identity is not None:
+                candidate_identity = (
+                    index.get("type"), root, asset.get("path"))
+                if candidate_identity != asset_identity:
+                    continue
             seen.add(candidate_key)
             candidates.append((root, index, lookup, geometry, ranges))
 
@@ -396,6 +402,17 @@ def _indexes_of_type(indexes, asset_type):
             if index.get("type") == asset_type]
 
 
+def _exact_asset_identity(binding):
+    if not isinstance(binding, AssetComponentBinding):
+        return None
+    if not (binding.status == "exact"
+            and binding.component_status == "exact"
+            and binding.range_status == "exact"
+            and binding.asset_type and binding.root and binding.asset):
+        return None
+    return binding.asset_type, binding.root, binding.asset
+
+
 def resolve_component(geometry_match, game, asset_entries):
     """Resolve one draw's geometry evidence without using texture evidence."""
     asset_type, indexes = _indexes_for_game(game, asset_entries)
@@ -411,9 +428,10 @@ def resolve_component(geometry_match, game, asset_entries):
 
 
 def resolve_groups(groups, game, asset_entries, *, availability=None):
-    """Return independent per-draw bindings in group order."""
+    """Return per-draw bindings with conservative shared-Asset narrowing."""
     if availability is not None:
         availability.clear()
+    detected_asset_type = _asset_type(game)
     asset_type, indexes = _indexes_for_game(
         game, asset_entries, availability=availability)
     if asset_type is None:
@@ -427,14 +445,40 @@ def resolve_groups(groups, game, asset_entries, *, availability=None):
         # Keep the normal return shape stable while allowing the caller that
         # owns the aggregate report to distinguish missing/invalid indexes.
         availability.setdefault("unavailable_roots", 0)
-    resolved = [[
-        _resolve_component_from_indexes(
-            (draw if isinstance(draw, GeometryMatch)
-            else getattr(draw, "geometry_match", None)), asset_type, indexes,
-            require_range=asset_type is None)
-        for draw in group.get("draws", [])]
-        for group in groups
-    ]
+    resolved = []
+    for group in groups:
+        group_bindings = []
+        for draw in group.get("draws", []):
+            geometry_match = (
+                draw if isinstance(draw, GeometryMatch)
+                else getattr(draw, "geometry_match", None))
+            group_bindings.append(_resolve_component_from_indexes(
+                geometry_match, asset_type, indexes,
+                require_range=asset_type is None))
+        resolved.append(group_bindings)
+    exact_identities = {
+        identity
+        for group_bindings in resolved
+        for identity in (_exact_asset_identity(binding)
+                         for binding in group_bindings)
+        if identity is not None
+    }
+    if detected_asset_type is not None and len(exact_identities) == 1:
+        preferred_identity = next(iter(exact_identities))
+        for group_index, group in enumerate(groups):
+            for draw_index, draw in enumerate(group.get("draws", [])):
+                if resolved[group_index][draw_index].status != "ambiguous":
+                    continue
+                geometry_match = (
+                    draw if isinstance(draw, GeometryMatch)
+                    else getattr(draw, "geometry_match", None))
+                narrowed = _resolve_component_from_indexes(
+                    geometry_match, asset_type, indexes,
+                    require_range=asset_type is None,
+                    asset_identity=preferred_identity)
+                if (_exact_asset_identity(narrowed)
+                        == preferred_identity):
+                    resolved[group_index][draw_index] = narrowed
     return resolved
 
 

--- a/src/tests/test_asset_loader.py
+++ b/src/tests/test_asset_loader.py
@@ -202,9 +202,9 @@ def test_gimi_face_parts_align_to_native_eyes_and_keep_eyes_unchanged(tmp_path):
         tuple(value for index in (0, 1, 2, 4, 5, 6)
               for value in body_rows[index][0]))
     face_positions = struct.unpack("<3f", parts["FaceEye"].positions[:12])
-    assert face_positions == pytest.approx((-0.75, 1.95, 3), abs=0.002)
+    assert face_positions == pytest.approx((-0.75, 2, 3))
     mouth_positions = struct.unpack("<3f", parts["Mouth"].positions[:12])
-    assert mouth_positions == pytest.approx((0.1, 1.55, 3), abs=0.002)
+    assert mouth_positions == pytest.approx((0.1, 1.6, 3), abs=1e-5)
     assert struct.unpack("<3f", parts["Mouth"].normals[:12]) == pytest.approx(
         (0, 0, 1))
     assert not any(item["reason"] == "face_alignment_unavailable"
@@ -224,7 +224,7 @@ def test_gimi_mouth_only_filter_uses_alignment_dependencies_without_emitting_the
     assert len(result.parts) == 1
     assert result.parts[0].component_name == "Mouth"
     assert struct.unpack("<3f", result.parts[0].positions[:12]) == \
-        pytest.approx((0.1, 1.55, 3), abs=0.002)
+        pytest.approx((0.1, 1.6, 3), abs=1e-5)
 
 
 def test_gimi_face_detection_uses_component_metadata_over_filename_heuristics():

--- a/src/tests/test_asset_loader.py
+++ b/src/tests/test_asset_loader.py
@@ -1,6 +1,7 @@
 """Focused direct Asset loading regressions."""
 
 import json
+import math
 import os
 import struct
 
@@ -49,6 +50,80 @@ def _fmt(path, stride, index_format, elements):
             "",
         ])
     path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _index_text(indices):
+    return ("first index: 0\n"
+            f"index count: {len(indices)}\n"
+            "topology: trianglelist\n"
+            + "\n".join(" ".join(str(value) for value in indices[index:index + 3])
+                         for index in range(0, len(indices), 3)) + "\n")
+
+
+def _gimi_face_asset(root, *, include_eyes=True):
+    asset = root / "Character"
+    asset.mkdir(parents=True)
+    entries = []
+    body_rows = []
+    if include_eyes:
+        body_rows = [
+            ((-0.79, 2, 3), (0, 0, 1), (0, 0)),
+            ((-0.75, 2, 3), (0, 0, 1), (1, 0)),
+            ((-0.75, 2.04, 3), (0, 0, 1), (0, 1)),
+            ((-0.71, 1.96, 3), (0, 0, 1), (1, 1)),
+            ((0.71, 2, 3), (0, 0, 1), (0, 0)),
+            ((0.75, 2, 3), (0, 0, 1), (1, 0)),
+            ((0.75, 2.04, 3), (0, 0, 1), (0, 1)),
+            ((0.79, 1.96, 3), (0, 0, 1), (1, 1)),
+        ]
+        body_indices = (0, 1, 2, 4, 5, 6)
+        _text_vb(asset / "CharacterEyesA-vb0=11111111.txt", 92, body_rows)
+        (asset / "CharacterEyesA-ib=aaaaaaaa.txt").write_text(
+            _index_text(body_indices), encoding="utf-8")
+        entries.append({
+            "ib": "aaaaaaaa", "vb0": "11111111", "component_name": "Eyes",
+            "object_indexes": [0], "object_index_counts": [len(body_indices)],
+        })
+
+    face_centers = ((4, -2, 6.25), (4, -2, 7.75))
+    face_rows = []
+    face_indices = []
+    for center in face_centers:
+        center_index = len(face_rows)
+        face_rows.append((center, (-1, 0, 0), (0, 0)))
+        ring = []
+        for ordinal in range(8):
+            angle = 2 * 3.141592653589793 * ordinal / 8
+            ring.append(len(face_rows))
+            face_rows.append((
+                (center[0], center[1] + 0.15 * math.sin(angle),
+                 center[2] + 0.15 * math.cos(angle)),
+                (-1, 0, 0), (0, 0)))
+        for ordinal, first in enumerate(ring):
+            face_indices.extend((center_index, first, ring[(ordinal + 1) % 8]))
+    _text_vb(asset / "CharacterFaceEyeA-vb0=22222222.txt", 92, face_rows)
+    (asset / "CharacterFaceEyeA-ib=bbbbbbbb.txt").write_text(
+        _index_text(face_indices), encoding="utf-8")
+    entries.append({
+        "ib": "bbbbbbbb", "vb0": "22222222", "component_name": "FaceEye",
+        "object_indexes": [0], "object_index_counts": [len(face_indices)],
+    })
+
+    mouth_rows = [
+        ((4, -2.4, 7.1), (-1, 0, 0), (0, 0)),
+        ((4, -2.3, 7), (-1, 0, 0), (1, 0)),
+        ((4, -2.4, 6.9), (-1, 0, 0), (0, 1)),
+    ]
+    mouth_indices = (0, 1, 2)
+    _text_vb(asset / "CharacterFaceMouthA-vb0=33333333.txt", 92, mouth_rows)
+    (asset / "CharacterFaceMouthA-ib=cccccccc.txt").write_text(
+        _index_text(mouth_indices), encoding="utf-8")
+    entries.append({
+        "ib": "cccccccc", "vb0": "33333333", "component_name": "Mouth",
+        "object_indexes": [0], "object_index_counts": [3],
+    })
+    _write_json(asset / "hash.json", entries)
+    return asset, body_rows, face_centers, mouth_rows
 
 
 def _wwmi_triangle(folder, *, component_name="Body", vb_hash="11111111",
@@ -111,6 +186,75 @@ def test_migoto_index_dump_separates_headers_from_index_rows(tmp_path):
     assert parsed.first_index == 43845
     assert parsed.index_count == 6
     assert parsed.index_format == "DXGI_FORMAT_R16_UINT"
+
+
+def test_gimi_face_parts_align_to_native_eyes_and_keep_eyes_unchanged(tmp_path):
+    root = tmp_path / "assets"
+    asset, body_rows, face_centers, mouth_rows = _gimi_face_asset(root)
+    index = build_index("GIMI", str(root))
+
+    result = load_asset("GIMI", str(root), index["assets"][0],
+                        geometry=GeometryBlob())
+
+    parts = {part.component_name: part for part in result.parts}
+    assert set(parts) == {"Eyes", "FaceEye", "Mouth"}
+    assert struct.unpack("<18f", parts["Eyes"].positions) == pytest.approx(
+        tuple(value for index in (0, 1, 2, 4, 5, 6)
+              for value in body_rows[index][0]))
+    face_positions = struct.unpack("<3f", parts["FaceEye"].positions[:12])
+    assert face_positions == pytest.approx((-0.75, 2, 3))
+    mouth_positions = struct.unpack("<3f", parts["Mouth"].positions[:12])
+    assert mouth_positions == pytest.approx((0.1, 1.6, 3), abs=1e-5)
+    assert struct.unpack("<3f", parts["Mouth"].normals[:12]) == pytest.approx(
+        (0, 0, 1))
+    assert not any(item["reason"] == "face_alignment_unavailable"
+                   for item in result.payload["metadata"]["asset"]["warnings"])
+
+
+def test_gimi_mouth_only_filter_uses_alignment_dependencies_without_emitting_them(
+        tmp_path):
+    root = tmp_path / "assets"
+    asset, _body_rows, _face_centers, _mouth_rows = _gimi_face_asset(root)
+    index = build_index("GIMI", str(root))
+
+    result = load_asset(
+        "GIMI", str(root), index["assets"][0], geometry=GeometryBlob(),
+        part_filter={ComponentCoverageKey("cccccccc", 0, 3)})
+
+    assert len(result.parts) == 1
+    assert result.parts[0].component_name == "Mouth"
+    assert struct.unpack("<3f", result.parts[0].positions[:12]) == \
+        pytest.approx((0.1, 1.6, 3), abs=1e-5)
+
+
+def test_gimi_face_alignment_failure_keeps_raw_geometry_and_warns(tmp_path):
+    root = tmp_path / "assets"
+    asset, _body_rows, face_centers, _mouth_rows = _gimi_face_asset(
+        root, include_eyes=False)
+    index = build_index("GIMI", str(root))
+
+    result = load_asset("GIMI", str(root), index["assets"][0],
+                        geometry=GeometryBlob())
+
+    face = next(part for part in result.parts
+                if part.component_name == "FaceEye")
+    assert struct.unpack("<3f", face.positions[:12]) == pytest.approx(face_centers[0])
+    assert any(item["reason"] == "face_alignment_unavailable"
+               for item in result.payload["metadata"]["asset"]["warnings"])
+
+
+def test_zzmi_face_named_parts_are_not_gimi_aligned(tmp_path):
+    root = tmp_path / "assets"
+    _asset, _body_rows, _face_centers, mouth_rows = _gimi_face_asset(root)
+    index = build_index("ZZMI", str(root))
+
+    result = load_asset("ZZMI", str(root), index["assets"][0],
+                        geometry=GeometryBlob())
+
+    mouth = next(part for part in result.parts
+                 if part.component_name == "Mouth")
+    assert struct.unpack("<3f", mouth.positions[:12]) == pytest.approx(
+        mouth_rows[0][0])
 
 
 def test_hash_asset_does_not_use_same_label_wrong_hash_vertex_dump(tmp_path):

--- a/src/tests/test_asset_loader.py
+++ b/src/tests/test_asset_loader.py
@@ -202,9 +202,9 @@ def test_gimi_face_parts_align_to_native_eyes_and_keep_eyes_unchanged(tmp_path):
         tuple(value for index in (0, 1, 2, 4, 5, 6)
               for value in body_rows[index][0]))
     face_positions = struct.unpack("<3f", parts["FaceEye"].positions[:12])
-    assert face_positions == pytest.approx((-0.75, 2, 3))
+    assert face_positions == pytest.approx((-0.75, 1.95, 3), abs=0.002)
     mouth_positions = struct.unpack("<3f", parts["Mouth"].positions[:12])
-    assert mouth_positions == pytest.approx((0.1, 1.6, 3), abs=1e-5)
+    assert mouth_positions == pytest.approx((0.1, 1.55, 3), abs=0.002)
     assert struct.unpack("<3f", parts["Mouth"].normals[:12]) == pytest.approx(
         (0, 0, 1))
     assert not any(item["reason"] == "face_alignment_unavailable"
@@ -224,7 +224,23 @@ def test_gimi_mouth_only_filter_uses_alignment_dependencies_without_emitting_the
     assert len(result.parts) == 1
     assert result.parts[0].component_name == "Mouth"
     assert struct.unpack("<3f", result.parts[0].positions[:12]) == \
-        pytest.approx((0.1, 1.6, 3), abs=1e-5)
+        pytest.approx((0.1, 1.55, 3), abs=0.002)
+
+
+def test_gimi_face_detection_uses_component_metadata_over_filename_heuristics():
+    record = hash_asset._HashAssetRecord(
+        metadata_path="Character/hash.json", entry={},
+        component_name="Eyewear", geometry_hash="aabbccdd",
+        vb_hash="11223344", ranges=(),
+        vb_file="CharacterFaceEyeA-vb0=11223344.txt", ib_files=())
+    assert not hash_asset._is_face_local_record(record)
+
+    unnamed = hash_asset._HashAssetRecord(
+        metadata_path="Character/hash.json", entry={},
+        component_name=None, geometry_hash="aabbccdd",
+        vb_hash="11223344", ranges=(),
+        vb_file="CharacterFaceEyeA-vb0=11223344.txt", ib_files=())
+    assert hash_asset._is_face_local_record(unnamed)
 
 
 def test_gimi_face_alignment_failure_keeps_raw_geometry_and_warns(tmp_path):

--- a/src/tests/test_asset_resolver.py
+++ b/src/tests/test_asset_resolver.py
@@ -386,6 +386,84 @@ def test_draw_count_does_not_become_asset_range_evidence(
     assert bindings[0][0].status == "ambiguous"
 
 
+def test_resolve_groups_narrows_shared_hash_to_unique_exact_asset(
+        tmp_path, monkeypatch):
+    root = os.path.normcase(os.path.abspath(str(tmp_path / "zzmi")))
+    entries = [{"type": "ZZMI", "path": root, "enabled": True}]
+    index = _index(root, asset_type="ZZMI", asset="Remielle",
+                   first_index=0)
+    shared_geometry = {
+        "hash": "aabbccdd",
+        "ranges": [{"firstIndex": 100, "indexCount": 12}],
+        "metadata": "Remielle/hash.json",
+        "componentName": "Hair",
+    }
+    index["assets"][0]["geometry"].append(shared_geometry)
+    index["byGeometryHash"]["aabbccdd"] = [{"asset": 0, "geometry": 1}]
+    for asset_name in ("RemielleMoonlight", "RemielleSummer"):
+        geometry = dict(shared_geometry)
+        geometry["metadata"] = f"{asset_name}/hash.json"
+        asset_index_entry = {
+            "path": asset_name, "geometry": [geometry],
+        }
+        asset_number = len(index["assets"])
+        index["assets"].append(asset_index_entry)
+        index["byGeometryHash"]["aabbccdd"].append({
+            "asset": asset_number, "geometry": 0,
+        })
+    monkeypatch.setattr(asset_index, "load_index",
+                        lambda asset_type, path: index)
+
+    bindings = resolve_groups([{"draws": [
+        DrawCall(geometry_match=GeometryMatch("73c8cae2", 0, 24)),
+        DrawCall(geometry_match=GeometryMatch("aabbccdd", 100, 12)),
+    ]}], "zzz", entries)
+
+    assert [item.status for item in bindings[0]] == ["exact", "exact"]
+    assert [item.asset for item in bindings[0]] == ["Remielle", "Remielle"]
+    assert bindings[0][1].component_name == "Hair"
+
+
+def test_resolve_groups_keeps_conflicting_exact_assets_ambiguous(
+        tmp_path, monkeypatch):
+    root = os.path.normcase(os.path.abspath(str(tmp_path / "zzmi")))
+    entries = [{"type": "ZZMI", "path": root, "enabled": True}]
+    index = _index(root, asset_type="ZZMI", asset="AssetA",
+                   first_index=0)
+    index["assets"].append({
+        "path": "AssetB",
+        "geometry": [{
+            "hash": "bbbbcccc",
+            "ranges": [{"firstIndex": 50, "indexCount": 8}],
+            "metadata": "AssetB/hash.json",
+            "componentName": "Legs",
+        }],
+    })
+    index["byGeometryHash"]["bbbbcccc"] = [{"asset": 1, "geometry": 0}]
+    for asset_number, asset_name in enumerate(("AssetA", "AssetB")):
+        geometry = {
+            "hash": "aabbccdd",
+            "ranges": [{"firstIndex": 100, "indexCount": 12}],
+            "metadata": f"{asset_name}/hash.json",
+            "componentName": "Hair",
+        }
+        index["assets"][asset_number]["geometry"].append(geometry)
+        index["byGeometryHash"].setdefault("aabbccdd", []).append({
+            "asset": asset_number, "geometry": 1,
+        })
+    monkeypatch.setattr(asset_index, "load_index",
+                        lambda asset_type, path: index)
+
+    bindings = resolve_groups([{"draws": [
+        DrawCall(geometry_match=GeometryMatch("73c8cae2", 0, 24)),
+        DrawCall(geometry_match=GeometryMatch("bbbbcccc", 50, 8)),
+        DrawCall(geometry_match=GeometryMatch("aabbccdd", 100, 12)),
+    ]}], "zzz", entries)
+
+    assert [item.status for item in bindings[0]] == [
+        "exact", "exact", "ambiguous"]
+
+
 def test_same_hash_same_range_remains_ambiguous(tmp_path, monkeypatch):
     roots = [os.path.normcase(os.path.abspath(str(tmp_path / name)))
              for name in ("one", "two")]

--- a/src/tests/test_asset_resolver.py
+++ b/src/tests/test_asset_resolver.py
@@ -390,6 +390,18 @@ def test_resolve_groups_narrows_shared_hash_to_unique_exact_asset(
         tmp_path, monkeypatch):
     root = os.path.normcase(os.path.abspath(str(tmp_path / "zzmi")))
     entries = [{"type": "ZZMI", "path": root, "enabled": True}]
+    asset_dir = tmp_path / "zzmi" / "Remielle"
+    asset_dir.mkdir(parents=True)
+    texture = asset_dir / "RemielleHairDiffuse.dds"
+    texture.write_bytes(b"remielle")
+    (asset_dir / "hash.json").write_text(json.dumps([{
+        "component_name": "Hair",
+        "ib": "aabbccdd",
+        "object_indexes": [100],
+        "texture_hashes": [[[
+            "Diffuse", ".dds", "11111111",
+        ]]],
+    }]), encoding="utf-8")
     index = _index(root, asset_type="ZZMI", asset="Remielle",
                    first_index=0)
     shared_geometry = {
@@ -414,14 +426,80 @@ def test_resolve_groups_narrows_shared_hash_to_unique_exact_asset(
     monkeypatch.setattr(asset_index, "load_index",
                         lambda asset_type, path: index)
 
-    bindings = resolve_groups([{"draws": [
-        DrawCall(geometry_match=GeometryMatch("73c8cae2", 0, 24)),
-        DrawCall(geometry_match=GeometryMatch("aabbccdd", 100, 12)),
-    ]}], "zzz", entries)
+    body_draw = DrawCall(geometry_match=GeometryMatch("73c8cae2", 0, 24))
+    hair_draw = DrawCall(geometry_match=GeometryMatch("aabbccdd", 100, 12))
+    groups = [{"draws": [body_draw, hair_draw]}]
+    bindings = resolve_groups(groups, "zzz", entries)
 
     assert [item.status for item in bindings[0]] == ["exact", "exact"]
     assert [item.asset for item in bindings[0]] == ["Remielle", "Remielle"]
     assert bindings[0][1].component_name == "Hair"
+    apply(groups, bindings)
+    assert hair_draw.asset_texture_defaults["diffuse"]["path"].casefold() == \
+        str(texture).casefold()
+    assert hair_draw.texture_provenance["diffuse"] == \
+        "asset_original_fallback"
+    assert "RemielleMoonlight" not in hair_draw.asset_texture_defaults[
+        "diffuse"]["path"]
+
+
+def test_resolve_groups_scopes_narrowing_to_shared_ini_provenance(
+        tmp_path, monkeypatch):
+    root = os.path.normcase(os.path.abspath(str(tmp_path / "zzmi")))
+    entries = [{"type": "ZZMI", "path": root, "enabled": True}]
+    index = _index(root, asset_type="ZZMI", asset="AssetA",
+                   first_index=0)
+    shared_a = {
+        "hash": "aabbccdd",
+        "ranges": [{"firstIndex": 100, "indexCount": 12}],
+        "metadata": "AssetA/hash.json",
+        "componentName": "Hair",
+    }
+    index["assets"][0]["geometry"].append(shared_a)
+    index["assets"].append({
+        "path": "AssetB",
+        "geometry": [{
+            "hash": "bbbbcccc",
+            "ranges": [{"firstIndex": 50, "indexCount": 8}],
+            "metadata": "AssetB/hash.json",
+            "componentName": "Legs",
+        }, {
+            "hash": "aabbccdd",
+            "ranges": [{"firstIndex": 100, "indexCount": 12}],
+            "metadata": "AssetB/hash.json",
+            "componentName": "Hair",
+        }],
+    })
+    index["byGeometryHash"]["aabbccdd"] = [
+        {"asset": 0, "geometry": 1},
+        {"asset": 1, "geometry": 1},
+    ]
+    index["byGeometryHash"]["bbbbcccc"] = [{"asset": 1, "geometry": 0}]
+    monkeypatch.setattr(asset_index, "load_index",
+                        lambda asset_type, path: index)
+
+    bindings = resolve_groups([
+        {"draws": [DrawCall(
+            sources=[{"ini_path": "ini-a.ini"}],
+            geometry_match=GeometryMatch("73c8cae2", 0, 24))]},
+        {"draws": [DrawCall(
+            sources=[{"ini_path": "ini-c.ini"}],
+            geometry_match=GeometryMatch("aabbccdd", 100, 12))]},
+        {"draws": [
+            DrawCall(
+                sources=[{"ini_path": "ini-b.ini"}],
+                geometry_match=GeometryMatch("bbbbcccc", 50, 8)),
+        ]},
+        {"draws": [DrawCall(
+            sources=[{"ini_path": "ini-b.ini"}],
+            geometry_match=GeometryMatch("aabbccdd", 100, 12))]},
+    ], "zzz", entries)
+
+    assert bindings[0][0].asset == "AssetA"
+    assert bindings[1][0].status == "ambiguous"
+    assert bindings[2][0].asset == "AssetB"
+    assert bindings[3][0].status == "exact"
+    assert bindings[3][0].asset == "AssetB"
 
 
 def test_resolve_groups_keeps_conflicting_exact_assets_ambiguous(

--- a/src/tests/test_gimi_face_alignment.py
+++ b/src/tests/test_gimi_face_alignment.py
@@ -4,8 +4,8 @@ import struct
 import pytest
 
 from app.asset_loader.gimi_face_alignment import (
-    AlignmentMesh, solve, transform_normal_bytes, transform_point,
-    transform_position_bytes)
+    AlignmentMesh, _fit_eye_surface_offset, solve, transform_normal_bytes,
+    transform_point, transform_position_bytes)
 
 
 def _face_mesh(centers, *, name="FaceEye", h=(0, 0, 1), v=(0, 1, 0),
@@ -61,8 +61,8 @@ def test_brow_and_mouth_landmarks_resolve_roll_without_mirroring():
     face = _face_mesh(
         ((4, -2, 6.25), (4, -2, 7.75)), v=(0, -1, 0))
 
-    brow = AlignmentMesh("Brow", ((4, -1.5, 7),), ())
-    brow_alignment = solve(body, face, brow, refine=False)
+    brow = AlignmentMesh("Marker", ((4, -1.5, 7),), ())
+    brow_alignment = solve(body, face, brow, landmark_kind="brow", refine=False)
     brow_mapped = transform_point(brow_alignment.matrix, brow.positions[0])
     assert brow_mapped[1] > 2
 
@@ -77,7 +77,7 @@ def test_already_aligned_face_stays_aligned_and_bad_spacing_is_rejected():
     body = _body_eyes((-0.75, 2, 3), (0.75, 2, 3))
     aligned = _face_mesh(((-0.75, 2, 3), (0.75, 2, 3)), h=(1, 0, 0),
                          v=(0, 1, 0))
-    result = solve(body, aligned, refine=False)
+    result = solve(body, aligned)
     assert result is not None
     assert result.matrix[0][0] == pytest.approx(1)
     assert result.matrix[1][1] == pytest.approx(1)
@@ -87,6 +87,43 @@ def test_already_aligned_face_stays_aligned_and_bad_spacing_is_rejected():
     too_wide = _face_mesh(((-1.25, 2, 3), (1.25, 2, 3)), h=(1, 0, 0),
                           v=(0, 1, 0))
     assert solve(body, too_wide, refine=False) is None
+
+
+def test_target_eye_axis_is_horizontal_even_when_centers_have_uneven_height():
+    body = _body_eyes((-0.75, 1.8, 3), (0.75, 2.2, 3))
+    face = _face_mesh(((4, -2, 6.25), (4, -2, 7.75)))
+
+    alignment = solve(body, face, refine=False)
+
+    assert alignment is not None
+    mapped = [transform_point(alignment.matrix, point)
+              for point in (face.positions[0], face.positions[9])]
+    assert mapped[0][1] == pytest.approx(2.0, abs=1e-5)
+    assert mapped[1][1] == pytest.approx(2.0, abs=1e-5)
+
+
+def test_surface_refinement_uses_corresponding_eye_surfaces():
+    identity = ((1.0, 0.0, 0.0, 0.0), (0.0, 1.0, 0.0, 0.0),
+                (0.0, 0.0, 1.0, 0.0), (0.0, 0.0, 0.0, 1.0))
+    body_centers = ((-1.0, 0.0, 0.0), (1.0, 0.0, 0.0))
+    body_groups = (
+        ((-1.0, -0.04, 0.0), (-1.0, 0.04, 0.0),
+         (-1.0, 0.0, -0.04), (-1.0, 0.0, 0.04)),
+        ((1.0, -0.04, 0.0), (1.0, 0.04, 0.0),
+         (1.0, 0.0, -0.04), (1.0, 0.0, 0.04)),
+    )
+    face_points = tuple(
+        (center[0], 0.2, center[2] + offset)
+        for center in body_centers for offset in (-0.04, 0.04))
+
+    fitted, improvement = _fit_eye_surface_offset(
+        face_points, tuple(point for group in body_groups for point in group),
+        identity, (0.0, 1.0, 0.0), (0.0, 0.0, 1.0), 2.0,
+        face_centers=body_centers, body_centers=body_centers,
+        body_groups=body_groups)
+
+    assert improvement >= 0.02
+    assert fitted[1][3] == pytest.approx(-0.2, abs=0.03)
 
 
 def test_packed_helpers_transform_positions_and_authored_normals_only():

--- a/src/tests/test_gimi_face_alignment.py
+++ b/src/tests/test_gimi_face_alignment.py
@@ -1,0 +1,110 @@
+import math
+import struct
+
+import pytest
+
+from app.asset_loader.gimi_face_alignment import (
+    AlignmentMesh, solve, transform_normal_bytes, transform_point,
+    transform_position_bytes)
+
+
+def _face_mesh(centers, *, name="FaceEye", h=(0, 0, 1), v=(0, 1, 0),
+               radius=0.15):
+    positions = []
+    indices = []
+    for center in centers:
+        center_index = len(positions)
+        positions.append(center)
+        ring = []
+        for ordinal in range(8):
+            angle = 2 * math.pi * ordinal / 8
+            ring.append(len(positions))
+            positions.append(tuple(
+                center[axis] + radius * (
+                    h[axis] * math.cos(angle) + v[axis] * math.sin(angle))
+                for axis in range(3)))
+        for ordinal, first in enumerate(ring):
+            indices.extend((center_index, first, ring[(ordinal + 1) % 8]))
+    return AlignmentMesh(name, tuple(positions), tuple(indices))
+
+
+def _body_eyes(left, right):
+    offsets = ((-0.04, 0, 0), (0.04, 0, 0),
+               (0, -0.04, 0), (0, 0.04, 0))
+    return AlignmentMesh(
+        "EyesA", tuple(tuple(center[axis] + offset[axis]
+                              for axis in range(3))
+                       for center in (left, right) for offset in offsets), ())
+
+
+def test_solver_recovers_rotation_translation_and_positive_determinant():
+    body = _body_eyes((-0.75, 2, 3), (0.75, 2, 3))
+    source_mid = (4, -2, 7)
+    face = _face_mesh(
+        (tuple(source_mid[axis] - (0, 0, 0.75)[axis]
+                for axis in range(3)),
+         tuple(source_mid[axis] + (0, 0, 0.75)[axis]
+               for axis in range(3))))
+
+    alignment = solve(body, face, refine=False)
+
+    assert alignment is not None
+    assert alignment.diagnostics["rotation_determinant"] == pytest.approx(1)
+    mapped = [transform_point(alignment.matrix, point)
+              for point in (face.positions[0], face.positions[9])]
+    assert mapped[0] == pytest.approx((-0.75, 2, 3), abs=1e-5)
+    assert mapped[1] == pytest.approx((0.75, 2, 3), abs=1e-5)
+
+
+def test_brow_and_mouth_landmarks_resolve_roll_without_mirroring():
+    body = _body_eyes((-0.75, 2, 3), (0.75, 2, 3))
+    face = _face_mesh(
+        ((4, -2, 6.25), (4, -2, 7.75)), v=(0, -1, 0))
+
+    brow = AlignmentMesh("Brow", ((4, -1.5, 7),), ())
+    brow_alignment = solve(body, face, brow, refine=False)
+    brow_mapped = transform_point(brow_alignment.matrix, brow.positions[0])
+    assert brow_mapped[1] > 2
+
+    mouth = AlignmentMesh("Mouth", ((4, -2.5, 7),), ())
+    mouth_alignment = solve(body, face, mouth, refine=False)
+    mouth_mapped = transform_point(mouth_alignment.matrix, mouth.positions[0])
+    assert mouth_mapped[1] < 2
+    assert mouth_alignment.diagnostics["rotation_determinant"] == pytest.approx(1)
+
+
+def test_already_aligned_face_stays_aligned_and_bad_spacing_is_rejected():
+    body = _body_eyes((-0.75, 2, 3), (0.75, 2, 3))
+    aligned = _face_mesh(((-0.75, 2, 3), (0.75, 2, 3)), h=(1, 0, 0),
+                         v=(0, 1, 0))
+    result = solve(body, aligned, refine=False)
+    assert result is not None
+    assert result.matrix[0][0] == pytest.approx(1)
+    assert result.matrix[1][1] == pytest.approx(1)
+    assert result.matrix[2][2] == pytest.approx(1)
+    assert result.matrix[0][3] == pytest.approx(0)
+
+    too_wide = _face_mesh(((-1.25, 2, 3), (1.25, 2, 3)), h=(1, 0, 0),
+                          v=(0, 1, 0))
+    assert solve(body, too_wide, refine=False) is None
+
+
+def test_packed_helpers_transform_positions_and_authored_normals_only():
+    matrix = ((0, -1, 0, 4), (1, 0, 0, 5), (0, 0, 1, 6),
+              (0, 0, 0, 1))
+    positions = struct.pack("<3f", 1, 2, 3)
+    normals = struct.pack("<3f", 1, 0, 0)
+
+    assert struct.unpack("<3f", transform_position_bytes(positions, matrix)) == \
+        pytest.approx((2, 6, 9))
+    assert struct.unpack("<3f", transform_normal_bytes(normals, matrix)) == \
+        pytest.approx((0, 1, 0))
+
+
+def test_malformed_boundary_geometry_returns_no_alignment():
+    body = _body_eyes((-0.75, 2, 3), (0.75, 2, 3))
+    malformed = AlignmentMesh(
+        "FaceEye", ((-0.75, 2, 3), (0.75, 2, 3), (0, 2, 3)),
+        (0, 1, 2))
+
+    assert solve(body, malformed, refine=False) is None

--- a/src/tests/test_gimi_face_alignment.py
+++ b/src/tests/test_gimi_face_alignment.py
@@ -9,22 +9,23 @@ from app.asset_loader.gimi_face_alignment import (
 
 
 def _face_mesh(centers, *, name="FaceEye", h=(0, 0, 1), v=(0, 1, 0),
-               radius=0.15):
+               radius=0.15, ring_vertices=8):
     positions = []
     indices = []
     for center in centers:
         center_index = len(positions)
         positions.append(center)
         ring = []
-        for ordinal in range(8):
-            angle = 2 * math.pi * ordinal / 8
+        for ordinal in range(ring_vertices):
+            angle = 2 * math.pi * ordinal / ring_vertices
             ring.append(len(positions))
             positions.append(tuple(
                 center[axis] + radius * (
                     h[axis] * math.cos(angle) + v[axis] * math.sin(angle))
                 for axis in range(3)))
         for ordinal, first in enumerate(ring):
-            indices.extend((center_index, first, ring[(ordinal + 1) % 8]))
+            indices.extend((center_index, first,
+                            ring[(ordinal + 1) % ring_vertices]))
     return AlignmentMesh(name, tuple(positions), tuple(indices))
 
 
@@ -35,6 +36,27 @@ def _body_eyes(left, right):
         "EyesA", tuple(tuple(center[axis] + offset[axis]
                               for axis in range(3))
                        for center in (left, right) for offset in offsets), ())
+
+
+def _dense_body_eyes(left, right):
+    offsets = (-0.04, -0.02, 0.0, 0.02, 0.04)
+    points = tuple(
+        (center[0] + offset_x, center[1], center[2])
+        for center in (left, right)
+        for offset_x in offsets for _ in offsets)
+    return AlignmentMesh("EyesA", points, ())
+
+
+def _face_mesh_with_offset_surface(centers):
+    base = _face_mesh(centers, radius=0.05)
+    positions = list(base.positions)
+    for center in centers:
+        for ordinal in range(32):
+            angle = 2 * math.pi * ordinal / 32
+            positions.append((
+                center[0], center[1] + 0.03,
+                center[2] + 0.01 * math.cos(angle)))
+    return AlignmentMesh(base.name, tuple(positions), base.indices)
 
 
 def test_solver_recovers_rotation_translation_and_positive_determinant():
@@ -106,24 +128,39 @@ def test_surface_refinement_uses_corresponding_eye_surfaces():
     identity = ((1.0, 0.0, 0.0, 0.0), (0.0, 1.0, 0.0, 0.0),
                 (0.0, 0.0, 1.0, 0.0), (0.0, 0.0, 0.0, 1.0))
     body_centers = ((-1.0, 0.0, 0.0), (1.0, 0.0, 0.0))
-    body_groups = (
-        ((-1.0, -0.04, 0.0), (-1.0, 0.04, 0.0),
-         (-1.0, 0.0, -0.04), (-1.0, 0.0, 0.04)),
-        ((1.0, -0.04, 0.0), (1.0, 0.04, 0.0),
-         (1.0, 0.0, -0.04), (1.0, 0.0, 0.04)),
-    )
+    offsets = (-0.04, -0.02, 0.0, 0.02, 0.04)
+    body_groups = tuple(
+        tuple((center[0] + offset_x, center[1] + offset_y, center[2])
+              for offset_x in offsets for offset_y in offsets)
+        for center in body_centers)
     face_points = tuple(
-        (center[0], 0.2, center[2] + offset)
-        for center in body_centers for offset in (-0.04, 0.04))
+        (center[0] + offset_x, 0.03, center[2] + offset_z)
+        for center in body_centers
+        for offset_x in (-0.03, -0.015, 0.0, 0.015, 0.03)
+        for offset_z in (-0.03, -0.015, 0.0, 0.015, 0.03))
 
     fitted, improvement = _fit_eye_surface_offset(
         face_points, tuple(point for group in body_groups for point in group),
-        identity, (0.0, 1.0, 0.0), (0.0, 0.0, 1.0), 2.0,
-        face_centers=body_centers, body_centers=body_centers,
-        body_groups=body_groups)
+        identity, (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0),
+        2.0, body_centers=body_centers, body_groups=body_groups)
 
     assert improvement >= 0.02
-    assert fitted[1][3] == pytest.approx(-0.2, abs=0.03)
+    assert fitted[1][3] == pytest.approx(-0.03, abs=0.01)
+
+
+def test_surface_refinement_runs_through_solver_with_enough_eye_surface_points():
+    body = _dense_body_eyes((-0.75, 2, 3), (0.75, 2, 3))
+    face = _face_mesh_with_offset_surface(
+        ((4, -2, 6.25), (4, -2, 7.75)))
+
+    alignment = solve(body, face)
+
+    assert alignment is not None
+    assert alignment.diagnostics["surface_fit_improvement"] >= 0.02
+    mapped = [transform_point(alignment.matrix, point)
+              for point in (face.positions[18], face.positions[50])]
+    assert mapped[0][1] == pytest.approx(2.0, abs=0.01)
+    assert mapped[1][1] == pytest.approx(2.0, abs=0.01)
 
 
 def test_packed_helpers_transform_positions_and_authored_normals_only():


### PR DESCRIPTION
## Summary

- Add geometry-derived rigid alignment for GIMI face-local Asset geometry.
- Keep alignment dependencies separate from selective Asset-part emission and leave native Eyes unchanged.
- Preserve raw geometry with a warning when alignment evidence is insufficient.
- Add unit and Asset-loader regression coverage and document the invariant.