### PR TITLE
refactor: decompose frontend application flow

### DIFF
--- a/src/tests/web/test_frontend.py
+++ b/src/tests/web/test_frontend.py
@@ -566,6 +566,46 @@ def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
         context.close()
 
 
+def test_frontend_public_surface_and_lifecycle_events(edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"ContractMod": _payload("ContractMod"),
+         "ContractAsset": _payload("ContractAsset")})
+    try:
+        assert page.evaluate("Object.keys(window.modViewer).sort()") == sorted([
+            "activeMeshes", "displayMeshPayload", "exportChanges",
+            "getCurrentSource", "getEnvironmentPreset", "getMaterialState",
+            "getOutlineState", "getRenderCount", "openMod",
+            "refreshControlSemantics", "refreshMeshSemantics",
+            "refreshPresentState", "reloadCurrentMod", "setEnvironmentPreset",
+            "setMaterialDebugMode", "setOutlineEnabled", "switchAsset",
+            "switchMod",
+        ])
+        page.evaluate("""() => {
+          window.__lifecycleEvents = [];
+          for (const name of [
+            'mod-viewer-mod-load-started', 'mod-viewer-mod-loaded',
+            'mod-viewer-asset-load-started', 'mod-viewer-asset-loaded',
+          ]) {
+            window.addEventListener(name, () => window.__lifecycleEvents.push(name));
+          }
+        }""")
+
+        _open(page, "ContractMod")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""async () => await window.modViewer.switchAsset(
+          'ContractAsset', {asset: 'ContractAsset', asset_type: 'GIMI'})""")
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadAsset.length === 1"
+            " && window.modViewer.getCurrentSource().kind === 'asset'")
+        assert page.evaluate("window.__lifecycleEvents") == [
+            "mod-viewer-mod-load-started", "mod-viewer-mod-loaded",
+            "mod-viewer-asset-load-started", "mod-viewer-asset-loaded",
+        ]
+    finally:
+        context.close()
+
+
 def test_asset_identity_and_texture_provenance_are_diagnostic_only(
         edge_browser, frontend_url):
     payload = _payload("Asset")

--- a/src/tests/web/test_frontend.py
+++ b/src/tests/web/test_frontend.py
@@ -3739,6 +3739,7 @@ def test_record_refreshes_controls_and_meshes_without_reloading_model(
         }""")
         assert page.locator("#toggle-list .toggle-unwired-badge").count() == 1
         assert page.locator("#export-btn").is_disabled()
+        assert "Record (⏺)" in page.locator("#export-btn").get_attribute("title")
 
         page.locator("#toggle-list [title^='Record']").click()
         page.locator("#toggle-list .toggle-row.recording").wait_for()

--- a/src/web/js/app/asset-fill.js
+++ b/src/web/js/app/asset-fill.js
@@ -1,0 +1,248 @@
+// Session-scoped Asset-fill transaction and its toolbar state.
+
+import { viewerState, samePath } from './state.js';
+import { adoptModelMeshes, fitTo, forgetModelMeshes } from '../scene/scene.js';
+import { requestRender } from '../scene/render-scheduler.js';
+import { addTexture, removeTextures } from '../mesh/mesh-factory.js';
+import { activeMeshes, removeMesh } from '../mesh/visibility.js';
+import { appendMeshPanel, removeAssetFillMeshPanel } from '../panels/mesh-panel.js';
+import { alertDialog } from '../ui/dialogs.js';
+import { setGeometryBlob } from '../textures/decode.js';
+import { createIcon } from '../ui/ui-icons.js';
+
+const $ = (id) => document.getElementById(id);
+
+export function updateAssetFillButton() {
+  const button = $('asset-fill-btn');
+  if (!button) return;
+  const { assetFill } = viewerState;
+  const available = assetFill.available
+    && viewerState.currentSource?.kind === 'mod' && !!viewerState.currentModPath;
+  const state = assetFill.loading ? 'loading' : assetFill.loaded ? 'remove' : 'load';
+  const label = state === 'remove'
+    ? 'Remove missing parts'
+    : state === 'loading'
+      ? assetFill.loaded ? 'Removing missing parts' : 'Loading missing parts'
+      : 'Load missing parts';
+  button.disabled = !available || assetFill.loading;
+  button.dataset.state = state;
+  button.setAttribute('aria-label', label);
+  button.setAttribute('aria-pressed', String(assetFill.loaded));
+  button.replaceChildren(createIcon(state === 'remove' ? 'close' : 'mesh-add'));
+  button.title = assetFill.loaded
+    ? 'Remove original Asset components added for this session.'
+    : 'Add original Asset components not handled by this mod.';
+}
+
+export function resetAssetFillState() {
+  const { assetFill } = viewerState;
+  removeTextures(assetFill.textureKeys);
+  assetFill.textureKeys = new Set();
+  assetFill.fillId = null;
+  assetFill.available = false;
+  assetFill.loaded = false;
+  assetFill.loading = false;
+}
+
+function assetFillOperationIsCurrent(operation, path) {
+  return operation === viewerState.assetFill.epoch
+    && viewerState.currentSource?.kind === 'mod'
+    && samePath(viewerState.currentModPath, path);
+}
+
+function rollbackAssetFillFrontend(addedMeshes, textureKeys) {
+  const targetMeshes = [...new Set(addedMeshes || [])];
+  const removedFromPanel = removeAssetFillMeshPanel(targetMeshes);
+  const remaining = targetMeshes.filter(mesh => activeMeshes.includes(mesh));
+  remaining.forEach(removeMesh);
+  const removed = [...new Set([...removedFromPanel, ...remaining])];
+  if (removed.length) {
+    forgetModelMeshes(removed);
+    requestRender();
+  }
+
+  const keys = new Set(textureKeys || []);
+  removeTextures(keys);
+  keys.forEach(key => viewerState.assetFill.textureKeys.delete(key));
+  viewerState.assetFill.loaded = false;
+  viewerState.assetFill.fillId = null;
+}
+
+async function releaseBackendAssetFill(path, fillId = null) {
+  try {
+    const result = await window.pywebview.api.remove_missing_asset_parts(
+      path, fillId);
+    if (result?.status === 'error') {
+      console.warn('Could not roll back missing Asset parts:', result.error);
+    }
+  } catch (error) {
+    console.warn('Could not roll back missing Asset parts:', error);
+  }
+}
+
+async function rollbackAssetFill(
+    path, operation, fillId, addedMeshes, textureKeys) {
+  if (assetFillOperationIsCurrent(operation, path)) {
+    rollbackAssetFillFrontend(addedMeshes, textureKeys);
+  } else {
+    // A stale operation must not touch the scene or global fill state. Texture
+    // entries are still owned by this transaction, so release only those.
+    const keys = new Set(textureKeys || []);
+    removeTextures(keys);
+    keys.forEach(key => viewerState.assetFill.textureKeys.delete(key));
+  }
+  await releaseBackendAssetFill(path, fillId);
+}
+
+export async function loadMissingAssetParts() {
+  const state = viewerState;
+  if (!state.currentModPath || state.currentSource?.kind !== 'mod'
+      || state.assetFill.loading) {
+    return false;
+  }
+  const path = state.currentModPath;
+  const operation = ++state.assetFill.epoch;
+  let backendLoaded = false;
+  let rolledBack = false;
+  let transactionFillId = null;
+  let addedMeshes = [];
+  const transactionTextureKeys = new Set();
+  const rollback = async () => {
+    if (rolledBack) return;
+    rolledBack = true;
+    if (backendLoaded) {
+      await rollbackAssetFill(
+        path, operation, transactionFillId,
+        addedMeshes, transactionTextureKeys);
+    }
+  };
+  state.assetFill.loading = true;
+  updateAssetFillButton();
+  try {
+    const result = await window.pywebview.api.load_missing_asset_parts(path);
+    if (!assetFillOperationIsCurrent(operation, path)) {
+      if (result?.status === 'loaded') {
+        backendLoaded = true;
+        transactionFillId = result.fill_id || null;
+      }
+      await rollback();
+      return false;
+    }
+    if (result?.status !== 'loaded') {
+      const messages = {
+        nothing_missing: 'No missing original Asset parts found.',
+        asset_ambiguous: 'Could not uniquely determine the original Asset.',
+        asset_not_found: 'No matching original Asset was found.',
+      };
+      if (result?.error) throw new Error(result.error);
+      await alertDialog(messages[result?.status] || 'No original Asset parts were loaded.');
+      return false;
+    }
+    backendLoaded = true;
+    transactionFillId = result.fill_id || null;
+    if (!assetFillOperationIsCurrent(operation, path)) {
+      await rollback();
+      return false;
+    }
+    const payload = result.payload || {};
+    const geometry = payload.geometry;
+    if (geometry) {
+      const response = await fetch(geometry.url, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`Geometry download failed (${response.status}).`);
+      const blob = await response.arrayBuffer();
+      if (blob.byteLength !== geometry.length) {
+        throw new Error('Geometry download was incomplete.');
+      }
+      if (!assetFillOperationIsCurrent(operation, path)) {
+        await rollback();
+        return false;
+      }
+      setGeometryBlob(blob);
+    }
+    for (const [key, uri] of Object.entries(payload.textures || {})) {
+      if (addTexture(key, uri)) {
+        state.assetFill.textureKeys.add(key);
+        transactionTextureKeys.add(key);
+      }
+    }
+    if (!assetFillOperationIsCurrent(operation, path)) {
+      await rollback();
+      return false;
+    }
+    const before = new Set(activeMeshes);
+    try {
+      appendMeshPanel(
+        payload.meshes || {}, null,
+        {}, payload.metadata?.material_profiles || {}, {
+          replace: false,
+          texturePools: payload.texture_pools || {},
+          readOnlySource: true,
+        });
+    } finally {
+      addedMeshes = activeMeshes.filter(mesh => !before.has(mesh));
+    }
+    adoptModelMeshes(addedMeshes);
+    if (!assetFillOperationIsCurrent(operation, path)) {
+      await rollback();
+      return false;
+    }
+    state.assetFill.loaded = true;
+    state.assetFill.fillId = transactionFillId;
+    fitTo(activeMeshes, {
+      preserveCamera: true,
+      preserveHomeView: true,
+    });
+    requestRender();
+    return true;
+  } catch (error) {
+    await rollback();
+    if (!assetFillOperationIsCurrent(operation, path)) return false;
+    await alertDialog('Could not load missing Asset parts:\n\n' + error.message);
+    return false;
+  } finally {
+    if (operation === state.assetFill.epoch) {
+      state.assetFill.loading = false;
+      updateAssetFillButton();
+    }
+  }
+}
+
+export async function removeMissingAssetParts() {
+  const state = viewerState;
+  if (!state.currentModPath || !state.assetFill.loaded || state.assetFill.loading) {
+    return false;
+  }
+  const path = state.currentModPath;
+  const operation = ++state.assetFill.epoch;
+  state.assetFill.loading = true;
+  updateAssetFillButton();
+  try {
+    const result = await window.pywebview.api.remove_missing_asset_parts(
+      path, state.assetFill.fillId);
+    if (!assetFillOperationIsCurrent(operation, path)) return false;
+    if (result?.status === 'error') throw new Error(result.error);
+    if (result?.stale) return false;
+    const removedMeshes = removeAssetFillMeshPanel();
+    forgetModelMeshes(removedMeshes);
+    removeTextures(state.assetFill.textureKeys);
+    state.assetFill.textureKeys = new Set();
+    state.assetFill.loaded = false;
+    state.assetFill.fillId = null;
+    requestRender();
+    return true;
+  } catch (error) {
+    if (!assetFillOperationIsCurrent(operation, path)) return false;
+    await alertDialog('Could not remove missing Asset parts:\n\n' + error.message);
+    return false;
+  } finally {
+    if (operation === state.assetFill.epoch) {
+      state.assetFill.loading = false;
+      updateAssetFillButton();
+    }
+  }
+}
+
+export async function toggleMissingAssetParts() {
+  return viewerState.assetFill.loaded
+    ? removeMissingAssetParts() : loadMissingAssetParts();
+}

