### PR TITLE
feat: add WebGPU viewport pipeline and GTAO

### DIFF
--- a/src/app/settings/paths.py
+++ b/src/app/settings/paths.py
@@ -61,5 +61,6 @@ def has_vendored_three():
         "three.webgpu.js",
         "three.tsl.js",
         os.path.join("addons", "controls", "ArcballControls.js"),
+        os.path.join("addons", "tsl", "display", "GTAONode.js"),
     )
     return all(os.path.isfile(os.path.join(vendor_dir(), rel)) for rel in required)

--- a/src/build.py
+++ b/src/build.py
@@ -89,6 +89,10 @@ ASSET_FILES = {
         "url": f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/examples/jsm/controls/ArcballControls.js",
         "sha256": "f80db7fe66685fc7f5438e3be44fed6684aed33a7b92b2442fe6958291156fb3",
     },
+    "addons/tsl/display/GTAONode.js": {
+        "url": f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/examples/jsm/tsl/display/GTAONode.js",
+        "sha256": "516e86dc398b8e2d93f693a168144fdd7420f261a72aaa7da6eb7f110cc8e3ef",
+    },
 }
 
 

--- a/src/tests/web/test_app_flow.py
+++ b/src/tests/web/test_app_flow.py
@@ -8,13 +8,13 @@ def test_frontend_public_surface_and_lifecycle_events(edge_browser, frontend_url
     try:
         assert page.evaluate("Object.keys(window.modViewer).sort()") == sorted([
             "activeMeshes", "displayMeshPayload", "exportChanges",
-            "getAmbientOcclusionRadiusFactor", "getCurrentSource",
+            "getAmbientOcclusionStrength", "getCurrentSource",
             "getEnvironmentPreset", "getMaterialState",
             "getOutlineState", "getRenderCount", "openMod",
             "refreshControlSemantics", "refreshMeshSemantics",
             "refreshPresentState", "reloadCurrentMod", "setEnvironmentPreset",
             "setMaterialDebugMode", "setOutlineEnabled", "switchAsset",
-            "setAmbientOcclusionRadiusFactor", "switchMod",
+            "setAmbientOcclusionStrength", "switchMod",
         ])
         page.evaluate("""() => {
           window.__lifecycleEvents = [];

--- a/src/tests/web/test_app_flow.py
+++ b/src/tests/web/test_app_flow.py
@@ -8,13 +8,13 @@ def test_frontend_public_surface_and_lifecycle_events(edge_browser, frontend_url
     try:
         assert page.evaluate("Object.keys(window.modViewer).sort()") == sorted([
             "activeMeshes", "displayMeshPayload", "exportChanges",
-            "getAmbientOcclusionEnabled", "getCurrentSource",
+            "getAmbientOcclusionRadiusFactor", "getCurrentSource",
             "getEnvironmentPreset", "getMaterialState",
             "getOutlineState", "getRenderCount", "openMod",
             "refreshControlSemantics", "refreshMeshSemantics",
             "refreshPresentState", "reloadCurrentMod", "setEnvironmentPreset",
             "setMaterialDebugMode", "setOutlineEnabled", "switchAsset",
-            "switchMod", "toggleAmbientOcclusion",
+            "setAmbientOcclusionRadiusFactor", "switchMod",
         ])
         page.evaluate("""() => {
           window.__lifecycleEvents = [];

--- a/src/tests/web/test_app_flow.py
+++ b/src/tests/web/test_app_flow.py
@@ -8,12 +8,13 @@ def test_frontend_public_surface_and_lifecycle_events(edge_browser, frontend_url
     try:
         assert page.evaluate("Object.keys(window.modViewer).sort()") == sorted([
             "activeMeshes", "displayMeshPayload", "exportChanges",
-            "getCurrentSource", "getEnvironmentPreset", "getMaterialState",
+            "getAmbientOcclusionEnabled", "getCurrentSource",
+            "getEnvironmentPreset", "getMaterialState",
             "getOutlineState", "getRenderCount", "openMod",
             "refreshControlSemantics", "refreshMeshSemantics",
             "refreshPresentState", "reloadCurrentMod", "setEnvironmentPreset",
             "setMaterialDebugMode", "setOutlineEnabled", "switchAsset",
-            "switchMod",
+            "switchMod", "toggleAmbientOcclusion",
         ])
         page.evaluate("""() => {
           window.__lifecycleEvents = [];

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1,16 +1,34 @@
 from .support import *
 from PIL import ImageChops
 
-def _enable_ao(page):
-    before = page.evaluate("window.modViewer.getRenderCount()")
-    page.locator("#ao-btn").click()
-    page.wait_for_function("""async count => {
+def _set_ao_level(page, level):
+    before = page.evaluate("""async () => {
       const {getViewportRenderPipelineDebugState} =
         await import('./js/scene/scene.js');
       const state = getViewportRenderPipelineDebugState();
-      return state.enabled && state.aoRenderCount > 0
-        && window.modViewer.getRenderCount() > count;
-    }""", arg=before)
+      return {level: Math.round(state.radiusFactor * 1000),
+              renderCount: window.modViewer.getRenderCount()};
+    }""")
+    if page.locator("#ao-popover").is_hidden():
+        page.locator("#ao-btn").click()
+    page.evaluate("""value => {
+      const slider = document.querySelector('#ao-slider');
+      slider.value = String(value);
+      slider.dispatchEvent(new Event('input', {bubbles: true}));
+    }""", level)
+    page.wait_for_function("""state => {
+      const slider = document.querySelector('#ao-slider');
+      const expectedFactor = state.level / 1000;
+      const current = window.modViewer.getAmbientOcclusionRadiusFactor();
+      return Number(slider.value) === state.level
+        && Math.abs(current - expectedFactor) < 1e-9
+        && (state.level === state.previousLevel
+          || window.modViewer.getRenderCount() > state.renderCount);
+    }""", arg={
+        "level": level,
+        "previousLevel": before["level"],
+        "renderCount": before["renderCount"],
+    })
 
 def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
     context = edge_browser.new_context(bypass_csp=True)
@@ -62,7 +80,7 @@ def test_viewport_pipeline_uses_character_layers_and_stable_ao_settings(
         _open(page, "Pipeline")
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
-        _enable_ao(page)
+        _set_ao_level(page, 100)
         state = page.evaluate("""async () => {
           const THREE = await import('three');
           const {getViewportRenderPipelineDebugState, scene} =
@@ -128,6 +146,8 @@ def test_camera_zoom_is_cursor_centered(edge_browser, frontend_url):
             cursorZoom: controls.cursorZoom,
             target: controls.target.toArray(),
             cameraPosition: camera.position.toArray(),
+            cameraUp: camera.up.toArray(),
+            cameraQuaternion: camera.quaternion.toArray(),
           };
         }""")
         assert state["cursorZoom"] is True
@@ -160,6 +180,107 @@ def test_camera_zoom_is_cursor_centered(edge_browser, frontend_url):
         )
         assert math.sqrt(sum(value * value for value in movement)) > 0
         assert math.sqrt(sum(value * value for value in cross)) > 1e-5
+
+        page.mouse.move(
+            canvas["x"] + canvas["width"] * 0.25,
+            canvas["y"] + canvas["height"] * 0.35)
+        for _ in range(8):
+            page.mouse.wheel(0, 100)
+            page.wait_for_timeout(25)
+        page.wait_for_timeout(200)
+        zoomed_far = page.evaluate("""async () => {
+          const {camera, controls} = await import('./js/scene/scene.js');
+          return {
+            target: controls.target.toArray(),
+            cameraPosition: camera.position.toArray(),
+          };
+        }""")
+        initial_distance = math.sqrt(sum(
+            (state["cameraPosition"][i] - state["target"][i]) ** 2
+            for i in range(3)))
+        far_distance = math.sqrt(sum(
+            (zoomed_far["cameraPosition"][i] - zoomed_far["target"][i]) ** 2
+            for i in range(3)))
+        assert far_distance > initial_distance
+
+        before_reset = page.evaluate("window.modViewer.getRenderCount()")
+        page.locator("#camera-reset-view-btn").click()
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=before_reset)
+        reset = page.evaluate("""async () => {
+          const {camera, controls} = await import('./js/scene/scene.js');
+          return {
+            target: controls.target.toArray(),
+            cameraPosition: camera.position.toArray(),
+            cameraUp: camera.up.toArray(),
+            cameraQuaternion: camera.quaternion.toArray(),
+          };
+        }""")
+        assert reset["target"] == pytest.approx(state["target"])
+        assert reset["cameraPosition"] == pytest.approx(state["cameraPosition"])
+        assert reset["cameraUp"] == pytest.approx(state["cameraUp"])
+        assert reset["cameraQuaternion"] == pytest.approx(state["cameraQuaternion"])
+
+        center = page.evaluate("""async () => {
+          const {camera, controls} = await import('./js/scene/scene.js');
+          const rect = document.querySelector('canvas').getBoundingClientRect();
+          const projected = controls.target.clone().project(camera);
+          return {
+            x: rect.left + (projected.x + 1) * rect.width * 0.5,
+            y: rect.top + (1 - projected.y) * rect.height * 0.5,
+          };
+        }""")
+        page.mouse.move(center["x"], center["y"])
+        before_center_zoom = page.evaluate("window.modViewer.getRenderCount()")
+        page.mouse.wheel(0, 100)
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count",
+            arg=before_center_zoom)
+        centered = page.evaluate("""async () => {
+          const {camera, controls} = await import('./js/scene/scene.js');
+          return {
+            target: controls.target.toArray(),
+            cameraPosition: camera.position.toArray(),
+          };
+        }""")
+        assert centered["target"] == pytest.approx(reset["target"])
+        center_movement = [centered["cameraPosition"][i]
+                           - reset["cameraPosition"][i] for i in range(3)]
+        reset_direction = [reset["cameraPosition"][i] - reset["target"][i]
+                           for i in range(3)]
+        center_cross = (
+            center_movement[1] * reset_direction[2]
+              - center_movement[2] * reset_direction[1],
+            center_movement[2] * reset_direction[0]
+              - center_movement[0] * reset_direction[2],
+            center_movement[0] * reset_direction[1]
+              - center_movement[1] * reset_direction[0],
+        )
+        center_movement_length = math.sqrt(sum(
+            value * value for value in center_movement))
+        center_cross_length = math.sqrt(sum(
+            value * value for value in center_cross))
+        assert center_movement_length > 0
+        assert center_cross_length / center_movement_length < 1e-3
+
+        before_second_reset = page.evaluate("window.modViewer.getRenderCount()")
+        page.locator("#camera-reset-view-btn").click()
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count",
+            arg=before_second_reset)
+        second_reset = page.evaluate("""async () => {
+          const {camera, controls} = await import('./js/scene/scene.js');
+          return {
+            target: controls.target.toArray(),
+            cameraPosition: camera.position.toArray(),
+            cameraUp: camera.up.toArray(),
+            cameraQuaternion: camera.quaternion.toArray(),
+          };
+        }""")
+        assert second_reset["target"] == pytest.approx(reset["target"])
+        assert second_reset["cameraPosition"] == pytest.approx(reset["cameraPosition"])
+        assert second_reset["cameraUp"] == pytest.approx(reset["cameraUp"])
+        assert second_reset["cameraQuaternion"] == pytest.approx(reset["cameraQuaternion"])
     finally:
         context.close()
 
@@ -170,14 +291,14 @@ def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
         _open(page, "Pipeline")
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
-        _enable_ao(page)
+        _set_ao_level(page, 100)
         initial = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
           return getViewportRenderPipelineDebugState();
         }""")
         assert initial["modelSize"] > 0
-        assert initial["radius"] == pytest.approx(initial["modelSize"] * 0.15)
+        assert initial["radius"] == pytest.approx(initial["modelSize"] * 0.10)
         assert initial["effectiveStrength"] == pytest.approx(initial["strength"])
         assert initial["directRenderCount"] > 0
         assert initial["aoRenderCount"] > 0
@@ -186,12 +307,17 @@ def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
 
         before_wireframe = initial["renderCount"]
         page.locator("#wire-btn").click()
-        page.wait_for_function("""async count => {
+        page.wait_for_function("""async stateBefore => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
           const state = getViewportRenderPipelineDebugState();
-          return state.effectiveStrength === 0 && state.renderCount > count;
-        }""", arg=before_wireframe)
+          return state.effectiveStrength === 0
+            && state.renderCount > stateBefore.renderCount
+            && state.directRenderCount > stateBefore.directRenderCount;
+        }""", arg={
+            "renderCount": before_wireframe,
+            "directRenderCount": initial["directRenderCount"],
+        })
         suppressed = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
@@ -225,7 +351,7 @@ def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
     finally:
         context.close()
 
-def test_viewport_ambient_occlusion_toolbar_toggles_direct_path(
+def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {"AO": _payload("AO")})
     try:
@@ -238,93 +364,52 @@ def test_viewport_ambient_occlusion_toolbar_toggles_direct_path(
           return getViewportRenderPipelineDebugState();
         }""")
         assert not startup["enabled"]
+        assert startup["radiusFactor"] == 0
         assert startup["directRenderCount"] > 0
         assert startup["aoRenderCount"] == 0
-        _enable_ao(page)
+        pipeline_id = startup["pipelineId"]
+
+        for level, factor in ((1, 0.001), (50, 0.05), (99, 0.099), (100, 0.1)):
+            _set_ao_level(page, level)
+            state = page.evaluate("""async () => {
+              const {getViewportRenderPipelineDebugState} =
+                await import('./js/scene/scene.js');
+              return getViewportRenderPipelineDebugState();
+            }""")
+            assert state["enabled"]
+            assert state["radiusFactor"] == pytest.approx(factor)
+            assert state["effectiveStrength"] == pytest.approx(state["strength"])
+            assert state["radius"] == pytest.approx(
+                max(state["modelSize"] * factor, 0.001))
+            assert state["aoRenderCount"] > 0
+            assert state["pipelineId"] == pipeline_id
+
         initial = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
-          const button = document.querySelector('#ao-btn');
-          return {
-            pipeline: getViewportRenderPipelineDebugState(),
-            button: {
-              pressed: button.getAttribute('aria-pressed'),
-              active: button.classList.contains('active'),
-            },
-          };
+          return getViewportRenderPipelineDebugState();
         }""")
-        assert initial["button"] == {"pressed": "true", "active": True}
-        assert initial["pipeline"]["enabled"]
-        assert initial["pipeline"]["directRenderCount"] > 0
-        assert initial["pipeline"]["aoRenderCount"] > 0
-
-        page.locator("#ao-btn").click()
-        page.wait_for_function("""async () => {
+        assert initial["radiusFactor"] == pytest.approx(0.1)
+        direct_before = initial["directRenderCount"]
+        ao_before = initial["aoRenderCount"]
+        _set_ao_level(page, 0)
+        page.wait_for_function("""async count => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
           const state = getViewportRenderPipelineDebugState();
-          return document.querySelector('#ao-btn').getAttribute('aria-pressed')
-            === 'false' && state.directRenderCount > 0;
-        }""")
+          return state.radiusFactor === 0 && state.effectiveStrength === 0
+            && state.directRenderCount > count;
+        }""", arg=direct_before)
         disabled = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
