### PR TITLE
feat: add profile-driven toon direct lighting

### DIFF
--- a/src/core/materials/game_profile.py
+++ b/src/core/materials/game_profile.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 import re
 
 from ..ini.sections import line_source
+from ..ini.texture_roles import _legacy_texture_evidence
 
 
 @dataclass(frozen=True)
@@ -144,6 +145,21 @@ def _command_texture_namespace(section):
 def _resource_namespace(value, pattern=_RESOURCE_ROLE_RE):
     match = pattern.match(str(value))
     return match.group(1).lower() if match else None
+
+
+def _legacy_direct_texture_item(items, sections):
+    """Return one validated classic direct texture binding, if present."""
+    section_lookup = {
+        str(name).casefold(): name for name in (sections or {})
+    }
+    for section, line, text in items:
+        match = _DIRECT_TEXTURE_RE.match(text)
+        if not match:
+            continue
+        if _legacy_texture_evidence(
+                match.group(1), sections, section_lookup):
+            return section, line
+    return None
 
 
 def _zzmi_texture_item(items):
@@ -285,11 +301,19 @@ def collect_game_evidence(sections, resources=None):
                             for section, _line, _text in items)
     has_texcoord_section = any(_section_is(section, "texcoord")
                                for section, _line, _text in items)
-    if (has_position_section and has_blend_section and has_texcoord_section
-            and has_vb1_blend):
+    classic_gimi_routing = (
+        has_position_section and has_blend_section and has_texcoord_section
+        and has_vb1_blend)
+    if classic_gimi_routing:
         section, line, _text = vb1_item
         _add(game, "genshin", 75, "gimi_position_blend_texcoord", section, line)
         _add(runtime, "gimi", 65, "gimi_position_blend_texcoord", section, line)
+
+        legacy_texture_item = _legacy_direct_texture_item(items, sections)
+        if legacy_texture_item:
+            _add(texture_api, "gimi", 32,
+                 "gimi_classic_direct_textures",
+                 legacy_texture_item[0], legacy_texture_item[1])
 
     # SetTextures sections are useful API evidence.  A command-list API is
     # stronger than a bare Resource namespace, but still does not use a

--- a/src/core/materials/profiles.py
+++ b/src/core/materials/profiles.py
@@ -76,6 +76,7 @@ class MaterialInterpretation:
     toon_specular_metal_cutoff: float | None = None
     shadow_threshold: float = 0.5
     shadow_softness: float = 0.08
+    shadow_level: float = 0.0
     shadow_mask_strength: float = 0.5
     shadow_influence: float = 1.0
     direct_shadow_model: str | None = None
@@ -105,7 +106,8 @@ class MaterialInterpretation:
                            for channel in self.normal_xy)):
                 raise ValueError(
                     "normal_xy must contain exactly two RGBA channels")
-        if self.direct_shadow_model not in (None, "genshin_toon", "wuwa_base"):
+        if self.direct_shadow_model not in (
+                None, "zzz_toon", "genshin_toon", "wuwa_base"):
             raise ValueError(
                 f"Unknown direct shadow model: {self.direct_shadow_model}")
         if self.direct_specular_model not in (None, "wuwa_body"):
@@ -148,6 +150,7 @@ class MaterialInterpretation:
             "toon_specular_metal_cutoff": self.toon_specular_metal_cutoff,
             "shadow_threshold": self.shadow_threshold,
             "shadow_softness": self.shadow_softness,
+            "shadow_level": self.shadow_level,
             "shadow_mask_strength": self.shadow_mask_strength,
             "shadow_influence": self.shadow_influence,
             "direct_shadow_model": self.direct_shadow_model,
@@ -170,11 +173,16 @@ def _base_profile_for(game, texture_api):
         return MaterialInterpretation(
             id=f"zzz:{texture_api}", game=game, texture_api=texture_api,
             material_id=ChannelRef("material_map", "r"),
-            # ZZZ's LightMap.G is the conservative metallic input.  The
-            # similarly named MaterialMap.G varies between characters and is
-            # not safe to treat as a full-range PBR metalness map.
+            # ZZZ toon diffuse currently uses N·L only. LightMap.G remains
+            # the validated metallic input and must not be reused as a shadow
+            # mask without new evidence.
             metalness=ChannelRef("light_map", "g"),
             specular=ChannelRef("material_map", "b"),
+            shadow_threshold=0.5,
+            shadow_softness=0.08,
+            shadow_level=0.35,
+            shadow_influence=1.0,
+            direct_shadow_model="zzz_toon",
         )
     if game == "genshin" and texture_api in ("gimi", "rabbitfx"):
         return MaterialInterpretation(
@@ -198,6 +206,7 @@ def _base_profile_for(game, texture_api):
             toon_specular_threshold_bias=1.015,
             toon_specular_softness=0.0,
             toon_specular_metal_cutoff=0.90,
+            shadow_level=0.35,
             direct_shadow_model="genshin_toon",
         )
     if game == "wuwa":

--- a/src/core/materials/profiles.py
+++ b/src/core/materials/profiles.py
@@ -179,9 +179,9 @@ def _base_profile_for(game, texture_api):
             metalness=ChannelRef("light_map", "g"),
             specular=ChannelRef("material_map", "b"),
             shadow_threshold=0.5,
-            shadow_softness=0.08,
+            shadow_softness=0.04,
             shadow_level=0.35,
-            shadow_influence=1.0,
+            shadow_influence=0.45,
             direct_shadow_model="zzz_toon",
         )
     if game == "genshin" and texture_api in ("gimi", "rabbitfx"):
@@ -206,7 +206,10 @@ def _base_profile_for(game, texture_api):
             toon_specular_threshold_bias=1.015,
             toon_specular_softness=0.0,
             toon_specular_metal_cutoff=0.90,
+            shadow_threshold=0.5,
+            shadow_softness=0.04,
             shadow_level=0.35,
+            shadow_influence=0.45,
             direct_shadow_model="genshin_toon",
         )
     if game == "wuwa":

--- a/src/tests/core/materials/test_game_profile.py
+++ b/src/tests/core/materials/test_game_profile.py
@@ -1,10 +1,23 @@
 """Structural game/runtime/texture-API detection regressions."""
 
+import pytest
+
 from core.materials.game_profile import detect_game
 from core.ini.analysis import analyze_ini
 from core.ini.parser import _scan_sections_for_draws
+from core.materials.profiles import material_profile_for
 from core.ini.sections import parse_sections
 from core.textures.profiles import texture_profile_for
+
+
+def _classic_gimi_sections():
+    return {
+        "TextureOverrideBodyPosition": ["vb0 = ResourceBodyPosition"],
+        "TextureOverrideBodyBlend": ["vb1 = ResourceBodyBlend"],
+        "TextureOverrideBodyTexcoord": ["vb0 = ResourceBodyTexcoord"],
+        "TextureOverrideBody": ["ps-t1 = ResourceBodyDiffuse"],
+        "ResourceBodyDiffuse": ["filename = body_diffuse.dds"],
+    }
 
 
 def test_wuwa_runtime_and_rabbitfx_api_are_separate():
@@ -27,6 +40,41 @@ def test_zzz_draw_type_vb2_blend_and_zzmi_texture_namespace():
     assert (detection.game, detection.runtime, detection.texture_api) == (
         "zzz", "zzmi", "zzmi")
     assert detection.confidence == "high"
+
+
+@pytest.mark.parametrize(
+    ("sections", "expected_api"),
+    [
+        (_classic_gimi_sections(), "gimi"),
+        ({
+            "TextureOverrideBody": ["ps-t1 = ResourceBodyDiffuse"],
+            "ResourceBodyDiffuse": ["filename = body_diffuse.dds"],
+        }, "raw"),
+        ({
+            **_classic_gimi_sections(),
+            r"CommandList\RabbitFX\SetTextures": [
+                r"Resource\RabbitFX\Diffuse = ref ResourceBodyDiffuse",
+            ],
+        }, "rabbitfx"),
+        ({
+            **_classic_gimi_sections(),
+            "TextureOverrideBody": ["ps-t1 = ResourceFoo"],
+            "ResourceFoo": ["filename = body_diffuse.dds"],
+        }, "raw"),
+        ({
+            **_classic_gimi_sections(),
+            "ResourceBodyDiffuse": ["format = rgba8"],
+        }, "raw"),
+    ],
+)
+def test_classic_gimi_direct_texture_detection_is_conservative(
+        sections, expected_api):
+    detection = detect_game(sections)
+
+    assert detection.texture_api == expected_api
+    if expected_api == "gimi":
+        assert (detection.game, detection.runtime) == ("genshin", "gimi")
+        assert material_profile_for(detection).id == "genshin:gimi"
 
 
 