--- a/src/web/js/app/model-flow.js
+++ b/src/web/js/app/model-flow.js
@@ -1,0 +1,428 @@
+// Model/source loading lifecycle and the application-facing transition flow.
+
+import { viewerState, samePath } from './state.js';
+import { resetAssetFillState, updateAssetFillButton } from './asset-fill.js';
+import { fitTo, isRendererAvailable } from '../scene/scene.js';
+import { setRightDockEnabled } from '../panels/right-dock.js';
+import { clearSelection } from '../scene/selection.js';
+import { clearInspector } from '../panels/inspector-panel.js';
+import { activeMeshes, reset, setStateRules } from '../mesh/visibility.js';
+import { setTextures } from '../mesh/mesh-factory.js';
+import { buildMeshPanel } from '../panels/mesh-panel.js';
+import { setMeshesAvailable } from '../panels/left-dock.js';
+import { buildTogglePanel } from '../panels/toggle-panel.js';
+import { buildMenuPanel } from '../panels/menu-panel.js';
+import { buildPresentPanel } from '../panels/present-panel.js';
+import { alertDialog, confirmDialog } from '../ui/dialogs.js';
+import { setGeometryBlob } from '../textures/decode.js';
+import {
+  refreshHealthReport, setAssetResolution, setHealthLoader,
+  setHealthReport,
+} from '../panels/health-report.js';
+import { setIniEditorContext } from '../editing/ini-editor.js';
+import { setOutlineSuppressedByDebug } from '../scene/outline-renderer.js';
+
+const $ = (id) => document.getElementById(id);
+
+export function syncViewportControlPlacement() {
+  setRightDockEnabled(viewerState.rightDockEnabled);
+}
+
+function showLoading(on, message) {
+  if (message) $('status-text').textContent = message;
+  $('loading').classList.toggle('show', on);
+}
+
+function hasUnwiredToggle() {
+  return Object.values(viewerState.lastToggles)
+    .some((info) => info.wired === false);
+}
+
+// Reflect the currently open mod's staged-but-not-yet-exported edits onto
+// the toolbar: Export only enables once there's something to export, and the
+// indicator is the persistent signal that something is unsaved.
+export async function refreshPendingState(
+    path = viewerState.currentModPath, guard = null) {
+  const pending = path ? await window.pywebview.api.has_pending_changes(path) : false;
+  if ((guard && !guard()) || (path && !samePath(viewerState.currentModPath, path))) {
+    return false;
+  }
+  $('pending-indicator').classList.toggle('show', pending);
+  const blocked = pending && hasUnwiredToggle();
+  $('export-btn').disabled = !pending || blocked;
+  $('export-btn').title = blocked
+    ? 'A newly-added toggle isn\'t wired to any mesh yet — Record (➤) or delete it before exporting.'
+    : '';
+}
+
+export function clearScene({ preserveModelOrientation = false } = {}) {
+  clearSelection();
+  clearInspector();
+  viewerState.rightDockEnabled = false;
+  reset({ preserveModelOrientation });
+  // Debug mode is material-local and does not survive a reload; keep outline
+  // suppression in the same lifecycle rather than carrying stale state onto
+  // the next mod's normal materials.
+  setOutlineSuppressedByDebug(false);
+  resetAssetFillState();
+  setTextures(null);
+  setGeometryBlob(null);
+  viewerState.lastToggles = {};
+  $('mesh-list').innerHTML = '';
+  $('camera-panel').style.display = 'none';
+  $('toggle-list').innerHTML = '';
+  $('toggle-panel').style.display = 'none';
+  $('present-list').innerHTML = '';
+  $('present-panel').style.display = 'none';
+  $('menu-list').innerHTML = '';
+  $('menu-panel').style.display = 'none';
+  setMeshesAvailable(false);
+  setRightDockEnabled(false);
+  syncViewportControlPlacement();
+  updateAssetFillButton();
+}
+
+function clearPendingState() {
+  $('pending-indicator').classList.remove('show');
+  $('export-btn').disabled = true;
+  $('export-btn').title = '';
+}
+
+function setSourceUi(kind) {
+  const asset = kind === 'asset';
+  document.body.classList.toggle('asset-preview-mode', asset);
+  if (asset) {
+    setHealthLoader(null);
+    setHealthReport(null, null);
+    setIniEditorContext(null, null);
+  }
+  $('pending-indicator').classList.toggle('show', false);
+  $('pending-indicator').setAttribute('aria-hidden', String(asset));
+  if (asset) $('export-btn').disabled = true;
+  updateAssetFillButton();
+}
+
+/** Commit the UI to a new folder before asking the backend to load it. */
+function beginModLoad(path, message, {
+  preserveModelOrientation = false,
+  onReload = null,
+} = {}) {
+  viewerState.assetFill.epoch += 1;
+  viewerState.currentModPath = path;
+  viewerState.currentSource = { kind: 'mod', path };
+  setSourceUi('mod');
+  viewerState.semanticRefreshEpoch += 1;
+  clearScene({ preserveModelOrientation });
+  clearPendingState();
+  window.dispatchEvent(new CustomEvent('mod-viewer-mod-load-started', {
+    detail: { path },
+  }));
+  $('hint').style.display = 'none';
+  $('empty-actions').style.display = 'none';
+  $('mod-path').textContent = path;
+  $('mod-path').title = path;
+  setHealthReport(null);
+  setHealthLoader(() => window.pywebview.api.get_diagnostics(path));
+  setIniEditorContext(path, onReload || reloadCurrentMod);
+  showLoading(true, message);
+}
+
+function beginAssetLoad(path, entry, message = 'Loading Asset…', {
+  preserveModelOrientation = false,
+} = {}) {
+  viewerState.assetFill.epoch += 1;
+  viewerState.currentModPath = null;
+  viewerState.currentSource = {
+    kind: 'asset', path, assetType: entry?.asset_type || null,
+  };
+  viewerState.semanticRefreshEpoch += 1;
+  clearScene({ preserveModelOrientation });
+  clearPendingState();
+  setSourceUi('asset');
+  window.dispatchEvent(new CustomEvent('mod-viewer-asset-load-started', {
+    detail: { path, entry },
+  }));
+  $('hint').style.display = 'none';
+  $('empty-actions').style.display = 'none';
+  $('mod-path').textContent = `Asset Preview  —  ${path}`;
+  $('mod-path').title = path;
+  setAssetResolution(null);
+  showLoading(true, message);
+}
+
+export async function displayMeshPayload(payload, {
+  preserveCamera = false,
+  onToggleChange = null,
+  onPresentChange = null,
+  onMaterialKindChanged = reloadCurrentMod,
+} = {}) {
+  const geometry = payload.geometry;
+  if (geometry) {
+    const response = await fetch(geometry.url, { cache: 'no-store' });
+    if (!response.ok) throw new Error(`Geometry download failed (${response.status}).`);
+    const blob = await response.arrayBuffer();
+    if (blob.byteLength !== geometry.length) throw new Error('Geometry download was incomplete.');
+    setGeometryBlob(blob);
+  } else {
+    setGeometryBlob(null);
+  }
+
+  const controls = payload.controls || {};
+  const state = payload.state || {};
+  const meshes = payload.meshes || {};
+  const assetMode = viewerState.currentSource?.kind === 'asset'
+    || payload.metadata?.source_kind === 'asset';
+  viewerState.assetFill.available = !assetMode
+    && Number(payload.asset_resolution?.configured_roots || 0) > 0;
+  if (assetMode && viewerState.currentSource?.kind !== 'asset') {
+    viewerState.currentSource = {
+      kind: 'asset', path: payload.metadata?.asset?.path || '',
+      assetType: payload.metadata?.asset?.type || null,
+    };
+    setSourceUi('asset');
+  }
+  const modelPath = assetMode ? null : viewerState.currentModPath;
+  viewerState.lastToggles = controls.toggles || {};
+  setStateRules(state.rules || [], state.defaults || {}, {
+    toggles: controls.toggles || {}, menu: controls.menu || {},
+  });
+  setTextures(payload.textures);
+  buildMeshPanel(
+    meshes, modelPath, payload.metadata?.mesh_names || {},
+    payload.metadata?.material_profiles || {},
+    {
+      onMaterialKindChanged: assetMode ? null : onMaterialKindChanged,
+      texturePools: payload.texture_pools || {},
+      assetResolution: payload.asset_resolution || null,
+      readOnlySource: assetMode,
+      texturePicker: assetMode
+        ? (role => window.pywebview.api.pick_asset_texture_file(
+          viewerState.currentSource.path, role)) : null,
+    });
+  buildTogglePanel(controls.toggles, {
+    modPath: viewerState.currentModPath, onChange: onToggleChange,
+  });
+  buildMenuPanel(controls.menu);
+  buildPresentPanel(controls.present, {
+    modPath: viewerState.currentModPath, onChange: onPresentChange,
+  });
+  setMeshesAvailable(true);
+  viewerState.rightDockEnabled = true;
+  syncViewportControlPlacement();
+  fitTo(activeMeshes, {
+    preserveCamera,
+    // WWMI models use the opposite horizontal facing convention from the
+    // viewer's default front view. Keep this as a model base transform so
+    // camera controls and viewer-only orientation state remain independent.
+    initialRotationY: payload.metadata?.game?.id === 'wuwa' ? Math.PI : 0,
+  });
+
+  updateAssetFillButton();
+  showLoading(false);
+}
+
+async function loadModAt(path, handlers = {}) {
+  const preserveViewerPose = samePath(viewerState.displayedModPath, path);
+  beginModLoad(path, 'Loading Model…', {
+    preserveModelOrientation: preserveViewerPose,
+    onReload: handlers.onReload,
+  });
+
+  const data = await window.pywebview.api.load_mod(path);
+  setHealthReport(data?.health, data?.asset_resolution);
+  if (data && data.error) {
+    showLoading(false);
+    await refreshPendingState();
+    await alertDialog('Could not load mod:\n\n' + data.error);
+    return false;
+  }
+  try {
+    await displayMeshPayload(data, {
+      preserveCamera: preserveViewerPose,
+      ...handlers,
+    });
+  } catch (error) {
+    clearScene({ preserveModelOrientation: preserveViewerPose });
+    clearPendingState();
+    showLoading(false);
+    await refreshPendingState();
+    await alertDialog('Could not load mod geometry:\n\n' + error.message);
+    return false;
+  }
+  await refreshPendingState();
+
+  // Lead with the folder name; the full path is long and rarely the useful part.
+  const folderName = path.replace(/\\/g, '/').split('/').filter(Boolean).at(-1);
+  $('mod-path').textContent = folderName;
+  $('mod-path').title = path;
+  viewerState.displayedModPath = path;
+  viewerState.displayedSource = { kind: 'mod', path };
+  window.dispatchEvent(new CustomEvent('mod-viewer-mod-loaded', {
+    detail: { path },
+  }));
+  // Diagnostics are independent of geometry rendering. Start them after the
+  // mod is visible so the toolbar badge is populated without requiring a
+  // click on the Diagnostics button.
+  void refreshHealthReport();
+  return true;
+}
+
+async function loadAssetAt(path, entry = {}, handlers = {}) {
+  const preserveViewerPose = viewerState.displayedSource?.kind === 'asset'
+    && samePath(viewerState.displayedSource.path, path);
+  beginAssetLoad(path, entry, 'Loading Asset…', {
+    preserveModelOrientation: preserveViewerPose,
+  });
+  const data = await window.pywebview.api.load_asset(path);
+  if (data && data.error) {
+    showLoading(false);
+    await alertDialog('Could not load Asset:\n\n' + data.error);
+    return false;
+  }
+  try {
+    await displayMeshPayload(data, {
+      preserveCamera: preserveViewerPose,
+      ...handlers,
+    });
+  } catch (error) {
+    clearScene({ preserveModelOrientation: preserveViewerPose });
+    clearPendingState();
+    showLoading(false);
+    await alertDialog('Could not load Asset geometry:\n\n' + error.message);
+    return false;
+  }
+  const folderName = path.replace(/\\/g, '/').split('/').filter(Boolean).at(-1);
+  $('mod-path').textContent = `Asset Preview  —  ${folderName}`;
+  $('mod-path').title = path;
+  viewerState.displayedModPath = null;
+  viewerState.displayedSource = { ...viewerState.currentSource };
+  window.dispatchEvent(new CustomEvent('mod-viewer-asset-loaded', {
+    detail: { path, entry, source: viewerState.displayedSource },
+  }));
+  return true;
+}
+
+async function performModSwitch(path, handlers = {}) {
+  // Switching to a different folder while the current one has staged,
+  // not-yet-exported edits would silently strand them in memory, so ask first.
+  if (viewerState.currentSource?.kind === 'mod' && viewerState.currentModPath
+      && !samePath(viewerState.currentModPath, path)
+      && await window.pywebview.api.has_pending_changes(viewerState.currentModPath)) {
+    const proceed = await confirmDialog(
+      'This mod has unsaved changes that haven\'t been exported.\n\n' +
+      'Opening a different mod folder will discard them. Continue?');
+    if (!proceed) return false;
+    await window.pywebview.api.discard_changes(viewerState.currentModPath);
+  }
+
+  return await loadModAt(path, handlers);
+}
+
+async function confirmLeaveCurrentModIfDirty() {
+  if (viewerState.currentSource?.kind !== 'mod' || !viewerState.currentModPath) return true;
+  if (!await window.pywebview.api.has_pending_changes(viewerState.currentModPath)) return true;
+  const proceed = await confirmDialog(
+    'This mod has unsaved changes that haven\'t been exported.\n\n' +
+    'Opening an Asset preview will discard them. Continue?');
+  if (!proceed) return false;
+  await window.pywebview.api.discard_changes(viewerState.currentModPath);
+  return true;
+}
+
+export async function switchAsset(path, entry = {}, handlers = {}) {
+  if (!path || !entry?.asset) return false;
+  return await runModTransition(async () => {
+    try {
+      if (!await confirmLeaveCurrentModIfDirty()) return false;
+      return await loadAssetAt(path, entry, handlers);
+    } catch (error) {
+      showLoading(false);
+      await alertDialog('Unexpected error while loading Asset:\n\n' + error);
+      return false;
+    }
+  });
+}
+
+export async function runModTransition(operation) {
+  if (viewerState.modTransitionInFlight || !isRendererAvailable()) return false;
+  viewerState.modTransitionInFlight = true;
+  const button = $('open-btn');
+  button.disabled = true;
+  try {
+    return await operation();
+  } finally {
+    viewerState.modTransitionInFlight = false;
+    button.disabled = !isRendererAvailable();
+  }
+}
+
+export async function switchMod(path, handlers = {}) {
+  if (!path) return false;
+  return await runModTransition(async () => {
+    try {
+      return await performModSwitch(path, handlers);
+    } catch (error) {
+      showLoading(false);
+      await alertDialog('Unexpected error:\n\n' + error);
+      return false;
+    }
+  });
+}
+
+export async function openMod(handlers = {}) {
+  return await runModTransition(async () => {
+    try {
+      const path = await window.pywebview.api.select_folder();
+      if (!path) return false;
+      return await performModSwitch(path, handlers);
+    } catch (error) {
+      showLoading(false);
+      await alertDialog('Unexpected error:\n\n' + error);
+      return false;
+    }
+  });
+}
+
+// Re-render the current authoritative edit session after a staged authoring
+// change, using the same load path as an ordinary reopen.
+export async function reloadCurrentMod(handlers = {}) {
+  if (!viewerState.currentModPath) return false;
+  return await runModTransition(async () => {
+    try {
+      return await loadModAt(viewerState.currentModPath, handlers);
+    } catch (error) {
+      showLoading(false);
+      await alertDialog('Unexpected error while reloading:\n\n' + error);
+      return false;
+    }
+  });
+}
+
+export async function exportChanges() {
+  if (!viewerState.currentModPath) return;
+  const button = $('export-btn');
+  button.disabled = true;
+  try {
+    const result = await window.pywebview.api.export_changes(viewerState.currentModPath);
+    if (result.error) {
+      // Refused outright — e.g. a newly-added toggle is still unwired. The
+      // button is normally already disabled for this case, so reaching here
+      // means the panel was momentarily stale; nothing was written either way.
+      await alertDialog('Export was blocked:\n\n' + result.error);
+    } else if (result.failed && result.failed.length) {
+      const detail = result.failed.map((failure) =>
+        `${failure.ini}: ${failure.error}`).join('\n');
+      await alertDialog(
+        `${result.saved.length} ini file(s) exported, but ${result.failed.length} failed ` +
+        `and are still pending:\n\n${detail}`);
+    }
+    // Export writes the authoritative staged documents but does not change
+    // the current model or control semantics. Refresh only session status;
+    // partial failures leave the affected edits pending for retry.
+    await refreshPendingState();
+    void refreshHealthReport();
+  } catch (error) {
+    await alertDialog('Unexpected error while exporting:\n\n' + error);
+    await refreshPendingState();
+  }
+}