-          const button = document.querySelector('#ao-btn');
-          return {
-            pipeline: getViewportRenderPipelineDebugState(),
-            button: {
-              pressed: button.getAttribute('aria-pressed'),
-              active: button.classList.contains('active'),
-              label: button.getAttribute('aria-label'),
-            },
-          };
-        }""")
-        assert not disabled["pipeline"]["enabled"]
-        assert disabled["pipeline"]["effectiveStrength"] == 0
-        assert disabled["pipeline"]["aoRenderCount"] == initial["pipeline"]["aoRenderCount"]
-        assert disabled["pipeline"]["pipelineId"] == initial["pipeline"]["pipelineId"]
-        assert disabled["button"] == {
-            "pressed": "false", "active": False, "label": "Ambient occlusion: off",
-        }
-
-        page.locator("#ao-btn").click()
-        page.wait_for_function("""async count => {
-          const {getViewportRenderPipelineDebugState} =
-            await import('./js/scene/scene.js');
-          const state = getViewportRenderPipelineDebugState();
-          return document.querySelector('#ao-btn').getAttribute('aria-pressed')
-            === 'true' && state.aoRenderCount > count;
-        }""", arg=disabled["pipeline"]["aoRenderCount"])
-        resumed = page.evaluate("""async () => {
-          const {getViewportRenderPipelineDebugState} =
-            await import('./js/scene/scene.js');
           return getViewportRenderPipelineDebugState();
         }""")
-        assert resumed["enabled"]
-        assert resumed["effectiveStrength"] == pytest.approx(resumed["strength"])
-        assert resumed["aoRenderCount"] > disabled["pipeline"]["aoRenderCount"]
-        assert resumed["pipelineId"] == initial["pipeline"]["pipelineId"]
-
-        page.evaluate("""async () => {
-          const {setAmbientOcclusionStrength} =
-            await import('./js/scene/scene.js');
-          setAmbientOcclusionStrength(0);
-        }""")
-        page.wait_for_function("""async count => {
-          const {getViewportRenderPipelineDebugState} =
-            await import('./js/scene/scene.js');
-          const state = getViewportRenderPipelineDebugState();
-          return state.effectiveStrength === 0 && state.directRenderCount > count;
-        }""", arg=resumed["directRenderCount"])
-        zero_strength = page.evaluate("""async () => {
-          const {getViewportRenderPipelineDebugState} =
-            await import('./js/scene/scene.js');
-          return getViewportRenderPipelineDebugState();
-        }""")
-        assert zero_strength["enabled"]
-        assert zero_strength["strength"] == 0
-        assert zero_strength["aoRenderCount"] == resumed["aoRenderCount"]
-        assert zero_strength["pipelineId"] == initial["pipeline"]["pipelineId"]
+        assert not disabled["enabled"]
+        assert disabled["radiusFactor"] == 0
+        assert disabled["effectiveStrength"] == 0
+        assert disabled["aoRenderCount"] == ao_before
+        assert disabled["pipelineId"] == pipeline_id
     finally:
         context.close()
 
@@ -339,7 +424,7 @@ def test_viewport_gtao_radius_scales_with_model_bounds(edge_browser, frontend_ur
         _open(page, label)
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
-        _enable_ao(page)
+        _set_ao_level(page, 100)
         state = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
@@ -348,7 +433,7 @@ def test_viewport_gtao_radius_scales_with_model_bounds(edge_browser, frontend_ur
         assert math.isfinite(state["modelSize"])
         assert math.isfinite(state["radius"])
         assert state["modelSize"] > 0
-        assert state["radius"] == pytest.approx(state["modelSize"] * 0.15)
+        assert state["radius"] == pytest.approx(state["modelSize"] * 0.10)
     finally:
         context.close()
 
@@ -359,7 +444,7 @@ def test_viewport_pipeline_resizes_pass_targets_without_rebuilding(
         _open(page, "Resize")
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
-        _enable_ao(page)
+        _set_ao_level(page, 100)
         initial = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
@@ -404,52 +489,20 @@ def test_viewport_gtao_is_visible_and_does_not_add_continuous_frames(
         _open(page, "AO")
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
-        _enable_ao(page)
+        _set_ao_level(page, 100)
+        page.locator("#ao-btn").click()
         page.wait_for_timeout(250)
         default_ao = Image.open(io.BytesIO(page.screenshot())).convert("RGB")
-        default_render_count = page.evaluate("window.modViewer.getRenderCount()")
 
-        page.evaluate("""async () => {
-          const {setAmbientOcclusionEnabled} =
-            await import('./js/scene/scene.js');
-          setAmbientOcclusionEnabled(false);
-        }""")
-        page.wait_for_function(
-            "count => window.modViewer.getRenderCount() > count",
-            arg=default_render_count)
+        _set_ao_level(page, 0)
+        page.locator("#ao-btn").click()
         without_default_ao = Image.open(
             io.BytesIO(page.screenshot())).convert("RGB")
         assert ImageChops.difference(default_ao, without_default_ao).getbbox()
 
-        before_enable = page.evaluate("window.modViewer.getRenderCount()")
-        page.evaluate("""async () => {
-          const {setAmbientOcclusionEnabled} =
-            await import('./js/scene/scene.js');
-          setAmbientOcclusionEnabled(true);
-        }""")
-        page.wait_for_function(
-            "count => window.modViewer.getRenderCount() > count",
-            arg=before_enable)
-        page.evaluate("""async () => {
-          const {setAmbientOcclusionStrength} =
-            await import('./js/scene/scene.js');
-          setAmbientOcclusionStrength(1);
-        }""")
-        page.wait_for_timeout(250)
-        with_ao = Image.open(io.BytesIO(page.screenshot())).convert("RGB")
-        render_count = page.evaluate("window.modViewer.getRenderCount()")
+        without_render_count = page.evaluate("window.modViewer.getRenderCount()")
         page.wait_for_timeout(200)
-        assert page.evaluate("window.modViewer.getRenderCount()") == render_count
-
-        page.evaluate("""async () => {
-          const {setAmbientOcclusionEnabled} =
-            await import('./js/scene/scene.js');
-          setAmbientOcclusionEnabled(false);
-        }""")
-        page.wait_for_function(
-            "count => window.modViewer.getRenderCount() > count", arg=render_count)
-        without_ao = Image.open(io.BytesIO(page.screenshot())).convert("RGB")
-        assert ImageChops.difference(with_ao, without_ao).getbbox()
+        assert page.evaluate("window.modViewer.getRenderCount()") == without_render_count
     finally:
         context.close()
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -87,6 +87,7 @@ def test_viewport_pipeline_uses_character_layers_and_stable_ao_settings(
         assert state["pipeline"]["characterAOLayer"] == 1
         assert state["pipeline"]["samples"] == 8
         assert state["pipeline"]["prePassSamples"] == 1
+        assert state["pipeline"]["prePassResolutionScale"] == pytest.approx(0.5)
         assert state["pipeline"]["beautyCameraIsSource"]
         assert state["pipeline"]["prePassCameraIsClone"]
         assert state["pipeline"]["cameraCoordinateSystem"] == (

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -106,7 +106,7 @@ def test_viewport_pipeline_uses_character_layers_and_stable_ao_settings(
             state["pipeline"]["rendererCoordinateSystem"])
         assert state["pipeline"]["resolutionScale"] == pytest.approx(0.5)
         assert state["pipeline"]["temporalFiltering"] is False
-        assert state["pipeline"]["strength"] == pytest.approx(0.22)
+        assert state["pipeline"]["strength"] == pytest.approx(0.55)
         assert not state["pipeline"]["pipelineNeedsUpdate"]
         assert state["pipeline"]["renderCount"] == state["viewerRenderCount"]
         assert state["meshHasCharacterLayer"]
@@ -405,6 +405,31 @@ def test_viewport_gtao_is_visible_and_does_not_add_continuous_frames(
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
         _enable_ao(page)
+        page.wait_for_timeout(250)
+        default_ao = Image.open(io.BytesIO(page.screenshot())).convert("RGB")
+        default_render_count = page.evaluate("window.modViewer.getRenderCount()")
+
+        page.evaluate("""async () => {
+          const {setAmbientOcclusionEnabled} =
+            await import('./js/scene/scene.js');
+          setAmbientOcclusionEnabled(false);
+        }""")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count",
+            arg=default_render_count)
+        without_default_ao = Image.open(
+            io.BytesIO(page.screenshot())).convert("RGB")
+        assert ImageChops.difference(default_ao, without_default_ao).getbbox()
+
+        before_enable = page.evaluate("window.modViewer.getRenderCount()")
+        page.evaluate("""async () => {
+          const {setAmbientOcclusionEnabled} =
+            await import('./js/scene/scene.js');
+          setAmbientOcclusionEnabled(true);
+        }""")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count",
+            arg=before_enable)
         page.evaluate("""async () => {
           const {setAmbientOcclusionStrength} =
             await import('./js/scene/scene.js');

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -6,7 +6,7 @@ def _set_ao_level(page, level):
       const {getViewportRenderPipelineDebugState} =
         await import('./js/scene/scene.js');
       const state = getViewportRenderPipelineDebugState();
-      return {level: Math.round(state.radiusFactor * 1000),
+      return {level: Math.round(state.strength * 100),
               renderCount: window.modViewer.getRenderCount()};
     }""")
     if page.locator("#ao-popover").is_hidden():
@@ -18,10 +18,10 @@ def _set_ao_level(page, level):
     }""", level)
     page.wait_for_function("""state => {
       const slider = document.querySelector('#ao-slider');
-      const expectedFactor = state.level / 1000;
-      const current = window.modViewer.getAmbientOcclusionRadiusFactor();
+      const expectedStrength = state.level / 100;
+      const current = window.modViewer.getAmbientOcclusionStrength();
       return Number(slider.value) === state.level
-        && Math.abs(current - expectedFactor) < 1e-9
+        && Math.abs(current - expectedStrength) < 1e-9
         && (state.level === state.previousLevel
           || window.modViewer.getRenderCount() > state.renderCount);
     }""", arg={
@@ -81,6 +81,12 @@ def test_viewport_pipeline_uses_character_layers_and_stable_ao_settings(
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
         _set_ao_level(page, 100)
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return state.strength === 1 && !state.pipelineNeedsUpdate;
+        }""")
         state = page.evaluate("""async () => {
           const THREE = await import('three');
           const {getViewportRenderPipelineDebugState, scene} =
@@ -124,7 +130,7 @@ def test_viewport_pipeline_uses_character_layers_and_stable_ao_settings(
             state["pipeline"]["rendererCoordinateSystem"])
         assert state["pipeline"]["resolutionScale"] == pytest.approx(0.5)
         assert state["pipeline"]["temporalFiltering"] is False
-        assert state["pipeline"]["strength"] == pytest.approx(0.55)
+        assert state["pipeline"]["strength"] == pytest.approx(1)
         assert not state["pipeline"]["pipelineNeedsUpdate"]
         assert state["pipeline"]["renderCount"] == state["viewerRenderCount"]
         assert state["meshHasCharacterLayer"]
@@ -298,7 +304,7 @@ def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
           return getViewportRenderPipelineDebugState();
         }""")
         assert initial["modelSize"] > 0
-        assert initial["radius"] == pytest.approx(initial["modelSize"] * 0.10)
+        assert initial["radius"] == pytest.approx(initial["modelSize"] * 0.005)
         assert initial["effectiveStrength"] == pytest.approx(initial["strength"])
         assert initial["directRenderCount"] > 0
         assert initial["aoRenderCount"] > 0
@@ -307,22 +313,24 @@ def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
 
         before_wireframe = initial["renderCount"]
         page.locator("#wire-btn").click()
-        page.wait_for_function("""async stateBefore => {
+        suppressed = page.evaluate("""async stateBefore => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
-          const state = getViewportRenderPipelineDebugState();
-          return state.effectiveStrength === 0
-            && state.renderCount > stateBefore.renderCount
-            && state.directRenderCount > stateBefore.directRenderCount;
+          const deadline = performance.now() + 5000;
+          while (performance.now() < deadline) {
+            const state = getViewportRenderPipelineDebugState();
+            if (state.effectiveStrength === 0
+                && state.renderCount > stateBefore.renderCount
+                && state.directRenderCount > stateBefore.directRenderCount) {
+              return state;
+            }
+            await new Promise(resolve => setTimeout(resolve, 16));
+          }
+          throw new Error('wireframe did not produce a direct render');
         }""", arg={
             "renderCount": before_wireframe,
             "directRenderCount": initial["directRenderCount"],
         })
-        suppressed = page.evaluate("""async () => {
-          const {getViewportRenderPipelineDebugState} =
-            await import('./js/scene/scene.js');
-          return getViewportRenderPipelineDebugState();
-        }""")
         assert suppressed["enabled"]
         assert suppressed["strength"] == pytest.approx(initial["strength"])
         assert suppressed["effectiveStrength"] == 0
@@ -364,12 +372,12 @@ def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
           return getViewportRenderPipelineDebugState();
         }""")
         assert not startup["enabled"]
-        assert startup["radiusFactor"] == 0
+        assert startup["radiusFactor"] == pytest.approx(0.005)
         assert startup["directRenderCount"] > 0
         assert startup["aoRenderCount"] == 0
         pipeline_id = startup["pipelineId"]
 
-        for level, factor in ((1, 0.001), (50, 0.05), (99, 0.099), (100, 0.1)):
+        for level, strength in ((1, 0.01), (50, 0.5), (99, 0.99), (100, 1)):
             _set_ao_level(page, level)
             state = page.evaluate("""async () => {
               const {getViewportRenderPipelineDebugState} =
@@ -377,10 +385,11 @@ def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
               return getViewportRenderPipelineDebugState();
             }""")
             assert state["enabled"]
-            assert state["radiusFactor"] == pytest.approx(factor)
-            assert state["effectiveStrength"] == pytest.approx(state["strength"])
+            assert state["radiusFactor"] == pytest.approx(0.005)
+            assert state["strength"] == pytest.approx(strength)
+            assert state["effectiveStrength"] == pytest.approx(strength)
             assert state["radius"] == pytest.approx(
-                max(state["modelSize"] * factor, 0.001))
+                max(state["modelSize"] * 0.005, 0.001))
             assert state["aoRenderCount"] > 0
             assert state["pipelineId"] == pipeline_id
 
@@ -389,7 +398,7 @@ def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
             await import('./js/scene/scene.js');
           return getViewportRenderPipelineDebugState();
         }""")
-        assert initial["radiusFactor"] == pytest.approx(0.1)
+        assert initial["radiusFactor"] == pytest.approx(0.005)
         direct_before = initial["directRenderCount"]
         ao_before = initial["aoRenderCount"]
         _set_ao_level(page, 0)
@@ -397,7 +406,7 @@ def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
           const state = getViewportRenderPipelineDebugState();
-          return state.radiusFactor === 0 && state.effectiveStrength === 0
+          return state.radiusFactor === 0.005 && state.effectiveStrength === 0
             && state.directRenderCount > count;
         }""", arg=direct_before)
         disabled = page.evaluate("""async () => {
@@ -406,7 +415,7 @@ def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
           return getViewportRenderPipelineDebugState();
         }""")
         assert not disabled["enabled"]
-        assert disabled["radiusFactor"] == 0
+        assert disabled["radiusFactor"] == pytest.approx(0.005)
         assert disabled["effectiveStrength"] == 0
         assert disabled["aoRenderCount"] == ao_before
         assert disabled["pipelineId"] == pipeline_id
@@ -433,7 +442,8 @@ def test_viewport_gtao_radius_scales_with_model_bounds(edge_browser, frontend_ur
         assert math.isfinite(state["modelSize"])
         assert math.isfinite(state["radius"])
         assert state["modelSize"] > 0
-        assert state["radius"] == pytest.approx(state["modelSize"] * 0.10)
+        assert state["radius"] == pytest.approx(
+            max(state["modelSize"] * 0.005, 0.001))
     finally:
         context.close()
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -85,7 +85,12 @@ def test_viewport_pipeline_uses_character_layers_and_stable_ao_settings(
         assert state["pipeline"]["hasGTAO"]
         assert state["pipeline"]["prePassLayerMask"] == 1 << 1
         assert state["pipeline"]["characterAOLayer"] == 1
-        assert state["pipeline"]["samples"] == 16
+        assert state["pipeline"]["samples"] == 8
+        assert state["pipeline"]["prePassSamples"] == 1
+        assert state["pipeline"]["beautyCameraIsSource"]
+        assert state["pipeline"]["prePassCameraIsClone"]
+        assert state["pipeline"]["cameraCoordinateSystem"] == (
+            state["pipeline"]["rendererCoordinateSystem"])
         assert state["pipeline"]["resolutionScale"] == pytest.approx(0.5)
         assert state["pipeline"]["temporalFiltering"] is False
         assert state["pipeline"]["strength"] == pytest.approx(0.22)
@@ -94,6 +99,54 @@ def test_viewport_pipeline_uses_character_layers_and_stable_ao_settings(
         assert state["meshHasCharacterLayer"]
         assert all(not helper["hasCharacterLayer"] for helper in state["helpers"])
         assert not errors, "\n".join(str(error) for error in errors)
+    finally:
+        context.close()
+
+def test_camera_zoom_is_cursor_centered(edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"CursorZoom": _payload("CursorZoom")})
+    try:
+        _open(page, "CursorZoom")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        state = page.evaluate("""async () => {
+          const {camera, controls} = await import('./js/scene/scene.js');
+          return {
+            cursorZoom: controls.cursorZoom,
+            target: controls.target.toArray(),
+            cameraPosition: camera.position.toArray(),
+          };
+        }""")
+        assert state["cursorZoom"] is True
+
+        canvas = page.locator("canvas").bounding_box()
+        render_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.mouse.move(
+            canvas["x"] + canvas["width"] * 0.25,
+            canvas["y"] + canvas["height"] * 0.35)
+        page.mouse.wheel(0, 100)
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count",
+            arg=render_count)
+        zoomed = page.evaluate("""async () => {
+          const {camera, controls} = await import('./js/scene/scene.js');
+          return {
+            target: controls.target.toArray(),
+            cameraPosition: camera.position.toArray(),
+          };
+        }""")
+        assert zoomed["target"] == pytest.approx(state["target"])
+        movement = [zoomed["cameraPosition"][i] - state["cameraPosition"][i]
+                    for i in range(3)]
+        direction = [state["cameraPosition"][i] - state["target"][i]
+                     for i in range(3)]
+        cross = (
+            movement[1] * direction[2] - movement[2] * direction[1],
+            movement[2] * direction[0] - movement[0] * direction[2],
+            movement[0] * direction[1] - movement[1] * direction[0],
+        )
+        assert math.sqrt(sum(value * value for value in movement)) > 0
+        assert math.sqrt(sum(value * value for value in cross)) > 1e-5
     finally:
         context.close()
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -305,6 +305,7 @@ def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
         }""")
         assert initial["modelSize"] > 0
         assert initial["radius"] == pytest.approx(initial["modelSize"] * 0.005)
