### PR TITLE
refactor: decompose bridge API

### DIFF
--- a/src/app/bridge/access.py
+++ b/src/app/bridge/access.py
@@ -1,0 +1,84 @@
+"""Authorization state for native-selected Mod and Asset folders."""
+
+from app.assets import folders as asset_folders
+from app.settings import mod_folders
+
+
+class FolderAccess:
+    """Keep the bridge's native-picker and registered-root trust boundaries."""
+
+    def __init__(self):
+        self._authorized_folders = set()
+        self._picker_authorized_folders = set()
+        self._authorized_roots = set()
+        self._authorized_asset_folders = set()
+        self._authorized_asset_roots = set()
+        try:
+            self.refresh_mod_roots(mod_folders.load_registry())
+        except mod_folders.ModFolderError:
+            # Optional malformed configuration is reported by the registry UI;
+            # it must not prevent the bridge from being constructed.
+            pass
+        try:
+            self.refresh_asset_roots(asset_folders.load_registry())
+        except asset_folders.AssetFolderError:
+            pass
+
+    def mod_folder(self, folder_path):
+        requested = mod_folders.normalize_path(folder_path)
+        if requested in self._authorized_folders:
+            return requested
+        if any(mod_folders.is_within(requested, root)
+               for root in self._authorized_roots):
+            # Preserve access to an exact descendant if its registry root is
+            # later edited or removed during this process lifetime.
+            self._authorized_folders.add(requested)
+            return requested
+        if not requested:
+            raise PermissionError(
+                "This folder was not selected through the native folder picker.")
+        raise PermissionError(
+            "This folder was not selected through the native folder picker.")
+
+    def asset_folder(self, folder_path):
+        requested = asset_folders.normalize_path(folder_path)
+        if requested in self._authorized_asset_folders:
+            return requested
+        if any(asset_folders.is_within(requested, root)
+               for root in self._authorized_asset_roots):
+            self._authorized_asset_folders.add(requested)
+            return requested
+        raise PermissionError(
+            "This folder is not inside a registered Asset Folder.")
+
+    def remember_mod_picker_selection(self, folder_path):
+        folder = mod_folders.normalize_path(folder_path)
+        self._authorized_folders.add(folder)
+        self._picker_authorized_folders.add(folder)
+        return folder
+
+    def remember_asset_picker_selection(self, folder_path):
+        folder = asset_folders.normalize_path(folder_path)
+        # Mod and Asset pickers deliberately share this prerequisite set, but
+        # selecting an Asset Folder never grants Mod Folder access.
+        self._picker_authorized_folders.add(folder)
+        return folder
+
+    def was_picker_selected(self, folder_path):
+        return mod_folders.normalize_path(folder_path) in \
+            self._picker_authorized_folders
+
+    def grant_asset_folder(self, folder_path):
+        self._authorized_asset_folders.add(
+            asset_folders.normalize_path(folder_path))
+
+    def refresh_mod_roots(self, entries):
+        self._authorized_roots = mod_folders.registered_paths(entries)
+
+    def refresh_asset_roots(self, entries):
+        roots = asset_folders.registered_paths(entries)
+        self._authorized_asset_roots = roots
+        self._authorized_asset_folders = {
+            path for path in self._authorized_asset_folders
+            if any(asset_folders.is_within(path, root) for root in roots)
+        }

--- a/src/app/bridge/api.py
+++ b/src/app/bridge/api.py
@@ -113,6 +113,8 @@ class ModViewerAPI:
                 self._mod_preview.authoritative_context(folder_path)
             return self._asset_preview.load_missing_asset_parts(
                 folder_path, context, overrides)