--- a/src/web/js/app/model-flow.js
+++ b/src/web/js/app/model-flow.js
@@ -51,7 +51,7 @@ export async function refreshPendingState(
   const blocked = pending && hasUnwiredToggle();
   $('export-btn').disabled = !pending || blocked;
   $('export-btn').title = blocked
-    ? 'A newly-added toggle isn\'t wired to any mesh yet — Record (➤) or delete it before exporting.'
+    ? 'A newly-added toggle isn\'t wired to any mesh yet — Record (⏺) or delete it before exporting.'
     : '';
 }
 

--- a/src/web/js/app/semantic-refresh.js
+++ b/src/web/js/app/semantic-refresh.js
@@ -1,0 +1,146 @@
+// Staged-edit semantic refreshes, guarded against older responses winning.
+
+import { viewerState, samePath } from './state.js';
+import { refreshAll, setStateRules, updateMeshSemantics } from '../mesh/visibility.js';
+import { refreshMeshAssetDiagnostics } from '../panels/mesh-panel.js';
+import { buildMenuPanel } from '../panels/menu-panel.js';
+import { buildPresentPanel } from '../panels/present-panel.js';
+import { buildTogglePanel } from '../panels/toggle-panel.js';
+import { refreshHealthReport, setAssetResolution } from '../panels/health-report.js';
+import { alertDialog } from '../ui/dialogs.js';
+
+export function beginSemanticRefresh() {
+  return {
+    path: viewerState.currentModPath,
+    epoch: ++viewerState.semanticRefreshEpoch,
+  };
+}
+
+export function semanticRefreshIsCurrent(path, epoch) {
+  return !!path && epoch === viewerState.semanticRefreshEpoch
+    && samePath(viewerState.currentModPath, path);
+}
+
+async function finishSemanticRefresh(path, epoch, { refreshPendingState } = {}) {
+  if (!semanticRefreshIsCurrent(path, epoch)) return;
+  if (refreshPendingState) {
+    await refreshPendingState(
+      path, () => semanticRefreshIsCurrent(path, epoch));
+  }
+  if (semanticRefreshIsCurrent(path, epoch)) void refreshHealthReport();
+}
+
+function handlersOrDefault(handlers = {}) {
+  return {
+    onPresentChange: handlers.onPresentChange || null,
+    onToggleChange: handlers.onToggleChange || null,
+    refreshPendingState: handlers.refreshPendingState || null,
+    syncViewportControlPlacement: handlers.syncViewportControlPlacement || (() => {}),
+  };
+}
+
+export async function refreshPresentState(change = {}, handlers = {}) {
+  const callbacks = handlersOrDefault(handlers);
+  const { path, epoch } = beginSemanticRefresh();
+  try {
+    if (!path) return false;
+    let result;
+    try {
+      result = await window.pywebview.api.get_present_state(path);
+    } catch (error) {
+      if (semanticRefreshIsCurrent(path, epoch)) {
+        await alertDialog('Could not refresh PRESENT:\n\n' + error);
+      }
+      return false;
+    }
+    if (!semanticRefreshIsCurrent(path, epoch)) return false;
+    if (result?.error) {
+      await alertDialog('Could not refresh PRESENT:\n\n' + result.error);
+      return false;
+    }
+    const context = { modPath: path, onChange: callbacks.onPresentChange };
+    if (Object.hasOwn(change, 'selectedPosition')) {
+      context.selectedPosition = change.selectedPosition;
+      context.applySelection = change.applySelection === true;
+    }
+    buildPresentPanel(result.present, context);
+    callbacks.syncViewportControlPlacement();
+    return true;
+  } finally {
+    await finishSemanticRefresh(path, epoch, callbacks);
+  }
+}
+
+export async function refreshControlSemantics(handlers = {}) {
+  const callbacks = handlersOrDefault(handlers);
+  const { path, epoch } = beginSemanticRefresh();
+  try {
+    if (!path) return false;
+    let result;
+    try {
+      result = await window.pywebview.api.get_control_state(path);
+    } catch (error) {
+      if (semanticRefreshIsCurrent(path, epoch)) {
+        await alertDialog('Could not refresh controls:\n\n' + error);
+      }
+      return false;
+    }
+    if (!semanticRefreshIsCurrent(path, epoch)) return false;
+    if (result?.error) {
+      await alertDialog('Could not refresh controls:\n\n' + result.error);
+      return false;
+    }
+    const controls = result.controls || {};
+    const state = result.state || {};
+    viewerState.lastToggles = controls.toggles || {};
+    setStateRules(state.rules || [], state.defaults || {}, {
+      toggles: controls.toggles || {}, menu: controls.menu || {},
+    });
+    buildTogglePanel(controls.toggles, {
+      modPath: path, onChange: callbacks.onToggleChange,
+    });
+    buildMenuPanel(controls.menu);
+    buildPresentPanel(controls.present, {
+      modPath: path, onChange: callbacks.onPresentChange,
+    });
+    callbacks.syncViewportControlPlacement();
+    refreshAll();
+    return true;
+  } finally {
+    await finishSemanticRefresh(path, epoch, callbacks);
+  }
+}
+
+export async function refreshMeshSemantics(handlers = {}) {
+  const callbacks = handlersOrDefault(handlers);
+  const { path, epoch } = beginSemanticRefresh();
+  try {
+    if (!path) return false;
+    let result;
+    try {
+      result = await window.pywebview.api.get_mesh_semantics(path);
+    } catch (error) {
+      if (semanticRefreshIsCurrent(path, epoch)) {
+        await alertDialog('Could not refresh mesh render semantics:\n\n' + error);
+      }
+      return false;
+    }
+    if (!semanticRefreshIsCurrent(path, epoch)) return false;
+    if (result?.error) {
+      await alertDialog('Could not refresh mesh render semantics:\n\n' + result.error);
+      return false;
+    }
+    if (!updateMeshSemantics(result.meshes)) {
+      await alertDialog('Could not refresh mesh render semantics:\n\n' +
+        'The staged draw set no longer matches the displayed model.');
+      return false;
+    }
+    const assetResolution = result.asset_resolution || null;
+    refreshMeshAssetDiagnostics(assetResolution);
+    setAssetResolution(assetResolution);
+    refreshAll();
+    return true;
+  } finally {
+    await finishSemanticRefresh(path, epoch, callbacks);
+  }
+}

