### PR TITLE
feat: add character shadows and rim lighting

### DIFF
--- a/src/tests/web/test_asset_flow.py
+++ b/src/tests/web/test_asset_flow.py
@@ -369,6 +369,45 @@ def test_missing_asset_parts_append_and_remove_without_reloading_mod(
     finally:
         context.close()
 
+
+def test_asset_fill_refits_character_shadows_without_moving_camera(
+        edge_browser, frontend_url):
+    payload = _payload("ShadowFill")
+    payload["asset_resolution"] = {"configured_roots": 1}
+    _add_asset_fill_response(payload, "ShadowFillAsset")
+    fill_entry = next(iter(payload["assetFillResponse"]["payload"]["meshes"].values()))
+    fill_entry["pos"] = _f32(5, 0, 0, 6, 0, 0, 5, 1, 0)
+    context, page = _page(edge_browser, frontend_url, {"ShadowFill": payload})
+    try:
+        _open(page, "ShadowFill")
+        page.locator(".draw-item").wait_for()
+        before = page.evaluate("""async () => {
+          const {camera, getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return {camera: camera.matrixWorld.toArray(), shadow: getCharacterShadowDebugState()};
+        }""")
+        page.locator("#asset-fill-btn").click()
+        page.locator("#asset-fill-btn[data-state='remove']").wait_for()
+        expanded = page.evaluate("""async () => {
+          const {camera, getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return {camera: camera.matrixWorld.toArray(), shadow: getCharacterShadowDebugState()};
+        }""")
+        assert expanded["camera"] == pytest.approx(before["camera"])
+        assert expanded["shadow"]["fitCount"] > before["shadow"]["fitCount"]
+        assert expanded["shadow"]["shadowUpdateCount"] > before["shadow"]["shadowUpdateCount"]
+        assert expanded["shadow"]["modelBounds"]["max"][0] > before["shadow"]["modelBounds"]["max"][0]
+        page.locator("#asset-fill-btn").click()
+        page.locator("#asset-fill-btn[data-state='load']").wait_for()
+        contracted = page.evaluate("""async () => {
+          const {camera, getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return {camera: camera.matrixWorld.toArray(), shadow: getCharacterShadowDebugState()};
+        }""")
+        assert contracted["camera"] == pytest.approx(before["camera"])
+        assert contracted["shadow"]["fitCount"] > expanded["shadow"]["fitCount"]
+        assert contracted["shadow"]["modelBounds"]["max"][0] < expanded["shadow"]["modelBounds"]["max"][0]
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["ShadowFill"]
+    finally:
+        context.close()
+
 def test_stale_missing_asset_response_is_rolled_back_after_mod_switch(
         edge_browser, frontend_url):
     first = _payload("FillRaceA")

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1611,3 +1611,188 @@ def test_wireframe_toggles_rim_uniform_without_rebuilding_material(
             "window.modViewer.activeMeshes[0].material.userData.gameMaterial.rimEnabledNode.value")
     finally:
         context.close()
+
+
+def test_key_light_mode_changes_restore_ground_without_refitting_shadows(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"LightMode": _payload("LightMode")})
+    try:
+        _open(page, "LightMode")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState().groundVisible;
+        }""")
+        before = page.evaluate("""async () => {
+          const {getCharacterShadowDebugState, setLightMode} = await import('./js/scene/scene.js');
+          setLightMode('off');
+          return getCharacterShadowDebugState();
+        }""")
+        page.wait_for_function("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return !getCharacterShadowDebugState().groundVisible;
+        }""")
+        off = page.evaluate("""async () => {
+          const {getCharacterShadowDebugState, setLightMode} = await import('./js/scene/scene.js');
+          setLightMode('current');
+          return getCharacterShadowDebugState();
+        }""")
+        page.wait_for_function("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState().groundVisible;
+        }""")
+        restored = page.evaluate("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState();
+        }""")
+        assert off["fitCount"] == before["fitCount"]
+        assert off["shadowUpdateCount"] == before["shadowUpdateCount"]
+        assert restored["fitCount"] == before["fitCount"]
+        assert restored["shadowUpdateCount"] == before["shadowUpdateCount"]
+    finally:
+        context.close()
+
+
+@pytest.mark.parametrize("scale", [0.01, 1, 100])
+def test_shadow_fit_and_bias_scale_with_model_size(edge_browser, frontend_url, scale):
+    label = f"ShadowScale{scale}"
+    payload = _payload(label)
+    entry = payload["meshes"][f"Body-{label}-0"]
+    entry["pos"] = _f32(0, 0, 0, scale, 0, 0, 0, scale, scale * 0.25)
+    context, page = _page(edge_browser, frontend_url, {label: payload})
+    try:
+        _open(page, label)
+        page.locator(".draw-item").wait_for()
+        state = page.evaluate("""async () => {
+          const {getCharacterShadowDebugState, scene} = await import('./js/scene/scene.js');
+          const light = scene.children.find(object => object.isDirectionalLight);
+          const camera = light.shadow.camera;
+          return {
+            debug: getCharacterShadowDebugState(),
+            camera: [camera.left, camera.right, camera.bottom, camera.top,
+              camera.near, camera.far],
+          };
+        }""")
+        assert all(math.isfinite(value) for value in state["camera"])
+        left, right, bottom, top, near, far = state["camera"]
+        assert left < right and bottom < top and near < far
+        bounds = state["debug"]["modelBounds"]
+        diagonal = math.dist(bounds["min"], bounds["max"])
+        assert state["debug"]["normalBias"] == pytest.approx(
+            max(diagonal, 0.001) * 0.0015)
+    finally:
+        context.close()
+
+
+def test_shape_and_view_changes_refit_character_shadows(edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"ShadowShape": _payload("ShadowShape")})
+    try:
+        _open(page, "ShadowShape")
+        page.locator(".draw-item").wait_for()
+        initial = page.evaluate("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState().fitCount;
+        }""")
+        page.evaluate("""async () => {
+          const {setControlValue} = await import('./js/editing/control-state.js');
+          const {refreshMeshes} = await import('./js/mesh/mesh-state.js');
+          setControlValue('shape', '1');
+          refreshMeshes();
+        }""")
+        page.wait_for_function("""async count => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState().fitCount > count;
+        }""", arg=initial)
+        after_shape = page.evaluate("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState().fitCount;
+        }""")
+        for button_id in ("#camera-flip-btn", "#camera-flip-horizontal-btn", "#camera-reset-view-btn"):
+            page.locator(button_id).click()
+            page.wait_for_function("""async count => {
+              const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+              return getCharacterShadowDebugState().fitCount > count;
+            }""", arg=after_shape)
+            after_shape = page.evaluate("""async () => {
+              const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+              return getCharacterShadowDebugState().fitCount;
+            }""")
+    finally:
+        context.close()
+
+
+def test_camera_motion_reuses_shadow_map_but_light_motion_updates_it(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"ShadowMotion": _payload("ShadowMotion")})
+    try:
+        _open(page, "ShadowMotion")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState().groundVisible;
+        }""")
+        baseline = page.evaluate("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState();
+        }""")
+        render_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.evaluate("""async () => {
+          const {camera} = await import('./js/scene/scene.js');
+          const {requestRender} = await import('./js/scene/render-scheduler.js');
+          camera.position.x += 0.2;
+          requestRender();
+        }""")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=render_count)
+        after_camera = page.evaluate("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState();
+        }""")
+        assert after_camera["fitCount"] == baseline["fitCount"]
+        assert after_camera["shadowUpdateCount"] == baseline["shadowUpdateCount"]
+
+        page.evaluate("""async () => {
+          const THREE = await import('three');
+          const {scene} = await import('./js/scene/scene.js');
+          const {requestRender} = await import('./js/scene/render-scheduler.js');
+          scene.children.find(object => object.isDirectionalLight)
+            .position.add(new THREE.Vector3(0.25, 0, 0));
+          requestRender();
+        }""")
+        page.wait_for_function("""async state => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          const next = getCharacterShadowDebugState();
+          return next.fitCount > state.fitCount
+            && next.shadowUpdateCount > state.shadowUpdateCount;
+        }""", arg=after_camera)
+    finally:
+        context.close()
+
+
+def test_debug_output_bypasses_viewer_rim_lighting(edge_browser, frontend_url):
+    payload = _packed_material_payload("wuwa:rabbitfx")
+    context, page = _page(edge_browser, frontend_url, {"DebugRim": payload})
+    try:
+        _open(page, "DebugRim")
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0]?.material?.userData?.gameMaterial")
+        page.evaluate("""async () => {
+          const {requestRender} = await import('./js/scene/render-scheduler.js');
+          const game = window.modViewer.activeMeshes[0].material.userData.gameMaterial;
+          game.rimStrengthNode.value = 0;
+          window.modViewer.setMaterialDebugMode('normal-data-b');
+          requestRender();
+        }""")
+        page.wait_for_timeout(250)
+        without_rim = _sample_mesh_pixel(page)
+        page.evaluate("""async () => {
+          const {requestRender} = await import('./js/scene/render-scheduler.js');
+          window.modViewer.activeMeshes[0].material.userData.gameMaterial
+            .rimStrengthNode.value = 20;
+          requestRender();
+        }""")
+        page.wait_for_timeout(250)
+        with_rim = _sample_mesh_pixel(page)
+        assert with_rim == pytest.approx(without_rim, abs=2)
+    finally:
+        context.close()

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1522,6 +1522,37 @@ def test_conditional_only_texture_survives_component_run_reconciliation(
     finally:
         context.close()
 
+
+def test_cached_model_bounds_do_not_rescan_positions(edge_browser, frontend_url):
+    context = edge_browser.new_context(bypass_csp=True)
+    page = context.new_page()
+    try:
+        page.goto(frontend_url)
+        page.locator("#open-btn:not([disabled])").wait_for(timeout=10000)
+        state = page.evaluate("""async () => {
+          const THREE = await import('three');
+          const {expandByModelMesh} = await import('./js/scene/model-bounds.js');
+          const geometry = new THREE.BufferGeometry();
+          const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+          geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+          const mesh = new THREE.Mesh(geometry, new THREE.MeshBasicMaterial());
+          const initial = new THREE.Box3();
+          expandByModelMesh(initial, mesh);
+          positions[0] = Infinity;
+          const cached = new THREE.Box3();
+          expandByModelMesh(cached, mesh);
+          return {
+            initialEmpty: initial.isEmpty(),
+            cachedEmpty: cached.isEmpty(),
+            boundsShared: cached.equals(initial),
+          };
+        }""")
+        assert state == {
+            "initialEmpty": False, "cachedEmpty": False, "boundsShared": True,
+        }
+    finally:
+        context.close()
+
 def test_character_shadows_are_on_demand_and_visibility_keeps_stable_ground(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {"Shadow": _payload("Shadow")})

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -9,7 +9,8 @@ def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
         page.wait_for_function(
             "import('./js/scene/scene.js').then(({renderer}) => renderer.currentSamples === 4)")
         state = page.evaluate("""async () => {
-          const {renderer} = await import('./js/scene/scene.js');
+          const {renderer, scene} = await import('./js/scene/scene.js');
+          const keyLight = scene.children.find(object => object.isDirectionalLight);
           return {
             isWebGPURenderer: renderer.isWebGPURenderer === true,
             isWebGPUBackend: renderer.backend?.isWebGPUBackend === true,
@@ -19,6 +20,10 @@ def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
             outputColorSpace: renderer.outputColorSpace,
             toneMapping: renderer.toneMapping,
             clearAlpha: renderer.getClearAlpha(),
+            shadowsEnabled: renderer.shadowMap.enabled,
+            keyCastsShadow: keyLight?.castShadow,
+            shadowAutoUpdate: keyLight?.shadow?.autoUpdate,
+            shadowMapSize: [keyLight?.shadow?.mapSize?.x, keyLight?.shadow?.mapSize?.y],
           };
         }""")
         assert state["isWebGPURenderer"]
@@ -29,6 +34,10 @@ def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
         assert state["outputColorSpace"] == "srgb"
         assert state["toneMapping"] == 0
         assert state["clearAlpha"] == 1
+        assert state["shadowsEnabled"]
+        assert state["keyCastsShadow"]
+        assert state["shadowAutoUpdate"] is False
+        assert state["shadowMapSize"] == [2048, 2048]
     finally:
         context.close()
 
@@ -1510,5 +1519,95 @@ def test_conditional_only_texture_survives_component_run_reconciliation(
             "diffuse::ConditionalOnly-two.png"
         assert page.evaluate("window.modViewer.activeMeshes[0].userData.texKey") == \
             "diffuse::ConditionalOnly-two.png"
+    finally:
+        context.close()
+
+def test_character_shadows_are_on_demand_and_visibility_keeps_stable_ground(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Shadow": _payload("Shadow")})
+    try:
+        _open(page, "Shadow")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState().shadowUpdateCount > 0;
+        }""")
+        initial = page.evaluate("""async () => {
+          const {getCharacterShadowDebugState, renderer, scene} =
+            await import('./js/scene/scene.js');
+          const ground = [];
+          scene.traverse(object => { if (object.userData.isViewerGround) ground.push(object); });
+          return {
+            enabled: renderer.shadowMap.enabled,
+            ground: ground.map(object => ({
+              receive: object.receiveShadow, cast: object.castShadow,
+              shadowMaterial: object.material.isShadowMaterial,
+              y: object.position.y,
+            })),
+            debug: getCharacterShadowDebugState(),
+          };
+        }""")
+        assert initial["enabled"]
+        assert initial["ground"] == [{
+            "receive": True, "cast": False, "shadowMaterial": True,
+            "y": initial["ground"][0]["y"],
+        }]
+        assert initial["debug"]["modelBounds"] is not None
+        assert initial["debug"]["casterBounds"] is not None
+
+        updated = page.evaluate("""async () => {
+          const {applyMeshVisibility} = await import('./js/mesh/mesh-state.js');
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          mesh.userData.manualVisible = false;
+          applyMeshVisibility(mesh);
+          return getCharacterShadowDebugState();
+        }""")
+        page.wait_for_function(
+            "previous => window.modViewer.getRenderCount() > previous",
+            arg=page.evaluate("window.modViewer.getRenderCount()"))
+        after = page.evaluate("""async () => {
+          const {getCharacterShadowDebugState, scene} = await import('./js/scene/scene.js');
+          let ground = null;
+          scene.traverse(object => { if (object.userData.isViewerGround) ground = object; });
+          return {debug: getCharacterShadowDebugState(), groundY: ground.position.y};
+        }""")
+        assert after["debug"]["fitCount"] > updated["fitCount"]
+        assert after["debug"]["shadowUpdateCount"] > updated["shadowUpdateCount"]
+        assert after["groundY"] == pytest.approx(initial["ground"][0]["y"])
+    finally:
+        context.close()
+
+
+def test_wireframe_toggles_rim_uniform_without_rebuilding_material(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Rim": _payload("Rim")})
+    try:
+        _open(page, "Rim")
+        page.locator(".draw-item").wait_for()
+        initial = page.evaluate("""() => {
+          const material = window.modViewer.activeMeshes[0].material;
+          window.__rimMaterial = material;
+          const state = material.userData.gameMaterial;
+          return {
+            version: material.version,
+            enabled: state.rimEnabledNode.value,
+            strength: state.rimStrengthNode.value,
+            power: state.rimPowerNode.value,
+          };
+        }""")
+        assert initial["enabled"] is True
+        assert initial["strength"] > 0
+        assert initial["power"] > 0
+        page.locator("#wire-btn").click()
+        disabled = page.evaluate("""() => {
+          const material = window.modViewer.activeMeshes[0].material;
+          return {same: material === window.__rimMaterial, version: material.version,
+            enabled: material.userData.gameMaterial.rimEnabledNode.value};
+        }""")
+        assert disabled == {"same": True, "version": initial["version"], "enabled": False}
+        page.locator("#wire-btn").click()
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].material.userData.gameMaterial.rimEnabledNode.value")
     finally:
         context.close()

