### PR TITLE
chore: clean up refactor residue and tests

### DIFF
--- a/src/app/mods/controls.py
+++ b/src/app/mods/controls.py
@@ -11,23 +11,31 @@ from core.textures import encode_texture_data_uri
 from app.mods.analysis import _ini_rel, analyze_mod_inis
 
 
-def _gating_vars(payload):
-    """Variables that decide some mesh's visibility or its texture."""
+_VARIANT_FIELDS = (
+    "texture_variants", "normal_map_variants", "normal_data_variants",
+    "light_map_variants", "material_map_variants",
+)
+
+
+def _gating_vars_from_entries(entries):
+    """Collect variables that decide entries' visibility or textures."""
     found = set()
-    for entry in payload.values():
-        if not isinstance(entry, dict):
-            continue
+    for entry in entries:
         for group in entry.get("conditions", []):
             for cond in group:
                 found.add(cond["var"])
-        for field in ("texture_variants", "normal_map_variants",
-                      "normal_data_variants", "light_map_variants",
-                      "material_map_variants"):
+        for field in _VARIANT_FIELDS:
             for variant in entry.get(field, []):
                 for group in variant.get("conditions", []):
                     for cond in group:
                         found.add(cond["var"])
     return found
+
+
+def _gating_vars(payload):
+    """Variables that decide some mesh's visibility or its texture."""
+    return _gating_vars_from_entries(
+        entry for entry in payload.values() if isinstance(entry, dict))
 
 
 def build_toggle_panel(toggle_keys, toggle_defaults, gating_vars, mod_dir=None,
@@ -149,34 +157,10 @@ def _gating_vars_from_groups(groups, mod_dir=None, game_profile=None,
             groups, mod_dir, game_profile=game_profile)
         draws = (entry for label, entry in semantics.items()
                  if label in active_mesh_keys)
-        found = set()
-        for draw in draws:
-            for cond_group in draw.get("conditions", []):
-                for cond in cond_group:
-                    found.add(cond["var"])
-            for field in ("texture_variants", "normal_map_variants",
-                          "normal_data_variants", "light_map_variants",
-                          "material_map_variants"):
-                for variant in draw.get(field, []):
-                    for cond_group in variant.get("conditions", []):
-                        for cond in cond_group:
-                            found.add(cond["var"])
-        return found
+        return _gating_vars_from_entries(draws)
 
-    found = set()
-    for group in groups:
-        for draw in group.get("draws", []):
-            for cond_group in draw.get("conditions", []):
-                for cond in cond_group:
-                    found.add(cond["var"])
-            for field in ("texture_variants", "normal_map_variants",
-                          "normal_data_variants", "light_map_variants",
-                          "material_map_variants"):
-                for variant in draw.get(field, []):
-                    for cond_group in variant.get("conditions", []):
-                        for cond in cond_group:
-                            found.add(cond["var"])
-    return found
+    return _gating_vars_from_entries(
+        draw for group in groups for draw in group.get("draws", []))
 
 
 def load_present_state(context, overrides=None):

--- a/src/core/geometry/mesh_builder.py
+++ b/src/core/geometry/mesh_builder.py
@@ -6,8 +6,7 @@ from dataclasses import dataclass
 
 from .buffers import (
     DEFAULT_UV_OFFSET, INDEX_SIZE, POSITION_OFFSET, POSITION_STRIDE,
-    BufferStore, _MAX_BUFFER_FILE_BYTES, _MAX_TOTAL_BUFFER_BYTES,
-    _detect_uv_best, _res_get, read_indices, read_positions, read_texcoords,
+    BufferStore, _res_get, read_indices, read_positions, read_texcoords,
 )
 from .conventions import geometry_convention_for
 from .packing import pack_draw_geometry
@@ -20,9 +19,6 @@ from .texture_bindings import (
 )
 from .transport import GeometryBlob
 from ..resource_paths import safe_resource_path
-
-
-_MAX_DRAWS = 10_000
 
 
 @dataclass

--- a/src/core/ini/parser.py
+++ b/src/core/ini/parser.py
@@ -27,7 +27,7 @@ from .sections import (SrcLine, extract_resources, first_source, line_source,
                        merge_sections, parse_sections, sections_from_document)
 from .state import extract_state_rules
 from .texture_roles import (
-    TextureOverrideIndex, TextureReplacement, _AUX_MAP_CHANNELS,
+    TextureOverrideIndex, TextureReplacement,
     _LEGACY_TEXTURE_RESOURCE_RE, _SEMANTIC_TEXTURE_RESOURCE_RE,
     _SEMANTIC_TEXTURE_ROLES, _TEXTURE_SOURCE_PRIORITY,
     _collect_slot_role_hints, _collect_structural_slot_role_hints,

--- a/src/core/ini/texture_roles.py
+++ b/src/core/ini/texture_roles.py
@@ -63,11 +63,6 @@ class TextureOverrideIndex:
             replacements_by_hash=replacements)
 
 
-_AUX_MAP_CHANNELS = {
-    "normalmap": "normal_map",
-    "lightmap": "light_map",
-    "materialmap": "material_map",
-}
 _SEMANTIC_TEXTURE_ROLES = {
     "diffuse": "diffuse",
     "normalmap": "normal_map",

--- a/src/tests/app/mods/test_controls.py
+++ b/src/tests/app/mods/test_controls.py
@@ -3,7 +3,10 @@
 from types import SimpleNamespace
 
 from app.mods.analysis import ParsedModAnalysis
-from app.mods.controls import load_control_state, load_present_state
+from app.mods.controls import (
+    _gating_vars, _gating_vars_from_groups, load_control_state,
+    load_present_state,
+)
 from app.mods.loader import ModLoadContext
 
 from app.mods.controls import build_toggle_panel
@@ -15,6 +18,31 @@ def _key(name, varvals, key="", key_display="", source=None, ini_path="mod.ini")
         "vars": dict(varvals), "source": source,
         "ini_path": ini_path, "section": f"Key{name}",
     }
+
+
+def test_gating_variable_collection_covers_draw_and_variant_conditions():
+    draw = {
+        "conditions": [[{"var": "draw", "value": "1", "negate": False}]],
+        "texture_variants": [{"conditions": [[{
+            "var": "texture", "value": "1", "negate": False,
+        }]]}],
+        "normal_map_variants": [{"conditions": [[{
+            "var": "normal", "value": "1", "negate": False,
+        }]]}],
+        "normal_data_variants": [{"conditions": [[{
+            "var": "normal_data", "value": "1", "negate": False,
+        }]]}],
+        "light_map_variants": [{"conditions": [[{
+            "var": "light", "value": "1", "negate": False,
+        }]]}],
+        "material_map_variants": [{"conditions": [[{
+            "var": "material", "value": "1", "negate": False,
+        }]]}],
+    }
+    expected = {"draw", "texture", "normal", "normal_data", "light", "material"}
+
+    assert _gating_vars({"Body-1": draw}) == expected
+    assert _gating_vars_from_groups([{"draws": [draw]}]) == expected
 
 
 def test_wired_toggle_shows_only_its_gating_vars():


### PR DESCRIPTION
## Summary
- Remove dead geometry and INI analysis names left after the recent extractions.
- Share control gating-variable traversal between full payloads and lightweight semantic reads.
- Consolidate redundant test setup into lifecycle scenarios, move integration-owned coverage, and remove a low-value browser layout assertion.
- Add test-design guidance that prevents duplicate lifecycle micro-tests while retaining security, atomicity, race, public-contract, corpus, and rendering regressions.