--- a/src/web/js/app/state.js
+++ b/src/web/js/app/state.js
@@ -1,0 +1,31 @@
+// Mutable application/session state shared by the frontend flow modules.
+
+export const viewerState = {
+  currentModPath: null,
+  currentSource: null,
+
+  displayedModPath: null,
+  displayedSource: null,
+
+  semanticRefreshEpoch: 0,
+  modTransitionInFlight: false,
+
+  rightDockEnabled: false,
+
+  lastToggles: {},
+
+  assetFill: {
+    available: false,
+    loaded: false,
+    loading: false,
+    textureKeys: new Set(),
+    fillId: null,
+    epoch: 0,
+  },
+};
+
+/** Normalize paths for same-folder comparisons across Windows path spellings. */
+export function samePath(a, b) {
+  const norm = (path) => path.replace(/\\/g, '/').toLowerCase().replace(/\/+$/, '');
+  return !!a && !!b && norm(a) === norm(b);
+}

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -1,1063 +1,115 @@
-// Entry point: wires the toolbar and orchestrates model loading.
+// Entry point: composes frontend application flows and initializes the UI.
 
-import { adoptModelMeshes, fitTo, forgetModelMeshes, resetView,
-         rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
-         toggleGrid, toggleTrackballGizmo,
-         getEnvironmentPreset, getLightMode, isRendererAvailable, rendererReady,
-         setEnvironmentPreset, setLightMode, getRenderCount } from './scene/scene.js';
-import { ENVIRONMENT_PRESETS } from './scene/environment.js';
-import { addTexture, refreshMeshTexture, removeTextures, setTextures } from './mesh/mesh-factory.js';
-import { activeMeshes, refreshAll, reset, resetMeshState, setStateRules,
-         toggleWireframe, toggleSmoothShading, toggleGlossy, removeMesh,
-         updateMeshSemantics } from './mesh/visibility.js';
-import { initSelection, clearSelection } from './scene/selection.js';
 import {
-  appendMeshPanel, buildMeshPanel, refreshMeshAssetDiagnostics,
-  removeAssetFillMeshPanel,
-} from './panels/mesh-panel.js';
-import { buildTogglePanel } from './panels/toggle-panel.js';
-import { buildMenuPanel } from './panels/menu-panel.js';
-import { buildPresentPanel } from './panels/present-panel.js';
+  getEnvironmentPreset, getRenderCount, isRendererAvailable, rendererReady,
+  resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
+  toggleGrid, toggleTrackballGizmo,
+} from './scene/scene.js';
+import {
+  activeMeshes, resetMeshState,
+  toggleGlossy, toggleSmoothShading, toggleWireframe,
+} from './mesh/visibility.js';
+import { refreshMeshTexture } from './mesh/mesh-factory.js';
+import { initSelection } from './scene/selection.js';
 import { initModFolderPanel } from './panels/mod-folder-panel.js';
 import { initAssetFolderPanel } from './panels/asset-folder-panel.js';
-import { initLeftDock, setLeftDockTab, setMeshesAvailable } from './panels/left-dock.js';
-import { alertDialog, confirmDialog } from './ui/dialogs.js';
-import { setGeometryBlob } from './textures/decode.js';
-import { refreshHealthReport, setAssetResolution, setHealthLoader,
-         setHealthReport } from './panels/health-report.js';
-import { setIniEditorContext } from './editing/ini-editor.js';
+import { initLeftDock, setLeftDockTab } from './panels/left-dock.js';
 import { getMaterialDebugMode, setMaterialDebugMode } from './mesh/material-profile.js';
 import { requestRender } from './scene/render-scheduler.js';
-import { setTextureDisplayMode } from './scene/render-modes.js';
-import { clearInspector, initInspectorPanel } from './panels/inspector-panel.js';
-import { initRightDock, setRightDockEnabled } from './panels/right-dock.js';
+import { initInspectorPanel } from './panels/inspector-panel.js';
+import { initRightDock } from './panels/right-dock.js';
 import { initPanelOpacityControl } from './ui/appearance.js';
-import { createIcon } from './ui/ui-icons.js';
 import {
   getOutlineState as getMeshOutlineState,
-  setOutlineSuppressedByDebug,
-  setOutlinesEnabled,
+  setOutlineSuppressedByDebug, setOutlinesEnabled,
 } from './scene/outline-renderer.js';
+import {
+  displayMeshPayload as displayMeshPayloadFlow,
+  exportChanges as exportChangesFlow,
+  openMod as openModFlow,
+  refreshPendingState,
+  reloadCurrentMod as reloadCurrentModFlow,
+  switchAsset as switchAssetFlow,
+  switchMod as switchModFlow,
+  syncViewportControlPlacement,
+} from './app/model-flow.js';
+import { toggleMissingAssetParts, updateAssetFillButton } from './app/asset-fill.js';
+import {
+  refreshControlSemantics as refreshControlSemanticsFlow,
+  refreshMeshSemantics as refreshMeshSemanticsFlow,
+  refreshPresentState as refreshPresentStateFlow,
+} from './app/semantic-refresh.js';
+import { viewerState } from './app/state.js';
+import {
+  initEnvironmentControl, initToolPopovers, initToolbarOverflow,
+} from './ui/toolbar.js';
+import { initPanelCollapse } from './ui/panel-utils.js';
 
 const $ = (id) => document.getElementById(id);
 