+        except PermissionError as error:
+            return {"status": "error", "error": str(error)}
         except Exception:
             traceback.print_exc()
             return {

--- a/src/app/bridge/api.py
+++ b/src/app/bridge/api.py
@@ -1,762 +1,247 @@
-"""The object bridged into JavaScript as `window.pywebview.api`.
+"""The explicit JavaScript facade for the Mod Viewer application.
 
-Every public method here is callable from the UI, so the surface is kept
-deliberately small: anything that doesn't need a window or a native dialog
-belongs in mod_loader instead.
+Every public method here is callable from the UI. Domain state and
+orchestration live in underscore-private collaborators so pywebview exposes
+only this class's deliberate bridge contract.
 """
 
-import os
 import traceback
-import uuid
 
 import webview
 
-from core.geometry.mesh_builder import GeometryBlob
-from core.textures import encode_texture_file
-from core.mod_discovery import discover_ini_paths
-from core.ini.health import analyze_mod
-from core.textures.profiles import texture_profile_for
-
-from app.assets import catalog as asset_catalog
-from app.assets import folders as asset_folders
-from app.assets import index as asset_index
-from app.assets import loader as asset_loader
-from app.assets import paths as asset_paths
-from app.assets.composition import plan_missing_asset_parts
+from app.bridge.access import FolderAccess
+from app.bridge.asset_preview import AssetPreview
 from app.bridge import ini as ini_api
 from app.bridge import present as present_api
+from app.bridge.mod_preview import ModPreview
+from app.bridge.registry import AssetFolderRegistry, ModFolderRegistry
 from app.bridge import toggle as toggle_api
-from app.mods import loader as mod_loader
-from app.mods import metadata
-from app.runtime import server
-from app.session import edit as edit_session
-from app.settings import mod_folders
-from app.assets.loader.models import build_asset_fill_payload
 
 
 class ModViewerAPI:
     def __init__(self):
         # Underscore-private on purpose: pywebview reflects over the js_api
         # object's public attributes to expose them to JavaScript, and the
-        # native window is a deeply self-referential COM object — exposing it
+        # native window is a deeply self-referential COM object. Exposing it
         # sends that reflection into infinite recursion.
         self._window = None
-        self._authorized_folders = set()
-        self._picker_authorized_folders = set()
-        self._authorized_roots = set()
-        self._authorized_asset_folders = set()
-        self._authorized_asset_roots = set()
-        self._active_mesh_keys = {}
-        self._dds_classification_caches = {}
-        self._asset_fill_sessions = {}
-        self._asset_fill_plan_cache = {}
-        try:
-            self._authorized_roots = mod_folders.registered_paths(
-                mod_folders.load_registry())
-        except mod_folders.ModFolderError:
-            # The UI can report the readable config error. Do not let malformed
-            # optional configuration prevent the viewer from starting.
-            pass
-        try:
-            self._authorized_asset_roots = asset_folders.registered_paths(
-                asset_folders.load_registry())
-        except asset_folders.AssetFolderError:
-            pass
+        self._access = FolderAccess()
+        self._mod_preview = ModPreview(self._access)
+        self._asset_preview = AssetPreview(self._access)
+        self._mod_registry = ModFolderRegistry(self._access)
+        self._asset_registry = AssetFolderRegistry(
+            self._access,
+            on_changed=self._asset_preview.invalidate_plan_cache)
 
-    def _folder(self, folder_path):
-        requested = mod_folders.normalize_path(folder_path)
-        if requested in self._authorized_folders:
-            return requested
-        if any(mod_folders.is_within(requested, root)
-               for root in self._authorized_roots):
-            # Preserve access to an exact descendant if its registry root is
-            # later edited or removed during this process lifetime.
-            self._authorized_folders.add(requested)
-            return requested
-        if not requested:
-            raise PermissionError("This folder was not selected through the native folder picker.")
-        raise PermissionError("This folder was not selected through the native folder picker.")
-
-    def _asset_folder(self, folder_path):
-        requested = asset_folders.normalize_path(folder_path)
-        if requested in self._authorized_asset_folders:
-            return requested
-        if any(asset_folders.is_within(requested, root)
-               for root in self._authorized_asset_roots):
-            self._authorized_asset_folders.add(requested)
-            return requested
-        raise PermissionError(
-            "This folder is not inside a registered Asset Folder.")
-
-    @staticmethod
-    def _active_texture_source(folder_path, validate=False):
-        publication = server.active_texture_publication(folder_path)
-        if publication is None:
-            return None
-        if not validate:
-            return publication.register
-
-        def register(path, role=None, transform=None):
-            return publication.register(
-                path, role, validate=True, transform=transform)
-
-        return register
-
-    def _clear_asset_fill(self, folder_path=None):
-        """Release session-only Asset-fill resources before a model change."""
-        keys = list(self._asset_fill_sessions)
-        if folder_path is not None:
-            requested = os.path.normcase(os.path.abspath(folder_path))
-            keys = [key for key in keys if key == requested]
-        for key in keys:
-            state = self._asset_fill_sessions.pop(key, None) or {}
-            server.release_texture_publication(state.get("publication"))
-            server.release_geometry(state.get("geometry_url"))
-
-    def _asset_fill_plan(self, folder_path, context, overrides):
-        revision = edit_session.current_revision(folder_path)
-        entries = tuple(sorted(
-            (item.get("type"), item.get("path"),
-             bool(item.get("enabled", True)))
-            for item in context.asset_folders
-            if isinstance(item, dict)))
-        index_versions = []
-        for asset_type, root, _enabled in entries:
-            try:
-                stat = os.stat(asset_index.index_path(asset_type, root))
-                stamp = (stat.st_mtime_ns, stat.st_size)
-            except OSError:
-                stamp = None
-            index_versions.append((asset_type, root, stamp))
-        key = (os.path.normcase(os.path.abspath(folder_path)), revision,
-               entries, tuple(index_versions))
-        cached = self._asset_fill_plan_cache.get(key)
-        if cached is not None:
-            return cached
-        plan = plan_missing_asset_parts(context, overrides)
-        self._asset_fill_plan_cache[key] = plan
-        return plan
-
-    def _invalidate_asset_fill_plan_cache(self):
-        """Drop plans whose Asset index or enabled-root state may have changed."""
-        self._asset_fill_plan_cache.clear()
+    # -- native folder pickers ---------------------------------------------
 
     def select_folder(self):
         """Open a native folder-picker dialog. Returns None if cancelled."""
         result = self._window.create_file_dialog(webview.FileDialog.FOLDER)
         if not result:
             return None
-        folder = mod_folders.normalize_path(result[0])
-        self._authorized_folders.add(folder)
-        self._picker_authorized_folders.add(folder)
-        return folder
+        return self._access.remember_mod_picker_selection(result[0])
 
     def select_asset_folder(self):
         """Pick an Asset Folder without granting mod-folder access."""
         result = self._window.create_file_dialog(webview.FileDialog.FOLDER)
         if not result:
             return None
-        folder = asset_folders.normalize_path(result[0])
-        self._picker_authorized_folders.add(folder)
-        return folder
+        return self._access.remember_asset_picker_selection(result[0])
 
     # -- persistent Mod Folders registry -----------------------------------
 
-    @staticmethod
-    def _folder_entries(entries):
-        return [{**entry, "exists": os.path.isdir(entry["path"])}
-                for entry in entries]
-
-    def _refresh_authorized_roots(self, entries):
-        self._authorized_roots = mod_folders.registered_paths(entries)
-
-    def _refresh_authorized_asset_roots(self, entries):
-        roots = asset_folders.registered_paths(entries)
-        self._authorized_asset_roots = roots
-        self._authorized_asset_folders = {
-            path for path in self._authorized_asset_folders
-            if any(asset_folders.is_within(path, root) for root in roots)
-        }
-
     def get_mod_folders(self):
-        try:
-            entries = mod_folders.load_registry()
-        except mod_folders.ModFolderError as error:
-            return {"folders": [], "error": str(error)}
-        self._refresh_authorized_roots(entries)
-        return {"folders": self._folder_entries(entries)}
+        return self._mod_registry.get_mod_folders()
 
     def get_panel_opacity(self):
-        try:
-            return {"value": mod_folders.load_panel_opacity()}
-        except mod_folders.ModFolderError as error:
-            return {"error": str(error), "value": mod_folders.DEFAULT_PANEL_OPACITY}
+        return self._mod_registry.get_panel_opacity()
 
     def set_panel_opacity(self, value):
-        try:
-            return {"value": mod_folders.save_panel_opacity(value)}
-        except mod_folders.ModFolderError as error:
-            return {"error": str(error)}
+        return self._mod_registry.set_panel_opacity(value)
 
     def add_mod_folder(self, name, folder_path):
-        folder_path = mod_folders.normalize_path(folder_path)
-        if folder_path not in self._picker_authorized_folders:
-            return {"error": "Choose the Mod Folder through the native folder picker first."}
-        try:
-            entries = mod_folders.add_folder(name, folder_path)
-        except mod_folders.ModFolderError as error:
-            return {"error": str(error)}
-        self._refresh_authorized_roots(entries)
-        return {"folders": self._folder_entries(entries)}
+        return self._mod_registry.add_mod_folder(name, folder_path)
 
     def edit_mod_folder(self, original_path, name, folder_path):
-        original_path = mod_folders.normalize_path(original_path)
-        folder_path = mod_folders.normalize_path(folder_path)
-        try:
-            entries = mod_folders.load_registry()
-            if not any(item["path"] == original_path for item in entries):
-                raise mod_folders.ModFolderError("That Mod Folder is not registered.")
-            if (folder_path != original_path and
-                    folder_path not in self._picker_authorized_folders):
-                raise mod_folders.ModFolderError(
-                    "Choose the new Mod Folder through the native folder picker first.")
-            entries = mod_folders.edit_folder(original_path, name, folder_path)
-        except mod_folders.ModFolderError as error:
-            return {"error": str(error)}
-        self._refresh_authorized_roots(entries)
-        return {"folders": self._folder_entries(entries)}
+        return self._mod_registry.edit_mod_folder(
+            original_path, name, folder_path)
 
     def delete_mod_folder(self, folder_path):
-        try:
-            entries = mod_folders.delete_folder(folder_path)
-        except mod_folders.ModFolderError as error:
-            return {"error": str(error)}
-        self._refresh_authorized_roots(entries)
-        return {"folders": self._folder_entries(entries)}
+        return self._mod_registry.delete_mod_folder(folder_path)
 
     def list_subfolders(self, folder_path):
-        requested = mod_folders.normalize_path(folder_path)
-        try:
-            entries = mod_folders.load_registry()
-            roots = [entry["path"] for entry in entries
-                     if mod_folders.is_within(requested, entry["path"])]
-            if not roots:
-                raise PermissionError(
-                    "That folder is not inside a registered Mod Folder.")
-            # The narrowest matching root is the most precise boundary when
-            # registered roots are nested.
-            root = max(roots, key=len)
-            return {"folders": mod_folders.list_subfolders(requested, root)}
-        except PermissionError as error:
-            return {"error": str(error)}
-        except mod_folders.ModFolderError as error:
-            return {"error": str(error)}
+        return self._mod_registry.list_subfolders(folder_path)
 
-    # -- persistent Asset Folders registry ----------------------------------
+    # -- persistent Asset Folders registry ---------------------------------
 
     def get_asset_folders(self):
-        try:
-            entries = asset_folders.load_registry()
-        except asset_folders.AssetFolderError as error:
-            return {"folders": [], "error": str(error)}
-        self._refresh_authorized_asset_roots(entries)
-        return {"folders": self._asset_folder_entries(entries)}
-
-    @staticmethod
-    def _asset_folder_entries(entries):
-        result = []
-        for entry in entries:
-            item = {**entry, "exists": os.path.isdir(entry["path"])}
-            item["index"] = asset_index.index_status(
-                entry["type"], entry["path"])
-            result.append(item)
-        return result
+        return self._asset_registry.get_asset_folders()
 
     def add_asset_folder(self, asset_type, folder_path):
-        folder_path = asset_folders.normalize_path(folder_path)
-        if folder_path not in self._picker_authorized_folders:
-            return {"error": "Choose the Asset Folder through the native folder picker first."}
-        try:
-            entries = asset_catalog.add(asset_type, folder_path)
-        except asset_catalog.AssetCatalogError as error:
-            return {"error": str(error)}
-        self._refresh_authorized_asset_roots(entries)
-        self._invalidate_asset_fill_plan_cache()
-        self._authorized_asset_folders.add(folder_path)
-        return {"folders": self._asset_folder_entries(entries)}
+        return self._asset_registry.add_asset_folder(asset_type, folder_path)
 
     def edit_asset_folder(self, original_path, asset_type, folder_path):
-        original_path = asset_folders.normalize_path(original_path)
-        folder_path = asset_folders.normalize_path(folder_path)
-        if (folder_path != original_path and
-                folder_path not in self._picker_authorized_folders):
-            return {"error": "Choose the new Asset Folder through the native folder picker first."}
-        try:
-            entries = asset_catalog.edit(original_path, asset_type, folder_path)
-        except asset_catalog.AssetCatalogError as error:
-            return {"error": str(error)}
-        self._refresh_authorized_asset_roots(entries)
-        self._invalidate_asset_fill_plan_cache()
-        self._authorized_asset_folders.add(folder_path)
-        return {"folders": self._asset_folder_entries(entries)}
+        return self._asset_registry.edit_asset_folder(
+            original_path, asset_type, folder_path)
 
     def delete_asset_folder(self, folder_path):
-        folder_path = asset_folders.normalize_path(folder_path)
-        try:
-            entries = asset_catalog.delete(folder_path)
-        except asset_catalog.AssetCatalogError as error:
-            return {"error": str(error)}
-        self._refresh_authorized_asset_roots(entries)
-        self._invalidate_asset_fill_plan_cache()
-        return {"folders": self._asset_folder_entries(entries)}
+        return self._asset_registry.delete_asset_folder(folder_path)
 
     def set_asset_folder_enabled(self, folder_path, enabled):
-        folder_path = asset_folders.normalize_path(folder_path)
-        try:
-            entries = asset_catalog.set_enabled(folder_path, enabled)
-        except asset_catalog.AssetCatalogError as error:
-            return {"error": str(error)}
-        self._refresh_authorized_asset_roots(entries)
-        self._invalidate_asset_fill_plan_cache()
-        return {"folders": self._asset_folder_entries(entries)}
+        return self._asset_registry.set_asset_folder_enabled(folder_path, enabled)
 
     def rebuild_asset_index(self, folder_path):
-        folder_path = asset_folders.normalize_path(folder_path)
-        try:
-            entries = asset_catalog.rebuild(folder_path)
-        except asset_catalog.AssetCatalogError as error:
-            return {
-                "error": f"Could not rebuild Asset index: {error}",
-                "indexPreserved": error.index_preserved,
-            }
-        self._refresh_authorized_asset_roots(entries)
-        self._invalidate_asset_fill_plan_cache()
-        return {"folders": self._asset_folder_entries(entries)}
+        return self._asset_registry.rebuild_asset_index(folder_path)
 
     def list_asset_subfolders(self, folder_path):
-        requested = asset_folders.normalize_path(folder_path)
-        try:
-            entries = asset_folders.load_registry()
-            roots = [entry for entry in entries
-                     if asset_folders.is_within(requested, entry["path"])]
-            if not roots:
-                raise PermissionError(
-                    "That folder is not inside a registered Asset Folder.")
-            entry = max(roots, key=lambda item: len(item["path"]))
-            index = None
-            try:
-                index = asset_index.load_index(entry["type"], entry["path"])
-            except asset_index.AssetIndexError:
-                # The tree remains browseable while the registry panel reports
-                # an invalid cache. The index is still the only asset authority.
-                index = None
-            return {"folders": asset_folders.list_subfolders(
-                requested, entry["path"], index=index,
-                asset_type=entry["type"])}
-        except PermissionError as error:
-            return {"error": str(error)}
-        except asset_folders.AssetFolderError as error:
-            return {"error": str(error)}
+        return self._asset_registry.list_asset_subfolders(folder_path)
 
-    def _asset_selection(self, folder_path):
-        requested = self._asset_folder(folder_path)
-        entries = asset_folders.load_registry()
-        roots = [entry for entry in entries
-                 if asset_folders.is_within(requested, entry["path"])]
-        if not roots:
-            raise PermissionError("This folder is not inside a registered Asset Folder.")
-        entry = max(roots, key=lambda item: len(item["path"]))
-        relative = asset_paths.relative_asset_path(entry["path"], requested)
-        if not relative or relative == ".":
-            raise asset_loader.AssetLoadError(
-                "Select an indexed Asset folder, not the Asset Folder root.")
-        asset_dir = asset_paths.safe_asset_dir(entry["path"], relative)
-        if not asset_dir:
-            raise asset_loader.AssetLoadError(
-                "The selected Asset folder is missing or escapes its registered root.")
-        index = asset_index.load_index(entry["type"], entry["path"])
-        if index is None:
-            raise asset_loader.AssetLoadError(
-                "Asset index is missing. Rebuild the registered Asset Folder first.")
-        record = asset_index.find_asset_by_path(index, relative)
-        if record is None:
-            raise asset_loader.AssetLoadError(
-                "The selected folder is a category or is not present in the Asset index.")
-        return requested, entry, index, record
+    # -- Asset preview and fill --------------------------------------------
 
     def load_asset(self, folder_path):
-        """Load one exact indexed Asset without creating or editing an INI."""
-        self._clear_asset_fill()
-        try:
-            selected, entry, _index, record = self._asset_selection(folder_path)
-            geometry = GeometryBlob()
-            publication = server.begin_texture_publication(selected)
-            publication.set_game_profile({
-                "GIMI": "genshin", "ZZMI": "zzz", "WWMI": "wuwa",
-            }[entry["type"]])
-            try:
-                loaded = asset_loader.load_asset(
-                    entry["type"], entry["path"], record, geometry=geometry,
-                    texture_source=publication.register)
-                payload = loaded.payload
-                server.publish_payload_geometry(payload, geometry)
-                publication.commit()
-                return payload
-            except Exception:
-                publication.discard()
-                raise
-        except (PermissionError, asset_folders.AssetFolderError,
-                asset_index.AssetIndexError, asset_loader.AssetLoadError) as error:
-            return {"error": str(error)}
-        except Exception:
-            traceback.print_exc()
-            return {"error": "Could not load Asset. See the application log for details."}
+        return self._asset_preview.load_asset(folder_path)
 
     def pick_asset_texture_file(self, folder_path, texture_role=None):
-        """Register a manually chosen Asset texture for the current preview only."""
-        try:
-            selected, entry, _index, _record = self._asset_selection(folder_path)
-            if texture_role not in (None, "normal_map", "light_map", "material_map"):
-                return {"error": "Unknown texture role."}
-            result = self._window.create_file_dialog(
-                webview.FileDialog.OPEN, directory=selected,
-                file_types=("Textures (*.dds;*.png;*.jpg;*.jpeg;*.tga)",))
-            if not result:
-                return None
-            chosen = asset_folders.normalize_path(result[0])
-            relative = asset_paths.relative_asset_path(entry["path"], chosen)
-            safe = asset_paths.safe_asset_path(entry["path"], relative)
-            if not safe:
-                return {"error": "Choose a texture inside the registered Asset root."}
-            publication = server.active_texture_publication(selected)
-            if publication is None:
-                return {"error": "The Asset preview is no longer active."}
-            role = texture_role or "diffuse"
-            from app.assets.loader.models import make_texture
-            texture = make_texture(
-                entry["path"], safe, role,
-                texture_source=publication.register, source="session")
-            if not texture:
-                return {"error": "The selected texture could not be published."}
-            return {"tex_key": texture.key, "uri": texture.uri,
-                    "file": relative, "role": role}
-        except (PermissionError, asset_folders.AssetFolderError,
-                asset_index.AssetIndexError, asset_loader.AssetLoadError) as error:
-            return {"error": str(error)}
-
-    def pick_texture_file(self, folder_path, texture_role=None):
-        """Open a native file-picker rooted at the mod folder for the
-        per-mesh/per-component texture picker. Returns {"tex_key", "uri"} / {"error"} on
-        a real pick, None if the dialog was cancelled -- same shape as
-        select_folder's own cancel case.
-        """
-        folder_path = self._folder(folder_path)
-        if texture_role not in (None, "normal_map", "light_map", "material_map"):
-            return {"error": "Unknown texture role."}
-        result = self._window.create_file_dialog(
-            webview.FileDialog.OPEN, directory=folder_path,
-            file_types=("Textures (*.dds;*.png;*.jpg;*.jpeg;*.tga)",))
-        if not result:
-            return None
-        texture_source = self._active_texture_source(
-            folder_path, validate=True)
-        publication = server.active_texture_publication(folder_path)
-        profile = texture_profile_for(
-            publication.game_profile if publication else None)
-        transport_role = texture_role
-        if (texture_role == "normal_map"
-                and profile.normal_transport_role == "normal_data"):
-            transport_role = profile.normal_transport_role
-        encoded = encode_texture_file(
-            folder_path, result[0], transport_role,
-            texture_source=texture_source, texture_profile=profile)
-        return encoded
-
-    def _authoritative_context(self, folder_path):
-        """Load active INI documents while preserving the current session."""
-        folder_path = self._folder(folder_path)
-        ini_paths = (edit_session.document_paths(folder_path)
-                     or discover_ini_paths(folder_path))
-        edit_session.load_documents(folder_path, ini_paths)
-        overrides = edit_session.overrides_for(folder_path)
-        pending_new_sections = edit_session.new_sections_for(folder_path)
-        context = mod_loader.ModLoadContext(
-            folder_path, ini_paths, edit_session.documents_for(folder_path),
-            metadata.load(folder_path))
-        cache_key = os.path.normcase(os.path.abspath(folder_path))
-        context.dds_classification_cache = \
-            self._dds_classification_caches.setdefault(cache_key, {})
-        try:
-            context.asset_folders = asset_folders.load_registry()
-        except asset_folders.AssetFolderError:
-            # Optional asset configuration must not make an otherwise valid
-            # mod unloadable; the asset UI reports the config error directly.
-            context.asset_folders = []
-        return folder_path, overrides, pending_new_sections, context
-
-    @staticmethod
-    def _semantic_read_error():
-        traceback.print_exc()
-        return {"error": "Unexpected backend error. See the application log for details."}
-
-    def load_mod(self, folder_path):
-        self._clear_asset_fill()
-        folder_path, overrides, pending_new_sections, context = \
-            self._authoritative_context(folder_path)
-        ini_paths = context.ini_paths
-        geometry = GeometryBlob()
-        publication = server.begin_texture_publication(folder_path)
-        try:
-            result = mod_loader.load_mod(
-                context=context, overrides=overrides,
-                pending_new_sections=pending_new_sections, geometry=geometry,
-                texture_source=publication.register)
-            if not isinstance(result, dict) or result.get("error"):
-                publication.discard()
-                self._active_mesh_keys.pop(folder_path, None)
-                return result
-
-            saved_metadata = context.metadata
-            result.setdefault("metadata", {})["mesh_names"] = \
-                saved_metadata.get("mesh_names", {})
-            game_metadata = result.get("metadata", {}).get("game", {})
-            publication.set_game_profile(game_metadata.get("id"))
-            metadata.hydrate_textures(
-                folder_path, result, saved_metadata,
-                texture_source=publication.register,
-                texture_profile=game_metadata.get("id"))
-            controls = result.setdefault("controls", {})
-            metadata.hydrate_present(folder_path, controls.get("present"),
-                                      saved_metadata)
-            server.publish_payload_geometry(result, geometry)
-            publication.commit()
-            self._active_mesh_keys[folder_path] = set(result.get("meshes", {}))
-            return result
-        except Exception:
-            publication.discard()
-            self._active_mesh_keys.pop(folder_path, None)
-            raise
+        return self._asset_preview.pick_asset_texture_file(
+            self._window, folder_path, texture_role)
 
     def load_missing_asset_parts(self, folder_path):
         """Append original Asset parts not covered by the current mod INIs."""
         try:
             folder_path, overrides, _pending, context = \
-                self._authoritative_context(folder_path)
-            key = os.path.normcase(os.path.abspath(folder_path))
-            existing = self._asset_fill_sessions.get(key)
-            if existing is not None:
-                return {**existing["summary"], "status": "loaded",
-                        "already_loaded": True,
-                        "fill_id": existing.get("fill_id")}
-            plan = self._asset_fill_plan(folder_path, context, overrides)
-            summary = plan.to_dict()
-            if plan.status != "ready":
-                return summary
-
-            geometry = GeometryBlob()
-            publication = server.begin_texture_publication(folder_path)
-            publication.set_game_profile({
-                "GIMI": "genshin", "ZZMI": "zzz", "WWMI": "wuwa",
-            }[plan.asset_type])
-            try:
-                loaded = asset_loader.load_asset_parts(
-                    plan.asset_type, plan.root, plan.asset,
-                    texture_source=publication.register,
-                    part_filter=set(plan.missing_parts))
-                payload = build_asset_fill_payload(
-                    plan.asset_type, plan.root, plan.asset, loaded.parts,
-                    geometry=geometry, warnings=loaded.warnings)
-                server.publish_payload_geometry(
-                    payload, geometry, replace=False)
-                publication.commit(replace=False)
-            except Exception:
-                publication.discard()
-                raise
-            summary["payload"] = payload
-            fill_id = uuid.uuid4().hex
-            self._asset_fill_sessions[key] = {
-                "fill_id": fill_id,
-                "publication": publication,
-                "geometry_url": payload.get("geometry", {}).get("url")
-                if payload.get("geometry") else None,
-                "summary": summary,
-            }
-            return {**summary, "status": "loaded", "fill_id": fill_id}
-        except (PermissionError, asset_folders.AssetFolderError,
-                asset_index.AssetIndexError, asset_loader.AssetLoadError) as error:
-            return {"status": "error", "error": str(error)}
+                self._mod_preview.authoritative_context(folder_path)
+            return self._asset_preview.load_missing_asset_parts(
+                folder_path, context, overrides)
         except Exception:
             traceback.print_exc()
-            return {"status": "error",
-                    "error": "Could not load missing Asset parts. See the application log for details."}
+            return {
+                "status": "error",
+                "error": "Could not load missing Asset parts. See the application log for details.",
+            }
 
     def remove_missing_asset_parts(self, folder_path, fill_id=None):
-        """Remove the current session-only original Asset fill."""
-        try:
-            folder_path = self._folder(folder_path)
-            key = os.path.normcase(os.path.abspath(folder_path))
-            state = self._asset_fill_sessions.get(key)
-            if state is None:
-                return {"status": "removed", "removed": False}
-            if fill_id is not None and state.get("fill_id") != fill_id:
-                return {"status": "removed", "removed": False, "stale": True}
-            self._asset_fill_sessions.pop(key, None)
-            server.release_texture_publication(state.get("publication"))
-            server.release_geometry(state.get("geometry_url"))
-            return {"status": "removed", "removed": True}
-        except (PermissionError, mod_folders.ModFolderError) as error:
-            return {"status": "error", "error": str(error)}
+        return self._asset_preview.remove_missing_asset_parts(
+            folder_path, fill_id)
+
+    # -- Mod preview --------------------------------------------------------
+
+    def load_mod(self, folder_path):
+        self._asset_preview.clear_fill()
+        return self._mod_preview.load_mod(folder_path)
 
     def get_present_state(self, folder_path):
-        """Return staged PRESENT state without loading geometry or textures."""
-        try:
-            folder_path, overrides, _pending, context = \
-                self._authoritative_context(folder_path)
-            present = mod_loader.load_present_state(context, overrides)
-            metadata.hydrate_present(folder_path, present, context.metadata)
-            return {"present": present}
-        except Exception:
-            return self._semantic_read_error()
+        return self._mod_preview.get_present_state(folder_path)
 
     def get_control_state(self, folder_path):
-        """Return staged control semantics without rebuilding the model."""
-        try:
-            folder_path, overrides, pending, context = \
-                self._authoritative_context(folder_path)
-            result = mod_loader.load_control_state(
-                context, overrides, pending,
-                active_mesh_keys=self._active_mesh_keys.get(folder_path))
-            metadata.hydrate_present(
-                folder_path, result["controls"]["present"], context.metadata)
-            return result
-        except Exception:
-            return self._semantic_read_error()
+        return self._mod_preview.get_control_state(folder_path)
 
     def get_mesh_semantics(self, folder_path):
-        """Return staged draw visibility semantics without rebuilding meshes."""
-        try:
-            _folder_path, overrides, _pending, context = \
-                self._authoritative_context(folder_path)
-            return mod_loader.load_mesh_semantics(
-                context, overrides, self._active_mesh_keys.get(_folder_path))
-        except Exception:
-            return self._semantic_read_error()
+        return self._mod_preview.get_mesh_semantics(folder_path)
 
     def get_diagnostics(self, folder_path):
-        """Return the read-only health scan for the current edit revision."""
-        folder_path = self._folder(folder_path)
-        cached = edit_session.cached_diagnostics(folder_path)
-        if cached is not None:
-            return cached
-        ini_paths = edit_session.document_paths(folder_path)
-        if not ini_paths:
-            ini_paths = discover_ini_paths(folder_path)
-            edit_session.load_documents(folder_path, ini_paths)
-        try:
-            report = analyze_mod(
-                folder_path, ini_paths=ini_paths,
-                overrides=edit_session.overrides_for(folder_path),
-                documents=edit_session.documents_for(folder_path))
-            return edit_session.cache_diagnostics(folder_path, report)
-        except Exception:
-            return edit_session.cache_diagnostics(folder_path, {
-                "summary": {"errors": 0, "warnings": 1, "issues": 1,
-                            "unused_files": 0, "unused_resources": 0},
-                "files": {"unreferenced": 0, "inactive_only": 0,
-                          "viewer_only": 0, "referenced": 0},
-                "issues": [{
-                    "code": "health_check_failed", "severity": "warning",
-                    "category": "ini",
-                    "message": "The INI diagnostics could not be completed.",
-                }],
-            })
+        return self._mod_preview.get_diagnostics(folder_path)
 
     def save_mesh_names(self, folder_path, names):
-        return metadata.save_mesh_names(self._folder(folder_path), names)
+        return self._mod_preview.save_mesh_names(folder_path, names)
 
     def save_mesh_textures(self, folder_path, textures):
-        folder_path = self._folder(folder_path)
-        result = metadata.save_textures(folder_path, textures)
-        edit_session.invalidate_diagnostics(folder_path)
-        return result
+        return self._mod_preview.save_mesh_textures(folder_path, textures)
 
     def save_component_material_kind(self, folder_path, source, component,
                                      material_kind):
-        folder_path = self._folder(folder_path)
-        result = metadata.save_component_material_kind(
+        return self._mod_preview.save_component_material_kind(
             folder_path, source, component, material_kind)
-        edit_session.invalidate_diagnostics(folder_path)
-        return result
+
+    def pick_texture_file(self, folder_path, texture_role=None):
+        return self._mod_preview.pick_texture_file(
+            self._window, folder_path, texture_role)
 
     # -- in-memory INI viewer/editor ----------------------------------------
 
     def list_ini_files(self, folder_path):
-        return ini_api.list_inis(self._folder(folder_path))
+        return ini_api.list_inis(self._access.mod_folder(folder_path))
 
     def get_ini_text(self, folder_path, ini_name):
-        return ini_api.get_text(self._folder(folder_path), ini_name)
+        return ini_api.get_text(self._access.mod_folder(folder_path), ini_name)
 
     def update_ini_text(self, folder_path, ini_name, text):
-        return ini_api.update_text(self._folder(folder_path), ini_name, text)
+        return ini_api.update_text(
+            self._access.mod_folder(folder_path), ini_name, text)
 
-    # -- toggle authoring -----------------------------------------------------
+    # -- toggle authoring ---------------------------------------------------
     #
     # Each call stages its change in memory only (app/session/edit.py) --
     # nothing reaches the real ini file until export_changes() is called.
 
     def list_toggle_source_inis(self, folder_path):
-        return toggle_api.list_source_inis(self._folder(folder_path))
+        return toggle_api.list_source_inis(
+            self._access.mod_folder(folder_path))
 
     def get_toggle_details(self, folder_path, ini_rel, section_name):
-        return toggle_api.get_toggle_details(self._folder(folder_path), ini_rel, section_name)
+        return toggle_api.get_toggle_details(
+            self._access.mod_folder(folder_path), ini_rel, section_name)
 
-    def add_toggle(self, folder_path, ini_rel, name, key_combo, var, values, options=None):
-        return toggle_api.add_toggle(self._folder(folder_path), ini_rel, name, key_combo, var, values, options)
+    def add_toggle(self, folder_path, ini_rel, name, key_combo, var, values,
+                   options=None):
+        return toggle_api.add_toggle(
+            self._access.mod_folder(folder_path), ini_rel, name, key_combo,
+            var, values, options)
 
     def edit_toggle(self, folder_path, ini_rel, section_name, changes=None):
-        return toggle_api.edit_toggle(self._folder(folder_path), ini_rel, section_name, changes)
+        return toggle_api.edit_toggle(
+            self._access.mod_folder(folder_path), ini_rel, section_name,
+            changes)
 
     def delete_toggle(self, folder_path, ini_rel, section_name):
-        return toggle_api.delete_toggle(self._folder(folder_path), ini_rel, section_name)
+        return toggle_api.delete_toggle(
+            self._access.mod_folder(folder_path), ini_rel, section_name)
 
-    # -- PRESENT preset cycle -----------------------------------------------
+    # -- PRESENT preset cycle ----------------------------------------------
 
     def add_present(self, folder_path, key_combo, back_combo, snapshots):
         return present_api.add_present(
-            self._folder(folder_path), key_combo, back_combo, snapshots)
+            self._access.mod_folder(folder_path), key_combo, back_combo,
+            snapshots)
 
     def edit_present(self, folder_path, key_combo, back_combo):
         return present_api.edit_present(
-            self._folder(folder_path), key_combo, back_combo)
+            self._access.mod_folder(folder_path), key_combo, back_combo)
 
     def delete_present(self, folder_path):
-        return present_api.delete_present(self._folder(folder_path))
+        return present_api.delete_present(self._access.mod_folder(folder_path))
 
     def capture_present(self, folder_path, snapshots, name, position=None,
                         allow_duplicate=False):
         return present_api.capture_present(
-            self._folder(folder_path), snapshots, name, position,
+            self._access.mod_folder(folder_path), snapshots, name, position,
             allow_duplicate)
 
     def delete_present_position(self, folder_path, position):
         return present_api.delete_present_position(
-            self._folder(folder_path), position)
+            self._access.mod_folder(folder_path), position)
 
-    # -- export / discard ----------------------------------------------------
+    # -- export / discard ---------------------------------------------------
 
     def has_pending_changes(self, folder_path):
-        return toggle_api.has_pending_changes(self._folder(folder_path))
+        return toggle_api.has_pending_changes(
+            self._access.mod_folder(folder_path))
 
     def export_changes(self, folder_path):
-        return toggle_api.export_changes(self._folder(folder_path))
+        return toggle_api.export_changes(
+            self._access.mod_folder(folder_path))
 
     def discard_changes(self, folder_path):
-        return toggle_api.discard_changes(self._folder(folder_path))
+        return toggle_api.discard_changes(
+            self._access.mod_folder(folder_path))
 
-    # -- record mode ----------------------------------------------------------
+    # -- record mode --------------------------------------------------------
 
     def get_record_positions(self, folder_path, ini_rel, section_name):
-        return toggle_api.get_record_positions(self._folder(folder_path), ini_rel, section_name)
+        return toggle_api.get_record_positions(
+            self._access.mod_folder(folder_path), ini_rel, section_name)
 
     def record_toggle(self, folder_path, ini_rel, section_name, position_lines):
-        return toggle_api.record_toggle(self._folder(folder_path), ini_rel, section_name, position_lines)
+        return toggle_api.record_toggle(
+            self._access.mod_folder(folder_path), ini_rel, section_name,
+            position_lines)

--- a/src/app/bridge/asset_preview.py
+++ b/src/app/bridge/asset_preview.py
@@ -1,0 +1,219 @@
+"""Indexed Asset preview and session-only fill orchestration."""
+
+import os
+import traceback
+import uuid
+
+import webview
+
+from core.geometry.mesh_builder import GeometryBlob
+
+from app.assets import folders as asset_folders
+from app.assets import index as asset_index
+from app.assets import loader as asset_loader
+from app.assets import paths as asset_paths
+from app.assets.composition import plan_missing_asset_parts
+from app.assets.loader.models import build_asset_fill_payload
+from app.runtime import server
+from app.session import edit as edit_session
+
+
+class AssetPreview:
+    def __init__(self, access):
+        self._access = access
+        self._asset_fill_sessions = {}
+        self._asset_fill_plan_cache = {}
+
+    def clear_fill(self, folder_path=None):
+        """Release session-only Asset-fill resources before a model change."""
+        keys = list(self._asset_fill_sessions)
+        if folder_path is not None:
+            requested = os.path.normcase(os.path.abspath(folder_path))
+            keys = [key for key in keys if key == requested]
+        for key in keys:
+            state = self._asset_fill_sessions.pop(key, None) or {}
+            server.release_texture_publication(state.get("publication"))
+            server.release_geometry(state.get("geometry_url"))
+
+    def _asset_fill_plan(self, folder_path, context, overrides):
+        revision = edit_session.current_revision(folder_path)
+        entries = tuple(sorted(
+            (item.get("type"), item.get("path"),
+             bool(item.get("enabled", True)))
+            for item in context.asset_folders
+            if isinstance(item, dict)))
+        index_versions = []
+        for asset_type, root, _enabled in entries:
+            try:
+                stat = os.stat(asset_index.index_path(asset_type, root))
+                stamp = (stat.st_mtime_ns, stat.st_size)
+            except OSError:
+                stamp = None
+            index_versions.append((asset_type, root, stamp))
+        key = (os.path.normcase(os.path.abspath(folder_path)), revision,
+               entries, tuple(index_versions))
+        cached = self._asset_fill_plan_cache.get(key)
+        if cached is not None:
+            return cached
+        plan = plan_missing_asset_parts(context, overrides)
+        self._asset_fill_plan_cache[key] = plan
+        return plan
+
+    def invalidate_plan_cache(self):
+        """Drop plans whose Asset index or enabled-root state may have changed."""
+        self._asset_fill_plan_cache.clear()
+
+    def _asset_selection(self, folder_path):
+        requested = self._access.asset_folder(folder_path)
+        entries = asset_folders.load_registry()
+        roots = [entry for entry in entries
+                 if asset_folders.is_within(requested, entry["path"])]
+        if not roots:
+            raise PermissionError(
+                "This folder is not inside a registered Asset Folder.")
+        entry = max(roots, key=lambda item: len(item["path"]))
+        relative = asset_paths.relative_asset_path(entry["path"], requested)
+        if not relative or relative == ".":
+            raise asset_loader.AssetLoadError(
+                "Select an indexed Asset folder, not the Asset Folder root.")
+        asset_dir = asset_paths.safe_asset_dir(entry["path"], relative)
+        if not asset_dir:
+            raise asset_loader.AssetLoadError(
+                "The selected Asset folder is missing or escapes its registered root.")
+        index = asset_index.load_index(entry["type"], entry["path"])
+        if index is None:
+            raise asset_loader.AssetLoadError(
+                "Asset index is missing. Rebuild the registered Asset Folder first.")
+        record = asset_index.find_asset_by_path(index, relative)
+        if record is None:
+            raise asset_loader.AssetLoadError(
+                "The selected folder is a category or is not present in the Asset index.")
+        return requested, entry, index, record
+
+    def load_asset(self, folder_path):
+        """Load one exact indexed Asset without creating or editing an INI."""
+        self.clear_fill()
+        try:
+            selected, entry, _index, record = self._asset_selection(folder_path)
+            geometry = GeometryBlob()
+            publication = server.begin_texture_publication(selected)
+            publication.set_game_profile({
+                "GIMI": "genshin", "ZZMI": "zzz", "WWMI": "wuwa",
+            }[entry["type"]])
+            try:
+                loaded = asset_loader.load_asset(
+                    entry["type"], entry["path"], record, geometry=geometry,
+                    texture_source=publication.register)
+                payload = loaded.payload
+                server.publish_payload_geometry(payload, geometry)
+                publication.commit()
+                return payload
+            except Exception:
+                publication.discard()
+                raise
+        except (PermissionError, asset_folders.AssetFolderError,
+                asset_index.AssetIndexError, asset_loader.AssetLoadError) as error:
+            return {"error": str(error)}
+        except Exception:
+            traceback.print_exc()
+            return {"error": "Could not load Asset. See the application log for details."}
+
+    def pick_asset_texture_file(self, window, folder_path, texture_role=None):
+        """Register a chosen Asset texture using the facade-owned window."""
+        try:
+            selected, entry, _index, _record = self._asset_selection(folder_path)
+            if texture_role not in (None, "normal_map", "light_map", "material_map"):
+                return {"error": "Unknown texture role."}
+            result = window.create_file_dialog(
+                webview.FileDialog.OPEN, directory=selected,
+                file_types=("Textures (*.dds;*.png;*.jpg;*.jpeg;*.tga)",))
+            if not result:
+                return None
+            chosen = asset_folders.normalize_path(result[0])
+            relative = asset_paths.relative_asset_path(entry["path"], chosen)
+            safe = asset_paths.safe_asset_path(entry["path"], relative)
+            if not safe:
+                return {"error": "Choose a texture inside the registered Asset root."}
+            publication = server.active_texture_publication(selected)
+            if publication is None:
+                return {"error": "The Asset preview is no longer active."}
+            role = texture_role or "diffuse"
+            from app.assets.loader.models import make_texture
+            texture = make_texture(
+                entry["path"], safe, role,
+                texture_source=publication.register, source="session")
+            if not texture:
+                return {"error": "The selected texture could not be published."}
+            return {"tex_key": texture.key, "uri": texture.uri,
+                    "file": relative, "role": role}
+        except (PermissionError, asset_folders.AssetFolderError,
+                asset_index.AssetIndexError, asset_loader.AssetLoadError) as error:
+            return {"error": str(error)}
+
+    def load_missing_asset_parts(self, folder_path, context, overrides):
+        """Append original Asset parts not covered by the current mod INIs."""
+        try:
+            key = os.path.normcase(os.path.abspath(folder_path))
+            existing = self._asset_fill_sessions.get(key)
+            if existing is not None:
+                return {**existing["summary"], "status": "loaded",
+                        "already_loaded": True,
+                        "fill_id": existing.get("fill_id")}
+            plan = self._asset_fill_plan(folder_path, context, overrides)
+            summary = plan.to_dict()
+            if plan.status != "ready":
+                return summary
+
+            geometry = GeometryBlob()
+            publication = server.begin_texture_publication(folder_path)
+            publication.set_game_profile({
+                "GIMI": "genshin", "ZZMI": "zzz", "WWMI": "wuwa",
+            }[plan.asset_type])
+            try:
+                loaded = asset_loader.load_asset_parts(
+                    plan.asset_type, plan.root, plan.asset,
+                    texture_source=publication.register,
+                    part_filter=set(plan.missing_parts))
+                payload = build_asset_fill_payload(
+                    plan.asset_type, plan.root, plan.asset, loaded.parts,
+                    geometry=geometry, warnings=loaded.warnings)
+                server.publish_payload_geometry(
+                    payload, geometry, replace=False)
+                publication.commit(replace=False)
+            except Exception:
+                publication.discard()
+                raise
+            summary["payload"] = payload
+            fill_id = uuid.uuid4().hex
+            self._asset_fill_sessions[key] = {
+                "fill_id": fill_id,
+                "publication": publication,
+                "geometry_url": payload.get("geometry", {}).get("url")
+                if payload.get("geometry") else None,
+                "summary": summary,
+            }
+            return {**summary, "status": "loaded", "fill_id": fill_id}
+        except (PermissionError, asset_folders.AssetFolderError,
+                asset_index.AssetIndexError, asset_loader.AssetLoadError) as error:
+            return {"status": "error", "error": str(error)}
+        except Exception:
+            traceback.print_exc()
+            return {"status": "error",
+                    "error": "Could not load missing Asset parts. See the application log for details."}
+
+    def remove_missing_asset_parts(self, folder_path, fill_id=None):
+        """Remove the current session-only original Asset fill."""
+        try:
+            folder_path = self._access.mod_folder(folder_path)
+            key = os.path.normcase(os.path.abspath(folder_path))
+            state = self._asset_fill_sessions.get(key)
+            if state is None:
+                return {"status": "removed", "removed": False}
+            if fill_id is not None and state.get("fill_id") != fill_id:
+                return {"status": "removed", "removed": False, "stale": True}
+            self._asset_fill_sessions.pop(key, None)
+            server.release_texture_publication(state.get("publication"))
+            server.release_geometry(state.get("geometry_url"))
+            return {"status": "removed", "removed": True}
+        except (PermissionError, asset_folders.AssetFolderError) as error:
+            return {"status": "error", "error": str(error)}

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -1,0 +1,207 @@
+"""Mod preview orchestration behind the JavaScript bridge facade."""
+
+import os
+import traceback
+
+import webview
+
+from core.geometry.mesh_builder import GeometryBlob
+from core.textures import encode_texture_file
+from core.mod_discovery import discover_ini_paths
+from core.ini.health import analyze_mod
+from core.textures.profiles import texture_profile_for
+
+from app.assets import folders as asset_folders
+from app.mods import loader as mod_loader
+from app.mods import metadata
+from app.runtime import server
+from app.session import edit as edit_session
+
+
+class ModPreview:
+    def __init__(self, access):
+        self._access = access
+        self._active_mesh_keys = {}
+        self._dds_classification_caches = {}
+
+    @staticmethod
+    def _active_texture_source(folder_path, validate=False):
+        publication = server.active_texture_publication(folder_path)
+        if publication is None:
+            return None
+        if not validate:
+            return publication.register
+
+        def register(path, role=None, transform=None):
+            return publication.register(
+                path, role, validate=True, transform=transform)
+
+        return register
+
+    def authoritative_context(self, folder_path):
+        """Load active INI documents while preserving the current session."""
+        folder_path = self._access.mod_folder(folder_path)
+        ini_paths = (edit_session.document_paths(folder_path)
+                     or discover_ini_paths(folder_path))
+        edit_session.load_documents(folder_path, ini_paths)
+        overrides = edit_session.overrides_for(folder_path)
+        pending_new_sections = edit_session.new_sections_for(folder_path)
+        context = mod_loader.ModLoadContext(
+            folder_path, ini_paths, edit_session.documents_for(folder_path),
+            metadata.load(folder_path))
+        cache_key = os.path.normcase(os.path.abspath(folder_path))
+        context.dds_classification_cache = \
+            self._dds_classification_caches.setdefault(cache_key, {})
+        try:
+            context.asset_folders = asset_folders.load_registry()
+        except asset_folders.AssetFolderError:
+            # Optional asset configuration must not make an otherwise valid
+            # mod unloadable; the asset UI reports the config error directly.
+            context.asset_folders = []
+        return folder_path, overrides, pending_new_sections, context
+
+    @staticmethod
+    def _semantic_read_error():
+        traceback.print_exc()
+        return {"error": "Unexpected backend error. See the application log for details."}
+
+    def load_mod(self, folder_path):
+        folder_path, overrides, pending_new_sections, context = \
+            self.authoritative_context(folder_path)
+        geometry = GeometryBlob()
+        publication = server.begin_texture_publication(folder_path)
+        try:
+            result = mod_loader.load_mod(
+                context=context, overrides=overrides,
+                pending_new_sections=pending_new_sections, geometry=geometry,
+                texture_source=publication.register)
+            if not isinstance(result, dict) or result.get("error"):
+                publication.discard()
+                self._active_mesh_keys.pop(folder_path, None)
+                return result
+
+            saved_metadata = context.metadata
+            result.setdefault("metadata", {})["mesh_names"] = \
+                saved_metadata.get("mesh_names", {})
+            game_metadata = result.get("metadata", {}).get("game", {})
+            publication.set_game_profile(game_metadata.get("id"))
+            metadata.hydrate_textures(
+                folder_path, result, saved_metadata,
+                texture_source=publication.register,
+                texture_profile=game_metadata.get("id"))
+            controls = result.setdefault("controls", {})
+            metadata.hydrate_present(folder_path, controls.get("present"),
+                                     saved_metadata)
+            server.publish_payload_geometry(result, geometry)
+            publication.commit()
+            self._active_mesh_keys[folder_path] = set(result.get("meshes", {}))
+            return result
+        except Exception:
+            publication.discard()
+            self._active_mesh_keys.pop(folder_path, None)
+            raise
+
+    def get_present_state(self, folder_path):
+        """Return staged PRESENT state without loading geometry or textures."""
+        try:
+            folder_path, overrides, _pending, context = \
+                self.authoritative_context(folder_path)
+            present = mod_loader.load_present_state(context, overrides)
+            metadata.hydrate_present(folder_path, present, context.metadata)
+            return {"present": present}
+        except Exception:
+            return self._semantic_read_error()
+
+    def get_control_state(self, folder_path):
+        """Return staged control semantics without rebuilding the model."""
+        try:
+            folder_path, overrides, pending, context = \
+                self.authoritative_context(folder_path)
+            result = mod_loader.load_control_state(
+                context, overrides, pending,
+                active_mesh_keys=self._active_mesh_keys.get(folder_path))
+            metadata.hydrate_present(
+                folder_path, result["controls"]["present"], context.metadata)
+            return result
+        except Exception:
+            return self._semantic_read_error()
+
+    def get_mesh_semantics(self, folder_path):
+        """Return staged draw visibility semantics without rebuilding meshes."""
+        try:
+            folder_path, overrides, _pending, context = \
+                self.authoritative_context(folder_path)
+            return mod_loader.load_mesh_semantics(
+                context, overrides, self._active_mesh_keys.get(folder_path))
+        except Exception:
+            return self._semantic_read_error()
+
+    def get_diagnostics(self, folder_path):
+        """Return the read-only health scan for the current edit revision."""
+        folder_path = self._access.mod_folder(folder_path)
+        cached = edit_session.cached_diagnostics(folder_path)
+        if cached is not None:
+            return cached
+        ini_paths = edit_session.document_paths(folder_path)
+        if not ini_paths:
+            ini_paths = discover_ini_paths(folder_path)
+            edit_session.load_documents(folder_path, ini_paths)
+        try:
+            report = analyze_mod(
+                folder_path, ini_paths=ini_paths,
+                overrides=edit_session.overrides_for(folder_path),
+                documents=edit_session.documents_for(folder_path))
+            return edit_session.cache_diagnostics(folder_path, report)
+        except Exception:
+            return edit_session.cache_diagnostics(folder_path, {
+                "summary": {"errors": 0, "warnings": 1, "issues": 1,
+                            "unused_files": 0, "unused_resources": 0},
+                "files": {"unreferenced": 0, "inactive_only": 0,
+                          "viewer_only": 0, "referenced": 0},
+                "issues": [{
+                    "code": "health_check_failed", "severity": "warning",
+                    "category": "ini",
+                    "message": "The INI diagnostics could not be completed.",
+                }],
+            })
+
+    def save_mesh_names(self, folder_path, names):
+        return metadata.save_mesh_names(self._access.mod_folder(folder_path), names)
+
+    def save_mesh_textures(self, folder_path, textures):
+        folder_path = self._access.mod_folder(folder_path)
+        result = metadata.save_textures(folder_path, textures)
+        edit_session.invalidate_diagnostics(folder_path)
+        return result
+
+    def save_component_material_kind(self, folder_path, source, component,
+                                     material_kind):
+        folder_path = self._access.mod_folder(folder_path)
+        result = metadata.save_component_material_kind(
+            folder_path, source, component, material_kind)
+        edit_session.invalidate_diagnostics(folder_path)
+        return result
+
+    def pick_texture_file(self, window, folder_path, texture_role=None):
+        """Pick a mod texture using the facade-owned native window."""
+        folder_path = self._access.mod_folder(folder_path)
+        if texture_role not in (None, "normal_map", "light_map", "material_map"):
+            return {"error": "Unknown texture role."}
+        result = window.create_file_dialog(
+            webview.FileDialog.OPEN, directory=folder_path,
+            file_types=("Textures (*.dds;*.png;*.jpg;*.jpeg;*.tga)",))
+        if not result:
+            return None
+        texture_source = self._active_texture_source(
+            folder_path, validate=True)
+        publication = server.active_texture_publication(folder_path)
+        profile = texture_profile_for(
+            publication.game_profile if publication else None)
+        transport_role = texture_role
+        if (texture_role == "normal_map"
+                and profile.normal_transport_role == "normal_data"):
+            transport_role = profile.normal_transport_role
+        encoded = encode_texture_file(
+            folder_path, result[0], transport_role,
+            texture_source=texture_source, texture_profile=profile)
+        return encoded

--- a/src/app/bridge/registry.py
+++ b/src/app/bridge/registry.py
@@ -1,0 +1,210 @@
+"""Bridge orchestration for Mod and Asset Folder registries."""
+
+import os
+
+from app.assets import catalog as asset_catalog
+from app.assets import folders as asset_folders
+from app.assets import index as asset_index
+from app.settings import mod_folders
+
+
+class ModFolderRegistry:
+    def __init__(self, access):
+        self._access = access
+
+    @staticmethod
+    def _folder_entries(entries):
+        return [{**entry, "exists": os.path.isdir(entry["path"])}
+                for entry in entries]
+
+    def get_mod_folders(self):
+        try:
+            entries = mod_folders.load_registry()
+        except mod_folders.ModFolderError as error:
+            return {"folders": [], "error": str(error)}
+        self._access.refresh_mod_roots(entries)
+        return {"folders": self._folder_entries(entries)}
+
+    def get_panel_opacity(self):
+        try:
+            return {"value": mod_folders.load_panel_opacity()}
+        except mod_folders.ModFolderError as error:
+            return {"error": str(error),
+                    "value": mod_folders.DEFAULT_PANEL_OPACITY}
+
+    def set_panel_opacity(self, value):
+        try:
+            return {"value": mod_folders.save_panel_opacity(value)}
+        except mod_folders.ModFolderError as error:
+            return {"error": str(error)}
+
+    def add_mod_folder(self, name, folder_path):
+        folder_path = mod_folders.normalize_path(folder_path)
+        if not self._access.was_picker_selected(folder_path):
+            return {
+                "error": "Choose the Mod Folder through the native folder picker first."
+            }
+        try:
+            entries = mod_folders.add_folder(name, folder_path)
+        except mod_folders.ModFolderError as error:
+            return {"error": str(error)}
+        self._access.refresh_mod_roots(entries)
+        return {"folders": self._folder_entries(entries)}
+
+    def edit_mod_folder(self, original_path, name, folder_path):
+        original_path = mod_folders.normalize_path(original_path)
+        folder_path = mod_folders.normalize_path(folder_path)
+        try:
+            entries = mod_folders.load_registry()
+            if not any(item["path"] == original_path for item in entries):
+                raise mod_folders.ModFolderError(
+                    "That Mod Folder is not registered.")
+            if (folder_path != original_path and
+                    not self._access.was_picker_selected(folder_path)):
+                raise mod_folders.ModFolderError(
+                    "Choose the new Mod Folder through the native folder picker first.")
+            entries = mod_folders.edit_folder(original_path, name, folder_path)
+        except mod_folders.ModFolderError as error:
+            return {"error": str(error)}
+        self._access.refresh_mod_roots(entries)
+        return {"folders": self._folder_entries(entries)}
+
+    def delete_mod_folder(self, folder_path):
+        try:
+            entries = mod_folders.delete_folder(folder_path)
+        except mod_folders.ModFolderError as error:
+            return {"error": str(error)}
+        self._access.refresh_mod_roots(entries)
+        return {"folders": self._folder_entries(entries)}
+
+    def list_subfolders(self, folder_path):
+        requested = mod_folders.normalize_path(folder_path)
+        try:
+            entries = mod_folders.load_registry()
+            roots = [entry["path"] for entry in entries
+                     if mod_folders.is_within(requested, entry["path"])]
+            if not roots:
+                raise PermissionError(
+                    "That folder is not inside a registered Mod Folder.")
+            # The narrowest matching root is the most precise boundary when
+            # registered roots are nested.
+            root = max(roots, key=len)
+            return {"folders": mod_folders.list_subfolders(requested, root)}
+        except PermissionError as error:
+            return {"error": str(error)}
+        except mod_folders.ModFolderError as error:
+            return {"error": str(error)}
+
+
+class AssetFolderRegistry:
+    def __init__(self, access, on_changed=None):
+        self._access = access
+        self._on_changed = on_changed
+
+    @staticmethod
+    def _asset_folder_entries(entries):
+        result = []
+        for entry in entries:
+            item = {**entry, "exists": os.path.isdir(entry["path"])}
+            item["index"] = asset_index.index_status(
+                entry["type"], entry["path"])
+            result.append(item)
+        return result
+
+    def _changed(self, entries, *, grant=None):
+        self._access.refresh_asset_roots(entries)
+        if grant is not None:
+            self._access.grant_asset_folder(grant)
+        if self._on_changed is not None:
+            self._on_changed()
+
+    def get_asset_folders(self):
+        try:
+            entries = asset_folders.load_registry()
+        except asset_folders.AssetFolderError as error:
+            return {"folders": [], "error": str(error)}
+        self._access.refresh_asset_roots(entries)
+        return {"folders": self._asset_folder_entries(entries)}
+
+    def add_asset_folder(self, asset_type, folder_path):
+        folder_path = asset_folders.normalize_path(folder_path)
+        if not self._access.was_picker_selected(folder_path):
+            return {
+                "error": "Choose the Asset Folder through the native folder picker first."
+            }
+        try:
+            entries = asset_catalog.add(asset_type, folder_path)
+        except asset_catalog.AssetCatalogError as error:
+            return {"error": str(error)}
+        self._changed(entries, grant=folder_path)
+        return {"folders": self._asset_folder_entries(entries)}
+
+    def edit_asset_folder(self, original_path, asset_type, folder_path):
+        original_path = asset_folders.normalize_path(original_path)
+        folder_path = asset_folders.normalize_path(folder_path)
+        if (folder_path != original_path and
+                not self._access.was_picker_selected(folder_path)):
+            return {
+                "error": "Choose the new Asset Folder through the native folder picker first."
+            }
+        try:
+            entries = asset_catalog.edit(original_path, asset_type, folder_path)
+        except asset_catalog.AssetCatalogError as error:
+            return {"error": str(error)}
+        self._changed(entries, grant=folder_path)
+        return {"folders": self._asset_folder_entries(entries)}
+
+    def delete_asset_folder(self, folder_path):
+        folder_path = asset_folders.normalize_path(folder_path)
+        try:
+            entries = asset_catalog.delete(folder_path)
+        except asset_catalog.AssetCatalogError as error:
+            return {"error": str(error)}
+        self._changed(entries)
+        return {"folders": self._asset_folder_entries(entries)}
+
+    def set_asset_folder_enabled(self, folder_path, enabled):
+        folder_path = asset_folders.normalize_path(folder_path)
+        try:
+            entries = asset_catalog.set_enabled(folder_path, enabled)
+        except asset_catalog.AssetCatalogError as error:
+            return {"error": str(error)}
+        self._changed(entries)
+        return {"folders": self._asset_folder_entries(entries)}
+
+    def rebuild_asset_index(self, folder_path):
+        folder_path = asset_folders.normalize_path(folder_path)
+        try:
+            entries = asset_catalog.rebuild(folder_path)
+        except asset_catalog.AssetCatalogError as error:
+            return {
+                "error": f"Could not rebuild Asset index: {error}",
+                "indexPreserved": error.index_preserved,
+            }
+        self._changed(entries)
+        return {"folders": self._asset_folder_entries(entries)}
+
+    def list_asset_subfolders(self, folder_path):
+        requested = asset_folders.normalize_path(folder_path)
+        try:
+            entries = asset_folders.load_registry()
+            roots = [entry for entry in entries
+                     if asset_folders.is_within(requested, entry["path"])]
+            if not roots:
+                raise PermissionError(
+                    "That folder is not inside a registered Asset Folder.")
+            entry = max(roots, key=lambda item: len(item["path"]))
+            index = None
+            try:
+                index = asset_index.load_index(entry["type"], entry["path"])
+            except asset_index.AssetIndexError:
+                # The tree remains browseable while the registry panel reports
+                # an invalid cache. The index is still the only asset authority.
+                index = None
+            return {"folders": asset_folders.list_subfolders(
+                requested, entry["path"], index=index,
+                asset_type=entry["type"])}
+        except PermissionError as error:
+            return {"error": str(error)}
+        except asset_folders.AssetFolderError as error:
+            return {"error": str(error)}

--- a/src/tests/app/assets/test_folders.py
+++ b/src/tests/app/assets/test_folders.py
@@ -144,21 +144,17 @@ def test_api_asset_authorization_is_separate_from_mod_roots(tmp_path, monkeypatc
     _gimi_asset(asset_root)
     monkeypatch.setattr(paths, "config_path", lambda: filename)
     api = ModViewerAPI()
-    api._authorized_folders.add(mod_folders.normalize_path(mod_root))
-    api._picker_authorized_folders.update({
-        mod_folders.normalize_path(mod_root),
-        mod_folders.normalize_path(asset_root),
-    })
+    api._access.remember_mod_picker_selection(mod_root)
+    api._access.remember_asset_picker_selection(asset_root)
     assert api.add_mod_folder("Mods", mod_root).get("folders")
     assert api.add_asset_folder("GIMI", asset_root).get("folders")[0]["enabled"] is True
     with pytest.raises(PermissionError):
-        api._folder(asset_root)
+        api._access.mod_folder(asset_root)
     with pytest.raises(PermissionError):
-        api._asset_folder(mod_root)
-    assert api._asset_folder(asset_root) == mod_folders.normalize_path(asset_root)
-    api._authorized_asset_folders.clear()
+        api._access.asset_folder(mod_root)
+    assert api._access.asset_folder(asset_root) == mod_folders.normalize_path(asset_root)
     assert api.set_asset_folder_enabled(asset_root, False)["folders"][0]["enabled"] is False
-    assert api._asset_folder(os.path.join(asset_root, "Character")) == \
+    assert api._access.asset_folder(os.path.join(asset_root, "Character")) == \
         mod_folders.normalize_path(os.path.join(asset_root, "Character"))
     assert [item["name"] for item in
             api.list_asset_subfolders(asset_root)["folders"]] == ["Character"]
@@ -174,10 +170,9 @@ def test_asset_picker_does_not_grant_mod_folder_access(tmp_path, monkeypatch):
         create_file_dialog=lambda *_args: [asset_root])
 
     assert api.select_asset_folder() == mod_folders.normalize_path(asset_root)
-    assert mod_folders.normalize_path(asset_root) in api._picker_authorized_folders
-    assert mod_folders.normalize_path(asset_root) not in api._authorized_folders
+    assert api._access.was_picker_selected(asset_root)
     with pytest.raises(PermissionError):
-        api._folder(asset_root)
+        api._access.mod_folder(asset_root)
 
 
 def test_api_asset_authorization_is_revoked_when_root_is_deleted(tmp_path, monkeypatch):
@@ -186,12 +181,12 @@ def test_api_asset_authorization_is_revoked_when_root_is_deleted(tmp_path, monke
     _gimi_asset(asset_root)
     monkeypatch.setattr(paths, "config_path", lambda: filename)
     api = ModViewerAPI()
-    api._picker_authorized_folders.add(mod_folders.normalize_path(asset_root))
+    api._access.remember_asset_picker_selection(asset_root)
 
     assert api.add_asset_folder("GIMI", asset_root).get("folders")
     cached_child = os.path.join(asset_root, "Character")
-    assert api._asset_folder(cached_child) == mod_folders.normalize_path(cached_child)
+    assert api._access.asset_folder(cached_child) == mod_folders.normalize_path(cached_child)
 
     assert api.delete_asset_folder(asset_root).get("folders") == []
     with pytest.raises(PermissionError):
-        api._asset_folder(cached_child)
+        api._access.asset_folder(cached_child)

--- a/src/tests/app/assets/test_index.py
+++ b/src/tests/app/assets/test_index.py
@@ -320,7 +320,7 @@ def test_api_add_rebuild_and_delete_manage_index_transactionally(
     root = _gimi_root(tmp_path)
     monkeypatch.setattr(paths, "config_path", lambda: config)
     api = ModViewerAPI()
-    api._picker_authorized_folders.add(asset_folders.normalize_path(str(root)))
+    api._access.remember_asset_picker_selection(str(root))
 
     added = api.add_asset_folder("GIMI", str(root))
     assert added["folders"][0]["index"]["status"] == "ready"
@@ -350,7 +350,7 @@ def test_api_add_failure_leaves_config_and_index_unchanged(tmp_path, monkeypatch
     root.mkdir()
     monkeypatch.setattr(paths, "config_path", lambda: config)
     api = ModViewerAPI()
-    api._picker_authorized_folders.add(asset_folders.normalize_path(str(root)))
+    api._access.remember_asset_picker_selection(str(root))
 
     result = api.add_asset_folder("GIMI", str(root))
 
@@ -365,7 +365,7 @@ def test_api_config_failure_restores_new_index(tmp_path, monkeypatch):
     monkeypatch.setattr(paths, "config_path", lambda: config)
     api = ModViewerAPI()
     normalized = asset_folders.normalize_path(str(root))
-    api._picker_authorized_folders.add(normalized)
+    api._access.remember_asset_picker_selection(normalized)
 
     def fail_write(_entries):
         raise asset_folders.AssetFolderError("config write failed")
@@ -385,7 +385,7 @@ def test_api_edit_reindexes_same_root_without_changing_enabled_state(
     monkeypatch.setattr(paths, "config_path", lambda: config)
     api = ModViewerAPI()
     normalized = asset_folders.normalize_path(str(root))
-    api._picker_authorized_folders.add(normalized)
+    api._access.remember_asset_picker_selection(normalized)
 
     assert api.add_asset_folder("GIMI", str(root))["folders"]
     assert api.set_asset_folder_enabled(str(root), False)["folders"][0]["enabled"] is False

--- a/src/tests/app/assets/test_loader.py
+++ b/src/tests/app/assets/test_loader.py
@@ -984,7 +984,7 @@ def test_api_load_missing_asset_parts_is_incremental_and_reversible(
     stale = api.remove_missing_asset_parts(str(mod), old_fill_id)
     assert stale == {"status": "removed", "removed": False, "stale": True}
     key = os.path.normcase(os.path.abspath(str(mod)))
-    assert api._asset_fill_sessions[key]["fill_id"] == new_fill_id
+    assert api._asset_preview._asset_fill_sessions[key]["fill_id"] == new_fill_id
 
     preview = api.load_asset(str(asset))
     assert preview["metadata"]["source_kind"] == "asset"

--- a/src/tests/app/bridge/test_access.py
+++ b/src/tests/app/bridge/test_access.py
@@ -1,0 +1,96 @@
+import json
+import os
+
+import pytest
+
+from app.bridge.access import FolderAccess
+from app.settings import paths
+from app.settings import mod_folders
+
+
+def _config(tmp_path, *, mod_entries=None, asset_entries=None):
+    filename = tmp_path / "config.json"
+    filename.write_text(json.dumps({
+        "version": 1,
+        "modFolders": mod_entries or [],
+        "assetFolders": asset_entries or [],
+    }), encoding="utf-8")
+    return filename
+
+
+def test_mod_picker_grants_mod_access_but_not_asset_access(tmp_path, monkeypatch):
+    root = tmp_path / "mods"
+    root.mkdir()
+    config = _config(tmp_path)
+    monkeypatch.setattr(paths, "config_path", lambda: str(config))
+
+    access = FolderAccess()
+    selected = access.remember_mod_picker_selection(str(root))
+
+    assert selected == mod_folders.normalize_path(str(root))
+    assert access.mod_folder(str(root)) == selected
+    with pytest.raises(PermissionError):
+        access.asset_folder(str(root))
+
+
+def test_asset_picker_uses_shared_picker_proof_without_mod_access(
+        tmp_path, monkeypatch):
+    root = tmp_path / "assets"
+    root.mkdir()
+    config = _config(tmp_path)
+    monkeypatch.setattr(paths, "config_path", lambda: str(config))
+
+    access = FolderAccess()
+    selected = access.remember_asset_picker_selection(str(root))
+
+    assert selected == mod_folders.normalize_path(str(root))
+    assert access.was_picker_selected(str(root))
+    with pytest.raises(PermissionError):
+        access.mod_folder(str(root))
+
+
+def test_mod_descendant_access_is_cached_after_registered_root_changes(
+        tmp_path, monkeypatch):
+    root = tmp_path / "mods"
+    child = root / "character"
+    child.mkdir(parents=True)
+    config = _config(tmp_path)
+    monkeypatch.setattr(paths, "config_path", lambda: str(config))
+    access = FolderAccess()
+
+    access.refresh_mod_roots([{"name": "Mods", "path": str(root)}])
+    normalized_child = access.mod_folder(str(child))
+    access.refresh_mod_roots([])
+
+    assert access.mod_folder(str(child)) == normalized_child
+    with pytest.raises(PermissionError):
+        access.mod_folder(str(tmp_path / "outside"))
+
+
+def test_asset_descendant_access_is_revoked_when_root_is_removed(
+        tmp_path, monkeypatch):
+    root = tmp_path / "assets"
+    child = root / "character"
+    child.mkdir(parents=True)
+    config = _config(tmp_path)
+    monkeypatch.setattr(paths, "config_path", lambda: str(config))
+    access = FolderAccess()
+    entry = {"type": "GIMI", "path": str(root), "enabled": True}
+
+    access.refresh_asset_roots([entry])
+    assert access.asset_folder(str(child)) == os.path.normcase(os.path.abspath(child))
+    access.refresh_asset_roots([])
+
+    with pytest.raises(PermissionError):
+        access.asset_folder(str(child))
+
+
+def test_malformed_optional_config_does_not_block_access_construction(
+        tmp_path, monkeypatch):
+    config = tmp_path / "config.json"
+    config.write_text("{", encoding="utf-8")
+    monkeypatch.setattr(paths, "config_path", lambda: str(config))
+
+    access = FolderAccess()
+
+    assert isinstance(access, FolderAccess)

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -92,3 +92,16 @@ def test_facade_composes_picker_registry_preview_and_editing(tmp_path, monkeypat
         assert "$Value = 0" in ini.read_text(encoding="utf-8")
     finally:
         edit_session.discard(selected)
+
+
+def test_missing_asset_parts_preserves_unauthorized_folder_error(
+        tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "config_path", lambda: str(tmp_path / "config.json"))
+    api = ModViewerAPI()
+
+    result = api.load_missing_asset_parts(str(tmp_path / "unselected"))
+
+    assert result == {
+        "status": "error",
+        "error": "This folder was not selected through the native folder picker.",
+    }

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -1,4 +1,8 @@
+from types import SimpleNamespace
+
 from app.bridge.api import ModViewerAPI
+from app.session import edit as edit_session
+from app.settings import paths
 
 
 EXPECTED_API_METHODS = {
@@ -62,3 +66,29 @@ def test_mod_viewer_api_surface_is_explicit_and_private_state_stays_private():
 
     assert public == EXPECTED_API_METHODS
     assert all(name.startswith("_") for name in vars(api))
+
+
+def test_facade_composes_picker_registry_preview_and_editing(tmp_path, monkeypatch):
+    root = tmp_path / "mods"
+    root.mkdir()
+    ini = root / "mod.ini"
+    ini.write_text("[Constants]\n$Value = 0\n", encoding="utf-8")
+    monkeypatch.setattr(paths, "config_path", lambda: str(tmp_path / "config.json"))
+
+    api = ModViewerAPI()
+    api._window = SimpleNamespace(
+        create_file_dialog=lambda *_args, **_kwargs: [str(root)])
+
+    try:
+        selected = api.select_folder()
+        assert api.add_mod_folder("Mods", selected)["folders"]
+        assert api.get_present_state(selected).get("error") is None
+
+        changed = api.update_ini_text(selected, "mod.ini",
+                                      "[Constants]\n$Value = 1\n")
+
+        assert changed["ok"] is True
+        assert "$Value = 1" in api.get_ini_text(selected, "mod.ini")["text"]
+        assert "$Value = 0" in ini.read_text(encoding="utf-8")
+    finally:
+        edit_session.discard(selected)

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -1,0 +1,64 @@
+from app.bridge.api import ModViewerAPI
+
+
+EXPECTED_API_METHODS = {
+    "add_asset_folder",
+    "add_mod_folder",
+    "add_present",
+    "add_toggle",
+    "capture_present",
+    "delete_asset_folder",
+    "delete_mod_folder",
+    "delete_present",
+    "delete_present_position",
+    "delete_toggle",
+    "discard_changes",
+    "edit_asset_folder",
+    "edit_mod_folder",
+    "edit_present",
+    "edit_toggle",
+    "export_changes",
+    "get_asset_folders",
+    "get_control_state",
+    "get_diagnostics",
+    "get_ini_text",
+    "get_mesh_semantics",
+    "get_mod_folders",
+    "get_panel_opacity",
+    "get_present_state",
+    "get_record_positions",
+    "get_toggle_details",
+    "has_pending_changes",
+    "list_asset_subfolders",
+    "list_ini_files",
+    "list_subfolders",
+    "list_toggle_source_inis",
+    "load_asset",
+    "load_missing_asset_parts",
+    "load_mod",
+    "pick_asset_texture_file",
+    "pick_texture_file",
+    "rebuild_asset_index",
+    "record_toggle",
+    "remove_missing_asset_parts",
+    "save_component_material_kind",
+    "save_mesh_names",
+    "save_mesh_textures",
+    "select_asset_folder",
+    "select_folder",
+    "set_asset_folder_enabled",
+    "set_panel_opacity",
+    "update_ini_text",
+}
+
+
+def test_mod_viewer_api_surface_is_explicit_and_private_state_stays_private():
+    api = ModViewerAPI()
+
+    public = {
+        name for name in dir(api)
+        if not name.startswith("_") and callable(getattr(api, name))
+    }
+
+    assert public == EXPECTED_API_METHODS
+    assert all(name.startswith("_") for name in vars(api))

--- a/src/tests/app/bridge/test_asset_preview.py
+++ b/src/tests/app/bridge/test_asset_preview.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+
+from app.bridge.asset_preview import AssetPreview
+
+
+class _Access:
+    def asset_folder(self, path):
+        return path
+
+    def mod_folder(self, path):
+        return path
+
+
+class _Publication:
+    def __init__(self, events):
+        self.events = events
+
+    def register(self, *args, **kwargs):
+        return "/texture/0"
+
+    def set_game_profile(self, value):
+        self.events.append(("profile", value))
+
+    def commit(self, **kwargs):
+        self.events.append(("commit", kwargs))
+
+    def discard(self):
+        self.events.append(("discard",))
+
+
+def test_direct_asset_load_publishes_geometry_before_commit(monkeypatch):
+    events = []
+    publication = _Publication(events)
+    preview = AssetPreview(_Access())
+    monkeypatch.setattr(
+        preview, "_asset_selection",
+        lambda _folder: ("asset", {"type": "GIMI", "path": "root"},
+                         {}, {"path": "Character"}),
+    )
+    monkeypatch.setattr(
+        "app.bridge.asset_preview.server.begin_texture_publication",
+        lambda _folder: publication)
+    monkeypatch.setattr(
+        "app.bridge.asset_preview.asset_loader.load_asset",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            payload={"meshes": {"Body": {}}}),
+    )
+    monkeypatch.setattr(
+        "app.bridge.asset_preview.server.publish_payload_geometry",
+        lambda *_args, **_kwargs: events.append(("publish",)),
+    )
+
+    result = preview.load_asset("asset")
+
+    assert result == {"meshes": {"Body": {}}}
+    assert [event[0] for event in events] == ["profile", "publish", "commit"]
+
+
+def test_asset_fill_uses_non_replacing_publication(monkeypatch):
+    events = []
+    publication = _Publication(events)
+    preview = AssetPreview(_Access())
+
+    class Plan:
+        status = "ready"
+        asset_type = "GIMI"
+        root = "asset-root"
+        asset = {"path": "Character"}
+        missing_parts = ("hair",)
+
+        def to_dict(self):
+            return {"status": self.status, "coverage": {}}
+
+    monkeypatch.setattr(preview, "_asset_fill_plan", lambda *_args: Plan())
+    monkeypatch.setattr(
+        "app.bridge.asset_preview.server.begin_texture_publication",
+        lambda _folder: publication)
+    monkeypatch.setattr(
+        "app.bridge.asset_preview.asset_loader.load_asset_parts",
+        lambda *_args, **_kwargs: SimpleNamespace(parts=["hair"], warnings=[]),
+    )
+    monkeypatch.setattr(
+        "app.bridge.asset_preview.build_asset_fill_payload",
+        lambda *_args, **_kwargs: {"geometry": {"url": "/geometry/fill"},
+                                   "meshes": {"Hair": {}}},
+    )
+    published = []
+    monkeypatch.setattr(
+        "app.bridge.asset_preview.server.publish_payload_geometry",
+        lambda *_args, **kwargs: published.append(kwargs),
+    )
+
+    result = preview.load_missing_asset_parts("mod", SimpleNamespace(), {})
+
+    assert result["status"] == "loaded"
+    assert published == [{"replace": False}]
+    assert [event[0] for event in events] == ["profile", "commit"]

--- a/src/tests/app/bridge/test_mod_preview.py
+++ b/src/tests/app/bridge/test_mod_preview.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.bridge.mod_preview import ModPreview
+
+
+class _Access:
+    def mod_folder(self, path):
+        return path
+
+
+class _Publication:
+    def __init__(self, events):
+        self.events = events
+        self.game_profile = "unknown"
+
+    def register(self, *args, **kwargs):
+        return "/texture/0"
+
+    def set_game_profile(self, value):
+        self.events.append(("profile", value))
+        self.game_profile = value
+
+    def commit(self, **kwargs):
+        self.events.append(("commit", kwargs))
+
+    def discard(self):
+        self.events.append(("discard",))
+
+
+def _context():
+    return SimpleNamespace(metadata={}, asset_folders=[])
+
+
+def test_load_commits_texture_publication_after_geometry(monkeypatch):
+    events = []
+    publication = _Publication(events)
+    preview = ModPreview(_Access())
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {}, {}, _context()))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.begin_texture_publication",
+        lambda _folder: publication)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.mod_loader.load_mod",
+        lambda **_kwargs: {
+            "meshes": {"Body-1": {}},
+            "metadata": {"game": {"id": "genshin"}},
+            "controls": {"present": {}},
+        })
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.hydrate_textures",
+        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.hydrate_present",
+        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.publish_payload_geometry",
+        lambda *_args, **_kwargs: events.append(("publish",)),
+    )
+
+    result = preview.load_mod("mod")
+
+    assert result["meshes"] == {"Body-1": {}}
+    assert [event[0] for event in events] == ["profile", "publish", "commit"]
+    assert preview._active_mesh_keys == {"mod": {"Body-1"}}
+
+
+def test_failed_load_discards_publication_and_clears_active_meshes(monkeypatch):
+    events = []
+    publication = _Publication(events)
+    preview = ModPreview(_Access())
+    preview._active_mesh_keys["mod"] = {"old"}
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {}, {}, _context()))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.begin_texture_publication",
+        lambda _folder: publication)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.mod_loader.load_mod",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("load failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        preview.load_mod("mod")
+
+    assert events == [("discard",)]
+    assert "mod" not in preview._active_mesh_keys
+
+
+def test_semantic_control_read_reuses_active_mesh_keys(monkeypatch):
+    preview = ModPreview(_Access())
+    preview._active_mesh_keys["mod"] = {"Body-1"}
+    captured = []
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {}, {"KeyNew"}, _context()))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.mod_loader.load_control_state",
+        lambda *args, **kwargs: captured.append((args, kwargs)) or {
+            "controls": {"present": {}},
+        })
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.hydrate_present",
+        lambda *_args, **_kwargs: None)
+
+    result = preview.get_control_state("mod")
+
+    assert result["controls"]["present"] == {}
+    assert captured[0][1]["active_mesh_keys"] == {"Body-1"}

--- a/src/tests/app/bridge/test_registry.py
+++ b/src/tests/app/bridge/test_registry.py
@@ -1,0 +1,98 @@
+import os
+from types import SimpleNamespace
+
+from app.assets import index as asset_index
+from app.bridge.registry import AssetFolderRegistry, ModFolderRegistry
+
+
+def test_asset_registry_notifies_fill_cache_after_successful_changes(
+        tmp_path, monkeypatch):
+    root = str(tmp_path / "asset-root")
+    entries = [{"type": "GIMI", "path": root, "enabled": True}]
+    events = []
+
+    class Access:
+        def __init__(self):
+            self.granted = []
+            self.refreshed = []
+
+        def was_picker_selected(self, _path):
+            return True
+
+        def refresh_asset_roots(self, value):
+            self.refreshed.append(value)
+
+        def grant_asset_folder(self, value):
+            self.granted.append(value)
+
+    access = Access()
+    registry = AssetFolderRegistry(access, on_changed=lambda: events.append(True))
+    monkeypatch.setattr(
+        "app.bridge.registry.asset_index.index_status",
+        lambda *_args: {"status": "ready"})
+    monkeypatch.setattr(
+        "app.bridge.registry.asset_catalog.add", lambda *_args: entries)
+    monkeypatch.setattr(
+        "app.bridge.registry.asset_catalog.edit", lambda *_args: entries)
+    monkeypatch.setattr(
+        "app.bridge.registry.asset_catalog.delete", lambda *_args: [])
+    monkeypatch.setattr(
+        "app.bridge.registry.asset_catalog.set_enabled", lambda *_args: entries)
+    monkeypatch.setattr(
+        "app.bridge.registry.asset_catalog.rebuild", lambda *_args: entries)
+
+    assert registry.add_asset_folder("GIMI", root)["folders"]
+    assert registry.edit_asset_folder(root, "GIMI", root)["folders"]
+    assert registry.delete_asset_folder(root)["folders"] == []
+    assert registry.set_asset_folder_enabled(root, False)["folders"]
+    assert registry.rebuild_asset_index(root)["folders"]
+
+    assert len(events) == 5
+    expected_root = os.path.normcase(os.path.abspath(root))
+    assert access.granted == [expected_root, expected_root]
+    assert len(access.refreshed) == 5
+
+
+def test_asset_registry_keeps_tree_browseable_when_index_is_invalid(monkeypatch):
+    entry = {"type": "GIMI", "path": "asset-root", "enabled": True}
+    access = SimpleNamespace()
+    registry = AssetFolderRegistry(access)
+    monkeypatch.setattr(
+        "app.bridge.registry.asset_folders.load_registry", lambda: [entry])
+    monkeypatch.setattr(
+        "app.bridge.registry.asset_folders.is_within", lambda *_args: True)
+    monkeypatch.setattr(
+        "app.bridge.registry.asset_index.load_index",
+        lambda *_args: (_ for _ in ()).throw(
+            asset_index.AssetIndexError("invalid index")))
+    monkeypatch.setattr(
+        "app.bridge.registry.asset_folders.list_subfolders",
+        lambda *_args, **_kwargs: [{"name": "Character", "asset": True}])
+
+    result = registry.list_asset_subfolders("asset-root/Character")
+
+    assert result == {"folders": [{"name": "Character", "asset": True}]}
+
+
+def test_mod_registry_returns_exists_flag_and_narrowest_registered_root(
+        tmp_path, monkeypatch):
+    outer = tmp_path / "outer"
+    inner = outer / "inner"
+    requested = inner / "requested"
+    requested.mkdir(parents=True)
+    entries = [
+        {"name": "Outer", "path": str(outer)},
+        {"name": "Inner", "path": str(inner)},
+    ]
+    access = SimpleNamespace(refresh_mod_roots=lambda _entries: None)
+    registry = ModFolderRegistry(access)
+    monkeypatch.setattr(
+        "app.bridge.registry.mod_folders.load_registry", lambda: entries)
+    monkeypatch.setattr(
+        "app.bridge.registry.mod_folders.list_subfolders",
+        lambda folder, root: [{"folder": folder, "root": root}])
+
+    result = registry.list_subfolders(str(requested))
+
+    assert result["folders"][0]["root"] == str(inner)
+    assert registry.get_mod_folders()["folders"][0]["exists"] is True

--- a/src/tests/app/settings/test_mod_folders.py
+++ b/src/tests/app/settings/test_mod_folders.py
@@ -191,17 +191,16 @@ def test_api_registry_authorizes_descendants_and_keeps_active_exact_path(
     monkeypatch.setattr("app.settings.paths.config_path", lambda: filename)
     api = ModViewerAPI()
     normalized_root = mod_folders.normalize_path(root)
-    api._authorized_folders.add(normalized_root)
-    api._picker_authorized_folders.add(normalized_root)
+    api._access.remember_mod_picker_selection(normalized_root)
     assert api.add_mod_folder("Root", root)["folders"][0]["name"] == "Root"
 
-    assert api._folder(child) == mod_folders.normalize_path(child)
+    assert api._access.mod_folder(child) == mod_folders.normalize_path(child)
     with pytest.raises(PermissionError):
-        api._folder(sibling)
+        api._access.mod_folder(sibling)
     assert api.delete_mod_folder(root)["folders"] == []
     # The descendant was promoted to an exact session authorization before the
     # root was removed, so existing open-mod operations remain usable.
-    assert api._folder(child) == mod_folders.normalize_path(child)
+    assert api._access.mod_folder(child) == mod_folders.normalize_path(child)
 
 
 def test_api_listing_requires_registered_root(tmp_path, monkeypatch):
@@ -212,8 +211,7 @@ def test_api_listing_requires_registered_root(tmp_path, monkeypatch):
     monkeypatch.setattr("app.settings.paths.config_path", lambda: filename)
     api = ModViewerAPI()
     normalized_root = mod_folders.normalize_path(root)
-    api._authorized_folders.add(normalized_root)
-    api._picker_authorized_folders.add(normalized_root)
+    api._access.remember_mod_picker_selection(normalized_root)
     api.add_mod_folder("Root", root)
 
     assert [item["path"] for item in api.list_subfolders(root)["folders"]] == [
@@ -230,13 +228,11 @@ def test_api_add_and_edit_require_native_picker_for_new_paths(tmp_path, monkeypa
     api = ModViewerAPI()
     normalized_first = mod_folders.normalize_path(first)
     normalized_second = mod_folders.normalize_path(second)
-    api._authorized_folders.add(normalized_first)
-    api._picker_authorized_folders.add(normalized_first)
+    api._access.remember_mod_picker_selection(normalized_first)
     assert api.add_mod_folder("First", first).get("folders")
     assert "error" in api.add_mod_folder("Invented", invented)
     assert "error" in api.edit_mod_folder(first, "Second", second)
-    api._authorized_folders.add(normalized_second)
-    api._picker_authorized_folders.add(normalized_second)
+    api._access.remember_mod_picker_selection(normalized_second)
     assert api.edit_mod_folder(first, "Second", second).get("folders")
 
 
@@ -249,17 +245,15 @@ def test_descendant_runtime_authorization_cannot_persist_without_picker(
     monkeypatch.setattr("app.settings.paths.config_path", lambda: filename)
     api = ModViewerAPI()
     normalized_root = mod_folders.normalize_path(root)
-    api._authorized_folders.add(normalized_root)
-    api._picker_authorized_folders.add(normalized_root)
+    api._access.remember_mod_picker_selection(normalized_root)
     assert api.add_mod_folder("Root", root).get("folders")
 
     # Browsing the child grants runtime access only; it is not picker proof.
-    assert api._folder(child) == mod_folders.normalize_path(child)
+    assert api._access.mod_folder(child) == mod_folders.normalize_path(child)
     assert "error" in api.add_mod_folder("Child", child)
     assert "error" in api.edit_mod_folder(root, "Child", child)
 
-    api._authorized_folders.add(mod_folders.normalize_path(replacement))
-    api._picker_authorized_folders.add(mod_folders.normalize_path(replacement))
+    api._access.remember_mod_picker_selection(replacement)
     assert api.edit_mod_folder(root, "Replacement", replacement).get("folders")
 
 

--- a/src/tests/core/textures/test_transport.py
+++ b/src/tests/core/textures/test_transport.py
@@ -213,7 +213,7 @@ def test_wuwa_manual_normal_pick_publishes_only_raw_source(tmp_path):
 
     api = ModViewerAPI()
     api._window = Dialog()
-    api._authorized_folders.add(os.path.normcase(os.path.abspath(tmp_path)))
+    api._access.remember_mod_picker_selection(tmp_path)
 
     result = api.pick_texture_file(str(tmp_path), "normal_map")
 

--- a/src/tests/integration/test_load_pipeline.py
+++ b/src/tests/integration/test_load_pipeline.py
@@ -326,7 +326,7 @@ def test_present_state_read_uses_staged_documents_without_geometry(
     assert added.get("ok") is True
 
     api = ModViewerAPI()
-    api._authorized_folders.add(os.path.normcase(os.path.abspath(root)))
+    api._access.remember_mod_picker_selection(root)
     with patch.object(mod_loader, "build_mesh_result",
                       side_effect=AssertionError("geometry must not be built")):
         result = api.get_present_state(root)

--- a/tools/benchmark_texture_pipeline.py
+++ b/tools/benchmark_texture_pipeline.py
@@ -453,7 +453,7 @@ def _run_browser(base_url, payload, profiler, sampler, concurrency,
 
 
 def _run_once(mod_path, concurrency, browser_channel):
-    from app.bridge import api as api_module
+    from app.bridge import mod_preview
     from app.session import edit as edit_session
     from app.mods import metadata, loader as mod_loader
     from app.runtime import server
@@ -467,7 +467,7 @@ def _run_once(mod_path, concurrency, browser_channel):
     old_hook = textures.set_texture_profile_hook(profiler)
     textures.reset_texture_cache()
     for module, name, label in (
-        (api_module, "discover_ini_paths", "ini_discovery"),
+        (mod_preview, "discover_ini_paths", "ini_discovery"),
         (edit_session, "load_documents", "session_load"),
         (metadata, "load", "metadata_load"),
         (mod_loader, "load_mod", "mod_loader_load_mod"),
@@ -477,7 +477,7 @@ def _run_once(mod_path, concurrency, browser_channel):
         _install_timing(module, name, label, timings)
 
     api = ModViewerAPI()
-    api._authorized_folders.add(os.path.normcase(os.path.abspath(mod_path)))
+    api._access.remember_mod_picker_selection(mod_path)
     backend_started = time.perf_counter()
     payload = api.load_mod(mod_path)
     backend_seconds = time.perf_counter() - backend_started


### PR DESCRIPTION
## Summary

- Keep ModViewerAPI as the explicit JavaScript-facing bridge facade.
- Extract folder authorization, folder registry orchestration, and Mod/Asset preview lifecycles into private collaborators.
- Preserve bridge method signatures, authorization boundaries, staged editing, publication ordering, and Asset-fill behavior.

## Scope

- Add focused bridge boundary and facade composition coverage.
- Update the texture benchmark caller for the extracted ownership.