+        assert initial["thickness"] == pytest.approx(initial["radius"] * 4)
         assert initial["effectiveStrength"] == pytest.approx(initial["strength"])
         assert initial["directRenderCount"] > 0
         assert initial["aoRenderCount"] > 0
@@ -373,6 +374,8 @@ def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
         }""")
         assert not startup["enabled"]
         assert startup["radiusFactor"] == pytest.approx(0.005)
+        assert startup["radius"] == pytest.approx(0.001 * 0.005)
+        assert startup["thickness"] == pytest.approx(startup["radius"] * 4)
         assert startup["directRenderCount"] > 0
         assert startup["aoRenderCount"] == 0
         pipeline_id = startup["pipelineId"]
@@ -388,8 +391,8 @@ def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
             assert state["radiusFactor"] == pytest.approx(0.005)
             assert state["strength"] == pytest.approx(strength)
             assert state["effectiveStrength"] == pytest.approx(strength)
-            assert state["radius"] == pytest.approx(
-                max(state["modelSize"] * 0.005, 0.001))
+            assert state["radius"] == pytest.approx(state["modelSize"] * 0.005)
+            assert state["thickness"] == pytest.approx(state["radius"] * 4)
             assert state["aoRenderCount"] > 0
             assert state["pipelineId"] == pipeline_id
 
@@ -416,6 +419,8 @@ def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
         }""")
         assert not disabled["enabled"]
         assert disabled["radiusFactor"] == pytest.approx(0.005)
+        assert disabled["radius"] == pytest.approx(0.001 * 0.005)
+        assert disabled["thickness"] == pytest.approx(disabled["radius"] * 4)
         assert disabled["effectiveStrength"] == 0
         assert disabled["aoRenderCount"] == ao_before
         assert disabled["pipelineId"] == pipeline_id
