### PR TITLE
refactor: decompose mesh builder

### DIFF
--- a/src/core/geometry/buffers.py
+++ b/src/core/geometry/buffers.py
@@ -1,0 +1,183 @@
+"""Bounded binary buffer access and vertex-stream decoding helpers."""
+
+import struct
+from dataclasses import dataclass
+import os
+
+
+POSITION_STRIDE = 40
+POSITION_OFFSET = 0
+DEFAULT_UV_OFFSET = 4
+INDEX_SIZE = 4
+
+_MAX_BUFFER_FILE_BYTES = 512 * 1024 * 1024
+_MAX_TOTAL_BUFFER_BYTES = 2 * 1024 * 1024 * 1024
+
+
+def _res_get(resources, name):
+    """Case-insensitive resource lookup (handles WWMI naming inconsistencies)."""
+    if not name:
+        return {}
+    lookup = getattr(resources, "get_ci", None)
+    if lookup is not None:
+        return lookup(name)
+    if name in resources:
+        return resources[name]
+    nl = name.lower()
+    for key, value in resources.items():
+        if key.lower() == nl:
+            return value
+    return {}
+
+
+def read_positions(buf_path, stride=POSITION_STRIDE):
+    positions = []
+    with open(buf_path, "rb") as file:
+        data = file.read()
+    for offset in range(0, len(data) - 11, stride):
+        positions.append(struct.unpack_from("<fff", data, offset + POSITION_OFFSET))
+    return positions
+
+
+_MIN_AXIS_SPREAD = 1e-4   # below this an axis is constant, i.e. not a real UV set
+_MIN_IN_RANGE = 0.95       # fraction of sampled UVs that must land in [0, 2]
+
+
+def _detect_uv_best(tc_path, stride, n=4096, data=None):
+    """Try (offset 0 or 4) x (float16 or float32) and return the (uv_off, fmt)
+    with the largest UV spread where all values are within [0, 2].
+
+    Candidates are sampled evenly across the whole buffer. A candidate whose U
+    or V axis is constant is rejected in favor of a real two-dimensional UV
+    set, while a small number of outliers is tolerated.
+    """
+    if data is None:
+        with open(tc_path, "rb") as file:
+            data = file.read()
+    size = len(data)
+    total = size // stride if stride else 0
+    if not total:
+        return (DEFAULT_UV_OFFSET, "<ee")
+    step = max(1, total // n)
+    scored = []
+    for uv_off in (0, 4):
+        for fmt in ("<ee", "<ff"):
+            fmtsize = struct.calcsize(fmt)
+            if uv_off + fmtsize > stride:
+                continue
+            us, vs, sampled = [], [], 0
+            for index in range(0, total, step):
+                offset = index * stride + uv_off
+                if offset + fmtsize > size:
+                    break
+                u, v = struct.unpack_from(fmt, data, offset)
+                sampled += 1
+                if -0.01 <= u <= 2.0 and -0.01 <= v <= 2.0:
+                    us.append(u)
+                    vs.append(v)
+            if not sampled or not us:
+                continue
+            in_range = len(us) / sampled
+            if in_range < _MIN_IN_RANGE:
+                continue
+            du, dv = max(us) - min(us), max(vs) - min(vs)
+            both_live = du >= _MIN_AXIS_SPREAD and dv >= _MIN_AXIS_SPREAD
+            scored.append((both_live, round(in_range, 3), round(du + dv, 3),
+                           uv_off, fmt))
+    if scored:
+        scored.sort(reverse=True)
+        return (scored[0][3], scored[0][4])
+    for uv_off in (DEFAULT_UV_OFFSET, 0):
+        if uv_off + 4 <= stride:
+            return (uv_off, "<ee")
+    return (0, "<ee")
+
+
+def read_texcoords(buf_path, stride, uv_off=DEFAULT_UV_OFFSET, uv_fmt="<ee",
+                   data=None):
+    """Read one UV pair per vertex, dropping a truncated final vertex."""
+    uvs = []
+    fmtsize = struct.calcsize(uv_fmt)
+    if data is None:
+        with open(buf_path, "rb") as file:
+            data = file.read()
+    for offset in range(0, len(data) - uv_off - fmtsize + 1, stride):
+        uvs.append(struct.unpack_from(uv_fmt, data, offset + uv_off))
+    return uvs
+
+
+def read_indices(ib_data, start_index=0, count=None, index_size=INDEX_SIZE):
+    total = len(ib_data) // index_size
+    if count is None:
+        count = total - start_index
+    end = min(start_index + count, total)
+    if end <= start_index:
+        return []
+    fmt = "H" if index_size == 2 else "I"
+    return list(struct.unpack_from(f"<{end - start_index}{fmt}", ib_data,
+                                   start_index * index_size))
+
+
+@dataclass(frozen=True)
+class VertexStreams:
+    """Resolved position/UV streams and the selected UV representation."""
+
+    position_data: bytes
+    position_stride: int
+    texcoord_data: bytes
+    texcoord_stride: int
+    uv_offset: int
+    uv_format: str
+
+
+class BufferStore:
+    """Build-scoped raw-buffer cache with the existing safety limits."""
+
+    def __init__(self):
+        self._raw = {}
+        self._streams = {}
+        self._total_bytes = 0
+
+    def raw(self, path):
+        if path not in self._raw:
+            size = os.path.getsize(path)
+            if size > _MAX_BUFFER_FILE_BYTES:
+                raise ValueError(
+                    f"Buffer file is too large ({size / 1048576:.1f} MiB).")
+            if self._total_bytes + size > _MAX_TOTAL_BUFFER_BYTES:
+                raise ValueError("Mod buffer data exceeds the 2 GiB safety limit.")
+            with open(path, "rb") as file:
+                data = file.read()
+            self._raw[path] = data
+            self._total_bytes += len(data)
+        return self._raw[path]
+
+    def vertex_streams(
+        self,
+        position_path,
+        position_stride,
+        texcoord_path,
+        texcoord_stride,
+    ):
+        key = (position_path, position_stride, texcoord_path, texcoord_stride)
+        if key not in self._streams:
+            position_data = self.raw(position_path)
+            texcoord_data = self.raw(texcoord_path)
+            uv_offset, uv_format = _detect_uv_best(
+                texcoord_path, texcoord_stride, data=texcoord_data)
+            self._streams[key] = VertexStreams(
+                position_data, position_stride,
+                texcoord_data, texcoord_stride,
+                uv_offset, uv_format)
+        return self._streams[key]
+
+    def indices(self, path, start, count, index_size=INDEX_SIZE):
+        return read_indices(self.raw(path), start, count, index_size)
+
+
+__all__ = [
+    "POSITION_STRIDE", "POSITION_OFFSET", "DEFAULT_UV_OFFSET", "INDEX_SIZE",
+    "BufferStore", "VertexStreams", "read_positions", "read_texcoords",
+    "read_indices", "_MAX_BUFFER_FILE_BYTES", "_MAX_TOTAL_BUFFER_BYTES",
+    "_detect_uv_best", "_res_get",
+]

--- a/src/core/geometry/mesh_builder.py
+++ b/src/core/geometry/mesh_builder.py
@@ -1,177 +1,28 @@
-"""3DMigoto binary buffer readers and in-memory mesh payload builder."""
+"""Public facade for semantic projection and mesh payload construction."""
 
-import math
-import re, struct, os, base64
+import base64
+import os
 from dataclasses import dataclass
 
-from .draw_call import DrawCall
+from .buffers import (
+    DEFAULT_UV_OFFSET, INDEX_SIZE, POSITION_OFFSET, POSITION_STRIDE,
+    BufferStore, _MAX_BUFFER_FILE_BYTES, _MAX_TOTAL_BUFFER_BYTES,
+    _detect_uv_best, _res_get, read_indices, read_positions, read_texcoords,
+)
 from .conventions import geometry_convention_for
+from .packing import pack_draw_geometry
+from .semantics import (
+    _deduplicate_draws, _rel_source, build_mesh_semantics,
+    deduplicate_draws, validate_draw_count,
+)
+from .texture_bindings import (
+    TextureRegistry, apply_draw_texture_bindings, build_texture_options,
+)
 from .transport import GeometryBlob
 from ..resource_paths import safe_resource_path
-from .vertex_attributes import decode_normals
-from ..textures.pipeline import (_texture_source_uri, _begin_texture_cache,
-                       encode_texture_data_uri, normalize_texture_role,
-                       normalize_texture_transform, texture_key)
 
-# ── Buffer constants ───────────────────────────────────────────────────────────
-POSITION_STRIDE   = 40
-POSITION_OFFSET   = 0
-DEFAULT_UV_OFFSET = 4
-INDEX_SIZE        = 4
 
-_MAX_BUFFER_FILE_BYTES = 512 * 1024 * 1024
-_MAX_TOTAL_BUFFER_BYTES = 2 * 1024 * 1024 * 1024
 _MAX_DRAWS = 10_000
-
-
-def _res_get(resources, name):
-    """Case-insensitive resource lookup (handles WWMI naming inconsistencies)."""
-    if not name: return {}
-    lookup = getattr(resources, "get_ci", None)
-    if lookup is not None:
-        return lookup(name)
-    if name in resources: return resources[name]
-    nl = name.lower()
-    for k, v in resources.items():
-        if k.lower() == nl: return v
-    return {}
-
-
-# ── Binary readers ─────────────────────────────────────────────────────────────
-
-def read_positions(buf_path, stride=POSITION_STRIDE):
-    positions = []
-    with open(buf_path, "rb") as f: data = f.read()
-    for off in range(0, len(data) - 11, stride):
-        positions.append(struct.unpack_from("<fff", data, off + POSITION_OFFSET))
-    return positions
-
-
-_MIN_AXIS_SPREAD = 1e-4   # below this an axis is constant, i.e. not a real UV set
-_MIN_IN_RANGE    = 0.95   # fraction of sampled UVs that must land in [0, 2]
-
-
-def _detect_uv_best(tc_path, stride, n=4096, data=None):
-    """Try (offset 0 or 4) x (float16 or float32) and return the (uv_off, fmt)
-    with the largest UV spread where all values are within [0, 2].
-
-    Candidates are sampled EVENLY ACROSS THE WHOLE BUFFER, not from the first
-    n vertices: consecutive vertices are spatially adjacent, so a head-only
-    window sees a tiny patch of the UV map where every candidate's spread is
-    near zero and noise decides the winner. Measured on a real stride-24 ZZMI
-    mod (Remielle/Elysian Abyss): over the first 30 vertices the wrong '<ff'
-    scored 0.0562 against the correct '<ee''s 0.0501 and won, mapping the whole
-    127,886-vertex mesh through UVs whose U axis spans 0.000..0.006 — a
-    one-pixel vertical stripe of the texture smeared over every triangle. Its
-    stride-24 sibling in the same mod won correctly by only 0.0206 vs 0.0131,
-    i.e. a coin flip rather than a real margin.
-
-    A candidate whose U or V axis is CONSTANT is preferred against last. A
-    misread float32 pair reliably decodes as (~0, plausible-looking) because
-    the low half of a float16 pair lands in the mantissa of the wider read, so
-    it can post a competitive total spread on the V axis alone while U carries
-    no information at all. No real UV set is one-dimensional.
-
-    A few out-of-range values are TOLERATED rather than disqualifying the whole
-    candidate. Real UV sets contain occasional outliers (one real 55,474-vertex
-    stride-20 buffer has 6), and rejecting on the first one handed the decision
-    to a degenerate float32 read that happened to have none -- dV exactly
-    0.0000 across the entire mesh. Spread is measured over the in-range samples
-    only, so outliers can't inflate it either.
-
-    The returned offset ALWAYS fits within `stride`. Some buffers reaching here
-    aren't texcoord buffers at all (an ini pointing a stride-4 Blend.buf or a
-    Unity `.assets` file at vb1/vb2 -- ~50 in the local corpus), and no
-    candidate is credible for those; returning the bare (4, '<ee') default
-    would make read_texcoords straddle the vertex boundary and yield one fewer
-    UV than there are positions. A fitting offset keeps that pathological case
-    merely useless (flat zero UVs) instead of misaligned.
-    """
-    if data is None:
-        with open(tc_path, 'rb') as f:
-            data = f.read()
-    size = len(data)
-    total = size // stride if stride else 0
-    if not total:
-        return (DEFAULT_UV_OFFSET, '<ee')
-    step = max(1, total // n)   # stride the sample across the entire buffer
-    # Rank every in-range candidate; prefer two live axes over a bigger total.
-    scored = []
-    for uv_off in (0, 4):
-        for fmt in ('<ee', '<ff'):
-            fmtsize = struct.calcsize(fmt)
-            if uv_off + fmtsize > stride:
-                continue
-            us, vs, sampled = [], [], 0
-            for i in range(0, total, step):
-                off = i * stride + uv_off
-                if off + fmtsize > size:
-                    break
-                u, v = struct.unpack_from(fmt, data, off)
-                sampled += 1
-                # NaN fails every comparison, so test for validity positively:
-                # a misread buffer routinely decodes to NaN/inf, which would
-                # otherwise slip through a `u < lo or u > hi` style check.
-                if -0.01 <= u <= 2.0 and -0.01 <= v <= 2.0:
-                    us.append(u); vs.append(v)
-            if not sampled or not us:
-                continue
-            in_range = len(us) / sampled
-            if in_range < _MIN_IN_RANGE:
-                continue
-            du, dv = max(us) - min(us), max(vs) - min(vs)
-            both_live = du >= _MIN_AXIS_SPREAD and dv >= _MIN_AXIS_SPREAD
-            scored.append((both_live, round(in_range, 3), round(du + dv, 3),
-                           uv_off, fmt))
-    if scored:
-        # Rank: both axes live, then cleanliness, then total spread. Cleanliness
-        # must outrank spread -- a misread float32 can post a huge spread (up to
-        # the full 0..2 window) while being 12% garbage, and swept across the
-        # corpus spread-first regressed 27 buffers where clean-first regressed
-        # none.
-        scored.sort(reverse=True)
-        return (scored[0][3], scored[0][4])
-    # Nothing decoded in range: fall back to the first offset that at least fits.
-    for uv_off in (DEFAULT_UV_OFFSET, 0):
-        if uv_off + 4 <= stride:
-            return (uv_off, '<ee')
-    return (0, '<ee')
-
-
-def read_texcoords(buf_path, stride, uv_off=DEFAULT_UV_OFFSET, uv_fmt='<ee',
-                   data=None):
-    """Read one UV pair per vertex. The bound accounts for uv_fmt's real width
-    (float32 pairs are 8 bytes, not 4), so a buffer whose last vertex is
-    truncated is dropped instead of raising out of struct.unpack_from."""
-    uvs = []
-    fmtsize = struct.calcsize(uv_fmt)
-    if data is None:
-        with open(buf_path, "rb") as f:
-            data = f.read()
-    for off in range(0, len(data) - uv_off - fmtsize + 1, stride):
-        uvs.append(struct.unpack_from(uv_fmt, data, off + uv_off))
-    return uvs
-
-
-def read_indices(ib_data, start_index=0, count=None, index_size=INDEX_SIZE):
-    total = len(ib_data) // index_size
-    if count is None: count = total - start_index
-    end = min(start_index + count, total)
-    if end <= start_index: return []
-    fmt = "H" if index_size == 2 else "I"
-    return list(struct.unpack_from(f"<{end - start_index}{fmt}", ib_data,
-                                   start_index * index_size))
-
-
-# ── Encoding helpers ───────────────────────────────────────────────────────────
-
-def _b64f(arr):
-    """Pack float list as little-endian Float32 and base64-encode."""
-    return base64.b64encode(struct.pack(f"<{len(arr)}f", *arr)).decode()
-
-def _b64u(arr):
-    """Pack int list as little-endian Uint32 and base64-encode."""
-    return base64.b64encode(struct.pack(f"<{len(arr)}I", *arr)).decode()
 
 
 @dataclass
@@ -179,686 +30,108 @@ class MeshBuildResult:
     """Named intermediate produced by the mesh-building pipeline.
 
     ``meshes`` contains only draw entries and ``textures`` is the shared
-    texture registry.  ``geometry`` records the optional caller-owned blob
-    writer used to produce offset/length references.  Keeping these outputs
-    separate prevents the application loader from translating a flat dict of
-    mesh data and reserved keys before it can assemble its public payload.
+    texture registry. ``geometry`` records the optional caller-owned blob
+    writer used to produce offset/length references.
     """
 
     meshes: dict
     textures: dict
     geometry: GeometryBlob | None = None
 
-# ── In-memory mesh payload builder ────────────────────────────────────────────
-
-def _rel_source(src, mod_dir):
-    """Provenance for the UI: ini path relative to the mod folder.
-
-    The absolute path stays on the Python side; the browser only needs enough
-    to identify the line and to echo it back on export.
-    """
-    path = src.get("ini_path")
-    if path:
-        try:
-            path = os.path.relpath(path, mod_dir).replace(os.sep, "/")
-        except ValueError:
-            path = os.path.basename(path)
-    return {"ini": path, "line": src.get("line_no"), "section": src.get("section")}
-
-
-def _deduplicate_draws(group, max_draws=0):
-    """Merge repeated draw regions while preserving every gate and source.
-
-    This is a distinct pipeline stage: geometry packing receives one
-    deterministic draw list and does not own the condition-merging rules.
-    """
-    merged = {}
-    order = []
-    for raw_draw in group["draws"]:
-        draw = DrawCall.from_mapping(raw_draw, group)
-        key = draw.render_identity()
-        if key not in merged:
-            merged[key] = {"draw": draw, "alts": [], "sources": []}
-            order.append(key)
-        entry = merged[key]
-        for src in draw.sources:
-            if src not in entry["sources"]:
-                entry["sources"].append(src)
-        cond_groups = draw.conditions
-        if not cond_groups:
-            if [] not in entry["alts"]:
-                entry["alts"].append([])
-        else:
-            for condition_group in cond_groups:
-                if condition_group not in entry["alts"]:
-                    entry["alts"].append(condition_group)
-
-    unique = []
-    for key in order:
-        entry = merged[key]
-        draw, alternatives = entry["draw"], entry["alts"]
-        draw.conditions = (
-            [] if any(not group for group in alternatives) else alternatives)
-        draw.sources = entry["sources"]
-        unique.append(draw)
-    return unique[:max_draws] if max_draws else unique
-
-
-def _semantic_texture_key(mod_dir, authored_path, role):
-    """Resolve a texture identity without opening or decoding the source."""
-    path = safe_resource_path(mod_dir, authored_path)
-    if not path or not os.path.exists(path):
-        return None
-    relative_path = os.path.relpath(path, mod_dir).replace(os.sep, "/")
-    return texture_key(relative_path, normalize_texture_role(role))
-
-
-def _semantic_asset_key(draw, role, transport_role=None):
-    item = draw.asset_texture_defaults.get(role) or {}
-    key = item.get("key") if isinstance(item, dict) else None
-    if not key:
-        return None
-    if transport_role and transport_role != role:
-        return texture_key(key, transport_role)
-    return texture_key(key, role)
-
-
-def _semantic_texture_variants(draw, mod_dir, authored_role, transport_role=None):
-    role = transport_role or authored_role
-    variants = []
-    for variant in draw.texture_rules(authored_role):
-        key = _semantic_texture_key(mod_dir, variant.get("file"), role)
-        if key:
-            variants.append({"conditions": variant["conditions"], "tex_key": key})
-    return variants
-
-
-def build_mesh_semantics(groups, mod_dir, max_draws=0, game_profile=None,
-                         active_mesh_keys=None):
-    """Return draw visibility semantics without resolving any geometry.
-
-    This is used after Record changes a draw's conditions.  Keep it separate
-    from :func:`build_mesh_result`: the incremental authoring path must not
-    read vertex/index buffers, publish textures, or allocate geometry storage.
-    """
-    draw_total = sum(len(group.get("draws", [])) for group in groups)
-    if draw_total > _MAX_DRAWS:
-        raise ValueError(
-            f"Mod has too many draws ({draw_total:,}; limit {_MAX_DRAWS:,}).")
-
-    from ..textures.profiles import texture_profile_for
-
-    texture_profile = texture_profile_for(game_profile)
-    normal_role = texture_profile.normal_transport_role
-    result = {}
-    for group in groups:
-        for draw in _deduplicate_draws(group, max_draws=max_draws):
-            if active_mesh_keys is not None and draw.label not in active_mesh_keys:
-                continue
-            entry = {
-                "conditions": draw.conditions or [],
-                "tex_key": (_semantic_asset_key(draw, "diffuse") or
-                            _semantic_texture_key(
-                                mod_dir, draw.texture_default("diffuse"),
-                                "diffuse")),
-                "normal_map_key": None,
-                "normal_data_key": None,
-                "light_map_key": (_semantic_asset_key(draw, "light_map") or
-                                  _semantic_texture_key(
-                                      mod_dir, draw.texture_default("light_map"),
-                                      "light_map")),
-                "material_map_key": (_semantic_asset_key(
-                    draw, "material_map") or _semantic_texture_key(
-                        mod_dir, draw.texture_default("material_map"),
-                        "material_map")),
-            }
-            normal_key = _semantic_texture_key(
-                mod_dir, draw.texture_default("normal_map"), normal_role)
-            normal_key = (_semantic_asset_key(
-                draw, "normal_map", normal_role) or normal_key)
-            entry[f"{normal_role}_key"] = normal_key
-            if draw.sources:
-                entry["sources"] = [_rel_source(source, mod_dir)
-                                     for source in draw.sources]
-
-            texture_variants = _semantic_texture_variants(
-                draw, mod_dir, "diffuse")
-            if len(texture_variants) > 1:
-                entry["texture_variants"] = texture_variants
-            for channel in ("light_map", "material_map"):
-                variants = _semantic_texture_variants(draw, mod_dir, channel)
-                if variants:
-                    entry[f"{channel}_variants"] = variants
-            normal_variants = _semantic_texture_variants(
-                draw, mod_dir, "normal_map", normal_role)
-            if normal_variants:
-                entry[f"{normal_role}_variants"] = normal_variants
-            binding = draw.asset_binding
-            if binding is not None and hasattr(binding, "to_dict"):
-                entry["asset_binding"] = binding.to_dict()
-            if draw.texture_provenance:
-                entry["texture_resolution"] = dict(draw.texture_provenance)
-            if draw.asset_slot_evidence:
-                entry["asset_slot_evidence"] = list(draw.asset_slot_evidence)
-            result[draw.label] = entry
-    return result
-
 
 def _geometry_ref(raw, geometry):
-    """Serialize one binary field into the caller-owned geometry store."""
+    """Serialize bytes into the caller-owned geometry store or base64."""
     if geometry is not None:
         return geometry.add(raw)
-    # Direct core fixtures and older integrations retain the historical
-    # base64 representation when no shared blob was supplied.
     return base64.b64encode(raw).decode()
-
-
-def _build_shape_buffers(shape_sliders, mod_dir, effective_pos_path, used,
-                         raw_buf_cache, sparse_shape_cache, read_buffer):
-    """Load and prepare dense or sparse shape targets for one draw."""
-    shape_buffers = []
-    for shape in shape_sliders or []:
-        shape_base_path = safe_resource_path(mod_dir, shape["base_file"])
-        if os.path.normcase(os.path.normpath(shape_base_path or "")) != \
-                os.path.normcase(os.path.normpath(effective_pos_path)):
-            continue
-        if shape.get("shape_id") is not None:
-            paths = tuple(safe_resource_path(mod_dir, shape[k]) for k in
-                          ("offset_file", "vertex_id_file", "vertex_offset_file"))
-            if not all(path and os.path.exists(path) for path in paths):
-                continue
-            # WWMI aligns each 127-key batch to a 128-entry container;
-            # user-facing IDs omit that padding slot (SkapeKeySetter.hlsl).
-            key_id = shape.get(
-                "buffer_shape_id",
-                shape["shape_id"] + shape["shape_id"] // 127)
-            cache_key = paths + (key_id,)
-            if cache_key not in sparse_shape_cache:
-                for path in paths:
-                    if path not in raw_buf_cache:
-                        raw_buf_cache[path] = read_buffer(path)
-                offsets, vertex_ids, deltas = (raw_buf_cache[path]
-                                               for path in paths)
-                if (key_id + 2) * 4 > len(offsets):
-                    continue
-                begin, end = struct.unpack_from("<II", offsets, key_id * 4)
-                entry_offset = shape.get("sparse_entry_offset", 0)
-                begin += entry_offset
-                end += entry_offset
-                limit = min(end, len(vertex_ids) // 4, len(deltas) // 12)
-                sparse = {}
-                for i in range(begin, limit):
-                    vertex_id = struct.unpack_from("<I", vertex_ids, i * 4)[0]
-                    delta = struct.unpack_from("<eee", deltas, i * 12)
-                    prior = sparse.get(vertex_id, (0., 0., 0.))
-                    sparse[vertex_id] = tuple(
-                        prior[j] + delta[j] for j in range(3))
-                sparse_shape_cache[cache_key] = sparse
-            shape_buffers.append((shape, sparse_shape_cache[cache_key],
-                                  bytearray(len(used) * 12), True))
-        else:
-            target_path = safe_resource_path(mod_dir, shape["target_file"])
-            if not target_path or not os.path.exists(target_path):
-                continue
-            if target_path not in raw_buf_cache:
-                raw_buf_cache[target_path] = read_buffer(target_path)
-            low_data = None
-            low_bytes = None
-            if shape.get("low_file"):
-                low_path = safe_resource_path(mod_dir, shape["low_file"])
-                if not low_path or not os.path.exists(low_path):
-                    continue
-                if low_path not in raw_buf_cache:
-                    raw_buf_cache[low_path] = read_buffer(low_path)
-                low_data = raw_buf_cache[low_path]
-                low_bytes = bytearray(len(used) * 12)
-            shape_buffers.append((shape, raw_buf_cache[target_path],
-                                  bytearray(len(used) * 12), False,
-                                  low_data, low_bytes))
-    return shape_buffers
 
 
 def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                       texture_source=None, game_profile=None):
+    """Build mesh draw entries and a shared texture registry.
+
+    Geometry packing and texture publication are delegated to focused stages;
+    this facade keeps transport compatibility and final payload metadata.
     """
-    Build mesh draw entries and a shared texture registry.
-
-    Returns :class:`MeshBuildResult` whose ``meshes`` map contains
-    ``{draw_label: {pos, uv, idx, tex_key, ...}}`` and whose ``textures`` map
-    contains rendered texture sources keyed by role-aware mod-relative filename.
-    With no ``texture_source`` callback these are encoded data URIs for direct
-    fixture compatibility. The application passes a callback that returns an
-    opaque localhost URL instead. Geometry is written into ``geometry`` when a
-    ``GeometryBlob`` is supplied; otherwise direct callers retain base64
-    geometry fields for fixture compatibility.
-
-    `drawindexed` is the ini's [count, start, base] triple (missing for the
-    rare unconditional whole-buffer draw); `source` is the per-ini tag from
-    build_draw_groups, present only in multi-ini mods. `component` is the
-    group's clean, never-disambiguated display name (see build_draw_groups)
-    — the UI groups and labels draw rows by this instead of parsing the
-    draw_label key, so a rare cross-ini name collision (label gets a "_2"
-    suffix for uniqueness) never leaks an ugly suffix into the display.
-
-    `tex_key` is this draw's own resolved default: whichever
-    semantic or proven slot-semantic texture assignment most recently ran
-    before it in the ini's execution order
-    (build_draw_groups' `texture_default_file`), NOT one
-    static value per component -- a section can reassign the diffuse several
-    times (see core.ini.parser._scan_sections_for_draws), so two draws in the same
-    TextureOverride section routinely resolve to different textures.
-    `texture_variants`, present only when a toggle conditionally reassigns
-    the diffuse at this exact point, is a list of {conditions, tex_key}
-    alternatives (same DNF shape as `conditions`) for the UI to pick between
-    as toggle state changes. `texture_options`, present when the component's
-    parser or candidate discovery references one or more distinct files
-    (regardless of position/condition), is the full deduplicated pool as
-    {tex_key, file, label} for a manual per-mesh override picker -- same list
-    object shared by every draw in the component, so it also serves as the
-    component-level "manage textures" pool.
-    """
-    _begin_texture_cache(mod_dir)
     from ..textures.profiles import texture_profile_for
+
     texture_profile = texture_profile_for(game_profile)
     geometry_convention = geometry_convention_for(game_profile)
-
-    result:    dict = {}
-    tex_uris:  dict = {}  # role-aware key -> data URI or lazy source URL
-    tex_cache: dict = {}  # (full path, role, transform) -> role-aware key
-    ib_cache:  dict = {}  # absolute ib path → raw bytes
-    buf_cache: dict = {}  # (pos_path, pos_stride, tc_path, tc_stride) → (positions, uvs)
-
-    raw_buf_cache = {}
+    validate_draw_count(groups)
+    registry = TextureRegistry(mod_dir, texture_profile, texture_source)
+    buffers = BufferStore()
     sparse_shape_cache = {}
-    total_buffer_bytes = 0
+    result = {}
 
-    def _read_buffer(path):
-        nonlocal total_buffer_bytes
-        size = os.path.getsize(path)
-        if size > _MAX_BUFFER_FILE_BYTES:
-            raise ValueError(f"Buffer file is too large ({size / 1048576:.1f} MiB).")
-        if total_buffer_bytes + size > _MAX_TOTAL_BUFFER_BYTES:
-            raise ValueError("Mod buffer data exceeds the 2 GiB safety limit.")
-        with open(path, "rb") as fh:
-            data = fh.read()
-        total_buffer_bytes += len(data)
-        return data
+    for group in groups:
+        pos_path = safe_resource_path(mod_dir, group["position_file"])
+        tc_path = safe_resource_path(mod_dir, group["texcoord_file"])
+        ib_path = safe_resource_path(mod_dir, group["ib_file"])
+        tc_stride = group["texcoord_stride"]
+        pos_stride = group.get("position_stride", POSITION_STRIDE)
+        index_size = group.get("index_size", INDEX_SIZE)
+        component = group.get("display_name") or group.get("name")
+        source = group.get("source")
 
-    draw_total = sum(len(group.get("draws", [])) for group in groups)
-    if draw_total > _MAX_DRAWS:
-        raise ValueError(f"Mod has too many draws ({draw_total:,}; limit {_MAX_DRAWS:,}).")
-
-    for grp in groups:
-        pos_path  = safe_resource_path(mod_dir, grp["position_file"])
-        tc_path   = safe_resource_path(mod_dir, grp["texcoord_file"])
-        ib_path   = safe_resource_path(mod_dir, grp["ib_file"])
-        tc_stride = grp["texcoord_stride"]
-        pos_stride = grp.get("position_stride", POSITION_STRIDE)
-        index_size = grp.get("index_size", INDEX_SIZE)
-        component = grp.get("display_name") or grp.get("name")
-        source    = grp.get("source")
-
-        if not all(p and os.path.exists(p) for p in [pos_path, tc_path, ib_path]):
+        if not all(path and os.path.exists(path)
+                   for path in (pos_path, tc_path, ib_path)):
             continue
 
-        def _load_buf(pos_path, pos_stride, tc_path, tc_stride):
-            key = (pos_path, pos_stride, tc_path, tc_stride)
-            if key not in buf_cache:
-                if pos_path not in raw_buf_cache:
-                    raw_buf_cache[pos_path] = _read_buffer(pos_path)
-                if tc_path not in raw_buf_cache:
-                    raw_buf_cache[tc_path] = _read_buffer(tc_path)
-                pos_data = raw_buf_cache[pos_path]
-                tc_data = raw_buf_cache[tc_path]
-                uv_off, uv_fmt = _detect_uv_best(
-                    tc_path, tc_stride, data=tc_data)
-                buf_cache[key] = (pos_data, pos_stride, tc_data, tc_stride,
-                                  uv_off, uv_fmt)
-            return buf_cache[key]
-
-        buffers = _load_buf(pos_path, pos_stride, tc_path, tc_stride)
-        if ib_path not in ib_cache:
-            ib_cache[ib_path] = _read_buffer(ib_path)
-
-        unique = _deduplicate_draws(grp, max_draws=max_draws)
-        # Draws have already been deduplicated by the named pipeline stage
-        # above; the remaining stages only resolve files and pack bytes.
-
-        # Resolve texture keys cheaply. Pool-only options are encoded lazily
-        # when selected in the UI. Direct callers encode defaults and toggle
-        # variants now; the application callback only publishes their source.
-        def _tex_key(dds_path, texture_role=None, texture_transform=None,
-                     texture_identity=None):
-            if not dds_path or not os.path.exists(dds_path):
-                return None
-            texture_role = normalize_texture_role(texture_role)
-            if texture_transform is None:
-                texture_transform = texture_profile.recipe_for(texture_role)
-            texture_transform = normalize_texture_transform(texture_transform)
-            cache_key = (dds_path, texture_role, texture_transform,
-                         texture_identity)
-            if cache_key not in tex_cache:
-                # Keyed by path, not basename: variant mods routinely keep
-                # same-named diffuses in per-variant folders (Texture\00..\04).
-                relative_path = texture_identity or os.path.relpath(
-                    dds_path, mod_dir).replace(os.sep, "/")
-                tex_cache[cache_key] = texture_key(relative_path, texture_role)
-            return tex_cache[cache_key]
-
-        def _ensure_texture(dds_path, texture_role=None, texture_identity=None):
-            texture_role = normalize_texture_role(texture_role)
-            texture_transform = texture_profile.recipe_for(texture_role)
-            key = _tex_key(dds_path, texture_role, texture_transform,
-                           texture_identity)
-            if key and key not in tex_uris:
-                if texture_source is None:
-                    value = encode_texture_data_uri(
-                        dds_path, texture_role=texture_role,
-                        texture_transform=texture_transform)
-                else:
-                    value = _texture_source_uri(
-                        texture_source, dds_path, texture_role,
-                        texture_transform)
-                tex_uris[key] = value or ""
-            return key
-
-        # Every parser-derived or discovered texture this component exposes,
-        # resolved once and shared by every draw in the group -- the UI's
-        # per-mesh texture picker list. The parser-owned diffuse pool remains
-        # separate from WuWa discovery; both use the same role-aware registry
-        # so duplicate files produce one option.
-        texture_options = []
-        texture_option_keys = set()
-
-        def _append_texture_option(key, filename, label, **metadata):
-            if not key or key in texture_option_keys:
-                return
-            texture_option_keys.add(key)
-            option = {"tex_key": key, "file": filename, "label": label}
-            option.update(metadata)
-            texture_options.append(option)
-
-        for pool_entry in grp.get("diffuse_pool_files") or []:
-            key = _tex_key(safe_resource_path(mod_dir, pool_entry["file"]))
-            if key:
-                res_name = pool_entry["res"]
-                label = res_name[8:] if res_name.startswith("Resource") else res_name
-                _append_texture_option(key, pool_entry["file"], label)
-
-        for candidate in grp.get("discovered_textures") or []:
-            filename = candidate.get("file")
-            path = safe_resource_path(mod_dir, filename)
-            if path is None:
-                continue
-            key = _tex_key(path)
-            label = os.path.splitext(
-                str(filename).replace("\\", "/").rsplit("/", 1)[-1]
-            )[0]
-            _append_texture_option(
-                key, filename, label,
-                candidate_source=candidate.get("source"),
-            )
+        default_streams = buffers.vertex_streams(
+            pos_path, pos_stride, tc_path, tc_stride)
+        # Preserve the original eager group-IB load and its build-scoped cache.
+        buffers.raw(ib_path)
+        unique = deduplicate_draws(group, max_draws=max_draws)
+        texture_options = build_texture_options(group, registry)
 
         for draw in unique:
-            lbl = draw.label
-            draw_ib_path = safe_resource_path(mod_dir, draw.ib_file)
-            if not draw_ib_path or not os.path.exists(draw_ib_path):
-                continue
-            if draw_ib_path not in ib_cache:
-                ib_cache[draw_ib_path] = _read_buffer(draw_ib_path)
-            raw = read_indices(
-                ib_cache[draw_ib_path], draw.start, draw.count,
-                draw.index_size if draw.index_size is not None else index_size)
-            if not raw:
-                continue
-            # DirectX resolves each index as index_buffer_value + BaseVertexLocation
-            # against the vertex buffer -- shared/merged buffers rely on this offset
-            # to pick out this draw's own vertex range.
-            base = draw.base
-            if base:
-                raw = [v + base for v in raw]
-            # A negative effective DirectX vertex index is invalid.  Reject it
-            # before buffer decoding, where negative offsets can be interpreted
-            # as end-relative instead of failing safely.
-            if any(index < 0 for index in raw):
+            packed = pack_draw_geometry(
+                draw, group,
+                mod_dir=mod_dir,
+                default_streams=default_streams,
+                default_index_size=index_size,
+                buffers=buffers,
+                geometry_convention=geometry_convention,
+                sparse_shape_cache=sparse_shape_cache,
+            )
+            if packed is None:
                 continue
 
-            # A mid-section `vb0/vb1/vb2 = ...` reassignment (paired with `ib`).
-            draw_buffers = buffers
-            draw_pos_path = safe_resource_path(mod_dir, draw.position_file)
-            draw_tc_path = safe_resource_path(mod_dir, draw.texcoord_file)
-            if not (draw_pos_path and draw_tc_path
-                    and os.path.exists(draw_pos_path)
-                    and os.path.exists(draw_tc_path)):
-                continue
-            effective_pos_path = draw_pos_path
-            draw_position_stride = (
-                draw.position_stride
-                if draw.position_stride is not None else pos_stride)
-            draw_texcoord_stride = (
-                draw.texcoord_stride
-                if draw.texcoord_stride is not None else tc_stride)
-            if (draw_pos_path != pos_path or draw_tc_path != tc_path
-                    or draw_position_stride != pos_stride
-                    or draw_texcoord_stride != tc_stride):
-                draw_buffers = _load_buf(
-                    draw_pos_path, draw_position_stride,
-                    draw_tc_path, draw_texcoord_stride)
-
-            pos_data, draw_pos_stride, tc_data, draw_tc_stride, uv_off, uv_fmt = draw_buffers
-            uv_size = struct.calcsize(uv_fmt)
-
-            # A malformed source buffer can contain NaN/Inf vertices.  Keep
-            # those values out of both the GPU payload and the camera bounds;
-            # dropping a whole triangle preserves index topology for the
-            # remaining geometry instead of silently connecting its neighbors.
-            def _finite_vertex(index):
-                pos_off = index * draw_pos_stride + POSITION_OFFSET
-                if pos_off < 0 or pos_off + 12 > len(pos_data):
-                    return False
-                position = struct.unpack_from("<fff", pos_data, pos_off)
-                if not all(math.isfinite(value) for value in position):
-                    return False
-                if tc_data:
-                    tc_off = index * draw_tc_stride + uv_off
-                    if tc_off < 0 or tc_off + uv_size > len(tc_data):
-                        return False
-                    texcoord = struct.unpack_from(uv_fmt, tc_data, tc_off)
-                    if not all(math.isfinite(value) for value in texcoord):
-                        return False
-                return True
-
-            valid_raw = []
-            for triangle_start in range(0, len(raw) - 2, 3):
-                triangle = raw[triangle_start:triangle_start + 3]
-                if all(_finite_vertex(index) for index in triangle):
-                    valid_raw.extend(triangle)
-            if not valid_raw:
-                continue
-            raw = valid_raw
-            if geometry_convention.reverse_winding:
-                for triangle_start in range(0, len(raw) - 2, 3):
-                    raw[triangle_start + 1], raw[triangle_start + 2] = (
-                        raw[triangle_start + 2], raw[triangle_start + 1])
-
-            # Compact: only export vertices actually referenced
-            used  = sorted(set(raw))
-            remap = {old: new for new, old in enumerate(used)}
-
-            pos_bytes = bytearray(len(used) * 12)
-            normal_bytes = None
-            normal_source = draw.normal_source
-            if normal_source is not None:
-                normal_path = safe_resource_path(mod_dir, normal_source.file)
-                if normal_path and os.path.exists(normal_path):
-                    if normal_path == draw_pos_path:
-                        normal_data = pos_data
-                    else:
-                        if normal_path not in raw_buf_cache:
-                            raw_buf_cache[normal_path] = _read_buffer(normal_path)
-                        normal_data = raw_buf_cache[normal_path]
-                    normal_bytes = decode_normals(
-                        normal_source, normal_data, used)
-            shape_buffers = _build_shape_buffers(
-                grp.get("shape_sliders"), mod_dir, effective_pos_path, used,
-                raw_buf_cache, sparse_shape_cache, _read_buffer)
-            uv_bytes = bytearray(len(used) * 8) if tc_data else None
-            for out_i, vi in enumerate(used):
-                pos_off = vi * draw_pos_stride + POSITION_OFFSET
-                if pos_off + 12 <= len(pos_data):
-                    x, y, z = struct.unpack_from("<fff", pos_data, pos_off)
-                else:
-                    x, y, z = 0., 0., 0.
-                struct.pack_into("<fff", pos_bytes, out_i * 12, x, y, z)
-                for item in shape_buffers:
-                    shape, target_data, target_bytes, sparse = item[:4]
-                    if sparse:
-                        dx, dy, dz = target_data.get(vi, (0., 0., 0.))
-                        tx, ty, tz = x + dx, y + dy, z + dz
-                    else:
-                        target_off = vi * shape["stride"] + POSITION_OFFSET
-                        if target_off + 12 <= len(target_data):
-                            tx, ty, tz = struct.unpack_from("<fff", target_data, target_off)
-                        else:
-                            tx, ty, tz = x, y, z
-                    struct.pack_into("<fff", target_bytes, out_i * 12, tx, ty, tz)
-                    if len(item) > 4 and item[4] is not None:
-                        low_data, low_bytes = item[4], item[5]
-                        low_off = vi * shape["stride"] + POSITION_OFFSET
-                        if low_off + 12 <= len(low_data):
-                            lx, ly, lz = struct.unpack_from("<fff", low_data, low_off)
-                        else:
-                            lx, ly, lz = x, y, z
-                        struct.pack_into("<fff", low_bytes, out_i * 12, lx, ly, lz)
-                if tc_data:
-                    tc_off = vi * draw_tc_stride + uv_off
-                    if tc_off + uv_size <= len(tc_data):
-                        u, v = struct.unpack_from(uv_fmt, tc_data, tc_off)
-                    else:
-                        u, v = 0., 0.
-                    struct.pack_into("<ff", uv_bytes, out_i * 8,
-                                     u, 1.0 - v)  # flip V for Three.js
-
-            idx_bytes = bytearray(len(raw) * 4)
-            for out_i, value in enumerate(raw):
-                struct.pack_into("<I", idx_bytes, out_i * 4, remap[value])
-
-            asset_default = draw.asset_texture_defaults.get("diffuse") or {}
-            default_key = _ensure_texture(
-                asset_default.get("path") or safe_resource_path(
-                    mod_dir, draw.texture_default("diffuse")),
-                "diffuse", asset_default.get("key"))
             entry: dict = {
-                "pos": _geometry_ref(pos_bytes, geometry),
-                "idx": _geometry_ref(idx_bytes, geometry),
-                "tex_key": default_key,
+                "pos": _geometry_ref(packed.positions, geometry),
+                "idx": _geometry_ref(packed.indices, geometry),
+                "tex_key": None,
                 "normal_map_y_sign": texture_profile.normal_y_sign,
                 "normal_map_enabled": texture_profile.bind_normal_map,
             }
-            # NormalMap is a user-facing authored role, but its transport is
-            # profile-owned.  WuWa publishes the intact packed source as
-            # normal_data; Genshin/ZZZ retain the derived normal_map path.
-            asset_normal = draw.asset_texture_defaults.get("normal_map") or {}
-            normal_path = asset_normal.get("path") or safe_resource_path(
-                mod_dir, draw.texture_default("normal_map"))
-            normal_role = texture_profile.normal_transport_role
-            normal_identity = asset_normal.get("key")
-            normal_key = _ensure_texture(
-                normal_path, normal_role, normal_identity)
-            if normal_key:
-                entry[f"{normal_role}_key"] = normal_key
-            for channel in ("light_map", "material_map"):
-                asset_default = draw.asset_texture_defaults.get(channel) or {}
-                key = _ensure_texture(
-                    asset_default.get("path") or safe_resource_path(
-                        mod_dir, draw.texture_default(channel)),
-                    channel, asset_default.get("key"))
-                if key:
-                    entry[f"{channel}_key"] = key
-            # The manager presents one row per diffuse. Seed that row with the
-            # auxiliary maps resolved alongside this draw so authored maps can
-            # be inspected/replaced with the same controls as manual ones.
-            def _seed_option_maps(diffuse_key):
-                if not diffuse_key:
-                    return
-                option = next((item for item in texture_options
-                               if item["tex_key"] == diffuse_key), None)
-                if option:
-                    for channel in ("normal_map", "light_map", "normal_data",
-                                    "material_map"):
-                        key = entry.get(f"{channel}_key")
-                        if key and not option.get(channel):
-                            option[channel] = key
-            _seed_option_maps(default_key)
-            if uv_bytes:
-                entry["uv"] = _geometry_ref(uv_bytes, geometry)
-            if normal_bytes is not None:
-                entry["normal"] = _geometry_ref(normal_bytes, geometry)
-            if shape_buffers:
+            apply_draw_texture_bindings(
+                entry, draw, texture_options, registry=registry)
+            if packed.texcoords is not None:
+                entry["uv"] = _geometry_ref(packed.texcoords, geometry)
+            if packed.normals is not None:
+                entry["normal"] = _geometry_ref(packed.normals, geometry)
+            if packed.shape_targets:
                 entry["shape_targets"] = []
-                for item in shape_buffers:
-                    shape, _target_data, target_bytes, _sparse = item[:4]
-                    target = {"var": shape["var"],
-                              "pos": _geometry_ref(target_bytes, geometry)}
-                    if shape.get("mode"):
-                        target["mode"] = shape["mode"]
-                    if len(item) > 5 and item[5] is not None:
-                        target["low_pos"] = _geometry_ref(item[5], geometry)
-                    entry["shape_targets"].append(target)
+                for target in packed.shape_targets:
+                    shape_entry = {
+                        "var": target.var,
+                        "pos": _geometry_ref(target.positions, geometry),
+                    }
+                    if target.mode:
+                        shape_entry["mode"] = target.mode
+                    if target.low_positions is not None:
+                        shape_entry["low_pos"] = _geometry_ref(
+                            target.low_positions, geometry)
+                    entry["shape_targets"].append(shape_entry)
             if draw.conditions:
                 entry["conditions"] = draw.conditions
             if draw.sources:
-                entry["sources"] = [_rel_source(s, mod_dir)
-                                    for s in draw.sources]
-            # A toggle can swap the diffuse texture.
-            texture_rules = draw.texture_rules("diffuse")
-            if texture_rules:
-                variants = []
-                for v in texture_rules:
-                    key = _ensure_texture(safe_resource_path(mod_dir, v["file"]))
-                    if key:
-                        # Auxiliary assignments after a conditional diffuse
-                        # branch belong to every branch reaching this draw,
-                        # not only to whichever branch supplied tex_key.
-                        _seed_option_maps(key)
-                        variants.append({"conditions": v["conditions"], "tex_key": key})
-                if len(variants) > 1:
-                    entry["texture_variants"] = variants
-            for channel in ("light_map", "material_map"):
-                rules = draw.texture_rules(channel)
-                variants = []
-                for variant in rules:
-                    key = _ensure_texture(
-                        safe_resource_path(mod_dir, variant["file"]), channel)
-                    if key:
-                        variants.append({
-                            "conditions": variant["conditions"],
-                            "tex_key": key,
-                        })
-                if variants:
-                    entry[f"{channel}_variants"] = variants
-            normal_rules = draw.texture_rules("normal_map")
-            normal_variants = []
-            for variant in normal_rules:
-                key = _ensure_texture(
-                    safe_resource_path(mod_dir, variant["file"]), normal_role)
-                if key:
-                    normal_variants.append({
-                        "conditions": variant["conditions"],
-                        "tex_key": key,
-                    })
-            if normal_variants:
-                entry[f"{normal_role}_variants"] = normal_variants
-            # Keep even a single resolved texture in the UI pool. A component
-            # with one diffuse still has a useful texture to display/manage;
-            # only components with no resolved textures need the frontend's
-            # empty fallback pool.
+                entry["sources"] = [_rel_source(item, mod_dir)
+                                    for item in draw.sources]
             if texture_options:
                 entry["texture_options"] = texture_options
-            # The literal `drawindexed = count, start, base` values, so the UI can
-            # show a meaningful per-draw label instead of a bare "#1"/"#2" index.
-            # Absent for the rare section with no drawindexed line at all (the
-            # whole index buffer is read unconditionally) — count is None.
+            # The literal drawindexed = count, start, base values let the UI
+            # show a meaningful per-draw label instead of a bare index.
             if draw.count is not None:
                 entry["drawindexed"] = [draw.count, draw.start, draw.base]
             if source:
@@ -872,27 +145,29 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 entry["texture_resolution"] = dict(draw.texture_provenance)
             if draw.asset_slot_evidence:
                 entry["asset_slot_evidence"] = list(draw.asset_slot_evidence)
-            result[lbl] = entry
+            result[draw.label] = entry
 
     return MeshBuildResult(
         meshes=result,
-        textures={k: v for k, v in tex_uris.items() if v},
+        textures=registry.sources,
         geometry=geometry,
     )
 
 
 def build_mesh_payload(groups, mod_dir, max_draws=0, geometry=None,
                        texture_source=None, game_profile=None):
-    """Compatibility wrapper for direct core fixtures.
-
-    The application uses :func:`build_mesh_result`; older tests and scripts
-    can continue to inspect the historical flat builder dictionary, including
-    its private ``__textures__`` entry.
-    """
-    built = build_mesh_result(groups, mod_dir, max_draws=max_draws,
-                              geometry=geometry,
-                              texture_source=texture_source,
-                              game_profile=game_profile)
+    """Legacy flat payload wrapper retaining the ``__textures__`` field."""
+    built = build_mesh_result(
+        groups, mod_dir, max_draws=max_draws, geometry=geometry,
+        texture_source=texture_source, game_profile=game_profile)
     payload = dict(built.meshes)
     payload["__textures__"] = built.textures
     return payload
+
+
+__all__ = [
+    "MeshBuildResult", "build_mesh_result", "build_mesh_semantics",
+    "build_mesh_payload", "GeometryBlob", "POSITION_STRIDE",
+    "POSITION_OFFSET", "DEFAULT_UV_OFFSET", "INDEX_SIZE", "_res_get",
+    "_deduplicate_draws", "read_positions", "read_texcoords", "read_indices",
+]

--- a/src/core/geometry/packing.py
+++ b/src/core/geometry/packing.py
@@ -1,0 +1,270 @@
+"""Per-draw geometry packing, compaction, and shape-target preparation."""
+
+import math
+import os
+import struct
+from dataclasses import dataclass
+
+from .buffers import POSITION_OFFSET, BufferStore
+from .conventions import GeometryConvention
+from .draw_call import DrawCall
+from .vertex_attributes import decode_normals
+from ..resource_paths import safe_resource_path
+
+
+@dataclass
+class PackedShapeTarget:
+    var: str
+    positions: bytes
+    low_positions: bytes | None = None
+    mode: str | None = None
+
+
+@dataclass
+class PackedDrawGeometry:
+    positions: bytes
+    indices: bytes
+    texcoords: bytes | None
+    normals: bytes | None
+    shape_targets: list[PackedShapeTarget]
+
+
+@dataclass
+class _ShapeBuffer:
+    shape: dict
+    target_data: bytes | dict
+    target_bytes: bytearray
+    sparse: bool
+    low_data: bytes | None = None
+    low_bytes: bytearray | None = None
+
+
+def _build_shape_buffers(shape_sliders, mod_dir, effective_pos_path, used,
+                         buffers, sparse_shape_cache):
+    """Load and prepare dense or sparse shape targets for one draw."""
+    shape_buffers = []
+    for shape in shape_sliders or []:
+        shape_base_path = safe_resource_path(mod_dir, shape["base_file"])
+        if os.path.normcase(os.path.normpath(shape_base_path or "")) != \
+                os.path.normcase(os.path.normpath(effective_pos_path)):
+            continue
+        if shape.get("shape_id") is not None:
+            paths = tuple(safe_resource_path(mod_dir, shape[key]) for key in
+                          ("offset_file", "vertex_id_file", "vertex_offset_file"))
+            if not all(path and os.path.exists(path) for path in paths):
+                continue
+            # WWMI aligns each 127-key batch to a 128-entry container;
+            # user-facing IDs omit that padding slot (SkapeKeySetter.hlsl).
+            key_id = shape.get(
+                "buffer_shape_id",
+                shape["shape_id"] + shape["shape_id"] // 127)
+            cache_key = paths + (key_id,)
+            if cache_key not in sparse_shape_cache:
+                offsets, vertex_ids, deltas = (buffers.raw(path) for path in paths)
+                if (key_id + 2) * 4 > len(offsets):
+                    continue
+                begin, end = struct.unpack_from("<II", offsets, key_id * 4)
+                entry_offset = shape.get("sparse_entry_offset", 0)
+                begin += entry_offset
+                end += entry_offset
+                limit = min(end, len(vertex_ids) // 4, len(deltas) // 12)
+                sparse = {}
+                for index in range(begin, limit):
+                    vertex_id = struct.unpack_from("<I", vertex_ids, index * 4)[0]
+                    delta = struct.unpack_from("<eee", deltas, index * 12)
+                    prior = sparse.get(vertex_id, (0., 0., 0.))
+                    sparse[vertex_id] = tuple(
+                        prior[j] + delta[j] for j in range(3))
+                sparse_shape_cache[cache_key] = sparse
+            shape_buffers.append(_ShapeBuffer(
+                shape, sparse_shape_cache[cache_key],
+                bytearray(len(used) * 12), True))
+        else:
+            target_path = safe_resource_path(mod_dir, shape["target_file"])
+            if not target_path or not os.path.exists(target_path):
+                continue
+            target_data = buffers.raw(target_path)
+            low_data = None
+            low_bytes = None
+            if shape.get("low_file"):
+                low_path = safe_resource_path(mod_dir, shape["low_file"])
+                if not low_path or not os.path.exists(low_path):
+                    continue
+                low_data = buffers.raw(low_path)
+                low_bytes = bytearray(len(used) * 12)
+            shape_buffers.append(_ShapeBuffer(
+                shape, target_data, bytearray(len(used) * 12), False,
+                low_data, low_bytes))
+    return shape_buffers
+
+
+def pack_draw_geometry(
+    draw: DrawCall,
+    group,
+    *,
+    mod_dir,
+    default_streams,
+    default_index_size,
+    buffers: BufferStore,
+    geometry_convention: GeometryConvention,
+    sparse_shape_cache,
+):
+    """Pack one resolved draw into compact raw geometry bytes.
+
+    Resource resolution, validation, triangle filtering, winding, compaction,
+    authored normals, and shape targets intentionally remain one operation so
+    their ordering cannot drift apart.
+    """
+    draw_ib_path = safe_resource_path(mod_dir, draw.ib_file)
+    if not draw_ib_path or not os.path.exists(draw_ib_path):
+        return None
+    raw = buffers.indices(
+        draw_ib_path, draw.start, draw.count,
+        draw.index_size if draw.index_size is not None else default_index_size)
+    if not raw:
+        return None
+    # DirectX resolves each index as index_buffer_value + BaseVertexLocation
+    # against the vertex buffer.
+    base = draw.base
+    if base:
+        raw = [value + base for value in raw]
+    # Reject before buffer decoding, where negative offsets could be treated as
+    # end-relative instead of failing safely.
+    if any(index < 0 for index in raw):
+        return None
+
+    draw_pos_path = safe_resource_path(mod_dir, draw.position_file)
+    draw_tc_path = safe_resource_path(mod_dir, draw.texcoord_file)
+    if not (draw_pos_path and draw_tc_path
+            and os.path.exists(draw_pos_path)
+            and os.path.exists(draw_tc_path)):
+        return None
+    effective_pos_path = draw_pos_path
+    draw_position_stride = (
+        draw.position_stride
+        if draw.position_stride is not None else default_streams.position_stride)
+    draw_texcoord_stride = (
+        draw.texcoord_stride
+        if draw.texcoord_stride is not None else default_streams.texcoord_stride)
+    if (draw_pos_path != safe_resource_path(mod_dir, group["position_file"])
+            or draw_tc_path != safe_resource_path(mod_dir, group["texcoord_file"])
+            or draw_position_stride != default_streams.position_stride
+            or draw_texcoord_stride != default_streams.texcoord_stride):
+        draw_streams = buffers.vertex_streams(
+            draw_pos_path, draw_position_stride,
+            draw_tc_path, draw_texcoord_stride)
+    else:
+        draw_streams = default_streams
+
+    pos_data = draw_streams.position_data
+    tc_data = draw_streams.texcoord_data
+    uv_offset = draw_streams.uv_offset
+    uv_format = draw_streams.uv_format
+    uv_size = struct.calcsize(uv_format)
+
+    def finite_vertex(index):
+        pos_offset = index * draw_streams.position_stride + POSITION_OFFSET
+        if pos_offset < 0 or pos_offset + 12 > len(pos_data):
+            return False
+        position = struct.unpack_from("<fff", pos_data, pos_offset)
+        if not all(math.isfinite(value) for value in position):
+            return False
+        if tc_data:
+            tc_offset = index * draw_streams.texcoord_stride + uv_offset
+            if tc_offset < 0 or tc_offset + uv_size > len(tc_data):
+                return False
+            texcoord = struct.unpack_from(uv_format, tc_data, tc_offset)
+            if not all(math.isfinite(value) for value in texcoord):
+                return False
+        return True
+
+    valid_raw = []
+    for triangle_start in range(0, len(raw) - 2, 3):
+        triangle = raw[triangle_start:triangle_start + 3]
+        if all(finite_vertex(index) for index in triangle):
+            valid_raw.extend(triangle)
+    if not valid_raw:
+        return None
+    raw = valid_raw
+    if geometry_convention.reverse_winding:
+        for triangle_start in range(0, len(raw) - 2, 3):
+            raw[triangle_start + 1], raw[triangle_start + 2] = (
+                raw[triangle_start + 2], raw[triangle_start + 1])
+
+    used = sorted(set(raw))
+    remap = {old: new for new, old in enumerate(used)}
+    pos_bytes = bytearray(len(used) * 12)
+    normal_bytes = None
+    normal_source = draw.normal_source
+    if normal_source is not None:
+        normal_path = safe_resource_path(mod_dir, normal_source.file)
+        if normal_path and os.path.exists(normal_path):
+            normal_data = (pos_data if normal_path == draw_pos_path
+                           else buffers.raw(normal_path))
+            normal_bytes = decode_normals(normal_source, normal_data, used)
+
+    shape_buffers = _build_shape_buffers(
+        group.get("shape_sliders"), mod_dir, effective_pos_path, used,
+        buffers, sparse_shape_cache)
+    uv_bytes = bytearray(len(used) * 8) if tc_data else None
+    for output_index, vertex_index in enumerate(used):
+        pos_offset = vertex_index * draw_streams.position_stride + POSITION_OFFSET
+        if pos_offset + 12 <= len(pos_data):
+            x, y, z = struct.unpack_from("<fff", pos_data, pos_offset)
+        else:
+            x, y, z = 0., 0., 0.
+        struct.pack_into("<fff", pos_bytes, output_index * 12, x, y, z)
+        for item in shape_buffers:
+            shape = item.shape
+            if item.sparse:
+                dx, dy, dz = item.target_data.get(vertex_index, (0., 0., 0.))
+                tx, ty, tz = x + dx, y + dy, z + dz
+            else:
+                target_offset = vertex_index * shape["stride"] + POSITION_OFFSET
+                if target_offset + 12 <= len(item.target_data):
+                    tx, ty, tz = struct.unpack_from(
+                        "<fff", item.target_data, target_offset)
+                else:
+                    tx, ty, tz = x, y, z
+            struct.pack_into("<fff", item.target_bytes, output_index * 12,
+                             tx, ty, tz)
+            if item.low_data is not None:
+                low_offset = vertex_index * shape["stride"] + POSITION_OFFSET
+                if low_offset + 12 <= len(item.low_data):
+                    lx, ly, lz = struct.unpack_from(
+                        "<fff", item.low_data, low_offset)
+                else:
+                    lx, ly, lz = x, y, z
+                struct.pack_into("<fff", item.low_bytes, output_index * 12,
+                                 lx, ly, lz)
+        if tc_data:
+            tc_offset = vertex_index * draw_streams.texcoord_stride + uv_offset
+            if tc_offset + uv_size <= len(tc_data):
+                u, v = struct.unpack_from(uv_format, tc_data, tc_offset)
+            else:
+                u, v = 0., 0.
+            struct.pack_into("<ff", uv_bytes, output_index * 8,
+                             u, 1.0 - v)  # flip V for Three.js
+
+    idx_bytes = bytearray(len(raw) * 4)
+    for output_index, value in enumerate(raw):
+        struct.pack_into("<I", idx_bytes, output_index * 4, remap[value])
+
+    shape_targets = [PackedShapeTarget(
+        var=item.shape["var"],
+        positions=bytes(item.target_bytes),
+        low_positions=bytes(item.low_bytes) if item.low_bytes is not None else None,
+        mode=item.shape.get("mode"),
+    ) for item in shape_buffers]
+    return PackedDrawGeometry(
+        positions=bytes(pos_bytes),
+        indices=bytes(idx_bytes),
+        texcoords=bytes(uv_bytes) if uv_bytes is not None else None,
+        normals=bytes(normal_bytes) if normal_bytes is not None else None,
+        shape_targets=shape_targets,
+    )
+
+
+__all__ = [
+    "PackedShapeTarget", "PackedDrawGeometry", "pack_draw_geometry",
+]

--- a/src/core/geometry/semantics.py
+++ b/src/core/geometry/semantics.py
@@ -1,0 +1,163 @@
+"""Geometry-free draw projection used by staged semantic refreshes."""
+
+import os
+
+from .draw_call import DrawCall
+from ..resource_paths import safe_resource_path
+from ..textures.pipeline import normalize_texture_role, texture_key
+
+
+_MAX_DRAWS = 10_000
+
+
+def _rel_source(src, mod_dir):
+    """Project absolute INI provenance to a browser-safe relative path."""
+    path = src.get("ini_path")
+    if path:
+        try:
+            path = os.path.relpath(path, mod_dir).replace(os.sep, "/")
+        except ValueError:
+            path = os.path.basename(path)
+    return {"ini": path, "line": src.get("line_no"), "section": src.get("section")}
+
+
+def deduplicate_draws(group, max_draws=0):
+    """Merge repeated draw regions while preserving every gate and source."""
+    merged = {}
+    order = []
+    for raw_draw in group["draws"]:
+        draw = DrawCall.from_mapping(raw_draw, group)
+        key = draw.render_identity()
+        if key not in merged:
+            merged[key] = {"draw": draw, "alts": [], "sources": []}
+            order.append(key)
+        entry = merged[key]
+        for source in draw.sources:
+            if source not in entry["sources"]:
+                entry["sources"].append(source)
+        cond_groups = draw.conditions
+        if not cond_groups:
+            if [] not in entry["alts"]:
+                entry["alts"].append([])
+        else:
+            for condition_group in cond_groups:
+                if condition_group not in entry["alts"]:
+                    entry["alts"].append(condition_group)
+
+    unique = []
+    for key in order:
+        entry = merged[key]
+        draw, alternatives = entry["draw"], entry["alts"]
+        draw.conditions = (
+            [] if any(not group for group in alternatives) else alternatives)
+        draw.sources = entry["sources"]
+        unique.append(draw)
+    return unique[:max_draws] if max_draws else unique
+
+
+# Existing integration fixtures import this private helper from mesh_builder.
+_deduplicate_draws = deduplicate_draws
+
+
+def _semantic_texture_key(mod_dir, authored_path, role):
+    """Resolve a texture identity without opening or decoding the source."""
+    path = safe_resource_path(mod_dir, authored_path)
+    if not path or not os.path.exists(path):
+        return None
+    relative_path = os.path.relpath(path, mod_dir).replace(os.sep, "/")
+    return texture_key(relative_path, normalize_texture_role(role))
+
+
+def _semantic_asset_key(draw, role, transport_role=None):
+    item = draw.asset_texture_defaults.get(role) or {}
+    key = item.get("key") if isinstance(item, dict) else None
+    if not key:
+        return None
+    if transport_role and transport_role != role:
+        return texture_key(key, transport_role)
+    return texture_key(key, role)
+
+
+def _semantic_texture_variants(draw, mod_dir, authored_role, transport_role=None):
+    role = transport_role or authored_role
+    variants = []
+    for variant in draw.texture_rules(authored_role):
+        key = _semantic_texture_key(mod_dir, variant.get("file"), role)
+        if key:
+            variants.append({"conditions": variant["conditions"], "tex_key": key})
+    return variants
+
+
+def validate_draw_count(groups):
+    draw_total = sum(len(group.get("draws", [])) for group in groups)
+    if draw_total > _MAX_DRAWS:
+        raise ValueError(
+            f"Mod has too many draws ({draw_total:,}; limit {_MAX_DRAWS:,}).")
+
+
+def build_mesh_semantics(groups, mod_dir, max_draws=0, game_profile=None,
+                         active_mesh_keys=None):
+    """Return draw visibility semantics without resolving any geometry."""
+    validate_draw_count(groups)
+    from ..textures.profiles import texture_profile_for
+
+    texture_profile = texture_profile_for(game_profile)
+    normal_role = texture_profile.normal_transport_role
+    result = {}
+    for group in groups:
+        for draw in deduplicate_draws(group, max_draws=max_draws):
+            if active_mesh_keys is not None and draw.label not in active_mesh_keys:
+                continue
+            entry = {
+                "conditions": draw.conditions or [],
+                "tex_key": (_semantic_asset_key(draw, "diffuse") or
+                            _semantic_texture_key(
+                                mod_dir, draw.texture_default("diffuse"),
+                                "diffuse")),
+                "normal_map_key": None,
+                "normal_data_key": None,
+                "light_map_key": (_semantic_asset_key(draw, "light_map") or
+                                  _semantic_texture_key(
+                                      mod_dir, draw.texture_default("light_map"),
+                                      "light_map")),
+                "material_map_key": (_semantic_asset_key(
+                    draw, "material_map") or _semantic_texture_key(
+                        mod_dir, draw.texture_default("material_map"),
+                        "material_map")),
+            }
+            normal_key = _semantic_texture_key(
+                mod_dir, draw.texture_default("normal_map"), normal_role)
+            normal_key = (_semantic_asset_key(
+                draw, "normal_map", normal_role) or normal_key)
+            entry[f"{normal_role}_key"] = normal_key
+            if draw.sources:
+                entry["sources"] = [_rel_source(source, mod_dir)
+                                     for source in draw.sources]
+
+            texture_variants = _semantic_texture_variants(
+                draw, mod_dir, "diffuse")
+            if len(texture_variants) > 1:
+                entry["texture_variants"] = texture_variants
+            for channel in ("light_map", "material_map"):
+                variants = _semantic_texture_variants(draw, mod_dir, channel)
+                if variants:
+                    entry[f"{channel}_variants"] = variants
+            normal_variants = _semantic_texture_variants(
+                draw, mod_dir, "normal_map", normal_role)
+            if normal_variants:
+                entry[f"{normal_role}_variants"] = normal_variants
+            binding = draw.asset_binding
+            if binding is not None and hasattr(binding, "to_dict"):
+                entry["asset_binding"] = binding.to_dict()
+            if draw.texture_provenance:
+                entry["texture_resolution"] = dict(draw.texture_provenance)
+            if draw.asset_slot_evidence:
+                entry["asset_slot_evidence"] = list(draw.asset_slot_evidence)
+            result[draw.label] = entry
+    return result
+
+
+__all__ = [
+    "build_mesh_semantics", "deduplicate_draws", "validate_draw_count",
+    "_deduplicate_draws", "_rel_source",
+]

--- a/src/core/geometry/texture_bindings.py
+++ b/src/core/geometry/texture_bindings.py
@@ -1,0 +1,184 @@
+"""Texture identity, lazy source publication, and draw binding assembly."""
+
+import os
+
+from ..resource_paths import safe_resource_path
+from ..textures.pipeline import (
+    _begin_texture_cache, _texture_source_uri, encode_texture_data_uri,
+    normalize_texture_role, normalize_texture_transform, texture_key,
+)
+
+
+class TextureRegistry:
+    """Build-scoped role-aware texture registry."""
+
+    def __init__(self, mod_dir, profile, texture_source=None):
+        _begin_texture_cache(mod_dir)
+        self.mod_dir = mod_dir
+        self.profile = profile
+        self.texture_source = texture_source
+        self._sources = {}
+        self._keys = {}
+
+    def key(self, path, role=None, *, identity=None, transform=None):
+        if not path or not os.path.exists(path):
+            return None
+        role = normalize_texture_role(role)
+        if transform is None:
+            transform = self.profile.recipe_for(role)
+        transform = normalize_texture_transform(transform)
+        cache_key = (path, role, transform, identity)
+        if cache_key not in self._keys:
+            relative_path = identity or os.path.relpath(
+                path, self.mod_dir).replace(os.sep, "/")
+            self._keys[cache_key] = texture_key(relative_path, role)
+        return self._keys[cache_key]
+
+    def ensure(self, path, role=None, *, identity=None):
+        role = normalize_texture_role(role)
+        transform = self.profile.recipe_for(role)
+        key = self.key(path, role, identity=identity, transform=transform)
+        if key and key not in self._sources:
+            if self.texture_source is None:
+                value = encode_texture_data_uri(
+                    path, texture_role=role, texture_transform=transform)
+            else:
+                value = _texture_source_uri(
+                    self.texture_source, path, role, transform)
+            self._sources[key] = value or ""
+        return key
+
+    @property
+    def sources(self):
+        return {key: value for key, value in self._sources.items() if value}
+
+
+def build_texture_options(group, registry):
+    """Build the lazy diffuse picker pool for one component/group."""
+    texture_options = []
+    texture_option_keys = set()
+
+    def append_texture_option(key, filename, label, **metadata):
+        if not key or key in texture_option_keys:
+            return
+        texture_option_keys.add(key)
+        option = {"tex_key": key, "file": filename, "label": label}
+        option.update(metadata)
+        texture_options.append(option)
+
+    for pool_entry in group.get("diffuse_pool_files") or []:
+        path = safe_resource_path(registry.mod_dir, pool_entry["file"])
+        key = registry.key(path)
+        if key:
+            res_name = pool_entry["res"]
+            label = res_name[8:] if res_name.startswith("Resource") else res_name
+            append_texture_option(key, pool_entry["file"], label)
+
+    for candidate in group.get("discovered_textures") or []:
+        filename = candidate.get("file")
+        path = safe_resource_path(registry.mod_dir, filename)
+        if path is None:
+            continue
+        key = registry.key(path)
+        label = os.path.splitext(
+            str(filename).replace("\\", "/").rsplit("/", 1)[-1]
+        )[0]
+        append_texture_option(
+            key, filename, label, candidate_source=candidate.get("source"))
+    return texture_options
+
+
+def apply_draw_texture_bindings(entry, draw, texture_options, *, registry):
+    """Apply default and conditional role-aware texture bindings to an entry."""
+    profile = registry.profile
+    mod_dir = registry.mod_dir
+
+    asset_default = draw.asset_texture_defaults.get("diffuse") or {}
+    default_key = registry.ensure(
+        asset_default.get("path") or safe_resource_path(
+            mod_dir, draw.texture_default("diffuse")),
+        "diffuse", identity=asset_default.get("key"))
+    entry["tex_key"] = default_key
+    entry["normal_map_y_sign"] = profile.normal_y_sign
+    entry["normal_map_enabled"] = profile.bind_normal_map
+
+    # NormalMap is a user-facing authored role, but its transport is
+    # profile-owned. WuWa publishes the intact packed source as normal_data;
+    # Genshin/ZZZ retain the derived normal_map path.
+    asset_normal = draw.asset_texture_defaults.get("normal_map") or {}
+    normal_path = asset_normal.get("path") or safe_resource_path(
+        mod_dir, draw.texture_default("normal_map"))
+    normal_role = profile.normal_transport_role
+    normal_key = registry.ensure(
+        normal_path, normal_role, identity=asset_normal.get("key"))
+    if normal_key:
+        entry[f"{normal_role}_key"] = normal_key
+    for channel in ("light_map", "material_map"):
+        asset_default = draw.asset_texture_defaults.get(channel) or {}
+        key = registry.ensure(
+            asset_default.get("path") or safe_resource_path(
+                mod_dir, draw.texture_default(channel)),
+            channel, identity=asset_default.get("key"))
+        if key:
+            entry[f"{channel}_key"] = key
+
+    # The manager presents one row per diffuse. Seed that row with auxiliary
+    # maps resolved alongside this draw so authored maps can be inspected or
+    # replaced with the same controls as manual ones.
+    def seed_option_maps(diffuse_key):
+        if not diffuse_key:
+            return
+        option = next((item for item in texture_options
+                       if item["tex_key"] == diffuse_key), None)
+        if option:
+            for channel in ("normal_map", "light_map", "normal_data",
+                            "material_map"):
+                key = entry.get(f"{channel}_key")
+                if key and not option.get(channel):
+                    option[channel] = key
+
+    seed_option_maps(default_key)
+    texture_rules = draw.texture_rules("diffuse")
+    if texture_rules:
+        variants = []
+        for variant in texture_rules:
+            key = registry.ensure(
+                safe_resource_path(mod_dir, variant["file"]))
+            if key:
+                # Auxiliary assignments after a conditional diffuse branch
+                # belong to every branch reaching this draw.
+                seed_option_maps(key)
+                variants.append({
+                    "conditions": variant["conditions"], "tex_key": key,
+                })
+        if len(variants) > 1:
+            entry["texture_variants"] = variants
+
+    for channel in ("light_map", "material_map"):
+        rules = draw.texture_rules(channel)
+        variants = []
+        for variant in rules:
+            key = registry.ensure(
+                safe_resource_path(mod_dir, variant["file"]), channel)
+            if key:
+                variants.append({
+                    "conditions": variant["conditions"], "tex_key": key,
+                })
+        if variants:
+            entry[f"{channel}_variants"] = variants
+
+    normal_variants = []
+    for variant in draw.texture_rules("normal_map"):
+        key = registry.ensure(
+            safe_resource_path(mod_dir, variant["file"]), normal_role)
+        if key:
+            normal_variants.append({
+                "conditions": variant["conditions"], "tex_key": key,
+            })
+    if normal_variants:
+        entry[f"{normal_role}_variants"] = normal_variants
+
+
+__all__ = [
+    "TextureRegistry", "build_texture_options", "apply_draw_texture_bindings",
+]

--- a/src/tests/core/geometry/test_buffers.py
+++ b/src/tests/core/geometry/test_buffers.py
@@ -1,0 +1,43 @@
+"""Bounded geometry-buffer access regressions."""
+
+from unittest.mock import patch
+
+import pytest
+
+from core.geometry import buffers
+
+
+def test_buffer_store_reads_shared_file_once(tmp_path):
+    path = tmp_path / "shared.buf"
+    path.write_bytes(b"shared")
+    store = buffers.BufferStore()
+
+    with patch("builtins.open", wraps=open) as reader:
+        assert store.raw(str(path)) == b"shared"
+        assert store.raw(str(path)) == b"shared"
+
+    assert reader.call_count == 1
+
+
+def test_buffer_store_preserves_single_file_limit(tmp_path, monkeypatch):
+    path = tmp_path / "large.buf"
+    path.write_bytes(b"12345")
+    monkeypatch.setattr(buffers, "_MAX_BUFFER_FILE_BYTES", 4)
+
+    with pytest.raises(ValueError, match="Buffer file is too large"):
+        buffers.BufferStore().raw(str(path))
+
+
+def test_buffer_store_preserves_cumulative_limit_but_not_shared_reads(
+        tmp_path, monkeypatch):
+    first = tmp_path / "first.buf"
+    second = tmp_path / "second.buf"
+    first.write_bytes(b"123")
+    second.write_bytes(b"456")
+    monkeypatch.setattr(buffers, "_MAX_TOTAL_BUFFER_BYTES", 5)
+    store = buffers.BufferStore()
+
+    store.raw(str(first))
+    store.raw(str(first))
+    with pytest.raises(ValueError, match="2 GiB safety limit"):
+        store.raw(str(second))

--- a/src/tests/core/geometry/test_mesh_builder.py
+++ b/src/tests/core/geometry/test_mesh_builder.py
@@ -6,6 +6,8 @@ import tempfile
 
 from core.ini.parser import (build_draw_groups, extract_resources,
                              extract_toggle_keys, merge_sections)
+from core.geometry.draw_call import DrawCall
+from core.geometry.mesh_builder import GeometryBlob, build_mesh_result
 from tests.support.provenance import IB_R16_INI, build_mesh_fixture, geometry_values, write
 
 IB_REASSIGN_INI = """[TextureOverrideBodyBlend]
@@ -64,6 +66,54 @@ def test_mid_section_ib_reassignment_mesh_builder():
 
         vert_sets = sorted(_verts(e) for e in meshes.values())
         assert (vert_sets == [[10, 11, 12], [20, 21, 22]]), (f"each mesh's own vertices come from its own reassigned ib (got {vert_sets})")
+
+
+def test_sparse_shape_boundary_packs_buffer_key_128(tmp_path):
+    """Shape id 127 uses the WWMI-aligned sparse buffer entry 128."""
+    (tmp_path / "position.buf").write_bytes(struct.pack(
+        "<9f", 0., 0., 0., 1., 0., 0., 0., 1., 0.))
+    (tmp_path / "texcoord.buf").write_bytes(b"\0" * 24)
+    (tmp_path / "body.ib").write_bytes(struct.pack("<3I", 0, 1, 2))
+
+    offsets = bytearray(130 * 4)
+    struct.pack_into("<II", offsets, 127 * 4, 0, 0)
+    struct.pack_into("<II", offsets, 128 * 4, 0, 1)
+    (tmp_path / "shape-offsets.buf").write_bytes(offsets)
+    (tmp_path / "shape-vertex-ids.buf").write_bytes(struct.pack("<I", 1))
+    (tmp_path / "shape-deltas.buf").write_bytes(
+        struct.pack("<eee", 1., 2., 3.) + b"\0" * 6)
+
+    draw = DrawCall(
+        label="Body-1", count=3, ib_file="body.ib",
+        index_size=4, position_file="position.buf",
+        position_stride=12, texcoord_file="texcoord.buf",
+        texcoord_stride=8)
+    groups = [{
+        "position_file": "position.buf",
+        "position_stride": 12,
+        "texcoord_file": "texcoord.buf",
+        "texcoord_stride": 8,
+        "ib_file": "body.ib",
+        "index_size": 4,
+        "draws": [draw],
+        "shape_sliders": [{
+            "var": "BodyShape",
+            "base_file": "position.buf",
+            "shape_id": 127,
+            "offset_file": "shape-offsets.buf",
+            "vertex_id_file": "shape-vertex-ids.buf",
+            "vertex_offset_file": "shape-deltas.buf",
+        }],
+    }]
+
+    geometry = GeometryBlob()
+    result = build_mesh_result(groups, str(tmp_path), geometry=geometry)
+    entry = result.meshes["Body-1"]
+    target = entry["shape_targets"][0]["pos"]
+    raw = geometry.data[target["offset"]:
+                       target["offset"] + target["length"]]
+    assert struct.unpack("<9f", raw) == (
+        0., 0., 0., 2., 2., 3., 0., 1., 0.)
 
 
 CROSS_IB_VB_INI = """[TextureOverrideSBSBlend]

--- a/src/tests/core/geometry/test_semantics.py
+++ b/src/tests/core/geometry/test_semantics.py
@@ -1,0 +1,19 @@
+"""Geometry-free semantic projection boundary regressions."""
+
+from unittest.mock import patch
+
+from core.geometry.draw_call import DrawCall
+from core.geometry.mesh_builder import build_mesh_semantics
+
+
+def test_mesh_semantics_does_not_read_buffers_or_publish_textures(tmp_path):
+    (tmp_path / "diffuse.dds").write_bytes(b"not decoded")
+    draw = DrawCall(label="Body-1", texture_default_file="diffuse.dds")
+    groups = [{"draws": [draw]}]
+
+    with patch("builtins.open", side_effect=AssertionError("buffer read")), \
+            patch("core.textures.pipeline.encode_texture_data_uri",
+                  side_effect=AssertionError("texture encoding")):
+        result = build_mesh_semantics(groups, str(tmp_path))
+
+    assert result["Body-1"]["tex_key"] == "diffuse::diffuse.dds"

--- a/src/tests/core/geometry/test_texture_bindings.py
+++ b/src/tests/core/geometry/test_texture_bindings.py
@@ -1,0 +1,29 @@
+"""Texture registry identity and lazy-option regressions."""
+
+import os
+
+from core.geometry.texture_bindings import TextureRegistry, build_texture_options
+from core.textures.profiles import texture_profile_for
+
+
+def test_pool_only_texture_options_are_not_published(tmp_path):
+    pool = tmp_path / "pool.dds"
+    discovered = tmp_path / "discovered.dds"
+    pool.write_bytes(b"pool")
+    discovered.write_bytes(b"discovered")
+    registry = TextureRegistry(
+        str(tmp_path), texture_profile_for("genshin"),
+        texture_source=lambda path, role, **kwargs:
+        f"/texture/{os.path.basename(path)}")
+
+    options = build_texture_options({
+        "diffuse_pool_files": [{"file": "pool.dds", "res": "ResourcePool"}],
+        "discovered_textures": [{"file": "discovered.dds", "source": "scan"}],
+    }, registry)
+
+    assert [item["tex_key"] for item in options] == [
+        "diffuse::pool.dds", "diffuse::discovered.dds"]
+    assert registry.sources == {}
+
+    assert registry.ensure(str(pool), "diffuse") == "diffuse::pool.dds"
+    assert registry.sources == {"diffuse::pool.dds": "/texture/pool.dds"}


### PR DESCRIPTION
## Summary

- Keep core.geometry.mesh_builder as the public facade for the existing builder entry points.
- Extract bounded buffer access and caching, geometry-free semantic projection, per-draw packing, and texture binding/publication into focused geometry modules.
- Preserve GeometryBlob and base64 transport compatibility, role-aware texture identities, lazy texture options, shape targets, draw identity, and safety limits.
- Add boundary regressions for shared-buffer caching, semantic no-I/O behavior, and lazy texture options.

## Scope

Behavior-preserving core geometry organization; no parser, DrawCall, texture-profile, frontend, or backend contract changes.