--- a/src/web/js/mesh/material-profile.js
+++ b/src/web/js/mesh/material-profile.js
@@ -17,6 +17,7 @@ import {
   Vector2,
 } from 'three/webgpu';
 import {
+  abs,
   clamp,
   color,
   diffuseColor,
@@ -324,6 +325,29 @@ function setStableMaterialNodes(material, state, fallbackColor) {
 
 }
 
+function applyDebugOverride(state, result) {
+  if (!state?.debugOutputNode || !state?.debugActiveNode) return result;
+  return state.debugActiveNode.lessThan(0.5).select(
+    result, vec4(state.debugOutputNode, result.a));
+}
+
+function applyViewerRim(state, result) {
+  if (!state?.rimEnabledNode || !state?.rimStrengthNode || !state?.rimPowerNode) {
+    return result;
+  }
+  const facing = abs(normalView.dot(positionViewDirection)).clamp(0, 1);
+  const edge = float(1).sub(facing);
+  const amount = edge.pow(state.rimPowerNode)
+    .mul(state.rimStrengthNode)
+    .mul(state.rimEnabledNode);
+  const tint = mix(diffuseColor.rgb, vec3(1), float(0.2));
+  return vec4(result.rgb.add(tint.mul(amount)), result.a);
+}
+
+function applyViewerOutput(state, result) {
+  return applyDebugOverride(state, applyViewerRim(state, result));
+}
+
 function physicalLightingFlags(material) {
   return [
     material.useClearcoat,
@@ -605,22 +629,14 @@ class GamePhysicalNodeMaterial extends MeshPhysicalNodeMaterial {
 
   setupOutput(builder, outputNode) {
     const result = super.setupOutput(builder, outputNode);
-    const state = this.userData.gameMaterial;
-    if (!state?.debugOutputNode || !state?.debugActiveNode) return result;
-    // Keep diagnostics out of the lighting, environment and fog result while
-    // leaving the normal graph and pipeline selected by the same uniform.
-    return state.debugActiveNode.lessThan(0.5).select(
-      result, vec4(state.debugOutputNode, result.a));
+    return applyViewerOutput(this.userData.gameMaterial, result);
   }
 }
 
 class GameStandardNodeMaterial extends MeshStandardNodeMaterial {
   setupOutput(builder, outputNode) {
     const result = super.setupOutput(builder, outputNode);
-    const state = this.userData.gameMaterial;
-    if (!state?.debugOutputNode || !state?.debugActiveNode) return result;
-    return state.debugActiveNode.lessThan(0.5).select(
-      result, vec4(state.debugOutputNode, result.a));
+    return applyViewerOutput(this.userData.gameMaterial, result);
   }
 }
 
@@ -715,6 +731,9 @@ export function configureGameMaterial(material, profile, options = {}) {
     toonSpecularMetalCutoffNode: hasNumericValue(profile?.toon_specular_metal_cutoff)
       ? uniform(Number(profile.toon_specular_metal_cutoff)) : null,
     debugModeNode: uniform(0),
+    rimEnabledNode: uniform(true),
+    rimStrengthNode: uniform(0.075),
+    rimPowerNode: uniform(4.0),
     hasMaterialId,
     hasSpecularArea,
     hasShadowMask,
@@ -847,4 +866,12 @@ export function getMaterialDebugMode(material) {
   const value = material?.userData?.gameMaterial?.debugModeNode?.value;
   return Object.entries(DEBUG_MODE_VALUES).find(([, id]) => id === value)?.[0]
     || 'off';
+}
+
+/** Toggle viewer rim lighting without rebuilding the material node graph. */
+export function setGameMaterialRimEnabled(material, enabled) {
+  const node = material?.userData?.gameMaterial?.rimEnabledNode;
+  if (!node) return false;
+  node.value = enabled === true;
+  return true;
 }

--- a/src/web/js/mesh/mesh-state.js
+++ b/src/web/js/mesh/mesh-state.js
@@ -1,6 +1,9 @@
 // Active meshes and the mod control state resolved onto their rendering data.
 
-import { scene, resetModelOrientation } from '../scene/scene.js';
+import {
+  invalidateCharacterShadowGeometry, invalidateCharacterShadowVisibility,
+  resetCharacterShadows, scene, resetModelOrientation,
+} from '../scene/scene.js';
 import { dnfSatisfied, getControlValue } from '../editing/control-state.js';
 import { disposeGameMaterial } from './material-profile.js';
 import { setMeshTextureState, updateGeometryNormals } from './mesh-factory.js';
@@ -24,6 +27,7 @@ export function resetMeshes({ preserveModelOrientation = false } = {}) {
   });
   activeMeshes.length = 0;
   resetModelOrientation({ preserveRotation: preserveModelOrientation });
+  resetCharacterShadows();
   requestRender();
 }
 
@@ -177,7 +181,9 @@ export function applyTextureVariant(mesh) {
 // The MESHES control is the direct visibility source. Automatic refreshes
 // re-baseline visibility and clear any transient manual eye-click marker.
 export function applyMeshVisibility(mesh, { notify = true } = {}) {
+  const previous = mesh.visible;
   mesh.visible = mesh.userData.manualVisible !== false;
+  if (previous !== mesh.visible) invalidateCharacterShadowVisibility();
   if (notify) notifyMeshStateChanged([mesh]);
   requestRender();
 }
@@ -220,6 +226,7 @@ function applyShapeTargets(mesh) {
   updateGeometryNormals(mesh, deformed);
   mesh.geometry.computeBoundingBox();
   mesh.geometry.computeBoundingSphere();
+  invalidateCharacterShadowGeometry();
 }
 
 export function refreshMeshes() {

--- a/src/web/js/scene/camera-frame.js
+++ b/src/web/js/scene/camera-frame.js
@@ -1,25 +1,10 @@
 // Camera/model framing, clipping, orientation and unobstructed viewport math.
 
 import * as THREE from 'three';
+import { computeModelBounds } from './model-bounds.js';
 
 const INITIAL_CAMERA_DIRECTION = new THREE.Vector3(0, 0, 1);
 const INITIAL_CAMERA_UP = new THREE.Vector3(0, 1, 0);
-
-function expandByBaseMesh(box, mesh) {
-  if (!mesh?.geometry) return;
-  const positions = mesh.geometry.attributes?.position?.array;
-  if (!positions || positions.length < 3) return;
-  for (let index = 0; index < positions.length; index++) {
-    if (!Number.isFinite(positions[index])) return;
-  }
-  mesh.updateWorldMatrix(true, false);
-  if (!mesh.geometry.boundingBox) mesh.geometry.computeBoundingBox();
-  if (!mesh.geometry.boundingBox) return;
-  const worldBox = mesh.geometry.boundingBox.clone().applyMatrix4(mesh.matrixWorld);
-  const values = [worldBox.min.x, worldBox.min.y, worldBox.min.z,
-    worldBox.max.x, worldBox.max.y, worldBox.max.z];
-  if (values.every(Number.isFinite)) box.union(worldBox);
-}
 
 export function createCameraFrame({
   camera, renderer, controls, grid, cancelViewSnap, onModelFit,
@@ -97,8 +82,7 @@ export function createCameraFrame({
   }
 
   function frameView(meshes = [], direction = null, targetYOffset = 0) {
-    const box = new THREE.Box3();
-    meshes.forEach(mesh => expandByBaseMesh(box, mesh));
+    const box = computeModelBounds(meshes);
     if (box.isEmpty()) return;
     const size = box.getSize(new THREE.Vector3());
     const center = box.getCenter(new THREE.Vector3());
@@ -128,8 +112,7 @@ export function createCameraFrame({
     // turn makes asymmetric models drift.
     let center = modelPivot && modelPivot.clone();
     if (!center) {
-      const box = new THREE.Box3();
-      meshes.forEach(mesh => expandByBaseMesh(box, mesh));
+      const box = computeModelBounds(meshes);
       if (box.isEmpty()) return;
       center = box.getCenter(new THREE.Vector3());
     }
@@ -201,8 +184,7 @@ export function createCameraFrame({
       mesh.position.copy(position);
     });
     modelRotation.identity();
-    const box = new THREE.Box3();
-    homeView.meshes.forEach(({ mesh }) => expandByBaseMesh(box, mesh));
+    const box = computeModelBounds(homeView.meshes.map(({ mesh }) => mesh));
     if (box.isEmpty()) return;
     const size = box.getSize(new THREE.Vector3());
     camera.up.copy(INITIAL_CAMERA_UP);
@@ -227,8 +209,7 @@ export function createCameraFrame({
     } : null;
     let homeMeshTransforms = null;
     if (!orientationInitialized && meshes.length) {
-      const rawBox = new THREE.Box3();
-      meshes.forEach(mesh => expandByBaseMesh(rawBox, mesh));
+      const rawBox = computeModelBounds(meshes);
       const rawSize = rawBox.getSize(new THREE.Vector3());
       uprightRotation.identity();
       if (rawSize.z > rawSize.y * 1.5 && rawSize.z > rawSize.x * 1.15) {
@@ -236,8 +217,7 @@ export function createCameraFrame({
           new THREE.Vector3(1, 0, 0), -Math.PI / 2);
       }
       meshes.forEach(mesh => mesh.quaternion.copy(uprightRotation));
-      const uprightBox = new THREE.Box3();
-      meshes.forEach(mesh => expandByBaseMesh(uprightBox, mesh));
+      const uprightBox = computeModelBounds(meshes);
       baseFacingRotation.identity();
       if (!uprightBox.isEmpty()) {
         modelPivot = uprightBox.getCenter(new THREE.Vector3());
@@ -257,8 +237,7 @@ export function createCameraFrame({
       rotateMeshesAroundCenter(meshes, modelRotation);
       orientationInitialized = true;
     }
-    const box = new THREE.Box3();
-    meshes.forEach(mesh => expandByBaseMesh(box, mesh));
+    const box = computeModelBounds(meshes);
     if (box.isEmpty()) return;
 
     const boxSize = box.getSize(new THREE.Vector3());

--- a/src/web/js/scene/character-shadow-controller.js
+++ b/src/web/js/scene/character-shadow-controller.js
@@ -54,6 +54,7 @@ export function createCharacterShadowController({ renderer, scene, light }) {
   let casterBounds = new THREE.Box3();
   let lastLightPosition = null;
   let lastLightTarget = null;
+  let groundAvailable = false;
   let fitCount = 0;
   let shadowUpdateCount = 0;
 
@@ -110,6 +111,7 @@ export function createCharacterShadowController({ renderer, scene, light }) {
     }
     casterBounds = computeModelBounds(meshes, { visibleOnly: true });
     if (!finiteBox(modelBounds) || !finiteBox(casterBounds)) {
+      groundAvailable = false;
       ground.visible = false;
       shadowFitDirty = false;
       fitCount += 1;
@@ -147,6 +149,7 @@ export function createCharacterShadowController({ renderer, scene, light }) {
     const lightSpace = footprint.map(point => point.clone().applyMatrix4(shadowCamera.matrixWorldInverse));
     const lightBox = new THREE.Box3().setFromPoints(lightSpace);
     if (!finiteBox(lightBox)) {
+      groundAvailable = false;
       ground.visible = false;
       shadowFitDirty = false;
       return false;
@@ -164,6 +167,7 @@ export function createCharacterShadowController({ renderer, scene, light }) {
     shadowCamera.updateProjectionMatrix();
     light.shadow.bias = -0.00002;
     light.shadow.normalBias = modelSize * NORMAL_BIAS_SCALE;
+    groundAvailable = true;
     ground.visible = light.intensity > 0;
     shadowFitDirty = false;
     fitCount += 1;
@@ -184,6 +188,7 @@ export function createCharacterShadowController({ renderer, scene, light }) {
       return;
     }
     if (shadowFitDirty) fitShadow();
+    else ground.visible = groundAvailable;
     if (shadowMapDirty) {
       light.shadow.needsUpdate = true;
       renderer.shadowMap.needsUpdate = true;
@@ -201,6 +206,7 @@ export function createCharacterShadowController({ renderer, scene, light }) {
     shadowMapDirty = false;
     lastLightPosition = null;
     lastLightTarget = null;
+    groundAvailable = false;
     ground.visible = false;
   }
 

--- a/src/web/js/scene/character-shadow-controller.js
+++ b/src/web/js/scene/character-shadow-controller.js
@@ -1,0 +1,226 @@
+// Model-scaled, on-demand directional shadows and their transparent receiver.
+
+import * as THREE from 'three/webgpu';
+import { computeModelBounds } from './model-bounds.js';
+
+const FIT_MARGIN = 0.12;
+const MAX_GROUND_REACH = 2.5;
+const NORMAL_BIAS_SCALE = 0.0015;
+const MIN_SIZE = 0.001;
+
+function finiteBox(box) {
+  return !box.isEmpty() && [
+    box.min.x, box.min.y, box.min.z, box.max.x, box.max.y, box.max.z,
+  ].every(Number.isFinite);
+}
+
+function boxCorners(box) {
+  const corners = [];
+  for (const x of [box.min.x, box.max.x]) {
+    for (const y of [box.min.y, box.max.y]) {
+      for (const z of [box.min.z, box.max.z]) corners.push(new THREE.Vector3(x, y, z));
+    }
+  }
+  return corners;
+}
+
+function sameVector(left, right) {
+  return !!left && left.distanceToSquared(right) < 0.0000000001;
+}
+
+export function createCharacterShadowController({ renderer, scene, light }) {
+  const ground = new THREE.Mesh(
+    new THREE.PlaneGeometry(1, 1),
+    new THREE.ShadowMaterial({ color: 0x000000, opacity: 0.32, transparent: true, depthWrite: false }),
+  );
+  ground.rotation.x = -Math.PI / 2;
+  ground.receiveShadow = true;
+  ground.castShadow = false;
+  ground.visible = false;
+  ground.userData.isViewerGround = true;
+  scene.add(ground);
+
+  renderer.shadowMap.enabled = true;
+  if (THREE.PCFShadowMap !== undefined) renderer.shadowMap.type = THREE.PCFShadowMap;
+  light.castShadow = true;
+  light.shadow.autoUpdate = false;
+  light.shadow.mapSize.set(2048, 2048);
+
+  let meshes = [];
+  let modelBoundsDirty = true;
+  let shadowFitDirty = true;
+  let shadowMapDirty = true;
+  let modelBounds = new THREE.Box3();
+  let casterBounds = new THREE.Box3();
+  let lastLightPosition = null;
+  let lastLightTarget = null;
+  let fitCount = 0;
+  let shadowUpdateCount = 0;
+
+  function invalidateGeometry() {
+    modelBoundsDirty = true;
+    shadowFitDirty = true;
+    shadowMapDirty = true;
+  }
+
+  function invalidateVisibility() {
+    shadowFitDirty = true;
+    shadowMapDirty = true;
+  }
+
+  function setMeshes(nextMeshes = []) {
+    meshes = [...new Set(nextMeshes.filter(Boolean))];
+    invalidateGeometry();
+  }
+
+  function adoptMeshes(nextMeshes = []) {
+    const known = new Set(meshes);
+    const added = nextMeshes.filter(mesh => mesh && !known.has(mesh));
+    if (added.length) {
+      meshes.push(...added);
+      invalidateGeometry();
+    }
+    return added;
+  }
+
+  function forgetMeshes(nextMeshes = []) {
+    const removed = new Set(nextMeshes);
+    const before = meshes.length;
+    meshes = meshes.filter(mesh => !removed.has(mesh));
+    if (meshes.length !== before) invalidateGeometry();
+  }
+
+  function projectGroundFootprint(corners, floorY, size, direction) {
+    const result = [...corners];
+    const vertical = direction.y;
+    if (Math.abs(vertical) < 0.00001) return result;
+    const maximumReach = Math.max(size * MAX_GROUND_REACH, MIN_SIZE);
+    for (const corner of corners) {
+      const distance = (floorY - corner.y) / vertical;
+      if (!Number.isFinite(distance) || distance < 0) continue;
+      result.push(corner.clone().addScaledVector(direction, Math.min(distance, maximumReach)));
+    }
+    return result;
+  }
+
+  function fitShadow() {
+    if (modelBoundsDirty) {
+      modelBounds = computeModelBounds(meshes);
+      modelBoundsDirty = false;
+    }
+    casterBounds = computeModelBounds(meshes, { visibleOnly: true });
+    if (!finiteBox(modelBounds) || !finiteBox(casterBounds)) {
+      ground.visible = false;
+      shadowFitDirty = false;
+      fitCount += 1;
+      return false;
+    }
+
+    const modelSize = Math.max(modelBounds.getSize(new THREE.Vector3()).length(), MIN_SIZE);
+    const lightDirection = light.target.position.clone().sub(light.position);
+    if (lightDirection.lengthSq() < 0.00000001) lightDirection.set(0, -1, 0);
+    lightDirection.normalize();
+    const casterCorners = boxCorners(casterBounds);
+    const footprint = projectGroundFootprint(
+      casterCorners, modelBounds.min.y, modelSize, lightDirection);
+    const footprintBox = new THREE.Box3().setFromPoints(footprint);
+    const footprintSize = footprintBox.getSize(new THREE.Vector3());
+    const groundMargin = Math.max(modelSize * FIT_MARGIN, MIN_SIZE);
+    ground.position.set(
+      footprintBox.getCenter(new THREE.Vector3()).x,
+      modelBounds.min.y - Math.max(modelSize * 0.0001, 0.000001),
+      footprintBox.getCenter(new THREE.Vector3()).z,
+    );
+    ground.scale.set(
+      Math.max(footprintSize.x + groundMargin * 2, MIN_SIZE),
+      Math.max(footprintSize.z + groundMargin * 2, MIN_SIZE), 1,
+    );
+
+    const shadowCamera = light.shadow.camera;
+    light.updateWorldMatrix(true, false);
+    light.target.updateWorldMatrix(true, false);
+    shadowCamera.position.copy(light.position);
+    shadowCamera.up.set(0, 1, 0);
+    if (Math.abs(lightDirection.dot(shadowCamera.up)) > 0.98) shadowCamera.up.set(0, 0, 1);
+    shadowCamera.lookAt(light.target.position);
+    shadowCamera.updateMatrixWorld(true);
+    const lightSpace = footprint.map(point => point.clone().applyMatrix4(shadowCamera.matrixWorldInverse));
+    const lightBox = new THREE.Box3().setFromPoints(lightSpace);
+    if (!finiteBox(lightBox)) {
+      ground.visible = false;
+      shadowFitDirty = false;
+      return false;
+    }
+    const size = lightBox.getSize(new THREE.Vector3());
+    const marginX = Math.max(size.x * FIT_MARGIN, MIN_SIZE);
+    const marginY = Math.max(size.y * FIT_MARGIN, MIN_SIZE);
+    const marginDepth = Math.max(size.z * FIT_MARGIN, MIN_SIZE);
+    shadowCamera.left = lightBox.min.x - marginX;
+    shadowCamera.right = lightBox.max.x + marginX;
+    shadowCamera.bottom = lightBox.min.y - marginY;
+    shadowCamera.top = lightBox.max.y + marginY;
+    shadowCamera.near = Math.max(MIN_SIZE, -lightBox.max.z - marginDepth);
+    shadowCamera.far = Math.max(shadowCamera.near + MIN_SIZE, -lightBox.min.z + marginDepth);
+    shadowCamera.updateProjectionMatrix();
+    light.shadow.bias = -0.00002;
+    light.shadow.normalBias = modelSize * NORMAL_BIAS_SCALE;
+    ground.visible = light.intensity > 0;
+    shadowFitDirty = false;
+    fitCount += 1;
+    return true;
+  }
+
+  function update() {
+    const changedLight = !sameVector(lastLightPosition, light.position)
+      || !sameVector(lastLightTarget, light.target.position);
+    if (changedLight) {
+      lastLightPosition = light.position.clone();
+      lastLightTarget = light.target.position.clone();
+      shadowFitDirty = true;
+      shadowMapDirty = true;
+    }
+    if (light.intensity <= 0) {
+      ground.visible = false;
+      return;
+    }
+    if (shadowFitDirty) fitShadow();
+    if (shadowMapDirty) {
+      light.shadow.needsUpdate = true;
+      renderer.shadowMap.needsUpdate = true;
+      shadowMapDirty = false;
+      shadowUpdateCount += 1;
+    }
+  }
+
+  function reset() {
+    meshes = [];
+    modelBounds = new THREE.Box3();
+    casterBounds = new THREE.Box3();
+    modelBoundsDirty = false;
+    shadowFitDirty = false;
+    shadowMapDirty = false;
+    lastLightPosition = null;
+    lastLightTarget = null;
+    ground.visible = false;
+  }
+
+  function getDebugState() {
+    const serialize = box => finiteBox(box) ? {
+      min: box.min.toArray(), max: box.max.toArray(),
+    } : null;
+    return {
+      modelBounds: serialize(modelBounds),
+      casterBounds: serialize(casterBounds),
+      fitCount,
+      shadowUpdateCount,
+      groundVisible: ground.visible,
+      normalBias: light.shadow.normalBias,
+    };
+  }
+
+  return {
+    setMeshes, adoptMeshes, forgetMeshes,
+    invalidateGeometry, invalidateVisibility,
+    update, reset, getDebugState,
+  };
+}

--- a/src/web/js/scene/key-light-controller.js
+++ b/src/web/js/scene/key-light-controller.js
@@ -60,7 +60,9 @@ export function createKeyLightController({
     if (!handleHit) return false;
     const visibleMeshes = [];
     scene.traverseVisible(object => {
-      if (object.isMesh && !object.userData.isViewerOutline) {
+      if (object.isMesh
+          && !object.userData.isViewerOutline
+          && !object.userData.isViewerGround) {
         visibleMeshes.push(object);
       }
     });

--- a/src/web/js/scene/model-bounds.js
+++ b/src/web/js/scene/model-bounds.js
@@ -1,0 +1,33 @@
+// Shared, defensive world-space bounds for viewer model meshes.
+
+import * as THREE from 'three';
+
+/** Expand `box` by a mesh only when its position data and world bounds are usable. */
+export function expandByModelMesh(box, mesh) {
+  if (!mesh?.geometry) return box;
+  const positions = mesh.geometry.attributes?.position?.array;
+  if (!positions || positions.length < 3) return box;
+  for (let index = 0; index < positions.length; index += 1) {
+    if (!Number.isFinite(positions[index])) return box;
+  }
+  mesh.updateWorldMatrix(true, false);
+  if (!mesh.geometry.boundingBox) mesh.geometry.computeBoundingBox();
+  if (!mesh.geometry.boundingBox) return box;
+  const worldBox = mesh.geometry.boundingBox.clone().applyMatrix4(mesh.matrixWorld);
+  const values = [
+    worldBox.min.x, worldBox.min.y, worldBox.min.z,
+    worldBox.max.x, worldBox.max.y, worldBox.max.z,
+  ];
+  if (values.every(Number.isFinite)) box.union(worldBox);
+  return box;
+}
+
+/** Return the world bounds of model meshes, optionally excluding hidden meshes. */
+export function computeModelBounds(meshes, { visibleOnly = false } = {}) {
+  const box = new THREE.Box3();
+  for (const mesh of meshes || []) {
+    if (visibleOnly && mesh?.visible !== true) continue;
+    expandByModelMesh(box, mesh);
+  }
+  return box;
+}

--- a/src/web/js/scene/model-bounds.js
+++ b/src/web/js/scene/model-bounds.js
@@ -5,15 +5,21 @@ import * as THREE from 'three';
 /** Expand `box` by a mesh only when its position data and world bounds are usable. */
 export function expandByModelMesh(box, mesh) {
   if (!mesh?.geometry) return box;
-  const positions = mesh.geometry.attributes?.position?.array;
-  if (!positions || positions.length < 3) return box;
-  for (let index = 0; index < positions.length; index += 1) {
-    if (!Number.isFinite(positions[index])) return box;
+  const geometry = mesh.geometry;
+  // Bounds are validated when first created. Shadow fitting can run on every
+  // key-light drag frame, so a cached bounding box must not rescan all vertices.
+  // Geometry mutation paths recompute this box before requesting a refit.
+  if (!geometry.boundingBox) {
+    const positions = geometry.attributes?.position?.array;
+    if (!positions || positions.length < 3) return box;
+    for (let index = 0; index < positions.length; index += 1) {
+      if (!Number.isFinite(positions[index])) return box;
+    }
+    geometry.computeBoundingBox();
   }
   mesh.updateWorldMatrix(true, false);
-  if (!mesh.geometry.boundingBox) mesh.geometry.computeBoundingBox();
-  if (!mesh.geometry.boundingBox) return box;
-  const worldBox = mesh.geometry.boundingBox.clone().applyMatrix4(mesh.matrixWorld);
+  if (!geometry.boundingBox) return box;
+  const worldBox = geometry.boundingBox.clone().applyMatrix4(mesh.matrixWorld);
   const values = [
     worldBox.min.x, worldBox.min.y, worldBox.min.z,
     worldBox.max.x, worldBox.max.y, worldBox.max.z,

--- a/src/web/js/scene/render-modes.js
+++ b/src/web/js/scene/render-modes.js
@@ -1,6 +1,7 @@
 // Viewer-only material display modes and their toolbar state.
 
 import { refreshMeshTexture, setTextureMode } from '../mesh/mesh-factory.js';
+import { setGameMaterialRimEnabled } from '../mesh/material-profile.js';
 import { setOutlineSuppressedByWireframe } from './outline-renderer.js';
 import { requestRender } from './render-scheduler.js';
 
@@ -23,6 +24,8 @@ export function initializeMeshRenderModes(mesh) {
   mesh.material.wireframe = wireframe;
   mesh.material.flatShading = !smoothShading;
   setMeshRoughness(mesh, glossy ? GLOSSY_ROUGHNESS : DEFAULT_ROUGHNESS);
+  const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+  materials.forEach(material => setGameMaterialRimEnabled(material, !wireframe));
 }
 
 export function toggleWireframeMode(meshes) {
@@ -34,7 +37,10 @@ export function toggleWireframeMode(meshes) {
   button.setAttribute('aria-label', `Wireframe rendering: ${wireframe ? 'on' : 'off'}`);
   meshes.forEach(mesh => {
     const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-    materials.forEach(material => { material.wireframe = wireframe; });
+    materials.forEach(material => {
+      material.wireframe = wireframe;
+      setGameMaterialRimEnabled(material, !wireframe);
+    });
   });
   requestRender();
 }

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -3,6 +3,7 @@
 import * as THREE from 'three/webgpu';
 import { ArcballControls } from 'three/addons/controls/ArcballControls.js';
 import { createCameraFrame } from './camera-frame.js';
+import { createCharacterShadowController } from './character-shadow-controller.js';
 import { createEnvironmentController } from './environment.js';
 import { createKeyLightController } from './key-light-controller.js';
 import { updateOutlineCameraScale } from './outline-renderer.js';
@@ -148,6 +149,9 @@ const environmentController = createEnvironmentController({
 const keyLightController = createKeyLightController({
   scene, camera, renderer, controls, light: keyLight, onChange: requestRender,
 });
+const characterShadowController = createCharacterShadowController({
+  renderer, scene, light: keyLight,
+});
 const viewGizmoController = createViewGizmoController({
   camera, controls, element: document.getElementById('view-gizmo'),
   onChange: requestRender,
@@ -172,6 +176,7 @@ function renderFrame() {
   if (rendererStopped || renderer.backend?.isWebGPUBackend !== true) return;
   const snapActive = viewGizmoController.updateSnap();
   keyLightController.update();
+  characterShadowController.update();
   cameraFrame.updateViewport();
   cameraFrame.updateClipping();
   updateOutlineCameraScale(camera, controls.target,
@@ -230,22 +235,26 @@ export function frameView(meshes = [], direction = null, targetYOffset = 0) {
 
 export function resetView() {
   cameraFrame.resetView();
+  characterShadowController.invalidateGeometry();
   requestRender();
 }
 
 export function adoptModelMeshes(meshes = []) {
   const adopted = cameraFrame.adoptModelMeshes(meshes);
+  characterShadowController.adoptMeshes(meshes);
   requestRender();
   return adopted;
 }
 
 export function fitTo(meshes, options) {
   cameraFrame.fitTo(meshes, options);
+  characterShadowController.setMeshes(meshes);
   requestRender();
 }
 
 export function forgetModelMeshes(meshes = []) {
   cameraFrame.forgetModelMeshes(meshes);
+  characterShadowController.forgetMeshes(meshes);
   requestRender();
 }
 
@@ -253,13 +262,33 @@ export function resetModelOrientation(options) {
   cameraFrame.resetModelOrientation(options);
 }
 
+export function resetCharacterShadows() {
+  characterShadowController.reset();
+}
+
+export function invalidateCharacterShadowGeometry() {
+  characterShadowController.invalidateGeometry();
+  requestRender();
+}
+
+export function invalidateCharacterShadowVisibility() {
+  characterShadowController.invalidateVisibility();
+  requestRender();
+}
+
+export function getCharacterShadowDebugState() {
+  return characterShadowController.getDebugState();
+}
+
 export function rotateModelQuarterTurn(meshes = []) {
   cameraFrame.rotateModelQuarterTurn(meshes);
+  characterShadowController.invalidateGeometry();
   requestRender();
 }
 
 export function rotateModelHorizontalQuarterTurn(meshes = []) {
   cameraFrame.rotateModelHorizontalQuarterTurn(meshes);
+  characterShadowController.invalidateGeometry();
   requestRender();
 }
 


### PR DESCRIPTION
## Summary
- add automatic directional character shadows and a transparent ground receiver
- fit shadow coverage to model and caster bounds across model lifecycle changes
- add stable material rim lighting that wireframe suppresses without rebuilding materials

## Tests
- add browser coverage for shadow, rim, and Asset-fill lifecycles