@@ -442,8 +447,8 @@ def test_viewport_gtao_radius_scales_with_model_bounds(edge_browser, frontend_ur
         assert math.isfinite(state["modelSize"])
         assert math.isfinite(state["radius"])
         assert state["modelSize"] > 0
-        assert state["radius"] == pytest.approx(
-            max(state["modelSize"] * 0.005, 0.001))
+        assert state["radius"] / state["modelSize"] == pytest.approx(0.005)
+        assert state["thickness"] == pytest.approx(state["radius"] * 4)
     finally:
         context.close()
 
@@ -2227,19 +2232,32 @@ def test_shape_and_view_changes_refit_character_shadows(edge_browser, frontend_u
         context.close()
 
 
-def test_camera_motion_reuses_shadow_map_but_light_motion_updates_it(
+def test_camera_motion_with_ao_reuses_shadow_map_but_light_motion_updates_it(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {"ShadowMotion": _payload("ShadowMotion")})
     try:
         _open(page, "ShadowMotion")
         page.locator(".draw-item").wait_for()
+        _set_ao_level(page, 100)
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return state.effectiveStrength === 1 && state.aoRenderCount > 0;
+        }""")
         page.wait_for_function("""async () => {
           const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
           return getCharacterShadowDebugState().groundVisible;
         }""")
         baseline = page.evaluate("""async () => {
-          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
-          return getCharacterShadowDebugState();
+          const {
+            getCharacterShadowDebugState,
+            getViewportRenderPipelineDebugState,
+          } = await import('./js/scene/scene.js');
+          return {
+            shadow: getCharacterShadowDebugState(),
+            ao: getViewportRenderPipelineDebugState(),
+          };
         }""")
         render_count = page.evaluate("window.modViewer.getRenderCount()")
         page.evaluate("""async () => {
@@ -2251,11 +2269,18 @@ def test_camera_motion_reuses_shadow_map_but_light_motion_updates_it(
         page.wait_for_function(
             "count => window.modViewer.getRenderCount() > count", arg=render_count)
         after_camera = page.evaluate("""async () => {
-          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
-          return getCharacterShadowDebugState();
+          const {
+            getCharacterShadowDebugState,
+            getViewportRenderPipelineDebugState,
+          } = await import('./js/scene/scene.js');
+          return {
+            shadow: getCharacterShadowDebugState(),
+            ao: getViewportRenderPipelineDebugState(),
+          };
         }""")
-        assert after_camera["fitCount"] == baseline["fitCount"]
-        assert after_camera["shadowUpdateCount"] == baseline["shadowUpdateCount"]
+        assert after_camera["shadow"]["fitCount"] == baseline["shadow"]["fitCount"]
+        assert after_camera["shadow"]["shadowUpdateCount"] == baseline["shadow"]["shadowUpdateCount"]
+        assert after_camera["ao"]["aoRenderCount"] > baseline["ao"]["aoRenderCount"]
 
         page.evaluate("""async () => {
           const THREE = await import('three');
@@ -2270,7 +2295,7 @@ def test_camera_motion_reuses_shadow_map_but_light_motion_updates_it(
           const next = getCharacterShadowDebugState();
           return next.fitCount > state.fitCount
             && next.shadowUpdateCount > state.shadowUpdateCount;
-        }""", arg=after_camera)
+        }""", arg=after_camera["shadow"])
     finally:
         context.close()
 
@@ -2287,6 +2312,31 @@ def test_debug_output_bypasses_viewer_rim_lighting(edge_browser, frontend_url):
           const game = window.modViewer.activeMeshes[0].material.userData.gameMaterial;
           game.rimStrengthNode.value = 0;
           window.modViewer.setMaterialDebugMode('normal-data-b');
+          window.modViewer.setAmbientOcclusionStrength(0);
+          requestRender();
+        }""")
+        page.wait_for_timeout(250)
+        without_ao = _sample_mesh_pixel(page)
+        before_ao = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        page.evaluate("window.modViewer.setAmbientOcclusionStrength(1)")
+        page.wait_for_function("""async state => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const next = getViewportRenderPipelineDebugState();
+          return next.effectiveStrength === 1
+            && next.aoRenderCount > state.aoRenderCount;
+        }""", arg=before_ao)
+        page.wait_for_timeout(250)
+        with_ao = _sample_mesh_pixel(page)
+        assert with_ao == pytest.approx(without_ao, abs=2)
+
+        page.evaluate("""async () => {
+          const {requestRender} = await import('./js/scene/render-scheduler.js');
+          window.modViewer.setAmbientOcclusionStrength(0);
           requestRender();
         }""")
         page.wait_for_timeout(250)

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1,6 +1,17 @@
 from .support import *
 from PIL import ImageChops
 
+def _enable_ao(page):
+    before = page.evaluate("window.modViewer.getRenderCount()")
+    page.locator("#ao-btn").click()
+    page.wait_for_function("""async count => {
+      const {getViewportRenderPipelineDebugState} =
+        await import('./js/scene/scene.js');
+      const state = getViewportRenderPipelineDebugState();
+      return state.enabled && state.aoRenderCount > 0
+        && window.modViewer.getRenderCount() > count;
+    }""", arg=before)
+
 def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
     context = edge_browser.new_context(bypass_csp=True)
     page = context.new_page()
@@ -51,6 +62,7 @@ def test_viewport_pipeline_uses_character_layers_and_stable_ao_settings(
         _open(page, "Pipeline")
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        _enable_ao(page)
         state = page.evaluate("""async () => {
           const THREE = await import('three');
           const {getViewportRenderPipelineDebugState, scene} =
@@ -158,6 +170,7 @@ def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
         _open(page, "Pipeline")
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        _enable_ao(page)
         initial = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
@@ -166,13 +179,19 @@ def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
         assert initial["modelSize"] > 0
         assert initial["radius"] == pytest.approx(initial["modelSize"] * 0.15)
         assert initial["effectiveStrength"] == pytest.approx(initial["strength"])
+        assert initial["directRenderCount"] > 0
+        assert initial["aoRenderCount"] > 0
+        assert (initial["directRenderCount"] + initial["aoRenderCount"]
+                == initial["renderCount"])
 
+        before_wireframe = initial["renderCount"]
         page.locator("#wire-btn").click()
-        page.wait_for_function("""async () => {
+        page.wait_for_function("""async count => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
-          return getViewportRenderPipelineDebugState().effectiveStrength === 0;
-        }""")
+          const state = getViewportRenderPipelineDebugState();
+          return state.effectiveStrength === 0 && state.renderCount > count;
+        }""", arg=before_wireframe)
         suppressed = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
@@ -181,14 +200,18 @@ def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
         assert suppressed["enabled"]
         assert suppressed["strength"] == pytest.approx(initial["strength"])
         assert suppressed["effectiveStrength"] == 0
+        assert suppressed["directRenderCount"] > initial["directRenderCount"]
+        assert suppressed["aoRenderCount"] == initial["aoRenderCount"]
         assert not suppressed["pipelineNeedsUpdate"]
 
+        before_restore = suppressed["renderCount"]
         page.locator("#wire-btn").click()
-        page.wait_for_function("""async () => {
+        page.wait_for_function("""async count => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
-          return getViewportRenderPipelineDebugState().effectiveStrength > 0;
-        }""")
+          const state = getViewportRenderPipelineDebugState();
+          return state.effectiveStrength > 0 && state.renderCount > count;
+        }""", arg=before_restore)
         restored = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
@@ -197,6 +220,111 @@ def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
         assert restored["effectiveStrength"] == pytest.approx(initial["strength"])
         assert restored["modelSize"] == pytest.approx(initial["modelSize"])
         assert restored["radius"] == pytest.approx(initial["radius"])
+        assert restored["aoRenderCount"] > suppressed["aoRenderCount"]
+        assert restored["pipelineId"] == initial["pipelineId"]
+    finally:
+        context.close()
+
+def test_viewport_ambient_occlusion_toolbar_toggles_direct_path(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"AO": _payload("AO")})
+    try:
+        _open(page, "AO")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        startup = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert not startup["enabled"]
+        assert startup["directRenderCount"] > 0
+        assert startup["aoRenderCount"] == 0
+        _enable_ao(page)
+        initial = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const button = document.querySelector('#ao-btn');
+          return {
+            pipeline: getViewportRenderPipelineDebugState(),
+            button: {
+              pressed: button.getAttribute('aria-pressed'),
+              active: button.classList.contains('active'),
+            },
+          };
+        }""")
+        assert initial["button"] == {"pressed": "true", "active": True}
+        assert initial["pipeline"]["enabled"]
+        assert initial["pipeline"]["directRenderCount"] > 0
+        assert initial["pipeline"]["aoRenderCount"] > 0
+
+        page.locator("#ao-btn").click()
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return document.querySelector('#ao-btn').getAttribute('aria-pressed')
+            === 'false' && state.directRenderCount > 0;
+        }""")
+        disabled = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const button = document.querySelector('#ao-btn');
+          return {
+            pipeline: getViewportRenderPipelineDebugState(),
+            button: {
+              pressed: button.getAttribute('aria-pressed'),
+              active: button.classList.contains('active'),
+              label: button.getAttribute('aria-label'),
+            },
+          };
+        }""")
+        assert not disabled["pipeline"]["enabled"]
+        assert disabled["pipeline"]["effectiveStrength"] == 0
+        assert disabled["pipeline"]["aoRenderCount"] == initial["pipeline"]["aoRenderCount"]
+        assert disabled["pipeline"]["pipelineId"] == initial["pipeline"]["pipelineId"]
+        assert disabled["button"] == {
+            "pressed": "false", "active": False, "label": "Ambient occlusion: off",
+        }
+
+        page.locator("#ao-btn").click()
+        page.wait_for_function("""async count => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return document.querySelector('#ao-btn').getAttribute('aria-pressed')
+            === 'true' && state.aoRenderCount > count;
+        }""", arg=disabled["pipeline"]["aoRenderCount"])
+        resumed = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert resumed["enabled"]
+        assert resumed["effectiveStrength"] == pytest.approx(resumed["strength"])
+        assert resumed["aoRenderCount"] > disabled["pipeline"]["aoRenderCount"]
+        assert resumed["pipelineId"] == initial["pipeline"]["pipelineId"]
+
+        page.evaluate("""async () => {
+          const {setAmbientOcclusionStrength} =
+            await import('./js/scene/scene.js');
+          setAmbientOcclusionStrength(0);
+        }""")
+        page.wait_for_function("""async count => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return state.effectiveStrength === 0 && state.directRenderCount > count;
+        }""", arg=resumed["directRenderCount"])
+        zero_strength = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert zero_strength["enabled"]
+        assert zero_strength["strength"] == 0
+        assert zero_strength["aoRenderCount"] == resumed["aoRenderCount"]
+        assert zero_strength["pipelineId"] == initial["pipeline"]["pipelineId"]
     finally:
         context.close()
 
@@ -211,6 +339,7 @@ def test_viewport_gtao_radius_scales_with_model_bounds(edge_browser, frontend_ur
         _open(page, label)
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        _enable_ao(page)
         state = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
@@ -230,6 +359,7 @@ def test_viewport_pipeline_resizes_pass_targets_without_rebuilding(
         _open(page, "Resize")
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        _enable_ao(page)
         initial = page.evaluate("""async () => {
           const {getViewportRenderPipelineDebugState} =
             await import('./js/scene/scene.js');
@@ -274,6 +404,7 @@ def test_viewport_gtao_is_visible_and_does_not_add_continuous_frames(
         _open(page, "AO")
         page.locator(".draw-item").wait_for()
         page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        _enable_ao(page)
         page.evaluate("""async () => {
           const {setAmbientOcclusionStrength} =
             await import('./js/scene/scene.js');

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1,4 +1,5 @@
 from .support import *
+from PIL import ImageChops
 
 def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
     context = edge_browser.new_context(bypass_csp=True)
@@ -38,6 +39,207 @@ def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
         assert state["keyCastsShadow"]
         assert state["shadowAutoUpdate"] is False
         assert state["shadowMapSize"] == [2048, 2048]
+    finally:
+        context.close()
+
+def test_viewport_pipeline_uses_character_layers_and_stable_ao_settings(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Pipeline": _payload("Pipeline")})
+    errors = []
+    page.on("pageerror", lambda error: errors.append(error))
+    try:
+        _open(page, "Pipeline")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        state = page.evaluate("""async () => {
+          const THREE = await import('three');
+          const {getViewportRenderPipelineDebugState, scene} =
+            await import('./js/scene/scene.js');
+          const {CHARACTER_AO_LAYER} =
+            await import('./js/scene/viewer-layers.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          const layer = new THREE.Layers();
+          layer.set(CHARACTER_AO_LAYER);
+          const helpers = [];
+          scene.traverse(object => {
+            if (object.userData.isViewerGround || object.isGridHelper
+                || object.isSprite || object.userData.isViewerOutline) {
+              helpers.push({
+                ground: object.userData.isViewerGround === true,
+                grid: object.isGridHelper === true,
+                sprite: object.isSprite === true,
+                outline: object.userData.isViewerOutline === true,
+                hasCharacterLayer: object.layers.test(layer),
+              });
+            }
+          });
+          return {
+            pipeline: getViewportRenderPipelineDebugState(),
+            meshHasCharacterLayer: mesh.layers.test(layer),
+            helpers,
+            viewerRenderCount: window.modViewer.getRenderCount(),
+          };
+        }""")
+        assert state["pipeline"]["hasRenderPipeline"]
+        assert state["pipeline"]["hasPrePass"]
+        assert state["pipeline"]["hasGTAO"]
+        assert state["pipeline"]["prePassLayerMask"] == 1 << 1
+        assert state["pipeline"]["characterAOLayer"] == 1
+        assert state["pipeline"]["samples"] == 16
+        assert state["pipeline"]["resolutionScale"] == pytest.approx(0.5)
+        assert state["pipeline"]["temporalFiltering"] is False
+        assert state["pipeline"]["strength"] == pytest.approx(0.22)
+        assert not state["pipeline"]["pipelineNeedsUpdate"]
+        assert state["pipeline"]["renderCount"] == state["viewerRenderCount"]
+        assert state["meshHasCharacterLayer"]
+        assert all(not helper["hasCharacterLayer"] for helper in state["helpers"])
+        assert not errors, "\n".join(str(error) for error in errors)
+    finally:
+        context.close()
+
+def test_viewport_pipeline_uses_model_scale_and_wireframe_bypass(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Pipeline": _payload("Pipeline")})
+    try:
+        _open(page, "Pipeline")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        initial = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert initial["modelSize"] > 0
+        assert initial["radius"] == pytest.approx(initial["modelSize"] * 0.15)
+        assert initial["effectiveStrength"] == pytest.approx(initial["strength"])
+
+        page.locator("#wire-btn").click()
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState().effectiveStrength === 0;
+        }""")
+        suppressed = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert suppressed["enabled"]
+        assert suppressed["strength"] == pytest.approx(initial["strength"])
+        assert suppressed["effectiveStrength"] == 0
+        assert not suppressed["pipelineNeedsUpdate"]
+
+        page.locator("#wire-btn").click()
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState().effectiveStrength > 0;
+        }""")
+        restored = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert restored["effectiveStrength"] == pytest.approx(initial["strength"])
+        assert restored["modelSize"] == pytest.approx(initial["modelSize"])
+        assert restored["radius"] == pytest.approx(initial["radius"])
+    finally:
+        context.close()
+
+@pytest.mark.parametrize("scale", [0.01, 1, 100])
+def test_viewport_gtao_radius_scales_with_model_bounds(edge_browser, frontend_url, scale):
+    label = f"PipelineScale{scale}"
+    payload = _payload(label)
+    entry = payload["meshes"][f"Body-{label}-0"]
+    entry["pos"] = _f32(0, 0, 0, scale, 0, 0, 0, scale, scale * 0.25)
+    context, page = _page(edge_browser, frontend_url, {label: payload})
+    try:
+        _open(page, label)
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        state = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert math.isfinite(state["modelSize"])
+        assert math.isfinite(state["radius"])
+        assert state["modelSize"] > 0
+        assert state["radius"] == pytest.approx(state["modelSize"] * 0.15)
+    finally:
+        context.close()
+
+def test_viewport_pipeline_resizes_pass_targets_without_rebuilding(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Resize": _payload("Resize")})
+    try:
+        _open(page, "Resize")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        initial = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert initial["resolution"][0] > 0
+        assert initial["resolution"][1] > 0
+        render_count = page.evaluate("window.modViewer.getRenderCount()")
+
+        page.evaluate("""async () => {
+          const {renderer} = await import('./js/scene/scene.js');
+          const {requestRender} = await import('./js/scene/render-scheduler.js');
+          renderer.setSize(900, 640);
+          requestRender();
+        }""")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=render_count)
+        resized = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert resized["resolution"][0] > 0
+        assert resized["resolution"][1] > 0
+        assert resized["resolutionScale"] == initial["resolutionScale"]
+        assert not resized["pipelineNeedsUpdate"]
+    finally:
+        context.close()
+
+def test_viewport_gtao_is_visible_and_does_not_add_continuous_frames(
+        edge_browser, frontend_url):
+    payload = _payload("AO")
+    entry = payload["meshes"]["Body-AO-0"]
+    entry["drawindexed"] = [12, 0, 0]
+    entry["pos"] = _f32(
+        -0.7, 0, -0.5, 0.7, 0, -0.5, 0.7, 0, 0.5, -0.7, 0, 0.5,
+        -0.7, 0, -0.5, 0.7, 0, -0.5, 0.7, 0.9, -0.5, -0.7, 0.9, -0.5,
+    )
+    entry["idx"] = _u32(0, 2, 1, 0, 3, 2, 4, 5, 6, 4, 6, 7)
+    context, page = _page(edge_browser, frontend_url, {"AO": payload})
+    try:
+        _open(page, "AO")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        page.evaluate("""async () => {
+          const {setAmbientOcclusionStrength} =
+            await import('./js/scene/scene.js');
+          setAmbientOcclusionStrength(1);
+        }""")
+        page.wait_for_timeout(250)
+        with_ao = Image.open(io.BytesIO(page.screenshot())).convert("RGB")
+        render_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.wait_for_timeout(200)
+        assert page.evaluate("window.modViewer.getRenderCount()") == render_count
+
+        page.evaluate("""async () => {
+          const {setAmbientOcclusionEnabled} =
+            await import('./js/scene/scene.js');
+          setAmbientOcclusionEnabled(false);
+        }""")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=render_count)
+        without_ao = Image.open(io.BytesIO(page.screenshot())).convert("RGB")
+        assert ImageChops.difference(with_ao, without_ao).getbbox()
     finally:
         context.close()
 

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -916,6 +916,60 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
         page.locator("#light-btn").click()
         assert page.locator("#light-popover").is_hidden()
 
+        ao_button = page.locator("#ao-btn")
+        assert ao_button.get_attribute("aria-pressed") is None
+        assert ao_button.get_attribute("aria-expanded") == "false"
+        assert ao_button.get_attribute("aria-controls") == "ao-popover"
+        assert ao_button.get_attribute("aria-label") == "Ambient occlusion: 0%"
+        assert not ao_button.evaluate("button => button.classList.contains('active')")
+        assert not ao_button.evaluate("button => button.classList.contains('partial')")
+
+        ao_button.click()
+        page.locator("#ao-popover:not([hidden])").wait_for()
+        assert ao_button.get_attribute("aria-expanded") == "true"
+        assert page.evaluate("document.activeElement.id") == "ao-slider"
+        slider = page.locator("#ao-slider")
+        assert slider.get_attribute("min") == "0"
+        assert slider.get_attribute("max") == "100"
+        assert slider.get_attribute("step") == "1"
+        assert slider.input_value() == "0"
+        ao_position = page.evaluate("""() => {
+          const button = document.querySelector('#ao-btn').getBoundingClientRect();
+          const popover = document.querySelector('#ao-popover').getBoundingClientRect();
+          return {
+            above: popover.bottom <= button.top,
+            within: popover.left >= 0 && popover.right <= window.innerWidth
+              && popover.top >= 0 && popover.bottom <= window.innerHeight,
+          };
+        }""")
+        assert ao_position == {"above": True, "within": True}
+
+        for level, class_name in ((1, "partial"), (50, "partial"),
+                                  (99, "partial"), (100, "active"), (0, None)):
+            page.evaluate("""value => {
+              const slider = document.querySelector('#ao-slider');
+              slider.value = String(value);
+              slider.dispatchEvent(new Event('input', {bubbles: true}));
+            }""", level)
+            assert slider.input_value() == str(level)
+            assert page.locator("#ao-value").inner_text() == f"{level}%"
+            assert ao_button.get_attribute("aria-label") == (
+                f"Ambient occlusion: {level}%")
+            assert ao_button.get_attribute("title") == f"Ambient occlusion: {level}%"
+            assert ao_button.evaluate(
+                "button => button.classList.contains('active')") is (level == 100)
+            assert ao_button.evaluate(
+                "button => button.classList.contains('partial')") is (class_name == "partial")
+
+        page.keyboard.press("Escape")
+        assert page.locator("#ao-popover").is_hidden()
+        assert ao_button.get_attribute("aria-expanded") == "false"
+        ao_button.click()
+        page.locator("#ao-popover:not([hidden])").wait_for()
+        page.locator("#footer").click(position={"x": 5, "y": 5})
+        assert page.locator("#ao-popover").is_hidden()
+        assert ao_button.get_attribute("aria-expanded") == "false"
+
         page.locator("#environment-btn").click()
         page.locator("#environment-popover:not([hidden])").wait_for()
         assert page.locator("#environment-btn").get_attribute("aria-expanded") == "true"

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -392,6 +392,9 @@ body.asset-preview-mode #toolbar-overflow [data-toolbar-target="export-btn"] {
 #texture-btn.diffuse-normal, #texture-btn.diffuse-only, #light-btn.current {
   background: rgba(227,179,65,.18); border-color: var(--warning); color: #f2cc72;
 }
+#ao-btn.partial {
+  background: rgba(227,179,65,.18); border-color: var(--warning); color: #f2cc72;
+}
 .nav-gizmo-icon { width: 24px; height: 24px; overflow: visible; }
 .nav-gizmo-icon path { fill: none; stroke-width: 1.7; stroke-linecap: round; }
 .nav-gizmo-icon circle { stroke: none; }
@@ -958,12 +961,15 @@ button:focus-visible, input:focus-visible, select:focus-visible,
   border-radius: var(--radius-md); box-shadow: 0 10px 28px rgba(0,0,0,.45);
 }
 .appearance-popover[hidden] { display: none; }
-.appearance-row {
+.range-control-row {
   display: flex; align-items: center; justify-content: space-between;
   gap: 12px; margin-bottom: 10px; font-size: 11px; font-weight: 600;
 }
-#panel-opacity-value { color: var(--accent-soft); font-variant-numeric: tabular-nums; }
-#panel-opacity { width: 100%; accent-color: var(--accent); cursor: pointer; }
+.range-control-value { color: var(--accent-soft); font-variant-numeric: tabular-nums; }
+.range-control-slider {
+  width: 100%; accent-color: var(--accent); cursor: pointer;
+}
+.ui-popover.range-popover { width: 190px; padding: 12px; }
 
 #right-dock {
   display: none; width: 316px; max-width: min(316px, calc(50vw - 24px));

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -27,6 +27,7 @@
   <symbol id="icon-texture" viewBox="0 0 24 24"><path d="M4 5h16v14H4zM7 16l3-4 2 2 2-3 3 5H7Z"/><circle cx="9" cy="9" r="1"/></symbol>
   <symbol id="icon-wireframe" viewBox="0 0 24 24"><path d="m12 3 8 4.5v9L12 21l-8-4.5v-9L12 3ZM4 7.5l8 4.5 8-4.5M12 12v9"/></symbol>
   <symbol id="icon-outline" viewBox="0 0 24 24"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="3"/></symbol>
+  <symbol id="icon-ao" viewBox="0 0 24 24"><circle cx="12" cy="12" r="7"/><path d="M5 17 17 5M8 20h8M4 8v8"/></symbol>
   <symbol id="icon-glossy" viewBox="0 0 24 24"><path d="m12 3 1.8 6.2L20 11l-6.2 1.8L12 19l-1.8-6.2L4 11l6.2-1.8L12 3Z"/><path d="m19 16 .7 2.3L22 19l-2.3.7L19 22l-.7-2.3L16 19l2.3-.7L19 16Z"/></symbol>
   <symbol id="icon-grid" viewBox="0 0 24 24"><path d="M4 4h16v16H4zM4 10h16M4 16h16M10 4v16M16 4v16"/></symbol>
   <symbol id="icon-shading" viewBox="0 0 24 24"><path d="M12 4a8 8 0 1 0 0 16 8 8 0 0 0 0-16Z"/><path d="M12 4v16"/></symbol>
@@ -220,6 +221,7 @@
     <div id="tool-buttons">
       <button id="wire-btn" class="tool-btn" title="Wireframe rendering: off" aria-label="Wireframe rendering: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-wireframe"></use></svg></button>
       <button id="outline-btn" class="tool-btn" title="Silhouette outlines: off" aria-label="Silhouette outlines: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-outline"></use></svg></button>
+      <button id="ao-btn" class="tool-btn" title="Ambient occlusion: off" aria-label="Ambient occlusion: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-ao"></use></svg></button>
       <button id="glossy-btn" class="tool-btn off" title="Glossy materials: off" aria-label="Glossy materials: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-glossy"></use></svg></button>
       <button id="grid-btn" class="tool-btn" title="Grid visibility: on" aria-label="Grid visibility: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-grid"></use></svg></button>
       <button id="shading-btn" class="tool-btn" title="Smooth shading: on" aria-label="Smooth shading: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-shading"></use></svg></button>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -99,11 +99,11 @@
     </button>
     <div id="appearance-popover" class="appearance-popover" role="dialog"
          aria-label="Appearance" hidden>
-      <div class="appearance-row">
+      <div class="range-control-row appearance-row">
         <label for="panel-opacity">Panel opacity</label>
-        <output id="panel-opacity-value" for="panel-opacity">58%</output>
+        <output id="panel-opacity-value" class="range-control-value" for="panel-opacity">58%</output>
       </div>
-      <input id="panel-opacity" type="range" min="0" max="100" step="1" value="58"/>
+      <input id="panel-opacity" class="range-control-slider" type="range" min="0" max="100" step="1" value="58"/>
     </div>
   </div>
 </div>
@@ -221,7 +221,8 @@
     <div id="tool-buttons">
       <button id="wire-btn" class="tool-btn" title="Wireframe rendering: off" aria-label="Wireframe rendering: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-wireframe"></use></svg></button>
       <button id="outline-btn" class="tool-btn" title="Silhouette outlines: off" aria-label="Silhouette outlines: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-outline"></use></svg></button>
-      <button id="ao-btn" class="tool-btn" title="Ambient occlusion: off" aria-label="Ambient occlusion: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-ao"></use></svg></button>
+      <button id="ao-btn" class="tool-btn" title="Ambient occlusion: 0%" aria-label="Ambient occlusion: 0%"
+              aria-expanded="false" aria-controls="ao-popover"><svg class="ui-icon" aria-hidden="true"><use href="#icon-ao"></use></svg></button>
       <button id="glossy-btn" class="tool-btn off" title="Glossy materials: off" aria-label="Glossy materials: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-glossy"></use></svg></button>
       <button id="grid-btn" class="tool-btn" title="Grid visibility: on" aria-label="Grid visibility: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-grid"></use></svg></button>
       <button id="shading-btn" class="tool-btn" title="Smooth shading: on" aria-label="Smooth shading: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-shading"></use></svg></button>
@@ -292,6 +293,15 @@
   </div>
   <div id="texture-popover" class="ui-popover tool-popover" role="menu" aria-label="Texture display options" hidden></div>
   <div id="light-popover" class="ui-popover tool-popover" role="menu" aria-label="Light options" hidden></div>
+  <div id="ao-popover" class="ui-popover tool-popover range-popover" role="dialog"
+       aria-label="Ambient occlusion" hidden>
+    <div class="range-control-row">
+      <label for="ao-slider">Ambient occlusion</label>
+      <output id="ao-value" class="range-control-value" for="ao-slider">0%</output>
+    </div>
+    <input id="ao-slider" class="range-control-slider" type="range"
+           min="0" max="100" step="1" value="0"/>
+  </div>
 </div>
 
 <div id="asset-folder-modal-backdrop" class="modal-backdrop">

--- a/src/web/js/app/asset-fill.js
+++ b/src/web/js/app/asset-fill.js
@@ -1,7 +1,7 @@
 // Session-scoped Asset-fill transaction and its toolbar state.
 
 import { viewerState, samePath } from './state.js';
-import { adoptModelMeshes, fitTo, forgetModelMeshes } from '../scene/scene.js';
+import { adoptModelMeshes, fitTo } from '../scene/scene.js';
 import { requestRender } from '../scene/render-scheduler.js';
 import { addTexture, removeTextures } from '../mesh/mesh-factory.js';
 import { activeMeshes, removeMesh } from '../mesh/visibility.js';
@@ -56,10 +56,7 @@ function rollbackAssetFillFrontend(addedMeshes, textureKeys) {
   const remaining = targetMeshes.filter(mesh => activeMeshes.includes(mesh));
   remaining.forEach(removeMesh);
   const removed = [...new Set([...removedFromPanel, ...remaining])];
-  if (removed.length) {
-    forgetModelMeshes(removed);
-    requestRender();
-  }
+  if (removed.length) requestRender();
 
   const keys = new Set(textureKeys || []);
   removeTextures(keys);
@@ -222,8 +219,7 @@ export async function removeMissingAssetParts() {
     if (!assetFillOperationIsCurrent(operation, path)) return false;
     if (result?.status === 'error') throw new Error(result.error);
     if (result?.stale) return false;
-    const removedMeshes = removeAssetFillMeshPanel();
-    forgetModelMeshes(removedMeshes);
+    removeAssetFillMeshPanel();
     removeTextures(state.assetFill.textureKeys);
     state.assetFill.textureKeys = new Set();
     state.assetFill.loaded = false;

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -1,10 +1,10 @@
 // Entry point: composes frontend application flows and initializes the UI.
 
 import {
-  getAmbientOcclusionRadiusFactor, getEnvironmentPreset, getRenderCount,
+  getAmbientOcclusionStrength, getEnvironmentPreset, getRenderCount,
   isRendererAvailable, rendererReady,
   resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
-  setAmbientOcclusionRadiusFactor, toggleGrid, toggleTrackballGizmo,
+  setAmbientOcclusionStrength, toggleGrid, toggleTrackballGizmo,
 } from './scene/scene.js';
 import {
   activeMeshes, resetMeshState,
@@ -238,9 +238,9 @@ rendererReady.then(ready => {
     activeMeshes,
     setEnvironmentPreset: applyEnvironmentPreset,
     getEnvironmentPreset,
-    getAmbientOcclusionRadiusFactor,
-    setAmbientOcclusionRadiusFactor: value => {
-      const changed = setAmbientOcclusionRadiusFactor(value);
+    getAmbientOcclusionStrength,
+    setAmbientOcclusionStrength: value => {
+      const changed = setAmbientOcclusionStrength(value);
       syncAmbientOcclusionControl?.();
       return changed;
     },

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -1,9 +1,10 @@
 // Entry point: composes frontend application flows and initializes the UI.
 
 import {
-  getEnvironmentPreset, getRenderCount, isRendererAvailable, rendererReady,
+  getAmbientOcclusionEnabled, getEnvironmentPreset, getRenderCount,
+  isRendererAvailable, rendererReady,
   resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
-  toggleGrid, toggleTrackballGizmo,
+  toggleAmbientOcclusion, toggleGrid, toggleTrackballGizmo,
 } from './scene/scene.js';
 import {
   activeMeshes, resetMeshState,
@@ -112,6 +113,17 @@ function exportChanges() {
   return exportChangesFlow();
 }
 
+function updateAmbientOcclusionButton(enabled) {
+  const button = $('ao-btn');
+  if (!button) return enabled;
+  const label = `Ambient occlusion: ${enabled ? 'on' : 'off'}`;
+  button.classList.toggle('active', enabled);
+  button.setAttribute('aria-pressed', String(enabled));
+  button.setAttribute('aria-label', label);
+  button.title = label;
+  return enabled;
+}
+
 initToolbarOverflow();
 initPanelOpacityControl();
 
@@ -125,6 +137,10 @@ rendererReady.then(ready => {
     void toggleMissingAssetParts();
   });
   $('wire-btn').addEventListener('click', toggleWireframe);
+  updateAmbientOcclusionButton(getAmbientOcclusionEnabled());
+  $('ao-btn').addEventListener('click', () => {
+    updateAmbientOcclusionButton(toggleAmbientOcclusion());
+  });
   $('outline-btn').addEventListener('click', () => {
     const enabled = setOutlinesEnabled();
     const button = $('outline-btn');
@@ -237,6 +253,9 @@ rendererReady.then(ready => {
     activeMeshes,
     setEnvironmentPreset: applyEnvironmentPreset,
     getEnvironmentPreset,
+    getAmbientOcclusionEnabled,
+    toggleAmbientOcclusion: () => updateAmbientOcclusionButton(
+      toggleAmbientOcclusion()),
     getMaterialState,
     getRenderCount,
     setMaterialDebugMode: setMaterialDebugModeForMeshes,

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -1,10 +1,10 @@
 // Entry point: composes frontend application flows and initializes the UI.
 
 import {
-  getAmbientOcclusionEnabled, getEnvironmentPreset, getRenderCount,
+  getAmbientOcclusionRadiusFactor, getEnvironmentPreset, getRenderCount,
   isRendererAvailable, rendererReady,
   resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
-  toggleAmbientOcclusion, toggleGrid, toggleTrackballGizmo,
+  setAmbientOcclusionRadiusFactor, toggleGrid, toggleTrackballGizmo,
 } from './scene/scene.js';
 import {
   activeMeshes, resetMeshState,
@@ -113,17 +113,6 @@ function exportChanges() {
   return exportChangesFlow();
 }
 
-function updateAmbientOcclusionButton(enabled) {
-  const button = $('ao-btn');
-  if (!button) return enabled;
-  const label = `Ambient occlusion: ${enabled ? 'on' : 'off'}`;
-  button.classList.toggle('active', enabled);
-  button.setAttribute('aria-pressed', String(enabled));
-  button.setAttribute('aria-label', label);
-  button.title = label;
-  return enabled;
-}
-
 initToolbarOverflow();
 initPanelOpacityControl();
 
@@ -137,10 +126,6 @@ rendererReady.then(ready => {
     void toggleMissingAssetParts();
   });
   $('wire-btn').addEventListener('click', toggleWireframe);
-  updateAmbientOcclusionButton(getAmbientOcclusionEnabled());
-  $('ao-btn').addEventListener('click', () => {
-    updateAmbientOcclusionButton(toggleAmbientOcclusion());
-  });
   $('outline-btn').addEventListener('click', () => {
     const enabled = setOutlinesEnabled();
     const button = $('outline-btn');
@@ -151,7 +136,7 @@ rendererReady.then(ready => {
   $('grid-btn').addEventListener('click', toggleGrid);
   $('shading-btn').addEventListener('click', toggleSmoothShading);
   $('glossy-btn').addEventListener('click', toggleGlossy);
-  initToolPopovers();
+  const syncAmbientOcclusionControl = initToolPopovers();
   $('reset-state-btn').addEventListener('click', event => {
     event.stopPropagation();
     resetMeshState();
@@ -253,9 +238,12 @@ rendererReady.then(ready => {
     activeMeshes,
     setEnvironmentPreset: applyEnvironmentPreset,
     getEnvironmentPreset,
-    getAmbientOcclusionEnabled,
-    toggleAmbientOcclusion: () => updateAmbientOcclusionButton(
-      toggleAmbientOcclusion()),
+    getAmbientOcclusionRadiusFactor,
+    setAmbientOcclusionRadiusFactor: value => {
+      const changed = setAmbientOcclusionRadiusFactor(value);
+      syncAmbientOcclusionControl?.();
+      return changed;
+    },
     getMaterialState,
     getRenderCount,
     setMaterialDebugMode: setMaterialDebugModeForMeshes,

--- a/src/web/js/mesh/mesh-factory.js
+++ b/src/web/js/mesh/mesh-factory.js
@@ -11,6 +11,7 @@ import { loadDDSTexture } from '../textures/dds-loader.js';
 import { requestRender } from '../scene/render-scheduler.js';
 import { supportsBCTextureCompression } from '../scene/renderer-capabilities.js';
 import { splitTextureKey } from '../textures/texture-key.js';
+import { CHARACTER_AO_LAYER } from '../scene/viewer-layers.js';
 
 // Textures arrive as data URIs or same-origin localhost URLs keyed by name;
 // loaders are cached so several meshes sharing a texture share one GPU upload.
@@ -303,6 +304,7 @@ export function buildMesh(name, data, materialProfile = null) {
     { hasUv: !!data.uv });
 
   const mesh = new THREE.Mesh(geo, mat);
+  mesh.layers.enable(CHARACTER_AO_LAYER);
   mesh.userData.basePositions = new Float32Array(geo.attributes.position.array);
   mesh.userData.baseNormals = data.normal
     ? new Float32Array(geo.attributes.normal.array) : null;

--- a/src/web/js/mesh/mesh-state.js
+++ b/src/web/js/mesh/mesh-state.js
@@ -2,6 +2,7 @@
 
 import {
   invalidateCharacterShadowGeometry, invalidateCharacterShadowVisibility,
+  forgetModelMeshes as forgetSceneModelMeshes,
   resetCharacterShadows, scene, resetModelOrientation,
 } from '../scene/scene.js';
 import { dnfSatisfied, getControlValue } from '../editing/control-state.js';
@@ -67,6 +68,7 @@ export function removeMesh(mesh) {
     material?.dispose?.();
   });
   activeMeshes.splice(index, 1);
+  forgetSceneModelMeshes([mesh]);
   return true;
 }
 

--- a/src/web/js/scene/camera-frame.js
+++ b/src/web/js/scene/camera-frame.js
@@ -191,7 +191,8 @@ export function createCameraFrame({
     frameView(homeView.meshes.map(({ mesh }) => mesh),
       INITIAL_CAMERA_DIRECTION, size.y * 0.08);
     camera.updateMatrix();
-    controls.update();
+    camera.updateMatrixWorld();
+    controls.setCamera(camera);
     controls.saveState();
   }
 

--- a/src/web/js/scene/render-modes.js
+++ b/src/web/js/scene/render-modes.js
@@ -4,6 +4,7 @@ import { refreshMeshTexture, setTextureMode } from '../mesh/mesh-factory.js';
 import { setGameMaterialRimEnabled } from '../mesh/material-profile.js';
 import { setOutlineSuppressedByWireframe } from './outline-renderer.js';
 import { requestRender } from './render-scheduler.js';
+import { setAmbientOcclusionSuppressedByWireframe } from './scene.js';
 
 let wireframe = false;
 let smoothShading = true;
@@ -31,6 +32,7 @@ export function initializeMeshRenderModes(mesh) {
 export function toggleWireframeMode(meshes) {
   wireframe = !wireframe;
   setOutlineSuppressedByWireframe(wireframe);
+  setAmbientOcclusionSuppressedByWireframe(wireframe);
   const button = document.getElementById('wire-btn');
   button.classList.toggle('active', wireframe);
   button.setAttribute('aria-pressed', String(wireframe));

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -137,6 +137,8 @@ camera.position.set(0, 1, 3);
 export const controls = new ArcballControls(camera, renderer.domElement, scene);
 controls.target.set(0, 0, 0);
 controls.enableAnimations = true;
+// Keep wheel zoom anchored to the point under the cursor for model inspection.
+controls.cursorZoom = true;
 // Model-scaled clipping belongs to cameraFrame; Arcball must not overwrite it.
 controls.adjustNearFar = false;
 controls.setGizmosVisible(false);

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -297,8 +297,17 @@ export function getViewportRenderPipelineDebugState() {
 }
 
 export function setAmbientOcclusionEnabled(enabled) {
-  viewportRenderPipeline.setAmbientOcclusionEnabled(enabled);
+  const value = viewportRenderPipeline.setAmbientOcclusionEnabled(enabled);
   requestRender();
+  return value;
+}
+
+export function getAmbientOcclusionEnabled() {
+  return viewportRenderPipeline.isAmbientOcclusionEnabled();
+}
+
+export function toggleAmbientOcclusion() {
+  return setAmbientOcclusionEnabled(!getAmbientOcclusionEnabled());
 }
 
 export function setAmbientOcclusionStrength(strength) {

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -296,14 +296,14 @@ export function getViewportRenderPipelineDebugState() {
   return viewportRenderPipeline.getDebugState();
 }
 
-export function setAmbientOcclusionRadiusFactor(value) {
-  const changed = viewportRenderPipeline.setAmbientOcclusionRadiusFactor(value);
+export function setAmbientOcclusionStrength(value) {
+  const changed = viewportRenderPipeline.setAmbientOcclusionStrength(value);
   if (changed) requestRender();
   return changed;
 }
 
-export function getAmbientOcclusionRadiusFactor() {
-  return viewportRenderPipeline.getAmbientOcclusionRadiusFactor();
+export function getAmbientOcclusionStrength() {
+  return viewportRenderPipeline.getAmbientOcclusionStrength();
 }
 
 export function setAmbientOcclusionSuppressedByWireframe(value) {

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -296,24 +296,14 @@ export function getViewportRenderPipelineDebugState() {
   return viewportRenderPipeline.getDebugState();
 }
 
-export function setAmbientOcclusionEnabled(enabled) {
-  const value = viewportRenderPipeline.setAmbientOcclusionEnabled(enabled);
-  requestRender();
-  return value;
-}
-
-export function getAmbientOcclusionEnabled() {
-  return viewportRenderPipeline.isAmbientOcclusionEnabled();
-}
-
-export function toggleAmbientOcclusion() {
-  return setAmbientOcclusionEnabled(!getAmbientOcclusionEnabled());
-}
-
-export function setAmbientOcclusionStrength(strength) {
-  const changed = viewportRenderPipeline.setAmbientOcclusionStrength(strength);
+export function setAmbientOcclusionRadiusFactor(value) {
+  const changed = viewportRenderPipeline.setAmbientOcclusionRadiusFactor(value);
   if (changed) requestRender();
   return changed;
+}
+
+export function getAmbientOcclusionRadiusFactor() {
+  return viewportRenderPipeline.getAmbientOcclusionRadiusFactor();
 }
 
 export function setAmbientOcclusionSuppressedByWireframe(value) {

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -9,6 +9,7 @@ import { createKeyLightController } from './key-light-controller.js';
 import { updateOutlineCameraScale } from './outline-renderer.js';
 import { setBCTextureCompression } from './renderer-capabilities.js';
 import { requestRender, setRenderCallback } from './render-scheduler.js';
+import { createViewportRenderPipeline } from './viewport-render-pipeline.js';
 import { createViewGizmoController } from './view-gizmo-controller.js';
 
 const container = document.getElementById('canvas-container');
@@ -152,6 +153,9 @@ const keyLightController = createKeyLightController({
 const characterShadowController = createCharacterShadowController({
   renderer, scene, light: keyLight,
 });
+const viewportRenderPipeline = createViewportRenderPipeline({
+  renderer, scene, camera,
+});
 const viewGizmoController = createViewGizmoController({
   camera, controls, element: document.getElementById('view-gizmo'),
   onChange: requestRender,
@@ -182,7 +186,7 @@ function renderFrame() {
   updateOutlineCameraScale(camera, controls.target,
     renderer.domElement.clientHeight);
   viewGizmoController.updateAxes();
-  renderer.render(scene, camera);
+  viewportRenderPipeline.render();
   renderCount += 1;
   if (snapActive) requestRender();
 }
@@ -236,12 +240,14 @@ export function frameView(meshes = [], direction = null, targetYOffset = 0) {
 export function resetView() {
   cameraFrame.resetView();
   characterShadowController.invalidateGeometry();
+  viewportRenderPipeline.invalidateGeometry();
   requestRender();
 }
 
 export function adoptModelMeshes(meshes = []) {
   const adopted = cameraFrame.adoptModelMeshes(meshes);
   characterShadowController.adoptMeshes(meshes);
+  viewportRenderPipeline.adoptMeshes(meshes);
   requestRender();
   return adopted;
 }
@@ -249,12 +255,14 @@ export function adoptModelMeshes(meshes = []) {
 export function fitTo(meshes, options) {
   cameraFrame.fitTo(meshes, options);
   characterShadowController.setMeshes(meshes);
+  viewportRenderPipeline.setMeshes(meshes);
   requestRender();
 }
 
 export function forgetModelMeshes(meshes = []) {
   cameraFrame.forgetModelMeshes(meshes);
   characterShadowController.forgetMeshes(meshes);
+  viewportRenderPipeline.forgetMeshes(meshes);
   requestRender();
 }
 
@@ -264,10 +272,12 @@ export function resetModelOrientation(options) {
 
 export function resetCharacterShadows() {
   characterShadowController.reset();
+  viewportRenderPipeline.reset();
 }
 
 export function invalidateCharacterShadowGeometry() {
   characterShadowController.invalidateGeometry();
+  viewportRenderPipeline.invalidateGeometry();
   requestRender();
 }
 
@@ -280,15 +290,37 @@ export function getCharacterShadowDebugState() {
   return characterShadowController.getDebugState();
 }
 
+export function getViewportRenderPipelineDebugState() {
+  return viewportRenderPipeline.getDebugState();
+}
+
+export function setAmbientOcclusionEnabled(enabled) {
+  viewportRenderPipeline.setAmbientOcclusionEnabled(enabled);
+  requestRender();
+}
+
+export function setAmbientOcclusionStrength(strength) {
+  const changed = viewportRenderPipeline.setAmbientOcclusionStrength(strength);
+  if (changed) requestRender();
+  return changed;
+}
+
+export function setAmbientOcclusionSuppressedByWireframe(value) {
+  viewportRenderPipeline.setAmbientOcclusionSuppressedByWireframe(value);
+  requestRender();
+}
+
 export function rotateModelQuarterTurn(meshes = []) {
   cameraFrame.rotateModelQuarterTurn(meshes);
   characterShadowController.invalidateGeometry();
+  viewportRenderPipeline.invalidateGeometry();
   requestRender();
 }
 
 export function rotateModelHorizontalQuarterTurn(meshes = []) {
   cameraFrame.rotateModelHorizontalQuarterTurn(meshes);
   characterShadowController.invalidateGeometry();
+  viewportRenderPipeline.invalidateGeometry();
   requestRender();
 }
 

--- a/src/web/js/scene/viewer-layers.js
+++ b/src/web/js/scene/viewer-layers.js
@@ -1,0 +1,3 @@
+// Viewer layer assignments used to keep presentation helpers out of effects.
+
+export const CHARACTER_AO_LAYER = 1;

--- a/src/web/js/scene/viewport-render-pipeline.js
+++ b/src/web/js/scene/viewport-render-pipeline.js
@@ -63,6 +63,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   // The pre-pass renders only character meshes. Its packed normal attachment
   // is deliberately 8-bit; depth remains the pass's depth texture.
   const prePass = pass(scene, prePassCamera, { samples: 1 });
+  prePass.setResolutionScale(AO_RESOLUTION_SCALE);
   prePass.name = 'Character AO pre-pass';
   prePass.transparent = false;
   prePass.setLayers(aoLayers);
@@ -206,6 +207,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
       temporalFiltering: aoPass.useTemporalFiltering === true,
       prePassLayerMask: prePass.getLayers()?.mask ?? 0,
       prePassSamples: prePass.renderTarget?.samples ?? 0,
+      prePassResolutionScale: prePass.getResolutionScale(),
       beautyCameraIsSource: scenePass.camera === camera,
       prePassCameraIsClone: prePass.camera !== camera,
       cameraCoordinateSystem: camera.coordinateSystem,

--- a/src/web/js/scene/viewport-render-pipeline.js
+++ b/src/web/js/scene/viewport-render-pipeline.js
@@ -24,6 +24,7 @@ const AO_SAMPLES = 8;
 const AO_RADIUS_FACTOR = 0.15;
 const MIN_MODEL_SIZE = 0.001;
 const MIN_AO_RADIUS = 0.001;
+let nextPipelineId = 0;
 
 function finitePositive(value) {
   return Number.isFinite(value) && value > 0;
@@ -47,16 +48,21 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   aoLayers.set(CHARACTER_AO_LAYER);
 
   const renderPipeline = new THREE.RenderPipeline(renderer);
+  const pipelineId = ++nextPipelineId;
   // RenderPipeline evaluates scene passes from inside the fullscreen quad.
   // Keep the beauty pass on the camera owned by ArcballControls. Only the
   // character pre-pass needs an isolated camera because it changes layers.
   const prePassCamera = camera.clone();
 
-  function syncPrePassCamera() {
+  function syncCameraCoordinateSystem() {
     if (camera.coordinateSystem !== renderer.coordinateSystem) {
       camera.coordinateSystem = renderer.coordinateSystem;
       camera.updateProjectionMatrix();
     }
+  }
+
+  function syncPrePassCamera() {
+    syncCameraCoordinateSystem();
     prePassCamera.copy(camera, false);
   }
 
@@ -94,10 +100,12 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   let meshes = [];
   let modelSizeDirty = true;
   let modelSize = MIN_MODEL_SIZE;
-  let enabled = true;
+  let enabled = false;
   let configuredStrength = AO_DEFAULT_STRENGTH;
   let suppressedByWireframe = false;
   let renderCount = 0;
+  let directRenderCount = 0;
+  let aoRenderCount = 0;
 
   function effectiveStrength() {
     return enabled && !suppressedByWireframe ? configuredStrength : 0;
@@ -157,6 +165,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   function setAmbientOcclusionEnabled(value) {
     enabled = !!value;
     applyStrength();
+    return enabled;
   }
 
   function setAmbientOcclusionStrength(value) {
@@ -172,12 +181,23 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   }
 
   function render() {
-    updateModelSize();
-    syncPrePassCamera();
+    const useAmbientOcclusion = effectiveStrength() > 0;
+    if (useAmbientOcclusion) {
+      updateModelSize();
+      syncPrePassCamera();
+    } else {
+      syncCameraCoordinateSystem();
+    }
     renderer.outputColorSpace = THREE.SRGBColorSpace;
     renderer.toneMapping = THREE.NoToneMapping;
     try {
-      renderPipeline.render();
+      if (useAmbientOcclusion) {
+        renderPipeline.render();
+        aoRenderCount += 1;
+      } else {
+        renderer.render(scene, camera);
+        directRenderCount += 1;
+      }
     } finally {
       // RenderPipeline temporarily switches to working color space while its
       // internal passes execute. Keep the renderer contract visible to the
@@ -194,12 +214,15 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
       strength: configuredStrength,
       effectiveStrength: effectiveStrength(),
       suppressedByWireframe,
+      pipelineId,
       resolutionScale: aoPass.resolutionScale,
       resolution: readResolution(aoPass.resolution),
       samples: readUniformValue(aoPass.samples),
       radius: readUniformValue(aoPass.radius),
       modelSize,
       renderCount,
+      directRenderCount,
+      aoRenderCount,
       pipelineNeedsUpdate: renderPipeline.needsUpdate,
       hasRenderPipeline: !!renderPipeline,
       hasPrePass: !!prePass,
@@ -232,6 +255,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     forgetMeshes,
     invalidateGeometry,
     reset,
+    isAmbientOcclusionEnabled: () => enabled,
     setAmbientOcclusionEnabled,
     setAmbientOcclusionStrength,
     setAmbientOcclusionSuppressedByWireframe,

--- a/src/web/js/scene/viewport-render-pipeline.js
+++ b/src/web/js/scene/viewport-render-pipeline.js
@@ -18,10 +18,10 @@ import { ao } from 'three/addons/tsl/display/GTAONode.js';
 import { computeModelBounds } from './model-bounds.js';
 import { CHARACTER_AO_LAYER } from './viewer-layers.js';
 
-const AO_DEFAULT_STRENGTH = 0.55;
+const AO_STRENGTH = 0.55;
 const AO_RESOLUTION_SCALE = 0.5;
 const AO_SAMPLES = 8;
-const AO_RADIUS_FACTOR = 0.15;
+const AO_MAX_RADIUS_FACTOR = 0.10;
 const MIN_MODEL_SIZE = 0.001;
 const MIN_AO_RADIUS = 0.001;
 let nextPipelineId = 0;
@@ -85,7 +85,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   aoPass.samples.value = AO_SAMPLES;
   aoPass.useTemporalFiltering = false;
 
-  const aoStrengthNode = uniform(AO_DEFAULT_STRENGTH);
+  const aoStrengthNode = uniform(AO_STRENGTH);
   const aoSample = aoPass.getTextureNode().sample(screenUV).r;
   const effectiveAO = mix(float(1), aoSample, aoStrengthNode);
 
@@ -100,15 +100,22 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   let meshes = [];
   let modelSizeDirty = true;
   let modelSize = MIN_MODEL_SIZE;
-  let enabled = false;
-  let configuredStrength = AO_DEFAULT_STRENGTH;
+  let radiusFactor = 0;
   let suppressedByWireframe = false;
   let renderCount = 0;
   let directRenderCount = 0;
   let aoRenderCount = 0;
 
+  function isAmbientOcclusionEnabled() {
+    return radiusFactor > 0;
+  }
+
+  function shouldRenderAO() {
+    return isAmbientOcclusionEnabled() && !suppressedByWireframe;
+  }
+
   function effectiveStrength() {
-    return enabled && !suppressedByWireframe ? configuredStrength : 0;
+    return shouldRenderAO() ? AO_STRENGTH : 0;
   }
 
   function applyStrength() {
@@ -125,8 +132,16 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
       modelSize = finitePositive(diagonal) ? Math.max(diagonal, MIN_MODEL_SIZE)
         : MIN_MODEL_SIZE;
     }
-    aoPass.radius.value = Math.max(modelSize * AO_RADIUS_FACTOR, MIN_AO_RADIUS);
     modelSizeDirty = false;
+  }
+
+  function updateRadius() {
+    if (!isAmbientOcclusionEnabled()) {
+      aoPass.radius.value = MIN_AO_RADIUS;
+      return;
+    }
+    updateModelSize();
+    aoPass.radius.value = Math.max(modelSize * radiusFactor, MIN_AO_RADIUS);
   }
 
   function invalidateGeometry() {
@@ -162,17 +177,14 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     aoPass.radius.value = MIN_AO_RADIUS;
   }
 
-  function setAmbientOcclusionEnabled(value) {
-    enabled = !!value;
-    applyStrength();
-    return enabled;
-  }
-
-  function setAmbientOcclusionStrength(value) {
+  function setAmbientOcclusionRadiusFactor(value) {
     if (!Number.isFinite(value)) return false;
-    configuredStrength = THREE.MathUtils.clamp(value, 0, 1);
+    const next = THREE.MathUtils.clamp(value, 0, AO_MAX_RADIUS_FACTOR);
+    const changed = next !== radiusFactor;
+    radiusFactor = next;
+    updateRadius();
     applyStrength();
-    return true;
+    return changed;
   }
 
   function setAmbientOcclusionSuppressedByWireframe(value) {
@@ -181,9 +193,9 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   }
 
   function render() {
-    const useAmbientOcclusion = effectiveStrength() > 0;
+    const useAmbientOcclusion = shouldRenderAO();
     if (useAmbientOcclusion) {
-      updateModelSize();
+      updateRadius();
       syncPrePassCamera();
     } else {
       syncCameraCoordinateSystem();
@@ -210,8 +222,9 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
 
   function getDebugState() {
     return {
-      enabled,
-      strength: configuredStrength,
+      enabled: isAmbientOcclusionEnabled(),
+      radiusFactor,
+      strength: AO_STRENGTH,
       effectiveStrength: effectiveStrength(),
       suppressedByWireframe,
       pipelineId,
@@ -255,9 +268,9 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     forgetMeshes,
     invalidateGeometry,
     reset,
-    isAmbientOcclusionEnabled: () => enabled,
-    setAmbientOcclusionEnabled,
-    setAmbientOcclusionStrength,
+    getAmbientOcclusionRadiusFactor: () => radiusFactor,
+    isAmbientOcclusionEnabled,
+    setAmbientOcclusionRadiusFactor,
     setAmbientOcclusionSuppressedByWireframe,
     getDebugState,
     dispose,

--- a/src/web/js/scene/viewport-render-pipeline.js
+++ b/src/web/js/scene/viewport-render-pipeline.js
@@ -21,8 +21,9 @@ import { CHARACTER_AO_LAYER } from './viewer-layers.js';
 const AO_RESOLUTION_SCALE = 0.5;
 const AO_SAMPLES = 8;
 const AO_RADIUS_FACTOR = 0.005;
+const AO_THICKNESS_RADIUS_RATIO = 4;
 const MIN_MODEL_SIZE = 0.001;
-const MIN_AO_RADIUS = 0.001;
+const MIN_AO_RADIUS = MIN_MODEL_SIZE * AO_RADIUS_FACTOR;
 let nextPipelineId = 0;
 
 function finitePositive(value) {
@@ -134,13 +135,16 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     modelSizeDirty = false;
   }
 
-  function updateRadius() {
+  function updateSpatialParameters() {
     if (!isAmbientOcclusionEnabled()) {
       aoPass.radius.value = MIN_AO_RADIUS;
+      aoPass.thickness.value = MIN_AO_RADIUS * AO_THICKNESS_RADIUS_RATIO;
       return;
     }
     updateModelSize();
-    aoPass.radius.value = Math.max(modelSize * AO_RADIUS_FACTOR, MIN_AO_RADIUS);
+    const radius = modelSize * AO_RADIUS_FACTOR;
+    aoPass.radius.value = radius;
+    aoPass.thickness.value = radius * AO_THICKNESS_RADIUS_RATIO;
   }
 
   function invalidateGeometry() {
@@ -174,6 +178,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     modelSize = MIN_MODEL_SIZE;
     modelSizeDirty = false;
     aoPass.radius.value = MIN_AO_RADIUS;
+    aoPass.thickness.value = MIN_AO_RADIUS * AO_THICKNESS_RADIUS_RATIO;
   }
 
   function setAmbientOcclusionStrength(value) {
@@ -181,7 +186,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     const next = THREE.MathUtils.clamp(value, 0, 1);
     const changed = next !== configuredStrength;
     configuredStrength = next;
-    updateRadius();
+    updateSpatialParameters();
     applyStrength();
     return changed;
   }
@@ -194,7 +199,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   function render() {
     const useAmbientOcclusion = shouldRenderAO();
     if (useAmbientOcclusion) {
-      updateRadius();
+      updateSpatialParameters();
       syncPrePassCamera();
     } else {
       syncCameraCoordinateSystem();
@@ -231,6 +236,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
       resolution: readResolution(aoPass.resolution),
       samples: readUniformValue(aoPass.samples),
       radius: readUniformValue(aoPass.radius),
+      thickness: readUniformValue(aoPass.thickness),
       modelSize,
       renderCount,
       directRenderCount,
@@ -258,6 +264,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     scenePass.renderTarget?.dispose?.();
   }
 
+  updateSpatialParameters();
   applyStrength();
 
   return {

--- a/src/web/js/scene/viewport-render-pipeline.js
+++ b/src/web/js/scene/viewport-render-pipeline.js
@@ -20,7 +20,7 @@ import { CHARACTER_AO_LAYER } from './viewer-layers.js';
 
 const AO_DEFAULT_STRENGTH = 0.22;
 const AO_RESOLUTION_SCALE = 0.5;
-const AO_SAMPLES = 16;
+const AO_SAMPLES = 8;
 const AO_RADIUS_FACTOR = 0.15;
 const MIN_MODEL_SIZE = 0.001;
 const MIN_AO_RADIUS = 0.001;
@@ -48,19 +48,21 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
 
   const renderPipeline = new THREE.RenderPipeline(renderer);
   // RenderPipeline evaluates scene passes from inside the fullscreen quad.
-  // Separate camera identities keep Three's scene/camera render-list cache
-  // from being re-entered by the normal pass and the character pre-pass.
+  // Keep the beauty pass on the camera owned by ArcballControls. Only the
+  // character pre-pass needs an isolated camera because it changes layers.
   const prePassCamera = camera.clone();
-  const scenePassCamera = camera.clone();
 
-  function syncPassCameras() {
-    prePassCamera.copy(camera);
-    scenePassCamera.copy(camera);
+  function syncPrePassCamera() {
+    if (camera.coordinateSystem !== renderer.coordinateSystem) {
+      camera.coordinateSystem = renderer.coordinateSystem;
+      camera.updateProjectionMatrix();
+    }
+    prePassCamera.copy(camera, false);
   }
 
   // The pre-pass renders only character meshes. Its packed normal attachment
   // is deliberately 8-bit; depth remains the pass's depth texture.
-  const prePass = pass(scene, prePassCamera);
+  const prePass = pass(scene, prePassCamera, { samples: 1 });
   prePass.name = 'Character AO pre-pass';
   prePass.transparent = false;
   prePass.setLayers(aoLayers);
@@ -83,7 +85,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   // The beauty pass retains the whole presentation scene. AO enters through
   // the lighting context so direct light, shadows, rim and debug outputs are
   // not multiplied as a final screen-space color operation.
-  const scenePass = pass(scene, scenePassCamera);
+  const scenePass = pass(scene, camera);
   scenePass.name = 'Viewport beauty pass';
   scenePass.contextNode = builtinAOContext(effectiveAO);
   renderPipeline.outputNode = scenePass;
@@ -170,7 +172,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
 
   function render() {
     updateModelSize();
-    syncPassCameras();
+    syncPrePassCamera();
     renderer.outputColorSpace = THREE.SRGBColorSpace;
     renderer.toneMapping = THREE.NoToneMapping;
     try {
@@ -203,6 +205,11 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
       hasGTAO: !!aoPass,
       temporalFiltering: aoPass.useTemporalFiltering === true,
       prePassLayerMask: prePass.getLayers()?.mask ?? 0,
+      prePassSamples: prePass.renderTarget?.samples ?? 0,
+      beautyCameraIsSource: scenePass.camera === camera,
+      prePassCameraIsClone: prePass.camera !== camera,
+      cameraCoordinateSystem: camera.coordinateSystem,
+      rendererCoordinateSystem: renderer.coordinateSystem,
       characterAOLayer: CHARACTER_AO_LAYER,
     };
   }

--- a/src/web/js/scene/viewport-render-pipeline.js
+++ b/src/web/js/scene/viewport-render-pipeline.js
@@ -18,7 +18,7 @@ import { ao } from 'three/addons/tsl/display/GTAONode.js';
 import { computeModelBounds } from './model-bounds.js';
 import { CHARACTER_AO_LAYER } from './viewer-layers.js';
 
-const AO_DEFAULT_STRENGTH = 0.22;
+const AO_DEFAULT_STRENGTH = 0.55;
 const AO_RESOLUTION_SCALE = 0.5;
 const AO_SAMPLES = 8;
 const AO_RADIUS_FACTOR = 0.15;

--- a/src/web/js/scene/viewport-render-pipeline.js
+++ b/src/web/js/scene/viewport-render-pipeline.js
@@ -18,10 +18,9 @@ import { ao } from 'three/addons/tsl/display/GTAONode.js';
 import { computeModelBounds } from './model-bounds.js';
 import { CHARACTER_AO_LAYER } from './viewer-layers.js';
 
-const AO_STRENGTH = 0.55;
 const AO_RESOLUTION_SCALE = 0.5;
 const AO_SAMPLES = 8;
-const AO_MAX_RADIUS_FACTOR = 0.10;
+const AO_RADIUS_FACTOR = 0.005;
 const MIN_MODEL_SIZE = 0.001;
 const MIN_AO_RADIUS = 0.001;
 let nextPipelineId = 0;
@@ -85,7 +84,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   aoPass.samples.value = AO_SAMPLES;
   aoPass.useTemporalFiltering = false;
 
-  const aoStrengthNode = uniform(AO_STRENGTH);
+  const aoStrengthNode = uniform(0);
   const aoSample = aoPass.getTextureNode().sample(screenUV).r;
   const effectiveAO = mix(float(1), aoSample, aoStrengthNode);
 
@@ -100,14 +99,14 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   let meshes = [];
   let modelSizeDirty = true;
   let modelSize = MIN_MODEL_SIZE;
-  let radiusFactor = 0;
+  let configuredStrength = 0;
   let suppressedByWireframe = false;
   let renderCount = 0;
   let directRenderCount = 0;
   let aoRenderCount = 0;
 
   function isAmbientOcclusionEnabled() {
-    return radiusFactor > 0;
+    return configuredStrength > 0;
   }
 
   function shouldRenderAO() {
@@ -115,7 +114,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   }
 
   function effectiveStrength() {
-    return shouldRenderAO() ? AO_STRENGTH : 0;
+    return shouldRenderAO() ? configuredStrength : 0;
   }
 
   function applyStrength() {
@@ -141,7 +140,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
       return;
     }
     updateModelSize();
-    aoPass.radius.value = Math.max(modelSize * radiusFactor, MIN_AO_RADIUS);
+    aoPass.radius.value = Math.max(modelSize * AO_RADIUS_FACTOR, MIN_AO_RADIUS);
   }
 
   function invalidateGeometry() {
@@ -177,11 +176,11 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     aoPass.radius.value = MIN_AO_RADIUS;
   }
 
-  function setAmbientOcclusionRadiusFactor(value) {
+  function setAmbientOcclusionStrength(value) {
     if (!Number.isFinite(value)) return false;
-    const next = THREE.MathUtils.clamp(value, 0, AO_MAX_RADIUS_FACTOR);
-    const changed = next !== radiusFactor;
-    radiusFactor = next;
+    const next = THREE.MathUtils.clamp(value, 0, 1);
+    const changed = next !== configuredStrength;
+    configuredStrength = next;
     updateRadius();
     applyStrength();
     return changed;
@@ -223,8 +222,8 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   function getDebugState() {
     return {
       enabled: isAmbientOcclusionEnabled(),
-      radiusFactor,
-      strength: AO_STRENGTH,
+      radiusFactor: AO_RADIUS_FACTOR,
+      strength: configuredStrength,
       effectiveStrength: effectiveStrength(),
       suppressedByWireframe,
       pipelineId,
@@ -268,9 +267,9 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     forgetMeshes,
     invalidateGeometry,
     reset,
-    getAmbientOcclusionRadiusFactor: () => radiusFactor,
+    getAmbientOcclusionStrength: () => configuredStrength,
     isAmbientOcclusionEnabled,
-    setAmbientOcclusionRadiusFactor,
+    setAmbientOcclusionStrength,
     setAmbientOcclusionSuppressedByWireframe,
     getDebugState,
     dispose,

--- a/src/web/js/scene/viewport-render-pipeline.js
+++ b/src/web/js/scene/viewport-render-pipeline.js
@@ -1,0 +1,232 @@
+// WebGPU-native viewport post-processing and character-only ambient occlusion.
+
+import * as THREE from 'three/webgpu';
+import {
+  builtinAOContext,
+  float,
+  mix,
+  mrt,
+  normalView,
+  packNormalToRGB,
+  pass,
+  sample,
+  screenUV,
+  uniform,
+  unpackRGBToNormal,
+} from 'three/tsl';
+import { ao } from 'three/addons/tsl/display/GTAONode.js';
+import { computeModelBounds } from './model-bounds.js';
+import { CHARACTER_AO_LAYER } from './viewer-layers.js';
+
+const AO_DEFAULT_STRENGTH = 0.22;
+const AO_RESOLUTION_SCALE = 0.5;
+const AO_SAMPLES = 16;
+const AO_RADIUS_FACTOR = 0.15;
+const MIN_MODEL_SIZE = 0.001;
+const MIN_AO_RADIUS = 0.001;
+
+function finitePositive(value) {
+  return Number.isFinite(value) && value > 0;
+}
+
+function readUniformValue(node, fallback = 0) {
+  return Number.isFinite(node?.value) ? node.value : fallback;
+}
+
+function readResolution(node) {
+  const value = node?.value;
+  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) {
+    return null;
+  }
+  return [value.x, value.y];
+}
+
+/** Create the one viewport render pipeline used by the scene renderer. */
+export function createViewportRenderPipeline({ renderer, scene, camera }) {
+  const aoLayers = new THREE.Layers();
+  aoLayers.set(CHARACTER_AO_LAYER);
+
+  const renderPipeline = new THREE.RenderPipeline(renderer);
+  // RenderPipeline evaluates scene passes from inside the fullscreen quad.
+  // Separate camera identities keep Three's scene/camera render-list cache
+  // from being re-entered by the normal pass and the character pre-pass.
+  const prePassCamera = camera.clone();
+  const scenePassCamera = camera.clone();
+
+  function syncPassCameras() {
+    prePassCamera.copy(camera);
+    scenePassCamera.copy(camera);
+  }
+
+  // The pre-pass renders only character meshes. Its packed normal attachment
+  // is deliberately 8-bit; depth remains the pass's depth texture.
+  const prePass = pass(scene, prePassCamera);
+  prePass.name = 'Character AO pre-pass';
+  prePass.transparent = false;
+  prePass.setLayers(aoLayers);
+  prePass.setMRT(mrt({ output: packNormalToRGB(normalView) }));
+  const normalTexture = prePass.getTexture('output');
+  normalTexture.type = THREE.UnsignedByteType;
+
+  const prePassNormal = sample(uv =>
+    unpackRGBToNormal(prePass.getTextureNode().sample(uv)));
+  const prePassDepth = prePass.getTextureNode('depth');
+  const aoPass = ao(prePassDepth, prePassNormal, camera);
+  aoPass.resolutionScale = AO_RESOLUTION_SCALE;
+  aoPass.samples.value = AO_SAMPLES;
+  aoPass.useTemporalFiltering = false;
+
+  const aoStrengthNode = uniform(AO_DEFAULT_STRENGTH);
+  const aoSample = aoPass.getTextureNode().sample(screenUV).r;
+  const effectiveAO = mix(float(1), aoSample, aoStrengthNode);
+
+  // The beauty pass retains the whole presentation scene. AO enters through
+  // the lighting context so direct light, shadows, rim and debug outputs are
+  // not multiplied as a final screen-space color operation.
+  const scenePass = pass(scene, scenePassCamera);
+  scenePass.name = 'Viewport beauty pass';
+  scenePass.contextNode = builtinAOContext(effectiveAO);
+  renderPipeline.outputNode = scenePass;
+
+  let meshes = [];
+  let modelSizeDirty = true;
+  let modelSize = MIN_MODEL_SIZE;
+  let enabled = true;
+  let configuredStrength = AO_DEFAULT_STRENGTH;
+  let suppressedByWireframe = false;
+  let renderCount = 0;
+
+  function effectiveStrength() {
+    return enabled && !suppressedByWireframe ? configuredStrength : 0;
+  }
+
+  function applyStrength() {
+    aoStrengthNode.value = effectiveStrength();
+  }
+
+  function updateModelSize() {
+    if (!modelSizeDirty) return;
+    const bounds = computeModelBounds(meshes);
+    if (bounds.isEmpty()) {
+      modelSize = MIN_MODEL_SIZE;
+    } else {
+      const diagonal = bounds.getSize(new THREE.Vector3()).length();
+      modelSize = finitePositive(diagonal) ? Math.max(diagonal, MIN_MODEL_SIZE)
+        : MIN_MODEL_SIZE;
+    }
+    aoPass.radius.value = Math.max(modelSize * AO_RADIUS_FACTOR, MIN_AO_RADIUS);
+    modelSizeDirty = false;
+  }
+
+  function invalidateGeometry() {
+    modelSizeDirty = true;
+  }
+
+  function setMeshes(nextMeshes = []) {
+    meshes = [...new Set(nextMeshes.filter(Boolean))];
+    invalidateGeometry();
+  }
+
+  function adoptMeshes(nextMeshes = []) {
+    const known = new Set(meshes);
+    const added = nextMeshes.filter(mesh => mesh && !known.has(mesh));
+    if (added.length) {
+      meshes.push(...added);
+      invalidateGeometry();
+    }
+    return added;
+  }
+
+  function forgetMeshes(nextMeshes = []) {
+    const removed = new Set(nextMeshes);
+    const before = meshes.length;
+    meshes = meshes.filter(mesh => !removed.has(mesh));
+    if (meshes.length !== before) invalidateGeometry();
+  }
+
+  function reset() {
+    meshes = [];
+    modelSize = MIN_MODEL_SIZE;
+    modelSizeDirty = false;
+    aoPass.radius.value = MIN_AO_RADIUS;
+  }
+
+  function setAmbientOcclusionEnabled(value) {
+    enabled = !!value;
+    applyStrength();
+  }
+
+  function setAmbientOcclusionStrength(value) {
+    if (!Number.isFinite(value)) return false;
+    configuredStrength = THREE.MathUtils.clamp(value, 0, 1);
+    applyStrength();
+    return true;
+  }
+
+  function setAmbientOcclusionSuppressedByWireframe(value) {
+    suppressedByWireframe = !!value;
+    applyStrength();
+  }
+
+  function render() {
+    updateModelSize();
+    syncPassCameras();
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.NoToneMapping;
+    try {
+      renderPipeline.render();
+    } finally {
+      // RenderPipeline temporarily switches to working color space while its
+      // internal passes execute. Keep the renderer contract visible to the
+      // rest of the viewer after the pipeline returns as well.
+      renderer.outputColorSpace = THREE.SRGBColorSpace;
+      renderer.toneMapping = THREE.NoToneMapping;
+    }
+    renderCount += 1;
+  }
+
+  function getDebugState() {
+    return {
+      enabled,
+      strength: configuredStrength,
+      effectiveStrength: effectiveStrength(),
+      suppressedByWireframe,
+      resolutionScale: aoPass.resolutionScale,
+      resolution: readResolution(aoPass.resolution),
+      samples: readUniformValue(aoPass.samples),
+      radius: readUniformValue(aoPass.radius),
+      modelSize,
+      renderCount,
+      pipelineNeedsUpdate: renderPipeline.needsUpdate,
+      hasRenderPipeline: !!renderPipeline,
+      hasPrePass: !!prePass,
+      hasGTAO: !!aoPass,
+      temporalFiltering: aoPass.useTemporalFiltering === true,
+      prePassLayerMask: prePass.getLayers()?.mask ?? 0,
+      characterAOLayer: CHARACTER_AO_LAYER,
+    };
+  }
+
+  function dispose() {
+    aoPass.dispose?.();
+    renderPipeline.dispose?.();
+    prePass.renderTarget?.dispose?.();
+    scenePass.renderTarget?.dispose?.();
+  }
+
+  applyStrength();
+
+  return {
+    render,
+    setMeshes,
+    adoptMeshes,
+    forgetMeshes,
+    invalidateGeometry,
+    reset,
+    setAmbientOcclusionEnabled,
+    setAmbientOcclusionStrength,
+    setAmbientOcclusionSuppressedByWireframe,
+    getDebugState,
+    dispose,
+  };
+}

--- a/src/web/js/ui/toolbar.js
+++ b/src/web/js/ui/toolbar.js
@@ -3,11 +3,24 @@
 import { activeMeshes } from '../mesh/visibility.js';
 import { ENVIRONMENT_PRESETS } from '../scene/environment.js';
 import {
-  getEnvironmentPreset, getLightMode, setEnvironmentPreset, setLightMode,
+  getAmbientOcclusionRadiusFactor, getEnvironmentPreset, getLightMode,
+  setAmbientOcclusionRadiusFactor, setEnvironmentPreset, setLightMode,
 } from '../scene/scene.js';
 import { setTextureDisplayMode } from '../scene/render-modes.js';
 
 const $ = (id) => document.getElementById(id);
+const AO_MAX_RADIUS_FACTOR = 0.10;
+
+function normalizeAmbientOcclusionLevel(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return 0;
+  return Math.min(100, Math.max(0, Math.round(number)));
+}
+
+function radiusFactorToAmbientOcclusionLevel(value) {
+  return normalizeAmbientOcclusionLevel(
+    Number(value) / AO_MAX_RADIUS_FACTOR * 100);
+}
 
 export function initEnvironmentControl() {
   const button = $('environment-btn');
@@ -79,8 +92,12 @@ export function initEnvironmentControl() {
 export function initToolPopovers() {
   const textureButton = $('texture-btn');
   const lightButton = $('light-btn');
+  const aoButton = $('ao-btn');
   const texturePopover = $('texture-popover');
   const lightPopover = $('light-popover');
+  const aoPopover = $('ao-popover');
+  const aoSlider = $('ao-slider');
+  const aoValue = $('ao-value');
   const close = popover => {
     if (!popover) return;
     popover.hidden = true;
@@ -102,9 +119,33 @@ export function initToolPopovers() {
   const closeAll = () => {
     close(texturePopover);
     close(lightPopover);
+    close(aoPopover);
     textureButton?.setAttribute('aria-expanded', 'false');
     lightButton?.setAttribute('aria-expanded', 'false');
+    aoButton?.setAttribute('aria-expanded', 'false');
     activeToolPopover = null;
+  };
+
+  const updateAmbientOcclusionControl = value => {
+    const level = normalizeAmbientOcclusionLevel(value);
+    if (aoSlider) aoSlider.value = String(level);
+    if (aoValue) {
+      aoValue.value = `${level}%`;
+      aoValue.textContent = `${level}%`;
+    }
+    aoButton?.classList.toggle('active', level === 100);
+    aoButton?.classList.toggle('partial', level > 0 && level < 100);
+    const label = `Ambient occlusion: ${level}%`;
+    aoButton?.setAttribute('aria-label', label);
+    if (aoButton) aoButton.title = label;
+    return level;
+  };
+
+  const applyAmbientOcclusionLevel = value => {
+    const level = normalizeAmbientOcclusionLevel(value);
+    setAmbientOcclusionRadiusFactor(level / 100 * AO_MAX_RADIUS_FACTOR);
+    return updateAmbientOcclusionControl(
+      radiusFactorToAmbientOcclusionLevel(getAmbientOcclusionRadiusFactor()));
   };
 
   function toggleTexturePopover() {
@@ -161,14 +202,37 @@ export function initToolPopovers() {
     positionPopover(lightPopover, lightButton);
   }
 
+  function toggleAmbientOcclusionPopover() {
+    if (!aoPopover) return;
+    const wasOpen = !aoPopover.hidden;
+    closeAll();
+    if (wasOpen) return;
+    updateAmbientOcclusionControl(
+      radiusFactorToAmbientOcclusionLevel(getAmbientOcclusionRadiusFactor()));
+    aoPopover.hidden = false;
+    aoButton?.setAttribute('aria-expanded', 'true');
+    activeToolPopover = { popover: aoPopover, button: aoButton };
+    positionPopover(aoPopover, aoButton);
+    aoSlider?.focus();
+  }
+
   textureButton?.setAttribute('aria-haspopup', 'menu');
   lightButton?.setAttribute('aria-haspopup', 'menu');
+  aoButton?.setAttribute('aria-haspopup', 'dialog');
   textureButton?.setAttribute('aria-expanded', 'false');
   lightButton?.setAttribute('aria-expanded', 'false');
+  aoButton?.setAttribute('aria-expanded', 'false');
+  updateAmbientOcclusionControl(
+    radiusFactorToAmbientOcclusionLevel(getAmbientOcclusionRadiusFactor()));
   textureButton?.addEventListener('click', toggleTexturePopover);
   lightButton?.addEventListener('click', toggleLightPopover);
+  aoButton?.addEventListener('click', toggleAmbientOcclusionPopover);
+  aoSlider?.addEventListener('input', () => applyAmbientOcclusionLevel(aoSlider.value));
   document.addEventListener('click', event => {
-    if (event.target.closest('#texture-btn, #texture-popover, #light-btn, #light-popover')) return;
+    if (event.target.closest(
+      '#texture-btn, #texture-popover, #light-btn, #light-popover, #ao-btn, #ao-popover')) {
+      return;
+    }
     closeAll();
   });
   document.addEventListener('keydown', event => {
@@ -179,6 +243,9 @@ export function initToolPopovers() {
       positionPopover(activeToolPopover.popover, activeToolPopover.button);
     }
   });
+
+  return () => updateAmbientOcclusionControl(
+    radiusFactorToAmbientOcclusionLevel(getAmbientOcclusionRadiusFactor()));
 }
 
 export function initToolbarOverflow() {

--- a/src/web/js/ui/toolbar.js
+++ b/src/web/js/ui/toolbar.js
@@ -3,13 +3,13 @@
 import { activeMeshes } from '../mesh/visibility.js';
 import { ENVIRONMENT_PRESETS } from '../scene/environment.js';
 import {
-  getAmbientOcclusionRadiusFactor, getEnvironmentPreset, getLightMode,
-  setAmbientOcclusionRadiusFactor, setEnvironmentPreset, setLightMode,
+  getAmbientOcclusionStrength, getEnvironmentPreset, getLightMode,
+  setAmbientOcclusionStrength, setEnvironmentPreset, setLightMode,
 } from '../scene/scene.js';
 import { setTextureDisplayMode } from '../scene/render-modes.js';
 
 const $ = (id) => document.getElementById(id);
-const AO_MAX_RADIUS_FACTOR = 0.10;
+const AO_MAX_STRENGTH = 1;
 
 function normalizeAmbientOcclusionLevel(value) {
   const number = Number(value);
@@ -17,9 +17,9 @@ function normalizeAmbientOcclusionLevel(value) {
   return Math.min(100, Math.max(0, Math.round(number)));
 }
 
-function radiusFactorToAmbientOcclusionLevel(value) {
+function strengthToAmbientOcclusionLevel(value) {
   return normalizeAmbientOcclusionLevel(
-    Number(value) / AO_MAX_RADIUS_FACTOR * 100);
+    Number(value) / AO_MAX_STRENGTH * 100);
 }
 
 export function initEnvironmentControl() {
@@ -143,9 +143,9 @@ export function initToolPopovers() {
 
   const applyAmbientOcclusionLevel = value => {
     const level = normalizeAmbientOcclusionLevel(value);
-    setAmbientOcclusionRadiusFactor(level / 100 * AO_MAX_RADIUS_FACTOR);
+    setAmbientOcclusionStrength(level / 100 * AO_MAX_STRENGTH);
     return updateAmbientOcclusionControl(
-      radiusFactorToAmbientOcclusionLevel(getAmbientOcclusionRadiusFactor()));
+      strengthToAmbientOcclusionLevel(getAmbientOcclusionStrength()));
   };
 
   function toggleTexturePopover() {
@@ -208,7 +208,7 @@ export function initToolPopovers() {
     closeAll();
     if (wasOpen) return;
     updateAmbientOcclusionControl(
-      radiusFactorToAmbientOcclusionLevel(getAmbientOcclusionRadiusFactor()));
+      strengthToAmbientOcclusionLevel(getAmbientOcclusionStrength()));
     aoPopover.hidden = false;
     aoButton?.setAttribute('aria-expanded', 'true');
     activeToolPopover = { popover: aoPopover, button: aoButton };
@@ -223,7 +223,7 @@ export function initToolPopovers() {
   lightButton?.setAttribute('aria-expanded', 'false');
   aoButton?.setAttribute('aria-expanded', 'false');
   updateAmbientOcclusionControl(
-    radiusFactorToAmbientOcclusionLevel(getAmbientOcclusionRadiusFactor()));
+    strengthToAmbientOcclusionLevel(getAmbientOcclusionStrength()));
   textureButton?.addEventListener('click', toggleTexturePopover);
   lightButton?.addEventListener('click', toggleLightPopover);
   aoButton?.addEventListener('click', toggleAmbientOcclusionPopover);
@@ -245,7 +245,7 @@ export function initToolPopovers() {
   });
 
   return () => updateAmbientOcclusionControl(
-    radiusFactorToAmbientOcclusionLevel(getAmbientOcclusionRadiusFactor()));
+    strengthToAmbientOcclusionLevel(getAmbientOcclusionStrength()));
 }
 
 export function initToolbarOverflow() {


### PR DESCRIPTION
## Summary

- Add a WebGPU viewport render pipeline with character-only GTAO.
- Keep AO scale-aware and compatible with existing debug and wireframe modes.
- Add vendored GTAO wiring and rendering coverage.