-function initEnvironmentControl() {
-  const button = $('environment-btn');
-  const icon = $('environment-icon');
-  const labels = Object.fromEntries(
-    Object.values(ENVIRONMENT_PRESETS).map(preset => [preset.id, preset.label]));
-  const popover = $('environment-popover');
-  let currentId = getEnvironmentPreset().id;
-
-  function updateControl(id) {
-    const name = labels[id] || id;
-    icon.dataset.environment = id;
-    button.dataset.environment = id;
-    button.setAttribute('aria-label', `Environment: ${name}. Click to change.`);
-    button.title = `Environment: ${name} (click to change)`;
-  }
-
-  function applyEnvironmentPreset(id) {
-    if (!setEnvironmentPreset(id)) return false;
-    currentId = getEnvironmentPreset().id;
-    updateControl(currentId);
-    return true;
-  }
-
-  function closePopover() {
-    if (!popover) return;
-    popover.hidden = true;
-    button.setAttribute('aria-expanded', 'false');
-  }
-
-  function openPopover() {
-    if (!popover) return;
-    popover.replaceChildren();
-    Object.values(ENVIRONMENT_PRESETS).forEach(preset => {
-      const option = document.createElement('button');
-      option.type = 'button';
-      option.className = 'ui-popover-option';
-      option.setAttribute('role', 'menuitem');
-      option.textContent = preset.label;
-      option.classList.toggle('selected', preset.id === currentId);
-      option.addEventListener('click', () => {
-        applyEnvironmentPreset(preset.id);
-        closePopover();
-      });
-      popover.appendChild(option);
-    });
-    popover.hidden = false;
-    button.setAttribute('aria-expanded', 'true');
-  }
-
-  updateControl(currentId);
-  button.setAttribute('aria-haspopup', 'menu');
-  button.setAttribute('aria-expanded', 'false');
-  button.addEventListener('click', () => {
-    if (popover?.hidden === false) closePopover();
-    else openPopover();
-  });
-  document.addEventListener('click', event => {
-    if (!popover || popover.hidden || event.target.closest('#environment-control, #environment-popover')) return;
-    closePopover();
-  });
-  document.addEventListener('keydown', event => {
-    if (event.key === 'Escape') closePopover();
-  });
-
-  return applyEnvironmentPreset;
-}
-
-function initToolPopovers() {
-  const textureButton = $('texture-btn');
-  const lightButton = $('light-btn');
-  const texturePopover = $('texture-popover');
-  const lightPopover = $('light-popover');
-  const close = popover => {
-    if (!popover) return;
-    popover.hidden = true;
+function semanticHandlers() {
+  return {
+    onPresentChange: handlePresentChange,
+    onToggleChange: handleToggleChange,
+    refreshPendingState,
+    syncViewportControlPlacement,
   };
-  let activeToolPopover = null;
-  const positionPopover = (popover, button) => {
-    if (!popover || !button) return;
-    const buttonRect = button.getBoundingClientRect();
-    const popoverRect = popover.getBoundingClientRect();
-    const gutter = 8;
-    const maxLeft = Math.max(gutter, window.innerWidth - popoverRect.width - gutter);
-    const desiredLeft = buttonRect.left
-      + (buttonRect.width - popoverRect.width) / 2;
-    const left = Math.min(maxLeft, Math.max(gutter, desiredLeft));
-    const top = Math.max(gutter, buttonRect.top - popoverRect.height - gutter);
-    popover.style.left = `${left}px`;
-    popover.style.top = `${top}px`;
+}
+
+function modelHandlers() {
+  return {
+    onMaterialKindChanged: reloadCurrentMod,
+    onPresentChange: handlePresentChange,
+    onReload: reloadCurrentMod,
+    onToggleChange: handleToggleChange,
   };
-  const closeAll = () => {
-    close(texturePopover);
-    close(lightPopover);
-    textureButton?.setAttribute('aria-expanded', 'false');
-    lightButton?.setAttribute('aria-expanded', 'false');
-    activeToolPopover = null;
-  };
-
-  function toggleTexturePopover() {
-    if (!texturePopover) return;
-    const wasOpen = !texturePopover.hidden;
-    closeAll();
-    if (wasOpen) return;
-    texturePopover.replaceChildren();
-    [
-      ['all', 'All maps'],
-      ['diffuse-normal', 'Diffuse and NormalMap'],
-      ['diffuse', 'Diffuse only'],
-      ['none', 'No textures'],
-    ].forEach(([mode, label]) => {
-      const option = document.createElement('button');
-      option.type = 'button';
-      option.className = 'ui-popover-option';
-      option.setAttribute('role', 'menuitem');
-      option.textContent = label;
-      option.addEventListener('click', () => {
-        setTextureDisplayMode(mode, activeMeshes);
-        closeAll();
-      });
-      texturePopover.appendChild(option);
-    });
-    texturePopover.hidden = false;
-    textureButton?.setAttribute('aria-expanded', 'true');
-    activeToolPopover = { popover: texturePopover, button: textureButton };
-    positionPopover(texturePopover, textureButton);
-  }
-
-  function toggleLightPopover() {
-    if (!lightPopover) return;
-    const wasOpen = !lightPopover.hidden;
-    closeAll();
-    if (wasOpen) return;
-    lightPopover.replaceChildren();
-    [['double', 'Bright'], ['current', 'Normal'], ['off', 'Off']].forEach(([mode, label]) => {
-      const option = document.createElement('button');
-      option.type = 'button';
-      option.className = 'ui-popover-option';
-      option.setAttribute('role', 'menuitemradio');
-      option.setAttribute('aria-checked', String(getLightMode() === mode));
-      option.textContent = label;
-      option.addEventListener('click', () => {
-        setLightMode(mode);
-        closeAll();
-      });
-      lightPopover.appendChild(option);
-    });
-    lightPopover.hidden = false;
-    lightButton?.setAttribute('aria-expanded', 'true');
-    activeToolPopover = { popover: lightPopover, button: lightButton };
-    positionPopover(lightPopover, lightButton);
-  }
-
-  textureButton?.setAttribute('aria-haspopup', 'menu');
-  lightButton?.setAttribute('aria-haspopup', 'menu');
-  textureButton?.setAttribute('aria-expanded', 'false');
-  lightButton?.setAttribute('aria-expanded', 'false');
-  textureButton?.addEventListener('click', toggleTexturePopover);
-  lightButton?.addEventListener('click', toggleLightPopover);
-  document.addEventListener('click', event => {
-    if (event.target.closest('#texture-btn, #texture-popover, #light-btn, #light-popover')) return;
-    closeAll();
-  });
-  document.addEventListener('keydown', event => {
-    if (event.key === 'Escape') closeAll();
-  });
-  window.addEventListener('resize', () => {
-    if (activeToolPopover) {
-      positionPopover(activeToolPopover.popover, activeToolPopover.button);
-    }
-  });
-}
-
-function syncViewportControlPlacement() {
-  setRightDockEnabled(rightDockEnabled);
-}
-
-function initToolbarOverflow() {
-  const button = $('toolbar-more');
-  const menu = $('toolbar-overflow');
-  if (!button || !menu) return;
-  const close = () => {
-    menu.hidden = true;
-    button.setAttribute('aria-expanded', 'false');
-  };
-  button.addEventListener('click', event => {
-    event.stopPropagation();
-    menu.hidden = !menu.hidden;
-    button.setAttribute('aria-expanded', String(!menu.hidden));
-  });
-  menu.addEventListener('click', event => {
-    const item = event.target.closest('[data-toolbar-target]');
-    if (!item) return;
-    const target = $(item.dataset.toolbarTarget);
-    if (target && !target.disabled) target.click();
-    close();
-  });
-  document.addEventListener('click', event => {
-    if (!event.target.closest('#toolbar-more, #toolbar-overflow')) close();
-  });
-  document.addEventListener('keydown', event => {
-    if (event.key === 'Escape') close();
-  });
-}
-
-// The currently open mod folder, so the Toggle panel's staged add/edit/delete
-// actions know which session to update and reloadCurrentMod() knows what to
-// refresh afterward.
-let currentModPath = null;
-let currentSource = null;
-let semanticRefreshEpoch = 0;
-// Unlike currentModPath, this changes only after a payload is displayed.
-// Camera framing follows displayed model identity so a failed switch and retry
-// still frames the replacement, while a reload of the visible mod does not.
-let displayedModPath = null;
-let displayedSource = null;
-let modTransitionInFlight = false;
-let rightDockEnabled = false;
-let assetFillAvailable = false;
-let assetFillLoaded = false;
-let assetFillLoading = false;
-let assetFillTextureKeys = new Set();
-let assetFillId = null;
-let assetFillEpoch = 0;
-
-// The last-loaded payload's controls.toggles model, kept
-// around purely so refreshPendingState() can check for a still-unwired
-// toggle without re-fetching anything — see hasUnwiredToggle().
-let lastToggles = {};
-
-function showLoading(on, message) {
-  if (message) $('status-text').textContent = message;
-  $('loading').classList.toggle('show', on);
-}
-
-function updateAssetFillButton() {
-  const button = $('asset-fill-btn');
-  if (!button) return;
-  const available = assetFillAvailable
-    && currentSource?.kind === 'mod' && !!currentModPath;
-  const state = assetFillLoading ? 'loading' : assetFillLoaded ? 'remove' : 'load';
-  const label = state === 'remove'
-    ? 'Remove missing parts'
-    : state === 'loading'
-      ? assetFillLoaded ? 'Removing missing parts' : 'Loading missing parts'
-      : 'Load missing parts';
-  button.disabled = !available || assetFillLoading;
-  button.dataset.state = state;
-  button.setAttribute('aria-label', label);
-  button.setAttribute('aria-pressed', String(assetFillLoaded));
-  button.replaceChildren(createIcon(state === 'remove' ? 'close' : 'mesh-add'));
-  button.title = assetFillLoaded
-    ? 'Remove original Asset components added for this session.'
-    : 'Add original Asset components not handled by this mod.';
-}
-
-/** Normalizes a Windows path for a same-folder comparison: slash direction,
- * case and a trailing separator all vary without the folder actually being
- * different. */
-function samePath(a, b) {
-  const norm = (p) => p.replace(/\\/g, '/').toLowerCase().replace(/\/+$/, '');
-  return !!a && !!b && norm(a) === norm(b);
-}
-
-/** True if the currently displayed Toggle panel has a toggle that doesn't
- * gate any mesh yet -- only ever a toggle just added via "＋ Add" this
- * session and not yet wired via Record mode; a pre-existing on-disk
- * non-gating key is never loaded into the panel at all. */
-function hasUnwiredToggle() {
-  return Object.values(lastToggles).some((info) => info.wired === false);
-}
-
-// Reflects the currently open mod's staged-but-not-yet-exported edits onto
-// the toolbar: Export only enables once there's something to export, and
-// the indicator is the persistent signal that something is unsaved.
-async function refreshPendingState(path = currentModPath, guard = null) {
-  const pending = path ? await window.pywebview.api.has_pending_changes(path) : false;
-  if ((guard && !guard()) || (path && !samePath(currentModPath, path))) return false;
-  $('pending-indicator').classList.toggle('show', pending);
-  const blocked = pending && hasUnwiredToggle();
-  $('export-btn').disabled = !pending || blocked;
-  $('export-btn').title = blocked
-    ? 'A newly-added toggle isn\'t wired to any mesh yet — Record (⏺) or delete it before exporting.'
-    : '';
-}
-
-function clearScene({ preserveModelOrientation = false } = {}) {
-  clearSelection();
-  clearInspector();
-  rightDockEnabled = false;
-  reset({ preserveModelOrientation });
-  // Debug mode is material-local and does not survive a reload; keep outline
-  // suppression in the same lifecycle rather than carrying stale state onto
-  // the next mod's normal materials.
-  setOutlineSuppressedByDebug(false);
-  setTextures(null);
-  removeTextures(assetFillTextureKeys);
-  assetFillTextureKeys = new Set();
-  assetFillId = null;
-  assetFillAvailable = false;
-  assetFillLoaded = false;
-  assetFillLoading = false;
-  setGeometryBlob(null);
-  lastToggles = {};
-  $('mesh-list').innerHTML = '';
-  $('camera-panel').style.display = 'none';
-  $('toggle-list').innerHTML = '';
-  $('toggle-panel').style.display = 'none';
-  $('present-list').innerHTML = '';
-  $('present-panel').style.display = 'none';
-  $('menu-list').innerHTML = '';
-  $('menu-panel').style.display = 'none';
-  setMeshesAvailable(false);
-  setRightDockEnabled(false);
-  syncViewportControlPlacement();
-  updateAssetFillButton();
-}
-
-function clearPendingState() {
-  $('pending-indicator').classList.remove('show');
-  $('export-btn').disabled = true;
-  $('export-btn').title = '';
-}
-
-function setSourceUi(kind) {
-  const asset = kind === 'asset';
-  document.body.classList.toggle('asset-preview-mode', asset);
-  if (asset) {
-    setHealthLoader(null);
-    setHealthReport(null, null);
-    setIniEditorContext(null, null);
-  }
-  $('pending-indicator').classList.toggle('show', false);
-  $('pending-indicator').setAttribute('aria-hidden', String(asset));
-  if (asset) $('export-btn').disabled = true;
-  updateAssetFillButton();
-}
-
-/** Commit the UI to a new folder before asking the backend to load it. This
- * makes the folder path, editor/diagnostic context, model, panels and pending
- * state one transition: a failed replacement can never leave the previous
- * mod visible under the new folder's toolbar state. */
-function beginModLoad(path, message, { preserveModelOrientation = false } = {}) {
-  assetFillEpoch += 1;
-  currentModPath = path;
-  currentSource = { kind: 'mod', path };
-  setSourceUi('mod');
-  semanticRefreshEpoch += 1;
-  clearScene({ preserveModelOrientation });
-  clearPendingState();
-  window.dispatchEvent(new CustomEvent('mod-viewer-mod-load-started', {
-    detail: { path },
-  }));
-  $('hint').style.display = 'none';
-  $('empty-actions').style.display = 'none';
-  $('mod-path').textContent = path;
-  $('mod-path').title = path;
-  setHealthReport(null);
-  setHealthLoader(() => window.pywebview.api.get_diagnostics(path));
-  setIniEditorContext(path, reloadCurrentMod);
-  showLoading(true, message);
-}
-
-function beginAssetLoad(path, entry, message = 'Loading Asset…',
-                        { preserveModelOrientation = false } = {}) {
-  assetFillEpoch += 1;
-  currentModPath = null;
-  currentSource = {
-    kind: 'asset', path, assetType: entry?.asset_type || null,
-  };
-  semanticRefreshEpoch += 1;
-  clearScene({ preserveModelOrientation });
-  clearPendingState();
-  setSourceUi('asset');
-  window.dispatchEvent(new CustomEvent('mod-viewer-asset-load-started', {
-    detail: { path, entry },
-  }));
-  $('hint').style.display = 'none';
-  $('empty-actions').style.display = 'none';
-  $('mod-path').textContent = `Asset Preview  —  ${path}`;
-  $('mod-path').title = path;
-  setAssetResolution(null);
-  showLoading(true, message);
-}
-
-async function displayMeshPayload(payload, { preserveCamera = false } = {}) {
-  const geometry = payload.geometry;
-  if (geometry) {
-    const response = await fetch(geometry.url, { cache: 'no-store' });
-    if (!response.ok) throw new Error(`Geometry download failed (${response.status}).`);
-    const blob = await response.arrayBuffer();
-    if (blob.byteLength !== geometry.length) throw new Error('Geometry download was incomplete.');
-    setGeometryBlob(blob);
-  } else {
-    setGeometryBlob(null);
-  }
-
-  const controls = payload.controls || {};
-  const state = payload.state || {};
-  const meshes = payload.meshes || {};
-  const assetMode = currentSource?.kind === 'asset'
-    || payload.metadata?.source_kind === 'asset';
-  assetFillAvailable = !assetMode
-    && Number(payload.asset_resolution?.configured_roots || 0) > 0;
-  if (assetMode && currentSource?.kind !== 'asset') {
-    currentSource = {
-      kind: 'asset', path: payload.metadata?.asset?.path || '',
-      assetType: payload.metadata?.asset?.type || null,
-    };
-    setSourceUi('asset');
-  }
-  const modelPath = assetMode ? null : currentModPath;
-  lastToggles = controls.toggles || {};
-  setStateRules(state.rules || [], state.defaults || {}, {
-    toggles: controls.toggles || {}, menu: controls.menu || {},
-  });
-  setTextures(payload.textures);
-  buildMeshPanel(
-    meshes, modelPath, payload.metadata?.mesh_names || {},
-    payload.metadata?.material_profiles || {},
-    {
-      onMaterialKindChanged: assetMode ? null : reloadCurrentMod,
-      texturePools: payload.texture_pools || {},
-      assetResolution: payload.asset_resolution || null,
-      readOnlySource: assetMode,
-      texturePicker: assetMode
-        ? (role => window.pywebview.api.pick_asset_texture_file(
-          currentSource.path, role)) : null,
-    });
-  buildTogglePanel(controls.toggles, {
-    modPath: currentModPath, onChange: handleToggleChange,
-  });
-  buildMenuPanel(controls.menu);
-  buildPresentPanel(controls.present, {
-    modPath: currentModPath, onChange: handlePresentChange,
-  });
-  setMeshesAvailable(true);
-  rightDockEnabled = true;
-  syncViewportControlPlacement();
-  fitTo(activeMeshes, {
-    preserveCamera,
-    // WWMI models use the opposite horizontal facing convention from the
-    // viewer's default front view.  Keep this as a model base transform so
-    // camera controls and viewer-only orientation state remain independent.
-    initialRotationY: payload.metadata?.game?.id === 'wuwa' ? Math.PI : 0,
-  });
-
-  updateAssetFillButton();
-  showLoading(false);
-}
-
-function assetFillOperationIsCurrent(operation, path) {
-  return operation === assetFillEpoch
-    && currentSource?.kind === 'mod'
-    && samePath(currentModPath, path);
-}
-
-function rollbackAssetFillFrontend(addedMeshes, textureKeys) {
-  const targetMeshes = [...new Set(addedMeshes || [])];
-  const removedFromPanel = removeAssetFillMeshPanel(targetMeshes);
-  const remaining = targetMeshes.filter(mesh => activeMeshes.includes(mesh));
-  remaining.forEach(removeMesh);
-  const removed = [...new Set([...removedFromPanel, ...remaining])];
-  if (removed.length) {
-    forgetModelMeshes(removed);
-    requestRender();
-  }
-
-  const keys = new Set(textureKeys || []);
-  removeTextures(keys);
-  keys.forEach(key => assetFillTextureKeys.delete(key));
-  assetFillLoaded = false;
-  assetFillId = null;
-}
-
-async function releaseBackendAssetFill(path, fillId = null) {
-  try {
-    const result = await window.pywebview.api.remove_missing_asset_parts(
-      path, fillId);
-    if (result?.status === 'error') {
-      console.warn('Could not roll back missing Asset parts:', result.error);
-    }
-  } catch (error) {
-    console.warn('Could not roll back missing Asset parts:', error);
-  }
-}
-
-async function rollbackAssetFill(
-    path, operation, fillId, addedMeshes, textureKeys) {
-  if (assetFillOperationIsCurrent(operation, path)) {
-    rollbackAssetFillFrontend(addedMeshes, textureKeys);
-  } else {
-    // A stale operation must not touch the scene or global fill state. Texture
-    // entries are still owned by this transaction, so release only those.
-    const keys = new Set(textureKeys || []);
-    removeTextures(keys);
-    keys.forEach(key => assetFillTextureKeys.delete(key));
-  }
-  await releaseBackendAssetFill(path, fillId);
-}
-
-async function loadMissingAssetParts() {
-  if (!currentModPath || currentSource?.kind !== 'mod' || assetFillLoading) {
-    return false;
-  }
-  const path = currentModPath;
-  const operation = ++assetFillEpoch;
-  let backendLoaded = false;
-  let rolledBack = false;
-  let transactionFillId = null;
-  let addedMeshes = [];
-  const transactionTextureKeys = new Set();
-  const rollback = async () => {
-    if (rolledBack) return;
-    rolledBack = true;
-    if (backendLoaded) {
-      await rollbackAssetFill(
-        path, operation, transactionFillId,
-        addedMeshes, transactionTextureKeys);
-    }
-  };
-  assetFillLoading = true;
-  updateAssetFillButton();
-  try {
-    const result = await window.pywebview.api.load_missing_asset_parts(path);
-    if (!assetFillOperationIsCurrent(operation, path)) {
-      if (result?.status === 'loaded') {
-        backendLoaded = true;
-        transactionFillId = result.fill_id || null;
-      }
-      await rollback();
-      return false;
-    }
-    if (result?.status !== 'loaded') {
-      const messages = {
-        nothing_missing: 'No missing original Asset parts found.',
-        asset_ambiguous: 'Could not uniquely determine the original Asset.',
-        asset_not_found: 'No matching original Asset was found.',
-      };
-      if (result?.error) throw new Error(result.error);
-      await alertDialog(messages[result?.status] || 'No original Asset parts were loaded.');
-      return false;
-    }
-    backendLoaded = true;
-    transactionFillId = result.fill_id || null;
-    if (!assetFillOperationIsCurrent(operation, path)) {
-      await rollback();
-      return false;
-    }
-    const payload = result.payload || {};
-    const geometry = payload.geometry;
-    if (geometry) {
-      const response = await fetch(geometry.url, { cache: 'no-store' });
-      if (!response.ok) throw new Error(`Geometry download failed (${response.status}).`);
-      const blob = await response.arrayBuffer();
-      if (blob.byteLength !== geometry.length) {
-        throw new Error('Geometry download was incomplete.');
-      }
-      if (!assetFillOperationIsCurrent(operation, path)) {
-        await rollback();
-        return false;
-      }
-      setGeometryBlob(blob);
-    }
-    for (const [key, uri] of Object.entries(payload.textures || {})) {
-      if (addTexture(key, uri)) {
-        assetFillTextureKeys.add(key);
-        transactionTextureKeys.add(key);
-      }
-    }
-    if (!assetFillOperationIsCurrent(operation, path)) {
-      await rollback();
-      return false;
-    }
-    const before = new Set(activeMeshes);
-    try {
-      appendMeshPanel(
-        payload.meshes || {}, null,
-        {}, payload.metadata?.material_profiles || {}, {
-          replace: false,
-          texturePools: payload.texture_pools || {},
-          readOnlySource: true,
-        });
-    } finally {
-      addedMeshes = activeMeshes.filter(mesh => !before.has(mesh));
-    }
-    adoptModelMeshes(addedMeshes);
-    if (!assetFillOperationIsCurrent(operation, path)) {
-      await rollback();
-      return false;
-    }
-    assetFillLoaded = true;
-    assetFillId = transactionFillId;
-    fitTo(activeMeshes, {
-      preserveCamera: true,
-      preserveHomeView: true,
-    });
-    requestRender();
-    return true;
-  } catch (error) {
-    await rollback();
-    if (!assetFillOperationIsCurrent(operation, path)) return false;
-    await alertDialog('Could not load missing Asset parts:\n\n' + error.message);
-    return false;
-  } finally {
-    if (operation === assetFillEpoch) {
-      assetFillLoading = false;
-      updateAssetFillButton();
-    }
-  }
-}
-
-async function removeMissingAssetParts() {
-  if (!currentModPath || !assetFillLoaded || assetFillLoading) return false;
-  const path = currentModPath;
-  const operation = ++assetFillEpoch;
-  assetFillLoading = true;
-  updateAssetFillButton();
-  try {
-    const result = await window.pywebview.api.remove_missing_asset_parts(
-      path, assetFillId);
-    if (!assetFillOperationIsCurrent(operation, path)) return false;
-    if (result?.status === 'error') throw new Error(result.error);
-    if (result?.stale) return false;
-    const removedMeshes = removeAssetFillMeshPanel();
-    forgetModelMeshes(removedMeshes);
-    removeTextures(assetFillTextureKeys);
-    assetFillTextureKeys = new Set();
-    assetFillLoaded = false;
-    assetFillId = null;
-    requestRender();
-    return true;
-  } catch (error) {
-    if (!assetFillOperationIsCurrent(operation, path)) return false;
-    await alertDialog('Could not remove missing Asset parts:\n\n' + error.message);
-    return false;
-  } finally {
-    if (operation === assetFillEpoch) {
-      assetFillLoading = false;
-      updateAssetFillButton();
-    }
-  }
-}
-
-async function toggleMissingAssetParts() {
-  return assetFillLoaded
-    ? removeMissingAssetParts() : loadMissingAssetParts();
-}
-
-function beginSemanticRefresh() {
-  return { path: currentModPath, epoch: ++semanticRefreshEpoch };
-}
-
-function semanticRefreshIsCurrent(path, epoch) {
-  return !!path && epoch === semanticRefreshEpoch
-    && samePath(currentModPath, path);
-}
-
-async function finishSemanticRefresh(path, epoch) {
-  if (!semanticRefreshIsCurrent(path, epoch)) return;
-  await refreshPendingState(
-    path, () => semanticRefreshIsCurrent(path, epoch));
-  if (semanticRefreshIsCurrent(path, epoch)) void refreshHealthReport();
-}
-
-async function refreshPresentState(change = {}) {
-  const { path, epoch } = beginSemanticRefresh();
-  try {
-    if (!path) return false;
-    let result;
-    try {
-      result = await window.pywebview.api.get_present_state(path);
-    } catch (error) {
-      if (semanticRefreshIsCurrent(path, epoch)) {
-        await alertDialog('Could not refresh PRESENT:\n\n' + error);
-      }
-      return false;
-    }
-    if (!semanticRefreshIsCurrent(path, epoch)) return false;
-    if (result?.error) {
-      await alertDialog('Could not refresh PRESENT:\n\n' + result.error);
-      return false;
-    }
-    const context = { modPath: path, onChange: handlePresentChange };
-    if (Object.hasOwn(change, 'selectedPosition')) {
-      context.selectedPosition = change.selectedPosition;
-      context.applySelection = change.applySelection === true;
-    }
-    buildPresentPanel(result.present, context);
-    syncViewportControlPlacement();
-    return true;
-  } finally {
-    await finishSemanticRefresh(path, epoch);
-  }
 }
 
 async function handlePresentChange(change = {}) {
-  return refreshPresentState(change);
-}
-
-async function refreshControlSemantics() {
-  const { path, epoch } = beginSemanticRefresh();
-  try {
-    if (!path) return false;
-    let result;
-    try {
-      result = await window.pywebview.api.get_control_state(path);
-    } catch (error) {
-      if (semanticRefreshIsCurrent(path, epoch)) {
-        await alertDialog('Could not refresh controls:\n\n' + error);
-      }
-      return false;
-    }
-    if (!semanticRefreshIsCurrent(path, epoch)) return false;
-    if (result?.error) {
-      await alertDialog('Could not refresh controls:\n\n' + result.error);
-      return false;
-    }
-    const controls = result.controls || {};
-    const state = result.state || {};
-    lastToggles = controls.toggles || {};
-    setStateRules(state.rules || [], state.defaults || {}, {
-      toggles: controls.toggles || {}, menu: controls.menu || {},
-    });
-    buildTogglePanel(controls.toggles, {
-      modPath: path, onChange: handleToggleChange,
-    });
-    buildMenuPanel(controls.menu);
-    buildPresentPanel(controls.present, {
-      modPath: path, onChange: handlePresentChange,
-    });
-    syncViewportControlPlacement();
-    refreshAll();
-    return true;
-  } finally {
-    await finishSemanticRefresh(path, epoch);
-  }
-}
-
-async function refreshMeshSemantics() {
-  const { path, epoch } = beginSemanticRefresh();
-  try {
-    if (!path) return false;
-    let result;
-    try {
-      result = await window.pywebview.api.get_mesh_semantics(path);
-    } catch (error) {
-      if (semanticRefreshIsCurrent(path, epoch)) {
-        await alertDialog('Could not refresh mesh render semantics:\n\n' + error);
-      }
-      return false;
-    }
-    if (!semanticRefreshIsCurrent(path, epoch)) return false;
-    if (result?.error) {
-      await alertDialog('Could not refresh mesh render semantics:\n\n' + result.error);
-      return false;
-    }
-    if (!updateMeshSemantics(result.meshes)) {
-      await alertDialog('Could not refresh mesh render semantics:\n\n' +
-        'The staged draw set no longer matches the displayed model.');
-      return false;
-    }
-    const assetResolution = result.asset_resolution || null;
-    refreshMeshAssetDiagnostics(assetResolution);
-    setAssetResolution(assetResolution);
-    refreshAll();
-    return true;
-  } finally {
-    await finishSemanticRefresh(path, epoch);
-  }
+  return refreshPresentStateFlow(change, semanticHandlers());
 }
 
 async function handleToggleChange(change = {}) {
   if (change.type === 'record') {
-    const meshesRefreshed = await refreshMeshSemantics();
-    return meshesRefreshed ? refreshControlSemantics() : false;
+    const meshesRefreshed = await refreshMeshSemanticsFlow(semanticHandlers());
+    return meshesRefreshed
+      ? refreshControlSemanticsFlow(semanticHandlers()) : false;
   }
   if (change.type === 'delete') {
     // Deleting a toggle rewrites every safe branch that references its
-    // variable, including resource bindings before drawindexed.  The draw
+    // variable, including resource bindings before drawindexed. The draw
     // label can survive while its geometry identity changes, so semantic
     // patching is not safe here; rebuild from the authoritative session.
     return reloadCurrentMod();
   }
-  return refreshControlSemantics();
+  return refreshControlSemanticsFlow(semanticHandlers());
 }
 
-async function loadModAt(path) {
-  const preserveViewerPose = samePath(displayedModPath, path);
-  beginModLoad(path, 'Loading Model…', {
-    preserveModelOrientation: preserveViewerPose,
-  });
-
-  const data = await window.pywebview.api.load_mod(path);
-  setHealthReport(data?.health, data?.asset_resolution);
-  if (data && data.error) {
-    showLoading(false);
-    await refreshPendingState();
-    await alertDialog('Could not load mod:\n\n' + data.error);
-    return false;
-  }
-  try {
-    await displayMeshPayload(data, { preserveCamera: preserveViewerPose });
-  } catch (error) {
-    clearScene({ preserveModelOrientation: preserveViewerPose });
-    clearPendingState();
-    showLoading(false);
-    await refreshPendingState();
-    await alertDialog('Could not load mod geometry:\n\n' + error.message);
-    return false;
-  }
-  await refreshPendingState();
-
-  // Lead with the folder name; the full path is long and rarely the useful part.
-  const folderName = path.replace(/\\/g, '/').split('/').filter(Boolean).at(-1);
-  $('mod-path').textContent = `${folderName}  —  ${path}`;
-  $('mod-path').textContent = folderName;
-  $('mod-path').title = path;
-  displayedModPath = path;
-  displayedSource = { kind: 'mod', path };
-  window.dispatchEvent(new CustomEvent('mod-viewer-mod-loaded', {
-    detail: { path },
-  }));
-  // Diagnostics are independent of geometry rendering. Start them after the
-  // mod is visible so the toolbar badge is populated without requiring a
-  // click on the Diagnostics button.
-  void refreshHealthReport();
-  return true;
-}
-
-async function loadAssetAt(path, entry = {}) {
-  const preserveViewerPose = displayedSource?.kind === 'asset'
-    && samePath(displayedSource.path, path);
-  beginAssetLoad(path, entry, 'Loading Asset…', {
-    preserveModelOrientation: preserveViewerPose,
-  });
-  const data = await window.pywebview.api.load_asset(path);
-  if (data && data.error) {
-    showLoading(false);
-    await alertDialog('Could not load Asset:\n\n' + data.error);
-    return false;
-  }
-  try {
-    await displayMeshPayload(data, { preserveCamera: preserveViewerPose });
-  } catch (error) {
-    clearScene({ preserveModelOrientation: preserveViewerPose });
-    clearPendingState();
-    showLoading(false);
-    await alertDialog('Could not load Asset geometry:\n\n' + error.message);
-    return false;
-  }
-  const folderName = path.replace(/\\/g, '/').split('/').filter(Boolean).at(-1);
-  $('mod-path').textContent = `Asset Preview  —  ${folderName}`;
-  $('mod-path').title = path;
-  displayedModPath = null;
-  displayedSource = { ...currentSource };
-  window.dispatchEvent(new CustomEvent('mod-viewer-asset-loaded', {
-    detail: { path, entry, source: displayedSource },
-  }));
-  return true;
-}
-
-async function performModSwitch(path) {
-  // Switching to a different folder while the current one has staged,
-  // not-yet-exported edits would silently strand them in memory, so ask
-  // first. Reopening the same folder, or one with nothing pending, needs
-  // no confirmation.
-  if (currentSource?.kind === 'mod' && currentModPath && !samePath(currentModPath, path) &&
-      await window.pywebview.api.has_pending_changes(currentModPath)) {
-    const proceed = await confirmDialog(
-      'This mod has unsaved changes that haven\'t been exported.\n\n' +
-      'Opening a different mod folder will discard them. Continue?');
-    if (!proceed) return false;
-    await window.pywebview.api.discard_changes(currentModPath);
-  }
-
-  return await loadModAt(path);
-}
-
-async function confirmLeaveCurrentModIfDirty() {
-  if (currentSource?.kind !== 'mod' || !currentModPath) return true;
-  if (!await window.pywebview.api.has_pending_changes(currentModPath)) return true;
-  const proceed = await confirmDialog(
-    'This mod has unsaved changes that haven\'t been exported.\n\n' +
-    'Opening an Asset preview will discard them. Continue?');
-  if (!proceed) return false;
-  await window.pywebview.api.discard_changes(currentModPath);
-  return true;
-}
-
-async function switchAsset(path, entry = {}) {
-  if (!path || !entry?.asset) return false;
-  return await runModTransition(async () => {
-    try {
-      if (!await confirmLeaveCurrentModIfDirty()) return false;
-      return await loadAssetAt(path, entry);
-    } catch (e) {
-      showLoading(false);
-      await alertDialog('Unexpected error while loading Asset:\n\n' + e);
-      return false;
-    }
+function displayMeshPayload(payload, options = {}) {
+  return displayMeshPayloadFlow(payload, {
+    ...options,
+    ...modelHandlers(),
   });
 }
 
-async function runModTransition(operation) {
-  if (modTransitionInFlight || !isRendererAvailable()) return false;
-  modTransitionInFlight = true;
-  const btn = $('open-btn');
-  btn.disabled = true;
-  try {
-    return await operation();
-  } finally {
-    modTransitionInFlight = false;
-    btn.disabled = !isRendererAvailable();
-  }
+function openMod() {
+  return openModFlow(modelHandlers());
 }
 
-async function switchMod(path) {
-  if (!path) return false;
-  return await runModTransition(async () => {
-    try {
-      return await performModSwitch(path);
-    } catch (e) {
-      showLoading(false);
-      await alertDialog('Unexpected error:\n\n' + e);
-      return false;
-    }
-  });
+function switchMod(path) {
+  return switchModFlow(path, modelHandlers());
 }
 
-async function openMod() {
-  return await runModTransition(async () => {
-    try {
-      const path = await window.pywebview.api.select_folder();
-      if (!path) return false;
-      return await performModSwitch(path);
-    } catch (e) {
-      showLoading(false);
-      await alertDialog('Unexpected error:\n\n' + e);
-      return false;
-    }
-  });
+function switchAsset(path, entry = {}) {
+  return switchAssetFlow(path, entry, modelHandlers());
 }
 
-// Re-renders the current authoritative edit session after a staged authoring
-// change, using the same load path as an ordinary reopen.
-export async function reloadCurrentMod() {
-  if (!currentModPath) return false;
-  return await runModTransition(async () => {
-    try {
-      return await loadModAt(currentModPath);
-    } catch (e) {
-      showLoading(false);
-      await alertDialog('Unexpected error while reloading:\n\n' + e);
-      return false;
-    }
-  });
+function reloadCurrentMod() {
+  return reloadCurrentModFlow(modelHandlers());
 }
 
-async function exportChanges() {
-  if (!currentModPath) return;
-  const btn = $('export-btn');
-  btn.disabled = true;
-  try {
-    const result = await window.pywebview.api.export_changes(currentModPath);
-    if (result.error) {
-      // Refused outright — e.g. a newly-added toggle is still unwired (see
-      // toggle_api.export_changes). The button is normally already disabled
-      // for this case (refreshPendingState/hasUnwiredToggle), so reaching
-      // here at all means the panel was momentarily stale; nothing was
-      // written either way.
-      await alertDialog('Export was blocked:\n\n' + result.error);
-    } else if (result.failed && result.failed.length) {
-      const detail = result.failed.map((f) => `${f.ini}: ${f.error}`).join('\n');
-      await alertDialog(
-        `${result.saved.length} ini file(s) exported, but ${result.failed.length} failed ` +
-        `and are still pending:\n\n${detail}`);
-    }
-    // Export writes the authoritative staged documents but does not change
-    // the current model or control semantics. Refresh only session status;
-    // partial failures leave the affected edits pending for retry.
-    await refreshPendingState();
-    void refreshHealthReport();
-  } catch (e) {
-    await alertDialog('Unexpected error while exporting:\n\n' + e);
-    await refreshPendingState();
-  }
-}
-
-// Collapses a panel's body when its header is clicked.
-function initPanelCollapse(panel, contentId) {
-  const hdr = panel.querySelector('.panel-hdr');
-  const chevron = hdr.querySelector('.group-toggle');
-  const content = $(contentId);
-  const storageKey = `mod-viewer.panel.${panel.id}.collapsed`;
-  const setCollapsed = (collapsed, persist = true) => {
-    chevron.classList.toggle('collapsed', collapsed);
-    content.classList.toggle('collapsed', collapsed);
-    chevron.setAttribute('aria-expanded', String(!collapsed));
-    chevron.setAttribute('aria-label', `${collapsed ? 'Expand' : 'Collapse'} ${panel.querySelector('h3')?.textContent || 'panel'}`);
-    if (persist) {
-      try { localStorage.setItem(storageKey, String(collapsed)); } catch (_) { /* private mode */ }
-    }
-  };
-  let initiallyCollapsed = false;
-  try { initiallyCollapsed = localStorage.getItem(storageKey) === 'true'; } catch (_) { /* private mode */ }
-  chevron.setAttribute('aria-controls', contentId);
-  setCollapsed(initiallyCollapsed, false);
-  const toggle = (e) => {
-    if (e?.target?.closest?.('.icon-btn, .panel-hdr-actions, .panel-actions, .panel-action-menu')) return;
-    e?.stopPropagation?.();
-    setCollapsed(!content.classList.contains('collapsed'));
-  };
-  hdr.addEventListener('click', e => {
-    if (e.target.closest('.icon-btn, .group-toggle, .panel-hdr-actions, .panel-actions, .panel-action-menu')) return;
-    setCollapsed(!content.classList.contains('collapsed'));
-  });
-  chevron.addEventListener('click', toggle);
+function exportChanges() {
+  return exportChangesFlow();
 }
 
 initToolbarOverflow();
@@ -1179,9 +231,14 @@ rendererReady.then(ready => {
   window.modViewer = {
     displayMeshPayload, openMod, switchMod, switchAsset, reloadCurrentMod,
     exportChanges,
-    refreshPresentState, refreshControlSemantics, refreshMeshSemantics, activeMeshes,
-    setEnvironmentPreset: applyEnvironmentPreset, getEnvironmentPreset,
-    getMaterialState, getRenderCount,
+    refreshPresentState: handlePresentChange,
+    refreshControlSemantics: () => refreshControlSemanticsFlow(semanticHandlers()),
+    refreshMeshSemantics: () => refreshMeshSemanticsFlow(semanticHandlers()),
+    activeMeshes,
+    setEnvironmentPreset: applyEnvironmentPreset,
+    getEnvironmentPreset,
+    getMaterialState,
+    getRenderCount,
     setMaterialDebugMode: setMaterialDebugModeForMeshes,
     setOutlineEnabled: value => {
       const enabled = setOutlinesEnabled(value);
@@ -1192,6 +249,7 @@ rendererReady.then(ready => {
       return enabled;
     },
     getOutlineState: index => getMeshOutlineState(activeMeshes[index]),
-    getCurrentSource: () => currentSource ? { ...currentSource } : null,
+    getCurrentSource: () => viewerState.currentSource
+      ? { ...viewerState.currentSource } : null,
   };
 });

--- a/src/web/js/ui/panel-utils.js
+++ b/src/web/js/ui/panel-utils.js
@@ -49,3 +49,34 @@ export function buildSourceSection(source, container, {
   container.append(header, items);
   return items;
 }
+
+// Collapse a panel body while preserving the shared local preference.
+export function initPanelCollapse(panel, contentId) {
+  const hdr = panel.querySelector('.panel-hdr');
+  const chevron = hdr.querySelector('.group-toggle');
+  const content = document.getElementById(contentId);
+  const storageKey = `mod-viewer.panel.${panel.id}.collapsed`;
+  const setCollapsed = (collapsed, persist = true) => {
+    chevron.classList.toggle('collapsed', collapsed);
+    content.classList.toggle('collapsed', collapsed);
+    chevron.setAttribute('aria-expanded', String(!collapsed));
+    chevron.setAttribute('aria-label', `${collapsed ? 'Expand' : 'Collapse'} ${panel.querySelector('h3')?.textContent || 'panel'}`);
+    if (persist) {
+      try { localStorage.setItem(storageKey, String(collapsed)); } catch (_) { /* private mode */ }
+    }
+  };
+  let initiallyCollapsed = false;
+  try { initiallyCollapsed = localStorage.getItem(storageKey) === 'true'; } catch (_) { /* private mode */ }
+  chevron.setAttribute('aria-controls', contentId);
+  setCollapsed(initiallyCollapsed, false);
+  const toggle = (event) => {
+    if (event?.target?.closest?.('.icon-btn, .panel-hdr-actions, .panel-actions, .panel-action-menu')) return;
+    event?.stopPropagation?.();
+    setCollapsed(!content.classList.contains('collapsed'));
+  };
+  hdr.addEventListener('click', event => {
+    if (event.target.closest('.icon-btn, .group-toggle, .panel-hdr-actions, .panel-actions, .panel-action-menu')) return;
+    setCollapsed(!content.classList.contains('collapsed'));
+  });
+  chevron.addEventListener('click', toggle);
+}

--- a/src/web/js/ui/toolbar.js
+++ b/src/web/js/ui/toolbar.js
@@ -1,0 +1,210 @@
+// Toolbar controls that only coordinate DOM state and viewer-wide controls.
+
+import { activeMeshes } from '../mesh/visibility.js';
+import { ENVIRONMENT_PRESETS } from '../scene/environment.js';
+import {
+  getEnvironmentPreset, getLightMode, setEnvironmentPreset, setLightMode,
+} from '../scene/scene.js';
+import { setTextureDisplayMode } from '../scene/render-modes.js';
+
+const $ = (id) => document.getElementById(id);
+
+export function initEnvironmentControl() {
+  const button = $('environment-btn');
+  const icon = $('environment-icon');
+  const labels = Object.fromEntries(
+    Object.values(ENVIRONMENT_PRESETS).map(preset => [preset.id, preset.label]));
+  const popover = $('environment-popover');
+  let currentId = getEnvironmentPreset().id;
+
+  function updateControl(id) {
+    const name = labels[id] || id;
+    icon.dataset.environment = id;
+    button.dataset.environment = id;
+    button.setAttribute('aria-label', `Environment: ${name}. Click to change.`);
+    button.title = `Environment: ${name} (click to change)`;
+  }
+
+  function applyEnvironmentPreset(id) {
+    if (!setEnvironmentPreset(id)) return false;
+    currentId = getEnvironmentPreset().id;
+    updateControl(currentId);
+    return true;
+  }
+
+  function closePopover() {
+    if (!popover) return;
+    popover.hidden = true;
+    button.setAttribute('aria-expanded', 'false');
+  }
+
+  function openPopover() {
+    if (!popover) return;
+    popover.replaceChildren();
+    Object.values(ENVIRONMENT_PRESETS).forEach(preset => {
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'ui-popover-option';
+      option.setAttribute('role', 'menuitem');
+      option.textContent = preset.label;
+      option.classList.toggle('selected', preset.id === currentId);
+      option.addEventListener('click', () => {
+        applyEnvironmentPreset(preset.id);
+        closePopover();
+      });
+      popover.appendChild(option);
+    });
+    popover.hidden = false;
+    button.setAttribute('aria-expanded', 'true');
+  }
+
+  updateControl(currentId);
+  button.setAttribute('aria-haspopup', 'menu');
+  button.setAttribute('aria-expanded', 'false');
+  button.addEventListener('click', () => {
+    if (popover?.hidden === false) closePopover();
+    else openPopover();
+  });
+  document.addEventListener('click', event => {
+    if (!popover || popover.hidden || event.target.closest('#environment-control, #environment-popover')) return;
+    closePopover();
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') closePopover();
+  });
+
+  return applyEnvironmentPreset;
+}
+
+export function initToolPopovers() {
+  const textureButton = $('texture-btn');
+  const lightButton = $('light-btn');
+  const texturePopover = $('texture-popover');
+  const lightPopover = $('light-popover');
+  const close = popover => {
+    if (!popover) return;
+    popover.hidden = true;
+  };
+  let activeToolPopover = null;
+  const positionPopover = (popover, button) => {
+    if (!popover || !button) return;
+    const buttonRect = button.getBoundingClientRect();
+    const popoverRect = popover.getBoundingClientRect();
+    const gutter = 8;
+    const maxLeft = Math.max(gutter, window.innerWidth - popoverRect.width - gutter);
+    const desiredLeft = buttonRect.left
+      + (buttonRect.width - popoverRect.width) / 2;
+    const left = Math.min(maxLeft, Math.max(gutter, desiredLeft));
+    const top = Math.max(gutter, buttonRect.top - popoverRect.height - gutter);
+    popover.style.left = `${left}px`;
+    popover.style.top = `${top}px`;
+  };
+  const closeAll = () => {
+    close(texturePopover);
+    close(lightPopover);
+    textureButton?.setAttribute('aria-expanded', 'false');
+    lightButton?.setAttribute('aria-expanded', 'false');
+    activeToolPopover = null;
+  };
+
+  function toggleTexturePopover() {
+    if (!texturePopover) return;
+    const wasOpen = !texturePopover.hidden;
+    closeAll();
+    if (wasOpen) return;
+    texturePopover.replaceChildren();
+    [
+      ['all', 'All maps'],
+      ['diffuse-normal', 'Diffuse and NormalMap'],
+      ['diffuse', 'Diffuse only'],
+      ['none', 'No textures'],
+    ].forEach(([mode, label]) => {
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'ui-popover-option';
+      option.setAttribute('role', 'menuitem');
+      option.textContent = label;
+      option.addEventListener('click', () => {
+        setTextureDisplayMode(mode, activeMeshes);
+        closeAll();
+      });
+      texturePopover.appendChild(option);
+    });
+    texturePopover.hidden = false;
+    textureButton?.setAttribute('aria-expanded', 'true');
+    activeToolPopover = { popover: texturePopover, button: textureButton };
+    positionPopover(texturePopover, textureButton);
+  }
+
+  function toggleLightPopover() {
+    if (!lightPopover) return;
+    const wasOpen = !lightPopover.hidden;
+    closeAll();
+    if (wasOpen) return;
+    lightPopover.replaceChildren();
+    [['double', 'Bright'], ['current', 'Normal'], ['off', 'Off']].forEach(([mode, label]) => {
+      const option = document.createElement('button');
+      option.type = 'button';
+      option.className = 'ui-popover-option';
+      option.setAttribute('role', 'menuitemradio');
+      option.setAttribute('aria-checked', String(getLightMode() === mode));
+      option.textContent = label;
+      option.addEventListener('click', () => {
+        setLightMode(mode);
+        closeAll();
+      });
+      lightPopover.appendChild(option);
+    });
+    lightPopover.hidden = false;
+    lightButton?.setAttribute('aria-expanded', 'true');
+    activeToolPopover = { popover: lightPopover, button: lightButton };
+    positionPopover(lightPopover, lightButton);
+  }
+
+  textureButton?.setAttribute('aria-haspopup', 'menu');
+  lightButton?.setAttribute('aria-haspopup', 'menu');
+  textureButton?.setAttribute('aria-expanded', 'false');
+  lightButton?.setAttribute('aria-expanded', 'false');
+  textureButton?.addEventListener('click', toggleTexturePopover);
+  lightButton?.addEventListener('click', toggleLightPopover);
+  document.addEventListener('click', event => {
+    if (event.target.closest('#texture-btn, #texture-popover, #light-btn, #light-popover')) return;
+    closeAll();
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') closeAll();
+  });
+  window.addEventListener('resize', () => {
+    if (activeToolPopover) {
+      positionPopover(activeToolPopover.popover, activeToolPopover.button);
+    }
+  });
+}
+
+export function initToolbarOverflow() {
+  const button = $('toolbar-more');
+  const menu = $('toolbar-overflow');
+  if (!button || !menu) return;
+  const close = () => {
+    menu.hidden = true;
+    button.setAttribute('aria-expanded', 'false');
+  };
+  button.addEventListener('click', event => {
+    event.stopPropagation();
+    menu.hidden = !menu.hidden;
+    button.setAttribute('aria-expanded', String(!menu.hidden));
+  });
+  menu.addEventListener('click', event => {
+    const item = event.target.closest('[data-toolbar-target]');
+    if (!item) return;
+    const target = $(item.dataset.toolbarTarget);
+    if (target && !target.disabled) target.click();
+    close();
+  });
+  document.addEventListener('click', event => {
+    if (!event.target.closest('#toolbar-more, #toolbar-overflow')) close();
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') close();
+  });
+}


### PR DESCRIPTION
## Summary

- Keep `src/web/js/main.js` as the stable browser bootstrap and preserve the existing `window.modViewer` surface.
- Extract shared viewer state, model/source transitions, semantic refreshes, and Asset-fill transactions into focused application modules.
- Move toolbar behavior into `ui/toolbar.js` and reuse `ui/panel-utils.js` for panel collapse.
- Add browser coverage for the public surface and Mod/Asset lifecycle events.

## Scope

This is a behavior-preserving frontend organization refactor. Rendering, backend contracts, panel design, and INI editing behavior are unchanged.