--- a/src/tests/core/materials/test_profiles.py
+++ b/src/tests/core/materials/test_profiles.py
@@ -16,7 +16,12 @@ def test_zzz_uses_light_map_g_for_metalness_and_material_map_b_for_specular():
     assert profile.metalness == ChannelRef("light_map", "g")
     assert profile.specular == ChannelRef("material_map", "b")
     assert profile.material_id == ChannelRef("material_map", "r")
-    assert profile.to_metadata()["specular_influence"] is None
+    assert profile.shadow_mask is None
+    assert profile.direct_shadow_model == "zzz_toon"
+    assert profile.shadow_level == pytest.approx(0.35)
+    metadata = profile.to_metadata()
+    assert metadata["shadow_level"] == pytest.approx(0.35)
+    assert metadata["direct_shadow_model"] == "zzz_toon"
 
 
 def test_genshin_uses_light_map_r_response_and_g_toon_shadow():
@@ -32,6 +37,8 @@ def test_genshin_uses_light_map_r_response_and_g_toon_shadow():
     assert profile.metalness_scale == 0.08
     assert profile.specular_scale == 1.0
     assert profile.specular_influence == 0.15
+    assert profile.direct_shadow_model == "genshin_toon"
+    assert profile.shadow_level == pytest.approx(0.35)
     assert (profile.toon_specular_shininess,
             profile.toon_specular_threshold_bias,
             profile.toon_specular_softness,
@@ -39,6 +46,22 @@ def test_genshin_uses_light_map_r_response_and_g_toon_shadow():
     assert (profile.shadow_threshold, profile.shadow_softness,
             profile.shadow_mask_strength, profile.shadow_influence) == (
                 0.5, 0.08, 0.5, 1.0)
+    metadata = profile.to_metadata()
+    assert metadata["shadow_level"] == pytest.approx(0.35)
+    assert metadata["direct_shadow_model"] == "genshin_toon"
+
+
+def test_material_profile_accepts_known_toon_models_and_rejects_unknown():
+    for model in ("zzz_toon", "genshin_toon", "wuwa_base"):
+        profile = MaterialInterpretation(
+            id="test", game="test", texture_api="test",
+            direct_shadow_model=model)
+        assert profile.direct_shadow_model == model
+
+    with pytest.raises(ValueError, match="Unknown direct shadow model"):
+        MaterialInterpretation(
+            id="test", game="test", texture_api="test",
+            direct_shadow_model="random_unknown_model")
 
 
 def test_material_profile_kind_falls_back_to_stable_base_profile():

--- a/src/tests/core/materials/test_profiles.py
+++ b/src/tests/core/materials/test_profiles.py
@@ -19,6 +19,8 @@ def test_zzz_uses_light_map_g_for_metalness_and_material_map_b_for_specular():
     assert profile.shadow_mask is None
     assert profile.direct_shadow_model == "zzz_toon"
     assert profile.shadow_level == pytest.approx(0.35)
+    assert (profile.shadow_threshold, profile.shadow_softness,
+            profile.shadow_influence) == (0.5, 0.04, 0.45)
     metadata = profile.to_metadata()
     assert metadata["shadow_level"] == pytest.approx(0.35)
     assert metadata["direct_shadow_model"] == "zzz_toon"
@@ -45,7 +47,7 @@ def test_genshin_uses_light_map_r_response_and_g_toon_shadow():
             profile.toon_specular_metal_cutoff) == (10.0, 1.015, 0.0, 0.90)
     assert (profile.shadow_threshold, profile.shadow_softness,
             profile.shadow_mask_strength, profile.shadow_influence) == (
-                0.5, 0.08, 0.5, 1.0)
+                0.5, 0.04, 0.5, 0.45)
     metadata = profile.to_metadata()
     assert metadata["shadow_level"] == pytest.approx(0.35)
     assert metadata["direct_shadow_model"] == "genshin_toon"

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1081,7 +1081,7 @@ def test_packed_material_profile_uses_tsl_nodes_and_stable_bindings(
         assert state["specularInfluence"] == (None if profile_id == "zzz:zzmi" else 0.15)
         assert (state["shadowThreshold"], state["shadowSoftness"],
                 state["shadowLevel"], state["shadowMaskStrength"],
-                state["shadowInfluence"]) == (0.5, 0.08, 0.35, 0.5, 1)
+                state["shadowInfluence"]) == (0.5, 0.04, 0.35, 0.5, 0.45)
         assert (state["materialKind"], state["materialKindReliable"],
                 state["materialProfileId"]) == ("body", False, profile_id)
         assert state["lightingModel"] == (
@@ -1451,6 +1451,90 @@ def test_toon_shadow_off_ignores_genshin_light_map_boundary_refinement(
         high_pixel = _sample_mesh_pixel(page)
         assert max(abs(a - b) for a, b in zip(low_pixel, high_pixel)) <= 3, (
             low_pixel, high_pixel)
+    finally:
+        context.close()
+
+
+@pytest.mark.parametrize("profile_id", ["wuwa:rabbitfx", "wuwa:rabbitfx:body"])
+def test_wuwa_toon_shadow_toggle_uses_stable_uniform(
+        edge_browser, frontend_url, profile_id):
+    payload = _packed_material_payload(profile_id)
+    entry = payload["meshes"]["Body-Packed-0"]
+    shadow_key = "light_map::Packed-wuwa-shadow.png"
+    payload["textures"] = {
+        "diffuse::Packed-one.png": _flat_png_uri((96, 96, 96, 255)),
+        entry["normal_data_key"]: _flat_png_uri((128, 128, 255, 255)),
+        shadow_key: _flat_png_uri((0, 16, 0, 255)),
+    }
+    entry["light_map_key"] = shadow_key
+
+    context, page = _page(edge_browser, frontend_url, {"Packed": payload})
+    try:
+        _open(page, "Packed")
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.bindings?.light_map?.enabledNode?.value === true
+        """)
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.bindings?.light_map?.textureNode?.value?.image
+            ?.width === 4
+        """)
+        _set_test_key_light(page)
+        before = page.evaluate("""() => {
+          const mesh = window.modViewer.activeMeshes[0];
+          const material = mesh.material;
+          const game = material.userData.gameMaterial;
+          window.__wuwaToonMaterial = material;
+          window.__wuwaToonEnabledNode = game.toonEnabledNode;
+          return {
+            profile: game.profile.id,
+            model: material.setupLightingModel().constructor.name,
+            version: material.version,
+            enabled: game.toonEnabledNode.value,
+          };
+        }""")
+        toon_pixel = _sample_mesh_pixel(page)
+
+        page.locator("#toon-btn").click()
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0].material.userData
+            .gameMaterial.toonEnabledNode.value === false
+        """)
+        page.wait_for_timeout(250)
+        off_pixel = _sample_mesh_pixel(page)
+        off = page.evaluate("""version => {
+          const mesh = window.modViewer.activeMeshes[0];
+          const material = mesh.material;
+          const game = material.userData.gameMaterial;
+          return {
+            sameMaterial: material === window.__wuwaToonMaterial,
+            sameNode: game.toonEnabledNode === window.__wuwaToonEnabledNode,
+            sameVersion: material.version === version,
+            enabled: game.toonEnabledNode.value,
+          };
+        }""", before["version"])
+
+        page.locator("#toon-btn").click()
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0].material.userData
+            .gameMaterial.toonEnabledNode.value === true
+        """)
+        page.wait_for_timeout(250)
+        toon_again_pixel = _sample_mesh_pixel(page)
+
+        assert before["profile"] == profile_id
+        assert before["model"] == (
+            "WuwaBodyLightingModel"
+            if profile_id.endswith(":body") else "WuwaLightingModel")
+        assert before["enabled"] is True
+        assert off == {
+            "sameMaterial": True, "sameNode": True,
+            "sameVersion": True, "enabled": False,
+        }
+        assert sum(off_pixel) > sum(toon_pixel) + 5, (
+            toon_pixel, off_pixel)
+        assert toon_again_pixel == pytest.approx(toon_pixel, abs=2)
     finally:
         context.close()
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1321,6 +1321,140 @@ def test_genshin_toon_uses_n_dot_l_when_light_map_is_missing(
         shadow_pixel, neutral_pixel)
 
 
+def test_toon_shadow_toggle_uses_stable_uniform_and_inherits_to_new_meshes(
+        edge_browser, frontend_url):
+    payload = _packed_material_payload("zzz:zzmi")
+    entry = payload["meshes"]["Body-Packed-0"]
+    entry.pop("uv")
+    entry["light_map_key"] = None
+    entry["material_map_key"] = None
+    entry["normal_data_key"] = None
+    payload["textures"] = {
+        "diffuse::Packed-one.png": _flat_png_uri((96, 96, 96, 255)),
+    }
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"A": payload, "B": copy.deepcopy(payload)},
+    )
+    try:
+        _open(page, "A")
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0]?.material?.userData"
+            "?.gameMaterial?.toonEnabledNode")
+        _set_test_key_light(page)
+        before = page.evaluate("""() => {
+          const mesh = window.modViewer.activeMeshes[0];
+          const material = mesh.material;
+          const game = material.userData.gameMaterial;
+          window.__toonMaterial = material;
+          window.__toonEnabledNode = game.toonEnabledNode;
+          return {
+            material,
+            version: material.version,
+            enabled: game.toonEnabledNode.value,
+            pixel: null,
+          };
+        }""")
+        before_pixel = _sample_mesh_pixel(page)
+        assert before["enabled"] is True
+        assert page.locator("#toon-btn").get_attribute("aria-label") == (
+            "Toon shadows: on")
+        assert page.locator("#toon-btn").get_attribute("aria-pressed") == "true"
+
+        render_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.locator("#toon-btn").click()
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0].material.userData.gameMaterial"
+            ".toonEnabledNode.value === false")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=render_count)
+        page.wait_for_timeout(250)
+        off_pixel = _sample_mesh_pixel(page)
+        off = page.evaluate("""version => {
+          const mesh = window.modViewer.activeMeshes[0];
+          const material = mesh.material;
+          const game = material.userData.gameMaterial;
+          return {
+            sameMaterial: material === window.__toonMaterial,
+            sameNode: game.toonEnabledNode === window.__toonEnabledNode,
+            sameVersion: material.version === version,
+            enabled: game.toonEnabledNode.value,
+          };
+        }""", before["version"])
+        assert off == {
+            "sameMaterial": True, "sameNode": True, "sameVersion": True,
+            "enabled": False,
+        }
+        assert page.locator("#toon-btn").get_attribute("aria-label") == (
+            "Toon shadows: off")
+        assert page.locator("#toon-btn").get_attribute("aria-pressed") == "false"
+        assert "off" in (page.locator("#toon-btn").get_attribute("class") or "")
+        assert sum(before_pixel) != sum(off_pixel), (before_pixel, off_pixel)
+
+        _open(page, "B")
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0]?.material?.userData"
+            "?.gameMaterial?.toonEnabledNode")
+        inherited = page.evaluate("""() => {
+          const mesh = window.modViewer.activeMeshes[0];
+          return mesh.material.userData.gameMaterial.toonEnabledNode.value;
+        }""")
+        assert inherited is False
+    finally:
+        context.close()
+
+
+def test_toon_shadow_off_ignores_genshin_light_map_boundary_refinement(
+        edge_browser, frontend_url):
+    payload = _packed_material_payload("genshin:gimi")
+    entry = payload["meshes"]["Body-Packed-0"]
+    low_key = "light_map::Packed-toon-low.png"
+    high_key = "light_map::Packed-toon-high.png"
+    payload["textures"] = {
+        "diffuse::Packed-one.png": _flat_png_uri((96, 96, 96, 255)),
+        low_key: _flat_png_uri((0, 0, 0, 255)),
+        high_key: _flat_png_uri((0, 255, 0, 255)),
+    }
+    entry["light_map_key"] = low_key
+    context, page = _page(edge_browser, frontend_url, {"Packed": payload})
+    try:
+        _open(page, "Packed")
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.bindings?.light_map?.enabledNode?.value === true
+        """)
+        _set_test_key_light(page)
+        page.locator("#toon-btn").click()
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.toonEnabledNode?.value === false
+        """)
+        page.wait_for_timeout(250)
+        low_pixel = _sample_mesh_pixel(page)
+        page.evaluate("""async key => {
+          const {setMeshTextureState} = await import('./js/mesh/mesh-factory.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          setMeshTextureState(mesh, {
+            diffuse: mesh.userData.texKey,
+            normal_map: mesh.userData.normalMapKey,
+            normal_data: null,
+            light_map: key,
+            material_map: null,
+          });
+        }""", high_key)
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.bindings?.light_map?.textureNode?.value?.image
+            ?.width === 4
+        """)
+        page.wait_for_timeout(250)
+        high_pixel = _sample_mesh_pixel(page)
+        assert max(abs(a - b) for a, b in zip(low_pixel, high_pixel)) <= 3, (
+            low_pixel, high_pixel)
+    finally:
+        context.close()
+
+
 def test_wuwa_debug_modes_are_capability_gated_and_uniform_only(
         edge_browser, frontend_url):
     payload = _packed_material_payload("wuwa:rabbitfx")

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1206,11 +1206,13 @@ def test_genshin_no_uv_keeps_a_and_b_out_of_conservative_material_graph(
         context.close()
 
 
+@pytest.mark.parametrize("has_uv", [True, False])
 def test_zzz_toon_lighting_works_without_light_or_material_maps(
-        edge_browser, frontend_url):
+        edge_browser, frontend_url, has_uv):
     payload = _packed_material_payload("zzz:zzmi")
     entry = payload["meshes"]["Body-Packed-0"]
-    entry.pop("uv")
+    if not has_uv:
+        entry.pop("uv")
     entry["light_map_key"] = None
     entry["material_map_key"] = None
     entry["normal_data_key"] = None

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1218,7 +1218,7 @@ def test_zzz_toon_lighting_works_without_light_or_material_maps(
         "diffuse::Packed-one.png": _flat_png_uri((96, 96, 96, 255)),
     }
 
-    def render(test_payload):
+    def render(test_payload, enable_toon):
         context, page = _page(edge_browser, frontend_url,
                                {"Packed": test_payload})
         try:
@@ -1227,6 +1227,11 @@ def test_zzz_toon_lighting_works_without_light_or_material_maps(
                 "window.modViewer.activeMeshes[0]?.material?.userData"
                 "?.gameMaterial")
             _set_test_key_light(page)
+            if enable_toon:
+                page.locator("#toon-btn").click()
+                page.wait_for_function(
+                    "window.modViewer.activeMeshes[0].material.userData"
+                    ".gameMaterial.toonEnabledNode.value === true")
             state = page.evaluate("""() => {
               const mesh = window.modViewer.activeMeshes[0];
               const material = mesh.material;
@@ -1242,7 +1247,7 @@ def test_zzz_toon_lighting_works_without_light_or_material_maps(
         finally:
             context.close()
 
-    toon_state, toon_pixel = render(payload)
+    toon_state, toon_pixel = render(payload, True)
     physical_payload = copy.deepcopy(payload)
     physical_payload["metadata"]["material_profiles"]["zzz:zzmi"] = (
         material_profile_for("zzz", "zzmi").to_metadata())
@@ -1250,7 +1255,7 @@ def test_zzz_toon_lighting_works_without_light_or_material_maps(
         **physical_payload["metadata"]["material_profiles"]["zzz:zzmi"],
         "direct_shadow_model": None,
     }
-    physical_state, physical_pixel = render(physical_payload)
+    physical_state, physical_pixel = render(physical_payload, False)
 
     assert toon_state == {
         "model": "ZzzLightingModel", "lightMap": False,
@@ -1290,6 +1295,10 @@ def test_genshin_toon_uses_n_dot_l_when_light_map_is_missing(
                 "window.modViewer.activeMeshes[0]?.material?.userData"
                 "?.gameMaterial")
             _set_test_key_light(page)
+            page.locator("#toon-btn").click()
+            page.wait_for_function(
+                "window.modViewer.activeMeshes[0].material.userData"
+                ".gameMaterial.toonEnabledNode.value === true")
             state = page.evaluate("""() => {
               const mesh = window.modViewer.activeMeshes[0];
               const material = mesh.material;
@@ -1356,21 +1365,22 @@ def test_toon_shadow_toggle_uses_stable_uniform_and_inherits_to_new_meshes(
           };
         }""")
         before_pixel = _sample_mesh_pixel(page)
-        assert before["enabled"] is True
+        assert before["enabled"] is False
         assert page.locator("#toon-btn").get_attribute("aria-label") == (
-            "Toon shadows: on")
-        assert page.locator("#toon-btn").get_attribute("aria-pressed") == "true"
+            "Toon shadows: off")
+        assert page.locator("#toon-btn").get_attribute("aria-pressed") == "false"
+        assert "off" in (page.locator("#toon-btn").get_attribute("class") or "")
 
         render_count = page.evaluate("window.modViewer.getRenderCount()")
         page.locator("#toon-btn").click()
         page.wait_for_function(
             "window.modViewer.activeMeshes[0].material.userData.gameMaterial"
-            ".toonEnabledNode.value === false")
+            ".toonEnabledNode.value === true")
         page.wait_for_function(
             "count => window.modViewer.getRenderCount() > count", arg=render_count)
         page.wait_for_timeout(250)
-        off_pixel = _sample_mesh_pixel(page)
-        off = page.evaluate("""version => {
+        toon_pixel = _sample_mesh_pixel(page)
+        toon = page.evaluate("""version => {
           const mesh = window.modViewer.activeMeshes[0];
           const material = mesh.material;
           const game = material.userData.gameMaterial;
@@ -1381,15 +1391,23 @@ def test_toon_shadow_toggle_uses_stable_uniform_and_inherits_to_new_meshes(
             enabled: game.toonEnabledNode.value,
           };
         }""", before["version"])
-        assert off == {
+        assert toon == {
             "sameMaterial": True, "sameNode": True, "sameVersion": True,
-            "enabled": False,
+            "enabled": True,
         }
         assert page.locator("#toon-btn").get_attribute("aria-label") == (
-            "Toon shadows: off")
-        assert page.locator("#toon-btn").get_attribute("aria-pressed") == "false"
-        assert "off" in (page.locator("#toon-btn").get_attribute("class") or "")
-        assert sum(before_pixel) != sum(off_pixel), (before_pixel, off_pixel)
+            "Toon shadows: on")
+        assert page.locator("#toon-btn").get_attribute("aria-pressed") == "true"
+        assert "active" in (page.locator("#toon-btn").get_attribute("class") or "")
+        assert sum(before_pixel) != sum(toon_pixel), (before_pixel, toon_pixel)
+
+        page.locator("#toon-btn").click()
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0].material.userData.gameMaterial"
+            ".toonEnabledNode.value === false")
+        page.wait_for_timeout(250)
+        off_again_pixel = _sample_mesh_pixel(page)
+        assert off_again_pixel == pytest.approx(before_pixel, abs=2)
 
         _open(page, "B")
         page.wait_for_function(
@@ -1424,7 +1442,6 @@ def test_toon_shadow_off_ignores_genshin_light_map_boundary_refinement(
             ?.gameMaterial?.bindings?.light_map?.enabledNode?.value === true
         """)
         _set_test_key_light(page)
-        page.locator("#toon-btn").click()
         page.wait_for_function("""
           () => window.modViewer.activeMeshes[0]?.material?.userData
             ?.gameMaterial?.toonEnabledNode?.value === false
@@ -1494,16 +1511,16 @@ def test_wuwa_toon_shadow_toggle_uses_stable_uniform(
             enabled: game.toonEnabledNode.value,
           };
         }""")
-        toon_pixel = _sample_mesh_pixel(page)
+        off_pixel = _sample_mesh_pixel(page)
 
         page.locator("#toon-btn").click()
         page.wait_for_function("""
           () => window.modViewer.activeMeshes[0].material.userData
-            .gameMaterial.toonEnabledNode.value === false
+            .gameMaterial.toonEnabledNode.value === true
         """)
         page.wait_for_timeout(250)
-        off_pixel = _sample_mesh_pixel(page)
-        off = page.evaluate("""version => {
+        toon_pixel = _sample_mesh_pixel(page)
+        toon = page.evaluate("""version => {
           const mesh = window.modViewer.activeMeshes[0];
           const material = mesh.material;
           const game = material.userData.gameMaterial;
@@ -1518,23 +1535,22 @@ def test_wuwa_toon_shadow_toggle_uses_stable_uniform(
         page.locator("#toon-btn").click()
         page.wait_for_function("""
           () => window.modViewer.activeMeshes[0].material.userData
-            .gameMaterial.toonEnabledNode.value === true
+            .gameMaterial.toonEnabledNode.value === false
         """)
         page.wait_for_timeout(250)
-        toon_again_pixel = _sample_mesh_pixel(page)
+        off_again_pixel = _sample_mesh_pixel(page)
 
         assert before["profile"] == profile_id
         assert before["model"] == (
             "WuwaBodyLightingModel"
             if profile_id.endswith(":body") else "WuwaLightingModel")
-        assert before["enabled"] is True
-        assert off == {
+        assert before["enabled"] is False
+        assert toon == {
             "sameMaterial": True, "sameNode": True,
-            "sameVersion": True, "enabled": False,
+            "sameVersion": True, "enabled": True,
         }
-        assert sum(off_pixel) > sum(toon_pixel) + 5, (
-            toon_pixel, off_pixel)
-        assert toon_again_pixel == pytest.approx(toon_pixel, abs=2)
+        assert sum(off_pixel) > sum(toon_pixel) + 5, (off_pixel, toon_pixel)
+        assert off_again_pixel == pytest.approx(off_pixel, abs=2)
     finally:
         context.close()
 
@@ -2064,6 +2080,12 @@ def test_wuwa_missing_lightmap_disables_shadow_mask_without_rebuilding(
           }
         """)
         page.wait_for_timeout(400)
+        page.locator("#toon-btn").click()
+        page.wait_for_function("""
+          () => window.modViewer.activeMeshes[0]?.material?.userData
+            ?.gameMaterial?.toonEnabledNode?.value === true
+        """)
+        page.wait_for_timeout(250)
         shadowed_pixel = _sample_mesh_pixel(page)
         before_version = page.evaluate("""() => {
           const mesh = window.modViewer.activeMeshes[0];

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -30,6 +30,31 @@ def _set_ao_level(page, level):
         "renderCount": before["renderCount"],
     })
 
+
+def _set_test_key_light(page, x=1.0, z=0.25):
+    page.evaluate("""async ({x, z}) => {
+      const THREE = await import('three');
+      const {scene, controls} = await import('./js/scene/scene.js');
+      const {requestRender} = await import('./js/scene/render-scheduler.js');
+      let key = null;
+      scene.traverse(object => {
+        if (object.isAmbientLight || object.isHemisphereLight) {
+          object.intensity = 0;
+        } else if (object.isSprite || object.isGridHelper) {
+          object.visible = false;
+        } else if (object.isDirectionalLight) {
+          if (!key) key = object;
+          else object.intensity = 0;
+        }
+      });
+      key.target.position.copy(controls.target);
+      key.position.copy(controls.target).add(new THREE.Vector3(x, 0, z));
+      key.intensity = 1;
+      requestRender();
+    }""", {"x": x, "z": z})
+    page.wait_for_timeout(400)
+
+
 def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
     context = edge_browser.new_context(bypass_csp=True)
     page = context.new_page()
@@ -1017,9 +1042,11 @@ def test_packed_material_profile_uses_tsl_nodes_and_stable_bindings(
           const mesh = window.modViewer.activeMeshes[0];
           const material = mesh.material;
           const game = material.userData.gameMaterial;
-          const packedRole = game.profile.id.startsWith('zzz') ? 'material_map' : 'light_map';
-          const lightingModel = material.setupLightingModel();
-          return {
+              const packedRole = game.profile.id.startsWith('zzz') ? 'material_map' : 'light_map';
+              const lightingModel = material.setupLightingModel();
+              window.__shadowLevelNode = game.shadowLevelNode;
+              window.__shadowThresholdNode = game.shadowThresholdNode;
+              return {
             physical: material.isMeshPhysicalNodeMaterial,
             profile: game.profile.id,
             hasGeneratedShaderState: Object.hasOwn(game, 'shader'),
@@ -1036,6 +1063,7 @@ def test_packed_material_profile_uses_tsl_nodes_and_stable_bindings(
             specularInfluence: game.profile.specular_influence,
             shadowThreshold: game.shadowThresholdNode.value,
             shadowSoftness: game.shadowSoftnessNode.value,
+            shadowLevel: game.shadowLevelNode.value,
             shadowMaskStrength: game.shadowMaskStrengthNode.value,
             shadowInfluence: game.shadowInfluenceNode.value,
             materialKind: mesh.userData.materialKind,
@@ -1052,13 +1080,13 @@ def test_packed_material_profile_uses_tsl_nodes_and_stable_bindings(
         assert state["specularScale"] == 1
         assert state["specularInfluence"] == (None if profile_id == "zzz:zzmi" else 0.15)
         assert (state["shadowThreshold"], state["shadowSoftness"],
-                state["shadowMaskStrength"], state["shadowInfluence"]) == (
-                    0.5, 0.08, 0.5, 1)
+                state["shadowLevel"], state["shadowMaskStrength"],
+                state["shadowInfluence"]) == (0.5, 0.08, 0.35, 0.5, 1)
         assert (state["materialKind"], state["materialKindReliable"],
                 state["materialProfileId"]) == ("body", False, profile_id)
         assert state["lightingModel"] == (
             "GenshinLightingModel" if profile_id == "genshin:gimi"
-            else "PhysicalLightingModel")
+            else "ZzzLightingModel")
         assert state["hasSpecularResponseNode"]
         assert state["sampledRole"]
         assert not runtime_errors, "\n".join(runtime_errors)
@@ -1084,6 +1112,8 @@ def test_packed_material_profile_uses_tsl_nodes_and_stable_bindings(
           return {
             sameTextureNode: game.bindings[packedRole].textureNode === packedNode,
             sameEnabledNode: game.bindings[packedRole].enabledNode === packedEnabled,
+            sameShadowLevelNode: game.shadowLevelNode === window.__shadowLevelNode,
+            sameShadowThresholdNode: game.shadowThresholdNode === window.__shadowThresholdNode,
             sameVersion: material.version === version,
             mapEnabled: packedEnabled.value,
             usesPlaceholder: game.bindings[packedRole].textureNode.value
@@ -1091,6 +1121,8 @@ def test_packed_material_profile_uses_tsl_nodes_and_stable_bindings(
           };
         }""")
         assert after == {"sameTextureNode": True, "sameEnabledNode": True,
+                         "sameShadowLevelNode": True,
+                         "sameShadowThresholdNode": True,
                          "sameVersion": True, "mapEnabled": False,
                          "usesPlaceholder": True}
     finally:
@@ -1157,18 +1189,137 @@ def test_genshin_no_uv_keeps_a_and_b_out_of_conservative_material_graph(
             packedResponse: game.packedResponse,
             hasMaterialId: game.hasMaterialId,
             hasSpecularArea: game.hasSpecularArea,
+            hasShadowMask: game.hasShadowMask,
             lightMap: game.bindings.light_map.enabledNode.value,
+            lightingModel: material.setupLightingModel().constructor.name,
           };
         }""")
         assert state == {
             "standard": True, "physical": False,
             "packedResponse": False,
             "hasMaterialId": False, "hasSpecularArea": False,
-            "lightMap": False,
+            "hasShadowMask": False, "lightMap": False,
+            "lightingModel": "GenshinLightingModel",
         }
         assert not uv_messages, uv_messages
     finally:
         context.close()
+
+
+def test_zzz_toon_lighting_works_without_light_or_material_maps(
+        edge_browser, frontend_url):
+    payload = _packed_material_payload("zzz:zzmi")
+    entry = payload["meshes"]["Body-Packed-0"]
+    entry.pop("uv")
+    entry["light_map_key"] = None
+    entry["material_map_key"] = None
+    entry["normal_data_key"] = None
+    payload["textures"] = {
+        "diffuse::Packed-one.png": _flat_png_uri((96, 96, 96, 255)),
+    }
+
+    def render(test_payload):
+        context, page = _page(edge_browser, frontend_url,
+                               {"Packed": test_payload})
+        try:
+            _open(page, "Packed")
+            page.wait_for_function(
+                "window.modViewer.activeMeshes[0]?.material?.userData"
+                "?.gameMaterial")
+            _set_test_key_light(page)
+            state = page.evaluate("""() => {
+              const mesh = window.modViewer.activeMeshes[0];
+              const material = mesh.material;
+              const game = material.userData.gameMaterial;
+              return {
+                model: material.setupLightingModel().constructor.name,
+                lightMap: game.bindings.light_map.enabledNode.value,
+                materialMap: game.bindings.material_map.enabledNode.value,
+                shadowLevel: game.shadowLevelNode.value,
+              };
+            }""")
+            return state, _sample_mesh_pixel(page)
+        finally:
+            context.close()
+
+    toon_state, toon_pixel = render(payload)
+    physical_payload = copy.deepcopy(payload)
+    physical_payload["metadata"]["material_profiles"]["zzz:zzmi"] = (
+        material_profile_for("zzz", "zzmi").to_metadata())
+    physical_payload["metadata"]["material_profiles"]["zzz:zzmi"] = {
+        **physical_payload["metadata"]["material_profiles"]["zzz:zzmi"],
+        "direct_shadow_model": None,
+    }
+    physical_state, physical_pixel = render(physical_payload)
+
+    assert toon_state == {
+        "model": "ZzzLightingModel", "lightMap": False,
+        "materialMap": False, "shadowLevel": 0.35,
+    }
+    assert physical_state["model"] == "PhysicalLightingModel"
+    assert sum(toon_pixel) > sum(physical_pixel) + 8, (
+        toon_pixel, physical_pixel)
+
+
+def test_genshin_toon_uses_n_dot_l_when_light_map_is_missing(
+        edge_browser, frontend_url):
+    base = _packed_material_payload("genshin:gimi")
+    base_entry = base["meshes"]["Body-Packed-0"]
+    light_key = base_entry["light_map_key"]
+    base["textures"] = {
+        "diffuse::Packed-one.png": _flat_png_uri((96, 96, 96, 255)),
+    }
+
+    def make_payload(green):
+        payload = copy.deepcopy(base)
+        entry = payload["meshes"]["Body-Packed-0"]
+        if green is None:
+            entry["light_map_key"] = None
+        else:
+            entry["light_map_key"] = light_key
+            payload["textures"][light_key] = _flat_png_uri(
+                (0, green, 0, 255))
+        return payload
+
+    def render(test_payload):
+        context, page = _page(edge_browser, frontend_url,
+                               {"Packed": test_payload})
+        try:
+            _open(page, "Packed")
+            page.wait_for_function(
+                "window.modViewer.activeMeshes[0]?.material?.userData"
+                "?.gameMaterial")
+            _set_test_key_light(page)
+            state = page.evaluate("""() => {
+              const mesh = window.modViewer.activeMeshes[0];
+              const material = mesh.material;
+              const game = material.userData.gameMaterial;
+              return {
+                model: material.setupLightingModel().constructor.name,
+                lightMap: game.bindings.light_map.enabledNode.value,
+                hasShadowMask: game.hasShadowMask,
+                shadowLevel: game.shadowLevelNode.value,
+              };
+            }""")
+            return state, _sample_mesh_pixel(page)
+        finally:
+            context.close()
+
+    missing_state, missing_pixel = render(make_payload(None))
+    neutral_state, neutral_pixel = render(make_payload(128))
+    shadow_state, shadow_pixel = render(make_payload(0))
+
+    assert missing_state == {
+        "model": "GenshinLightingModel", "lightMap": False,
+        "hasShadowMask": True, "shadowLevel": 0.35,
+    }
+    assert neutral_state["lightMap"]
+    assert neutral_state["hasShadowMask"]
+    assert max(abs(a - b) for a, b in zip(missing_pixel, neutral_pixel)) <= 3, (
+        missing_pixel, neutral_pixel)
+    assert sum(shadow_pixel) + 8 < sum(neutral_pixel), (
+        shadow_pixel, neutral_pixel)
+
 
 def test_wuwa_debug_modes_are_capability_gated_and_uniform_only(
         edge_browser, frontend_url):

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -840,6 +840,12 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
             "toolsDirection": "row",
             "cameraLabelsHidden": True,
         }
+        toon_button = page.locator("#toon-btn")
+        assert toon_button.get_attribute("title") == "Toon shadows: on"
+        assert toon_button.get_attribute("aria-label") == "Toon shadows: on"
+        assert toon_button.get_attribute("aria-pressed") == "true"
+        assert toon_button.evaluate(
+            "button => button.classList.contains('active')")
         toolbar_center = page.evaluate("""() => {
           const box = document.querySelector('#tool-panel').getBoundingClientRect();
           return box.left + box.width / 2;

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -841,11 +841,15 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
             "cameraLabelsHidden": True,
         }
         toon_button = page.locator("#toon-btn")
-        assert toon_button.get_attribute("title") == "Toon shadows: on"
-        assert toon_button.get_attribute("aria-label") == "Toon shadows: on"
-        assert toon_button.get_attribute("aria-pressed") == "true"
+        assert toon_button.get_attribute("title") == "Toon shadows: off"
+        assert toon_button.get_attribute("aria-label") == "Toon shadows: off"
+        assert toon_button.get_attribute("aria-pressed") == "false"
         assert toon_button.evaluate(
-            "button => button.classList.contains('active')")
+            "button => button.classList.contains('off')")
+        tool_order = page.evaluate(
+            "() => [...document.querySelectorAll('#tool-buttons > .tool-btn')]"
+            ".map(button => button.id)")
+        assert tool_order.index("toon-btn") == tool_order.index("grid-btn") - 1
         toolbar_center = page.evaluate("""() => {
           const box = document.querySelector('#tool-panel').getBoundingClientRect();
           return box.left + box.width / 2;

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -373,6 +373,8 @@ body.asset-preview-mode #toolbar-overflow [data-toolbar-target="export-btn"] {
 #grid-btn.off { background: var(--bg-control); }
 #shading-btn { background: var(--accent); }
 #shading-btn.off { background: var(--bg-control); }
+#toon-btn { background: var(--accent); }
+#toon-btn.off { background: var(--bg-control); }
 #glossy-btn { background: var(--accent); }
 #glossy-btn.off { background: var(--bg-control); }
 #texture-btn { background: var(--accent); }
@@ -384,7 +386,7 @@ body.asset-preview-mode #toolbar-overflow [data-toolbar-target="export-btn"] {
 #trackball-btn { background: var(--accent); }
 #trackball-btn.off { background: var(--bg-control); }
 .tool-btn.active,
-#grid-btn:not(.off), #shading-btn:not(.off), #glossy-btn:not(.off),
+#grid-btn:not(.off), #shading-btn:not(.off), #toon-btn:not(.off), #glossy-btn:not(.off),
 #texture-btn:not(.off), #trackball-btn:not(.off),
 #light-btn.double, #light-btn.current {
   background: rgba(31,111,235,.22); border-color: var(--accent-soft); color: var(--accent-soft);

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -225,9 +225,9 @@
       <button id="ao-btn" class="tool-btn" title="Ambient occlusion: 0%" aria-label="Ambient occlusion: 0%"
               aria-expanded="false" aria-controls="ao-popover"><svg class="ui-icon" aria-hidden="true"><use href="#icon-ao"></use></svg></button>
       <button id="glossy-btn" class="tool-btn off" title="Glossy materials: off" aria-label="Glossy materials: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-glossy"></use></svg></button>
+      <button id="toon-btn" class="tool-btn off" title="Toon shadows: off" aria-label="Toon shadows: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-toon"></use></svg></button>
       <button id="grid-btn" class="tool-btn" title="Grid visibility: on" aria-label="Grid visibility: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-grid"></use></svg></button>
       <button id="shading-btn" class="tool-btn" title="Smooth shading: on" aria-label="Smooth shading: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-shading"></use></svg></button>
-      <button id="toon-btn" class="tool-btn active" title="Toon shadows: on" aria-label="Toon shadows: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-toon"></use></svg></button>
       <button id="texture-btn" class="tool-btn" title="Textures: all maps" aria-label="Textures: all maps"><svg class="ui-icon" aria-hidden="true"><use href="#icon-texture"></use></svg></button>
       <button id="light-btn" class="tool-btn double" title="Key light: double brightness and handle size" aria-label="Key light: double" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-light"></use></svg></button>
       <button id="trackball-btn" class="tool-btn active" title="Toggle navigation gizmo: on" aria-label="Toggle navigation gizmo: on" aria-pressed="true">

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -31,6 +31,7 @@
   <symbol id="icon-glossy" viewBox="0 0 24 24"><path d="m12 3 1.8 6.2L20 11l-6.2 1.8L12 19l-1.8-6.2L4 11l6.2-1.8L12 3Z"/><path d="m19 16 .7 2.3L22 19l-2.3.7L19 22l-.7-2.3L16 19l2.3-.7L19 16Z"/></symbol>
   <symbol id="icon-grid" viewBox="0 0 24 24"><path d="M4 4h16v16H4zM4 10h16M4 16h16M10 4v16M16 4v16"/></symbol>
   <symbol id="icon-shading" viewBox="0 0 24 24"><path d="M12 4a8 8 0 1 0 0 16 8 8 0 0 0 0-16Z"/><path d="M12 4v16"/></symbol>
+  <symbol id="icon-toon" viewBox="0 0 24 24"><path d="M12 4a8 8 0 1 0 0 16 8 8 0 0 0 0-16Z"/><path d="M12 4a8 8 0 0 1 0 16Z" fill="currentColor" stroke="none"/></symbol>
   <symbol id="icon-light" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3M4.9 4.9 7 7M17 17l2.1 2.1M19.1 4.9 17 7M7 17l-2.1 2.1"/></symbol>
   <symbol id="icon-appearance" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 4a8 8 0 0 0 0 16Z" fill="currentColor" stroke="none"/></symbol>
   <symbol id="icon-cycle" viewBox="0 0 24 24"><path d="M5 8h11l-3-3M19 16H8l3 3M16 8a6 6 0 0 1 3 5M8 16a6 6 0 0 1-3-5"/></symbol>
@@ -226,6 +227,7 @@
       <button id="glossy-btn" class="tool-btn off" title="Glossy materials: off" aria-label="Glossy materials: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-glossy"></use></svg></button>
       <button id="grid-btn" class="tool-btn" title="Grid visibility: on" aria-label="Grid visibility: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-grid"></use></svg></button>
       <button id="shading-btn" class="tool-btn" title="Smooth shading: on" aria-label="Smooth shading: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-shading"></use></svg></button>
+      <button id="toon-btn" class="tool-btn active" title="Toon shadows: on" aria-label="Toon shadows: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-toon"></use></svg></button>
       <button id="texture-btn" class="tool-btn" title="Textures: all maps" aria-label="Textures: all maps"><svg class="ui-icon" aria-hidden="true"><use href="#icon-texture"></use></svg></button>
       <button id="light-btn" class="tool-btn double" title="Key light: double brightness and handle size" aria-label="Key light: double" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-light"></use></svg></button>
       <button id="trackball-btn" class="tool-btn active" title="Toggle navigation gizmo: on" aria-label="Toggle navigation gizmo: on" aria-pressed="true">

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -8,7 +8,7 @@ import {
 } from './scene/scene.js';
 import {
   activeMeshes, resetMeshState,
-  toggleGlossy, toggleSmoothShading, toggleWireframe,
+  toggleGlossy, toggleSmoothShading, toggleToonShading, toggleWireframe,
 } from './mesh/visibility.js';
 import { refreshMeshTexture } from './mesh/mesh-factory.js';
 import { initSelection } from './scene/selection.js';
@@ -135,6 +135,7 @@ rendererReady.then(ready => {
   });
   $('grid-btn').addEventListener('click', toggleGrid);
   $('shading-btn').addEventListener('click', toggleSmoothShading);
+  $('toon-btn').addEventListener('click', toggleToonShading);
   $('glossy-btn').addEventListener('click', toggleGlossy);
   const syncAmbientOcclusionControl = initToolPopovers();
   $('reset-state-btn').addEventListener('click', event => {

--- a/src/web/js/mesh/material-profile.js
+++ b/src/web/js/mesh/material-profile.js
@@ -436,10 +436,7 @@ class GenshinLightingModel extends ThreePhysicalLightingModel {
     const {
       profile,
       bindings,
-      shadowThresholdNode,
-      shadowSoftnessNode,
       shadowMaskStrengthNode,
-      shadowInfluenceNode,
       specularAreaNode,
       toonSpecularShininessNode,
       toonSpecularThresholdBiasNode,
@@ -764,7 +761,7 @@ export function configureGameMaterial(material, profile, options = {}) {
       numericOr(profile?.shadow_softness, 0.08)),
     shadowLevelNode: uniform(
       numericOr(resolvedProfile?.shadow_level, 0)),
-    toonEnabledNode: uniform(true),
+    toonEnabledNode: uniform(false),
     shadowMaskStrengthNode: uniform(
       numericOr(profile?.shadow_mask_strength, 0.5)),
     shadowInfluenceNode: uniform(

--- a/src/web/js/mesh/material-profile.js
+++ b/src/web/js/mesh/material-profile.js
@@ -48,6 +48,8 @@ import {
 } from 'three/tsl';
 
 const specularColorBlended = TSL.specularColorBlended;
+const BRDF_Lambert = TSL.BRDF_Lambert;
+const diffuseContribution = TSL.diffuseContribution;
 
 const SOURCE_INFO = Object.freeze({
   normal_data: true,
@@ -359,6 +361,59 @@ function physicalLightingFlags(material) {
   ].map(value => value === true);
 }
 
+function toonLightCoordinate(lightDirection) {
+  return normalView
+    .dot(lightDirection)
+    .clamp(-1, 1)
+    .mul(0.5)
+    .add(0.5);
+}
+
+function toonDiffuseFactor(state, lightDirection, boundary) {
+  const physicalFactor = normalView
+    .dot(lightDirection)
+    .clamp(0, 1);
+  const band = smoothstep(
+    state.shadowThresholdNode.sub(state.shadowSoftnessNode),
+    state.shadowThresholdNode.add(state.shadowSoftnessNode),
+    boundary,
+  );
+  const toonFactor = mix(state.shadowLevelNode, float(1), band);
+  return mix(physicalFactor, toonFactor, state.shadowInfluenceNode);
+}
+
+function replaceDirectDiffuse(
+    reflectedLight, diffuseBefore, lightColor, irradianceFactor) {
+  const irradiance = lightColor.mul(irradianceFactor);
+  const toonDiffuse = irradiance.mul(
+    BRDF_Lambert({ diffuseColor: diffuseContribution }),
+  );
+  reflectedLight.directDiffuse.assign(
+    diffuseBefore.add(toonDiffuse),
+  );
+}
+
+class ZzzLightingModel extends ThreePhysicalLightingModel {
+  constructor(material, state) {
+    super(...physicalLightingFlags(material));
+    this.gameMaterialState = state;
+  }
+
+  direct(lightData, builder) {
+    const { lightDirection, lightColor, reflectedLight } = lightData;
+    const diffuseBefore = reflectedLight.directDiffuse.toVar(
+      'zzzDirectDiffuseBefore');
+    super.direct(lightData, builder);
+
+    const factor = toonDiffuseFactor(
+      this.gameMaterialState,
+      lightDirection,
+      toonLightCoordinate(lightDirection),
+    );
+    replaceDirectDiffuse(reflectedLight, diffuseBefore, lightColor, factor);
+  }
+}
+
 /**
  * Genshin's LightMap.G is a per-light toon-shadow mask. The lighting model
  * captures only the direct diffuse contribution produced by the current
@@ -371,7 +426,7 @@ class GenshinLightingModel extends ThreePhysicalLightingModel {
   }
 
   direct(lightData, builder) {
-    const { lightDirection, reflectedLight } = lightData;
+    const { lightDirection, lightColor, reflectedLight } = lightData;
     const diffuseBefore = reflectedLight.directDiffuse.toVar('gameDirectDiffuseBefore');
     const specularBefore = reflectedLight.directSpecular.toVar('gameDirectSpecularBefore');
     super.direct(lightData, builder);
@@ -390,27 +445,19 @@ class GenshinLightingModel extends ThreePhysicalLightingModel {
       toonSpecularMetalCutoffNode,
     } = this.gameMaterialState;
     const maskRef = profile.shadow_mask;
-    const maskBinding = bindings[maskRef.source];
-    const authoredMask = maskBinding.enabledNode.select(
-      channelNode(maskRef, bindings), float(0.5));
-    const lightValue = lightDirection.dot(normalView).clamp()
-      .mul(0.5).add(0.5);
-    const boundary = lightValue.add(
-      authoredMask.sub(0.5).mul(shadowMaskStrengthNode));
-    const factor = smoothstep(
-      shadowThresholdNode.sub(shadowSoftnessNode),
-      shadowThresholdNode.add(shadowSoftnessNode),
-      boundary);
-    const influencedFactor = mix(float(1), factor, shadowInfluenceNode);
-    const enabledFactor = maskBinding.enabledNode.select(
-      influencedFactor, float(1));
-    const diffuseContribution = reflectedLight.directDiffuse.sub(diffuseBefore);
-    reflectedLight.directDiffuse.assign(
-      diffuseBefore.add(diffuseContribution.mul(enabledFactor)));
+    let boundary = toonLightCoordinate(lightDirection);
+    if (this.gameMaterialState.hasShadowMask && validRef(maskRef)) {
+      const authoredMask = enabledChannelNode(maskRef, bindings, 0.5);
+      boundary = boundary.add(
+        authoredMask.sub(0.5).mul(shadowMaskStrengthNode));
+    }
+    const factor = toonDiffuseFactor(
+      this.gameMaterialState, lightDirection, boundary);
+    replaceDirectDiffuse(reflectedLight, diffuseBefore, lightColor, factor);
 
     const areaRef = profile.specular_area;
     let areaGate = float(1);
-    if (validRef(areaRef)) {
+    if (this.gameMaterialState.hasSpecularArea && validRef(areaRef)) {
       const areaBinding = bindings[areaRef.source];
       const threshold = toonSpecularThresholdBiasNode.sub(specularAreaNode);
       const halfDirection = lightDirection.add(positionViewDirection).normalize();
@@ -596,6 +643,25 @@ class WuwaBodyLightingModel extends WuwaLightingModel {
   }
 }
 
+function createGameLightingModel(
+    material, state, { allowPackedSpecializations = true } = {}) {
+  switch (state?.profile?.direct_shadow_model) {
+    case 'zzz_toon':
+      return new ZzzLightingModel(material, state);
+    case 'genshin_toon':
+      return new GenshinLightingModel(material, state);
+    case 'wuwa_base':
+      if (allowPackedSpecializations) {
+        if (state.profile.direct_specular_model === 'wuwa_body') {
+          return new WuwaBodyLightingModel(material, state);
+        }
+        return new WuwaLightingModel(material, state);
+      }
+      break;
+  }
+  return new ThreePhysicalLightingModel(...physicalLightingFlags(material));
+}
+
 class GamePhysicalNodeMaterial extends MeshPhysicalNodeMaterial {
   setupSpecular() {
     const response = this.userData.gameMaterial?.specularResponseNode ?? float(1);
@@ -614,17 +680,7 @@ class GamePhysicalNodeMaterial extends MeshPhysicalNodeMaterial {
   }
 
   setupLightingModel() {
-    const state = this.userData.gameMaterial;
-    if (state?.profile?.direct_shadow_model === 'genshin_toon') {
-      return new GenshinLightingModel(this, state);
-    }
-    if (state?.profile?.direct_shadow_model === 'wuwa_base') {
-      if (state.profile.direct_specular_model === 'wuwa_body') {
-        return new WuwaBodyLightingModel(this, state);
-      }
-      return new WuwaLightingModel(this, state);
-    }
-    return new ThreePhysicalLightingModel(...physicalLightingFlags(this));
+    return createGameLightingModel(this, this.userData.gameMaterial);
   }
 
   setupOutput(builder, outputNode) {
@@ -634,6 +690,12 @@ class GamePhysicalNodeMaterial extends MeshPhysicalNodeMaterial {
 }
 
 class GameStandardNodeMaterial extends MeshStandardNodeMaterial {
+  setupLightingModel() {
+    return createGameLightingModel(this, this.userData.gameMaterial, {
+      allowPackedSpecializations: false,
+    });
+  }
+
   setupOutput(builder, outputNode) {
     const result = super.setupOutput(builder, outputNode);
     return applyViewerOutput(this.userData.gameMaterial, result);
@@ -695,6 +757,8 @@ export function configureGameMaterial(material, profile, options = {}) {
       numericOr(profile?.shadow_threshold, 0.5)),
     shadowSoftnessNode: uniform(
       numericOr(profile?.shadow_softness, 0.08)),
+    shadowLevelNode: uniform(
+      numericOr(resolvedProfile?.shadow_level, 0)),
     shadowMaskStrengthNode: uniform(
       numericOr(profile?.shadow_mask_strength, 0.5)),
     shadowInfluenceNode: uniform(

--- a/src/web/js/mesh/material-profile.js
+++ b/src/web/js/mesh/material-profile.js
@@ -514,6 +514,7 @@ class WuwaLightingModel extends ThreePhysicalLightingModel {
       wuwaShadowMaskCutoffNode,
       wuwaShadowMaskEndpointToleranceNode,
       wuwaShadowInfluenceNode,
+      toonEnabledNode,
     } = this.gameMaterialState;
     const maskRef = profile.shadow_mask;
     const maskBinding = validRef(maskRef) ? bindings[maskRef.source] : null;
@@ -548,8 +549,10 @@ class WuwaLightingModel extends ThreePhysicalLightingModel {
     const authoredVisibility = endpointTolerance.greaterThan(0)
       .select(endpointAwareVisibility, classifiedVisibility);
     const shadowArea = lightBoundary.mul(authoredVisibility).clamp(0, 1);
+    const effectiveInfluence = wuwaShadowInfluenceNode
+      .mul(toonEnabledNode);
     const computedFactor = mix(
-      float(1), shadowArea, wuwaShadowInfluenceNode);
+      float(1), shadowArea, effectiveInfluence);
     // A missing Lightmap is an explicit no-mask case, not permission to
     // borrow Diffuse.A or a Normalmap channel.
     const factor = maskBinding

--- a/src/web/js/mesh/material-profile.js
+++ b/src/web/js/mesh/material-profile.js
@@ -379,7 +379,9 @@ function toonDiffuseFactor(state, lightDirection, boundary) {
     boundary,
   );
   const toonFactor = mix(state.shadowLevelNode, float(1), band);
-  return mix(physicalFactor, toonFactor, state.shadowInfluenceNode);
+  const effectiveInfluence = state.shadowInfluenceNode
+    .mul(state.toonEnabledNode);
+  return mix(physicalFactor, toonFactor, effectiveInfluence);
 }
 
 function replaceDirectDiffuse(
@@ -759,6 +761,7 @@ export function configureGameMaterial(material, profile, options = {}) {
       numericOr(profile?.shadow_softness, 0.08)),
     shadowLevelNode: uniform(
       numericOr(resolvedProfile?.shadow_level, 0)),
+    toonEnabledNode: uniform(true),
     shadowMaskStrengthNode: uniform(
       numericOr(profile?.shadow_mask_strength, 0.5)),
     shadowInfluenceNode: uniform(
@@ -935,6 +938,14 @@ export function getMaterialDebugMode(material) {
 /** Toggle viewer rim lighting without rebuilding the material node graph. */
 export function setGameMaterialRimEnabled(material, enabled) {
   const node = material?.userData?.gameMaterial?.rimEnabledNode;
+  if (!node) return false;
+  node.value = enabled === true;
+  return true;
+}
+
+/** Toggle profile-driven toon direct diffuse without rebuilding the material. */
+export function setGameMaterialToonEnabled(material, enabled) {
+  const node = material?.userData?.gameMaterial?.toonEnabledNode;
   if (!node) return false;
   node.value = enabled === true;
   return true;

--- a/src/web/js/mesh/visibility.js
+++ b/src/web/js/mesh/visibility.js
@@ -9,7 +9,7 @@ import {
 } from './mesh-state.js';
 import {
   toggleGlossyMode, toggleSmoothShadingMode, toggleTextureDisplayMode,
-  toggleWireframeMode,
+  toggleToonShadingMode, toggleWireframeMode,
 } from '../scene/render-modes.js';
 import { clearViewSyncs, syncView, syncViews } from '../scene/view-sync.js';
 
@@ -56,6 +56,10 @@ export function toggleSmoothShading() {
 
 export function toggleGlossy() {
   toggleGlossyMode(activeMeshes);
+}
+
+export function toggleToonShading() {
+  toggleToonShadingMode(activeMeshes);
 }
 
 export function toggleTextures() {

--- a/src/web/js/scene/render-modes.js
+++ b/src/web/js/scene/render-modes.js
@@ -1,7 +1,9 @@
 // Viewer-only material display modes and their toolbar state.
 
 import { refreshMeshTexture, setTextureMode } from '../mesh/mesh-factory.js';
-import { setGameMaterialRimEnabled } from '../mesh/material-profile.js';
+import {
+  setGameMaterialRimEnabled, setGameMaterialToonEnabled,
+} from '../mesh/material-profile.js';
 import { setOutlineSuppressedByWireframe } from './outline-renderer.js';
 import { requestRender } from './render-scheduler.js';
 import { setAmbientOcclusionSuppressedByWireframe } from './scene.js';
@@ -9,6 +11,7 @@ import { setAmbientOcclusionSuppressedByWireframe } from './scene.js';
 let wireframe = false;
 let smoothShading = true;
 let glossy = false;
+let toonShading = true;
 const DEFAULT_ROUGHNESS = 1.0;
 const GLOSSY_ROUGHNESS = 0.2;
 const textureModes = ['all', 'diffuse-normal', 'diffuse', 'none'];
@@ -26,7 +29,10 @@ export function initializeMeshRenderModes(mesh) {
   mesh.material.flatShading = !smoothShading;
   setMeshRoughness(mesh, glossy ? GLOSSY_ROUGHNESS : DEFAULT_ROUGHNESS);
   const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-  materials.forEach(material => setGameMaterialRimEnabled(material, !wireframe));
+  materials.forEach(material => {
+    setGameMaterialRimEnabled(material, !wireframe);
+    setGameMaterialToonEnabled(material, toonShading);
+  });
 }
 
 export function toggleWireframeMode(meshes) {
@@ -77,6 +83,22 @@ export function toggleGlossyMode(meshes) {
   button.setAttribute('aria-pressed', String(glossy));
   meshes.forEach(mesh => {
     setMeshRoughness(mesh, glossy ? GLOSSY_ROUGHNESS : DEFAULT_ROUGHNESS);
+  });
+  requestRender();
+}
+
+export function toggleToonShadingMode(meshes) {
+  toonShading = !toonShading;
+  const button = document.getElementById('toon-btn');
+  button.classList.toggle('active', toonShading);
+  button.classList.toggle('off', !toonShading);
+  const label = `Toon shadows: ${toonShading ? 'on' : 'off'}`;
+  button.title = label;
+  button.setAttribute('aria-label', label);
+  button.setAttribute('aria-pressed', String(toonShading));
+  meshes.forEach(mesh => {
+    const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+    materials.forEach(material => setGameMaterialToonEnabled(material, toonShading));
   });
   requestRender();
 }

--- a/src/web/js/scene/render-modes.js
+++ b/src/web/js/scene/render-modes.js
@@ -11,7 +11,7 @@ import { setAmbientOcclusionSuppressedByWireframe } from './scene.js';
 let wireframe = false;
 let smoothShading = true;
 let glossy = false;
-let toonShading = true;
+let toonShading = false;
 const DEFAULT_ROUGHNESS = 1.0;
 const GLOSSY_ROUGHNESS = 0.2;
 const textureModes = ['all', 'diffuse-normal', 'diffuse', 'none'];


### PR DESCRIPTION
## Summary

- Add profile-driven direct diffuse lighting for validated ZZZ and Genshin materials.
- Add a session-scoped global Toon Shadows toggle using stable material uniforms.
- Apply the toggle to the existing WuWa RabbitFX shadow model.
- Recognize validated classic GIMI direct texture bindings.
- Use softer default ZZZ and Genshin toon transitions.
- Add detection and rendering regression coverage.
