### PR TITLE
feat: make silhouette outlines perspective-correct

### DIFF
--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -2419,16 +2419,24 @@ def test_outline_child_shares_geometry_and_render_modes_suppress_it(
         assert structure["depthWrite"] is False
         assert structure["renderOrder"] > structure["baseRenderOrder"]
         assert structure["map"] is None
+        assert structure["state"]["referenceProjectionSpan"] > 0
         base_outline_state = {
             "attached": True, "visible": False, "globalEnabled": False,
-            "widthPixels": 1.5, "scaleMode": "view-depth",
+            "widthPixels": 1.5, "effectiveWidthPixels": 1.5,
+            "scaleMode": "view-depth-adaptive",
             "scalePerDepth": pytest.approx(
                 2 * math.tan(math.radians(45 / 2)) * 1.5
                 / structure["state"]["viewportHeight"]),
             "viewportHeight": structure["state"]["viewportHeight"],
             "effectiveFov": 45,
+            "projectionSpan": structure["state"]["projectionSpan"],
+            "referenceProjectionSpan": structure["state"][
+                "referenceProjectionSpan"],
+            "projectionRatio": pytest.approx(1),
             "suppressedByWireframe": False, "suppressedByDebug": False,
         }
+        assert structure["state"]["projectionSpan"] == pytest.approx(
+            structure["state"]["referenceProjectionSpan"])
         assert structure["state"] == base_outline_state
 
         page.locator("#outline-btn").click()
@@ -2467,6 +2475,8 @@ def test_outline_width_is_perspective_correct_and_material_stable(
         page.wait_for_function("window.modViewer.activeMeshes.length === 2")
         page.evaluate("""async () => {
           const {camera, controls, scene} = await import('./js/scene/scene.js');
+          const {resetOutlineProjectionReference} =
+            await import('./js/scene/outline-renderer.js');
           const {requestRender} = await import('./js/scene/render-scheduler.js');
           scene.traverse(object => {
             if (object.isGridHelper || object.isSprite) object.visible = false;
@@ -2483,6 +2493,7 @@ def test_outline_width_is_perspective_correct_and_material_stable(
           camera.lookAt(controls.target);
           camera.updateMatrixWorld();
           controls.update();
+          resetOutlineProjectionReference(camera, controls.target);
           const outlines = window.modViewer.activeMeshes.map(
             mesh => mesh.userData.viewerOutline);
           window.__outlineRefs = {
@@ -2536,28 +2547,42 @@ def test_outline_width_is_perspective_correct_and_material_stable(
         scale_widths = _outline_widths(page)
 
         distance_widths = []
-        distance_scales = []
-        for camera_z in (4.5, 8, 12):
+        distance_states = []
+        distance_cases = (
+            (4, 1.5),
+            (8, 1.5),
+            (16, 1.5 * math.sqrt(0.5)),
+            (32, 0.75),
+            (48, 0.75),
+        )
+        for camera_z, expected_width in distance_cases:
             configure(
                 positions=((0, 0, 0), (0, 0, 0)), scales=(1, 1),
                 camera_z=camera_z, visible=(True, False))
             distance_widths.extend(_outline_widths(page))
-            distance_scales.append(
-                page.evaluate("window.modViewer.getOutlineState(0).scalePerDepth"))
+            state = page.evaluate("window.modViewer.getOutlineState(0)")
+            assert state["effectiveWidthPixels"] == pytest.approx(expected_width)
+            distance_states.append(state)
 
         fov_widths = []
+        fov_states = []
         for fov in (30, 60):
             configure(
                 positions=((0, 0, 0), (0, 0, 0)), scales=(1, 1),
                 fov=fov, visible=(True, False))
             fov_widths.extend(_outline_widths(page))
+            fov_states.append(page.evaluate(
+                "window.modViewer.getOutlineState(0)"))
 
         zoom_widths = []
+        zoom_states = []
         for camera_zoom in (0.75, 1.5):
             configure(
                 positions=((0, 0, 0), (0, 0, 0)), scales=(1, 1),
                 camera_zoom=camera_zoom, visible=(True, False))
             zoom_widths.extend(_outline_widths(page))
+            zoom_states.append(page.evaluate(
+                "window.modViewer.getOutlineState(0)"))
 
         initial_viewport_height = page.evaluate(
             "window.modViewer.getOutlineState(0).viewportHeight")
@@ -2581,9 +2606,13 @@ def test_outline_width_is_perspective_correct_and_material_stable(
         assert all(1 <= width <= 3 for width in all_widths), all_widths
         assert max(depth_widths) - min(depth_widths) <= 1, depth_widths
         assert max(scale_widths) - min(scale_widths) <= 1, scale_widths
-        assert max(distance_widths) - min(distance_widths) <= 1, distance_widths
-        assert max(fov_widths) - min(fov_widths) <= 1, fov_widths
-        assert max(zoom_widths) - min(zoom_widths) <= 1, zoom_widths
+        assert [state["projectionRatio"] for state in distance_states] == (
+            pytest.approx([2, 1, 0.5, 0.25, 1 / 6]))
+        for state in fov_states + zoom_states:
+            expected_factor = max(
+                0.5, min(1, math.sqrt(state["projectionRatio"])))
+            assert state["effectiveWidthPixels"] == pytest.approx(
+                1.5 * expected_factor)
         resized_canvas_height = page.evaluate("""async () => {
           const {renderer} = await import('./js/scene/scene.js');
           return renderer.domElement.clientHeight;
@@ -2591,7 +2620,20 @@ def test_outline_width_is_perspective_correct_and_material_stable(
         assert resized_state["viewportHeight"] == resized_canvas_height
         assert resized_state["viewportHeight"] != initial_viewport_height
         assert resized_state["effectiveFov"] == 45
-        assert max(distance_scales) == pytest.approx(min(distance_scales))
+        assert resized_state["effectiveWidthPixels"] == pytest.approx(1.5)
+
+        configure(
+            positions=((0, 0, 0), (0, 0, 0)), scales=(1, 1),
+            camera_z=16, visible=(True, False))
+        assert page.evaluate(
+            "window.modViewer.getOutlineState(0).effectiveWidthPixels") < 1.5
+        before_reset = page.evaluate("window.modViewer.getRenderCount()")
+        page.locator("#camera-reset-view-btn").click()
+        page.wait_for_function(
+            "before => window.modViewer.getRenderCount() > before", arg=before_reset)
+        reset_state = page.evaluate("window.modViewer.getOutlineState(0)")
+        assert reset_state["projectionRatio"] == pytest.approx(1)
+        assert reset_state["effectiveWidthPixels"] == pytest.approx(1.5)
 
         stability = page.evaluate("""() => {
           const current = window.modViewer.activeMeshes.map(

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -55,6 +55,123 @@ def _set_test_key_light(page, x=1.0, z=0.25):
     page.wait_for_timeout(400)
 
 
+def _outline_payload():
+    payload = _payload("Outline")
+    positions = (
+        0, 1, 0,
+        1, 0, 0,
+        0, 0, 1,
+        -1, 0, 0,
+        0, 0, -1,
+        0, -1, 0,
+    )
+    indices = (
+        0, 2, 1, 0, 3, 2, 0, 4, 3, 0, 1, 4,
+        5, 1, 2, 5, 2, 3, 5, 3, 4, 5, 4, 1,
+    )
+    template = next(iter(payload["meshes"].values()))
+    template.update({
+        "component": "Outline Near",
+        "drawindexed": [len(indices), 0, 0],
+        "pos": _f32(*positions),
+        "normal": _f32(*positions),
+        "idx": _u32(*indices),
+        "tex_key": None,
+        "texture_pool_id": None,
+        "texture_variants": [],
+        "shape_targets": [],
+    })
+    second = copy.deepcopy(template)
+    second["component"] = "Outline Far"
+    payload["meshes"] = {
+        "Outline-Near-0": template,
+        "Outline-Far-0": second,
+    }
+    payload["texture_pools"] = {}
+    payload["textures"] = {}
+    return payload
+
+
+def _outline_widths(page):
+    canvas = page.locator("#canvas-container canvas")
+
+    def set_enabled(value):
+        before = page.evaluate("window.modViewer.getRenderCount()")
+        page.evaluate("""async value => {
+          const {setOutlinesEnabled} =
+            await import('./js/scene/outline-renderer.js');
+          setOutlinesEnabled(value);
+        }""", value)
+        page.wait_for_function("""({value, before}) =>
+          window.modViewer.getOutlineState(0).visible === value
+          && window.modViewer.getRenderCount() > before
+        """, arg={"value": value, "before": before})
+
+    set_enabled(False)
+    bounds = page.evaluate("""async () => {
+      const THREE = await import('three');
+      const {camera, renderer} = await import('./js/scene/scene.js');
+      camera.updateMatrixWorld();
+      const rect = renderer.domElement.getBoundingClientRect();
+      return window.modViewer.activeMeshes
+        .filter(mesh => mesh.visible)
+        .map(mesh => {
+          mesh.updateWorldMatrix(true, true);
+          const position = mesh.geometry.attributes.position;
+          const points = [];
+          for (let i = 0; i < position.count; i += 1) {
+            const projected = new THREE.Vector3()
+              .fromBufferAttribute(position, i)
+              .applyMatrix4(mesh.matrixWorld)
+              .project(camera);
+            points.push({
+              x: (projected.x + 1) * rect.width / 2,
+              y: (1 - projected.y) * rect.height / 2,
+            });
+          }
+          const center = new THREE.Vector3()
+            .applyMatrix4(mesh.matrixWorld)
+            .project(camera);
+          return {
+            minX: Math.min(...points.map(point => point.x)),
+            maxX: Math.max(...points.map(point => point.x)),
+            centerY: (1 - center.y) * rect.height / 2,
+          };
+        });
+    }""")
+    without_outline = Image.open(
+        io.BytesIO(canvas.screenshot())).convert("RGB")
+    set_enabled(True)
+    with_outline = Image.open(
+        io.BytesIO(canvas.screenshot())).convert("RGB")
+    difference = ImageChops.difference(without_outline, with_outline)
+
+    widths = []
+    for item in bounds:
+        row_widths = []
+        center_y = round(item["centerY"])
+        for y in range(center_y - 2, center_y + 3):
+            if not 0 <= y < difference.height:
+                continue
+            windows = (
+                (math.floor(item["minX"]) - 6,
+                 math.ceil(item["minX"]) + 2),
+                (math.floor(item["maxX"]) - 2,
+                 math.ceil(item["maxX"]) + 6),
+            )
+            for start, end in windows:
+                changed = [
+                    x for x in range(max(0, start), min(difference.width, end + 1))
+                    if max(difference.getpixel((x, y))) > 0
+                ]
+                if changed:
+                    row_widths.append(len(changed))
+        assert row_widths, (item, difference.getbbox())
+        ordered = sorted(row_widths)
+        widths.append(ordered[len(ordered) // 2])
+    return widths
+
+
 def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
     context = edge_browser.new_context(bypass_csp=True)
     page = context.new_page()
@@ -2282,6 +2399,7 @@ def test_outline_child_shares_geometry_and_render_modes_suppress_it(
             count: outline.length,
             sharedGeometry: item?.geometry === mesh.geometry,
             isMeshBasicNodeMaterial: item?.material?.isMeshBasicNodeMaterial === true,
+            hasVertexNode: item?.material?.vertexNode?.isNode === true,
             side: item?.material?.side,
             backSide: THREE.BackSide,
             depthTest: item?.material?.depthTest,
@@ -2295,34 +2413,37 @@ def test_outline_child_shares_geometry_and_render_modes_suppress_it(
         assert structure["count"] == 1
         assert structure["sharedGeometry"]
         assert structure["isMeshBasicNodeMaterial"]
+        assert structure["hasVertexNode"]
         assert structure["side"] == structure["backSide"]
         assert structure["depthTest"] is True
         assert structure["depthWrite"] is False
         assert structure["renderOrder"] > structure["baseRenderOrder"]
         assert structure["map"] is None
-        assert structure["state"] == {
+        base_outline_state = {
             "attached": True, "visible": False, "globalEnabled": False,
-            "widthPixels": 1.5, "suppressedByWireframe": False,
-            "suppressedByDebug": False,
+            "widthPixels": 1.5, "scaleMode": "view-depth",
+            "scalePerDepth": pytest.approx(
+                2 * math.tan(math.radians(45 / 2)) * 1.5
+                / structure["state"]["viewportHeight"]),
+            "viewportHeight": structure["state"]["viewportHeight"],
+            "effectiveFov": 45,
+            "suppressedByWireframe": False, "suppressedByDebug": False,
         }
+        assert structure["state"] == base_outline_state
 
         page.locator("#outline-btn").click()
         assert page.evaluate("window.modViewer.getOutlineState(0)") == {
-            "attached": True, "visible": True, "globalEnabled": True,
-            "widthPixels": 1.5, "suppressedByWireframe": False,
-            "suppressedByDebug": False,
+            **base_outline_state, "visible": True, "globalEnabled": True,
         }
         page.locator("#wire-btn").click()
         assert page.evaluate("window.modViewer.getOutlineState(0)") == {
-            "attached": True, "visible": False, "globalEnabled": True,
-            "widthPixels": 1.5, "suppressedByWireframe": True,
-            "suppressedByDebug": False,
+            **base_outline_state, "globalEnabled": True,
+            "suppressedByWireframe": True,
         }
         page.locator("#wire-btn").click()
         page.evaluate("window.modViewer.setMaterialDebugMode('shadow-mask')")
         assert page.evaluate("window.modViewer.getOutlineState(0)") == {
-            "attached": True, "visible": False, "globalEnabled": True,
-            "widthPixels": 1.5, "suppressedByWireframe": False,
+            **base_outline_state, "globalEnabled": True,
             "suppressedByDebug": True,
         }
         page.evaluate("window.modViewer.setMaterialDebugMode('off')")
@@ -2331,12 +2452,174 @@ def test_outline_child_shares_geometry_and_render_modes_suppress_it(
         page.evaluate("window.modViewer.reloadCurrentMod()")
         page.wait_for_function("window.modViewer.activeMeshes.length === 1")
         assert page.evaluate("window.modViewer.getOutlineState(0)") == {
-            "attached": True, "visible": True, "globalEnabled": True,
-            "widthPixels": 1.5, "suppressedByWireframe": False,
-            "suppressedByDebug": False,
+            **base_outline_state, "visible": True, "globalEnabled": True,
         }
     finally:
         context.close()
+
+
+def test_outline_width_is_perspective_correct_and_material_stable(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"Outline": _outline_payload()})
+    try:
+        _open(page, "Outline")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 2")
+        page.evaluate("""async () => {
+          const {camera, controls, scene} = await import('./js/scene/scene.js');
+          const {requestRender} = await import('./js/scene/render-scheduler.js');
+          scene.traverse(object => {
+            if (object.isGridHelper || object.isSprite) object.visible = false;
+          });
+          for (const mesh of window.modViewer.activeMeshes) {
+            mesh.material.color.setHex(0xeeeeee);
+          }
+          camera.up.set(0, 1, 0);
+          camera.zoom = 1;
+          camera.fov = 45;
+          camera.position.set(0, 0, 8);
+          controls.target.set(0, 0, 0);
+          camera.updateProjectionMatrix();
+          camera.lookAt(controls.target);
+          camera.updateMatrixWorld();
+          controls.update();
+          const outlines = window.modViewer.activeMeshes.map(
+            mesh => mesh.userData.viewerOutline);
+          window.__outlineRefs = {
+            outlines,
+            materials: outlines.map(outline => outline.material),
+            versions: outlines.map(outline => outline.material.version),
+          };
+          requestRender();
+        }""")
+
+        def configure(*, positions, scales, camera_z=8, fov=45,
+                      camera_zoom=1,
+                      visible=(True, True)):
+            before = page.evaluate("window.modViewer.getRenderCount()")
+            page.evaluate("""async state => {
+              const {camera, controls} = await import('./js/scene/scene.js');
+              const {requestRender} = await import('./js/scene/render-scheduler.js');
+              window.modViewer.activeMeshes.forEach((mesh, index) => {
+                mesh.position.fromArray(state.positions[index]);
+                mesh.scale.setScalar(state.scales[index]);
+                mesh.visible = state.visible[index];
+                mesh.updateMatrix();
+              });
+              camera.position.set(0, 0, state.cameraZ);
+              camera.fov = state.fov;
+              camera.zoom = state.cameraZoom;
+              controls.target.set(0, 0, 0);
+              camera.updateProjectionMatrix();
+              camera.lookAt(controls.target);
+              camera.updateMatrixWorld();
+              controls.update();
+              requestRender();
+            }""", {
+                "positions": positions, "scales": scales,
+                "cameraZ": camera_z, "fov": fov,
+                "cameraZoom": camera_zoom,
+                "visible": visible,
+            })
+            page.wait_for_function(
+                "before => window.modViewer.getRenderCount() > before",
+                arg=before)
+
+        configure(
+            positions=((-1.5, 0, 2), (1.5, 0, -2)),
+            scales=(0.85, 0.85))
+        depth_widths = _outline_widths(page)
+
+        configure(
+            positions=((-1.5, 0, 0), (1.5, 0, 0)),
+            scales=(0.5, 1.8))
+        scale_widths = _outline_widths(page)
+
+        distance_widths = []
+        distance_scales = []
+        for camera_z in (4.5, 8, 12):
+            configure(
+                positions=((0, 0, 0), (0, 0, 0)), scales=(1, 1),
+                camera_z=camera_z, visible=(True, False))
+            distance_widths.extend(_outline_widths(page))
+            distance_scales.append(
+                page.evaluate("window.modViewer.getOutlineState(0).scalePerDepth"))
+
+        fov_widths = []
+        for fov in (30, 60):
+            configure(
+                positions=((0, 0, 0), (0, 0, 0)), scales=(1, 1),
+                fov=fov, visible=(True, False))
+            fov_widths.extend(_outline_widths(page))
+
+        zoom_widths = []
+        for camera_zoom in (0.75, 1.5):
+            configure(
+                positions=((0, 0, 0), (0, 0, 0)), scales=(1, 1),
+                camera_zoom=camera_zoom, visible=(True, False))
+            zoom_widths.extend(_outline_widths(page))
+
+        initial_viewport_height = page.evaluate(
+            "window.modViewer.getOutlineState(0).viewportHeight")
+        page.set_viewport_size({"width": 900, "height": 600})
+        configure(
+            positions=((0, 0, 0), (0, 0, 0)), scales=(1, 1),
+            visible=(True, False))
+        resized_width = _outline_widths(page)[0]
+        resized_state = page.evaluate("window.modViewer.getOutlineState(0)")
+
+        before_turn = page.evaluate("window.modViewer.getRenderCount()")
+        page.locator("#camera-flip-btn").click()
+        page.wait_for_function(
+            "before => window.modViewer.getRenderCount() > before", arg=before_turn)
+        rotated_width = _outline_widths(page)[0]
+
+        all_widths = (
+            depth_widths + scale_widths + distance_widths + fov_widths
+            + zoom_widths
+            + [resized_width, rotated_width])
+        assert all(1 <= width <= 3 for width in all_widths), all_widths
+        assert max(depth_widths) - min(depth_widths) <= 1, depth_widths
+        assert max(scale_widths) - min(scale_widths) <= 1, scale_widths
+        assert max(distance_widths) - min(distance_widths) <= 1, distance_widths
+        assert max(fov_widths) - min(fov_widths) <= 1, fov_widths
+        assert max(zoom_widths) - min(zoom_widths) <= 1, zoom_widths
+        resized_canvas_height = page.evaluate("""async () => {
+          const {renderer} = await import('./js/scene/scene.js');
+          return renderer.domElement.clientHeight;
+        }""")
+        assert resized_state["viewportHeight"] == resized_canvas_height
+        assert resized_state["viewportHeight"] != initial_viewport_height
+        assert resized_state["effectiveFov"] == 45
+        assert max(distance_scales) == pytest.approx(min(distance_scales))
+
+        stability = page.evaluate("""() => {
+          const current = window.modViewer.activeMeshes.map(
+            mesh => mesh.userData.viewerOutline);
+          return {
+            sameOutlines: current.every(
+              (outline, index) => outline === window.__outlineRefs.outlines[index]),
+            sameMaterials: current.every((outline, index) =>
+              outline.material === window.__outlineRefs.materials[index]),
+            sameVersions: current.every((outline, index) =>
+              outline.material.version === window.__outlineRefs.versions[index]),
+            sharedMaterial: current[0].material === current[1].material,
+            sharedGeometry: current.every((outline, index) =>
+              outline.geometry === window.modViewer.activeMeshes[index].geometry),
+          };
+        }""")
+        assert stability == {
+            "sameOutlines": True, "sameMaterials": True,
+            "sameVersions": True, "sharedMaterial": True,
+            "sharedGeometry": True,
+        }
+
+        settled_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.wait_for_timeout(250)
+        assert page.evaluate("window.modViewer.getRenderCount()") == settled_count
+    finally:
+        context.close()
+
 
 def test_wuwa_models_start_with_a_180_degree_base_turn(
         edge_browser, frontend_url):

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -2422,10 +2422,13 @@ def test_outline_child_shares_geometry_and_render_modes_suppress_it(
         assert structure["state"]["referenceProjectionSpan"] > 0
         base_outline_state = {
             "attached": True, "visible": False, "globalEnabled": False,
-            "widthPixels": 1.5, "effectiveWidthPixels": 1.5,
+            "referenceWidthPixels": 0.75,
+            "minWidthPixels": 0.5,
+            "maxWidthPixels": 1.5,
+            "effectiveWidthPixels": 0.75,
             "scaleMode": "view-depth-adaptive",
             "scalePerDepth": pytest.approx(
-                2 * math.tan(math.radians(45 / 2)) * 1.5
+                2 * math.tan(math.radians(45 / 2)) * 0.75
                 / structure["state"]["viewportHeight"]),
             "viewportHeight": structure["state"]["viewportHeight"],
             "effectiveFov": 45,
@@ -2549,11 +2552,12 @@ def test_outline_width_is_perspective_correct_and_material_stable(
         distance_widths = []
         distance_states = []
         distance_cases = (
-            (4, 1.5),
-            (8, 1.5),
-            (16, 1.5 * math.sqrt(0.5)),
-            (32, 0.75),
-            (48, 0.75),
+            (2, 1.5),
+            (4, 0.75 * math.sqrt(2)),
+            (8, 0.75),
+            (16, 0.75 * math.sqrt(0.5)),
+            (32, 0.5),
+            (48, 0.5),
         )
         for camera_z, expected_width in distance_cases:
             configure(
@@ -2607,12 +2611,13 @@ def test_outline_width_is_perspective_correct_and_material_stable(
         assert max(depth_widths) - min(depth_widths) <= 1, depth_widths
         assert max(scale_widths) - min(scale_widths) <= 1, scale_widths
         assert [state["projectionRatio"] for state in distance_states] == (
-            pytest.approx([2, 1, 0.5, 0.25, 1 / 6]))
+            pytest.approx([4, 2, 1, 0.5, 0.25, 1 / 6]))
         for state in fov_states + zoom_states:
-            expected_factor = max(
-                0.5, min(1, math.sqrt(state["projectionRatio"])))
+            expected_width = max(
+                0.5,
+                min(1.5, 0.75 * math.sqrt(state["projectionRatio"])))
             assert state["effectiveWidthPixels"] == pytest.approx(
-                1.5 * expected_factor)
+                expected_width)
         resized_canvas_height = page.evaluate("""async () => {
           const {renderer} = await import('./js/scene/scene.js');
           return renderer.domElement.clientHeight;
@@ -2620,20 +2625,20 @@ def test_outline_width_is_perspective_correct_and_material_stable(
         assert resized_state["viewportHeight"] == resized_canvas_height
         assert resized_state["viewportHeight"] != initial_viewport_height
         assert resized_state["effectiveFov"] == 45
-        assert resized_state["effectiveWidthPixels"] == pytest.approx(1.5)
+        assert resized_state["effectiveWidthPixels"] == pytest.approx(0.75)
 
         configure(
             positions=((0, 0, 0), (0, 0, 0)), scales=(1, 1),
             camera_z=16, visible=(True, False))
         assert page.evaluate(
-            "window.modViewer.getOutlineState(0).effectiveWidthPixels") < 1.5
+            "window.modViewer.getOutlineState(0).effectiveWidthPixels") < 0.75
         before_reset = page.evaluate("window.modViewer.getRenderCount()")
         page.locator("#camera-reset-view-btn").click()
         page.wait_for_function(
             "before => window.modViewer.getRenderCount() > before", arg=before_reset)
         reset_state = page.evaluate("window.modViewer.getOutlineState(0)")
         assert reset_state["projectionRatio"] == pytest.approx(1)
-        assert reset_state["effectiveWidthPixels"] == pytest.approx(1.5)
+        assert reset_state["effectiveWidthPixels"] == pytest.approx(0.75)
 
         stability = page.evaluate("""() => {
           const current = window.modViewer.activeMeshes.map(

--- a/src/web/js/scene/outline-renderer.js
+++ b/src/web/js/scene/outline-renderer.js
@@ -1,11 +1,17 @@
 // Shared WebGPU/TSL inverted-hull silhouette outlines.
 
 import * as THREE from 'three/webgpu';
-import { normalLocal, positionLocal, uniform } from 'three/tsl';
+import {
+  cameraProjectionMatrix,
+  normalViewGeometry,
+  positionView,
+  uniform,
+  vec4,
+} from 'three/tsl';
 import { requestRender } from './render-scheduler.js';
 
 const OUTLINE_WIDTH_PIXELS = 1.5;
-const outlineWidthWorldNode = uniform(0);
+const outlineScalePerDepthNode = uniform(0);
 const outlineMaterial = new THREE.MeshBasicNodeMaterial({
   color: 0x111318,
   side: THREE.BackSide,
@@ -13,13 +19,19 @@ const outlineMaterial = new THREE.MeshBasicNodeMaterial({
   depthWrite: false,
 });
 outlineMaterial.toneMapped = false;
-outlineMaterial.positionNode = positionLocal.add(
-  normalLocal.normalize().mul(outlineWidthWorldNode));
+const outlineViewDepth = positionView.z.negate().max(0.000001);
+const outlineWidthView = outlineViewDepth.mul(outlineScalePerDepthNode);
+const displacedOutlinePositionView = positionView.add(
+  normalViewGeometry.mul(outlineWidthView));
+outlineMaterial.vertexNode = cameraProjectionMatrix.mul(
+  vec4(displacedOutlinePositionView, 1));
 
 const attachedOutlines = new Set();
 let outlinesEnabled = false;
 let suppressedByWireframe = false;
 let suppressedByDebug = false;
+let outlineViewportHeight = 0;
+let outlineEffectiveFov = 0;
 
 function outlinesVisible() {
   return outlinesEnabled && !suppressedByWireframe && !suppressedByDebug;
@@ -84,22 +96,28 @@ export function setOutlineSuppressedByDebug(value) {
   requestRender();
 }
 
-/** Update the shared world-space extrusion from the current CSS viewport. */
-export function updateOutlineCameraScale(camera, target, viewportHeight) {
+/** Update the shared view-space extrusion scale from the CSS viewport. */
+export function updateOutlineProjectionScale(camera, viewportHeight) {
   const height = Number(viewportHeight);
-  const distance = camera?.position?.distanceTo(target);
+  const effectiveFov = typeof camera?.getEffectiveFOV === 'function'
+    ? camera.getEffectiveFOV() : camera?.fov;
+  const fovDegrees = Number(effectiveFov);
   if (!camera || !Number.isFinite(height) || height <= 0
-      || !Number.isFinite(distance) || distance <= 0) {
-    outlineWidthWorldNode.value = 0;
+      || !Number.isFinite(fovDegrees)
+      || fovDegrees <= 0 || fovDegrees >= 180) {
+    outlineScalePerDepthNode.value = 0;
+    outlineViewportHeight = 0;
+    outlineEffectiveFov = 0;
     return 0;
   }
-  const effectiveFov = typeof camera.getEffectiveFOV === 'function'
-    ? camera.getEffectiveFOV() : camera.fov;
-  const fov = THREE.MathUtils.degToRad(Number(effectiveFov));
-  const worldHeight = 2 * distance * Math.tan(fov / 2);
-  const width = worldHeight / height * OUTLINE_WIDTH_PIXELS;
-  outlineWidthWorldNode.value = Number.isFinite(width) ? width : 0;
-  return outlineWidthWorldNode.value;
+  const fov = THREE.MathUtils.degToRad(fovDegrees);
+  const scalePerDepth = 2 * Math.tan(fov / 2)
+    * OUTLINE_WIDTH_PIXELS / height;
+  outlineScalePerDepthNode.value = Number.isFinite(scalePerDepth)
+    ? scalePerDepth : 0;
+  outlineViewportHeight = height;
+  outlineEffectiveFov = fovDegrees;
+  return outlineScalePerDepthNode.value;
 }
 
 export function getOutlineState(mesh) {
@@ -109,6 +127,10 @@ export function getOutlineState(mesh) {
     visible: !!outline?.visible,
     globalEnabled: outlinesEnabled,
     widthPixels: OUTLINE_WIDTH_PIXELS,
+    scaleMode: 'view-depth',
+    scalePerDepth: outlineScalePerDepthNode.value,
+    viewportHeight: outlineViewportHeight,
+    effectiveFov: outlineEffectiveFov,
     suppressedByWireframe,
     suppressedByDebug,
   };

--- a/src/web/js/scene/outline-renderer.js
+++ b/src/web/js/scene/outline-renderer.js
@@ -10,7 +10,8 @@ import {
 } from 'three/tsl';
 import { requestRender } from './render-scheduler.js';
 
-const OUTLINE_WIDTH_PIXELS = 1.5;
+const OUTLINE_WIDTH_PIXELS = 1.0;
+const MIN_OUTLINE_WIDTH_FACTOR = 0.5;
 const outlineScalePerDepthNode = uniform(0);
 const outlineMaterial = new THREE.MeshBasicNodeMaterial({
   color: 0x111318,
@@ -32,6 +33,10 @@ let suppressedByWireframe = false;
 let suppressedByDebug = false;
 let outlineViewportHeight = 0;
 let outlineEffectiveFov = 0;
+let outlineEffectiveWidthPixels = OUTLINE_WIDTH_PIXELS;
+let outlineProjectionSpan = 0;
+let outlineReferenceProjectionSpan = 0;
+let outlineProjectionRatio = 1;
 
 function outlinesVisible() {
   return outlinesEnabled && !suppressedByWireframe && !suppressedByDebug;
@@ -96,27 +101,64 @@ export function setOutlineSuppressedByDebug(value) {
   requestRender();
 }
 
-/** Update the shared view-space extrusion scale from the CSS viewport. */
-export function updateOutlineProjectionScale(camera, viewportHeight) {
-  const height = Number(viewportHeight);
+function effectiveFovRadians(camera) {
   const effectiveFov = typeof camera?.getEffectiveFOV === 'function'
     ? camera.getEffectiveFOV() : camera?.fov;
   const fovDegrees = Number(effectiveFov);
+  if (!Number.isFinite(fovDegrees)
+      || fovDegrees <= 0 || fovDegrees >= 180) return null;
+  return {
+    degrees: fovDegrees,
+    radians: THREE.MathUtils.degToRad(fovDegrees),
+  };
+}
+
+function projectionSpan(camera, target, fovRadians) {
+  if (!camera?.position || !target) return 0;
+  const distance = camera?.position?.distanceTo(target);
+  const span = distance * Math.tan(fovRadians / 2);
+  return Number.isFinite(span) && span > 0 ? span : 0;
+}
+
+/** Capture the fitted camera projection without changing it during Arcball zoom. */
+export function resetOutlineProjectionReference(camera, target) {
+  const fov = effectiveFovRadians(camera);
+  outlineReferenceProjectionSpan = fov
+    ? projectionSpan(camera, target, fov.radians) : 0;
+  return outlineReferenceProjectionSpan;
+}
+
+/** Update the shared view-space extrusion scale from camera projection and CSS viewport. */
+export function updateOutlineProjectionScale(camera, target, viewportHeight) {
+  const height = Number(viewportHeight);
+  const fov = effectiveFovRadians(camera);
+  const currentSpan = fov
+    ? projectionSpan(camera, target, fov.radians) : 0;
   if (!camera || !Number.isFinite(height) || height <= 0
-      || !Number.isFinite(fovDegrees)
-      || fovDegrees <= 0 || fovDegrees >= 180) {
+      || !fov || currentSpan <= 0) {
     outlineScalePerDepthNode.value = 0;
     outlineViewportHeight = 0;
     outlineEffectiveFov = 0;
+    outlineEffectiveWidthPixels = 0;
+    outlineProjectionSpan = 0;
+    outlineProjectionRatio = 0;
     return 0;
   }
-  const fov = THREE.MathUtils.degToRad(fovDegrees);
-  const scalePerDepth = 2 * Math.tan(fov / 2)
-    * OUTLINE_WIDTH_PIXELS / height;
+  const referenceSpan = outlineReferenceProjectionSpan > 0
+    ? outlineReferenceProjectionSpan : currentSpan;
+  const ratio = referenceSpan / currentSpan;
+  const widthFactor = THREE.MathUtils.clamp(
+    Math.sqrt(ratio), MIN_OUTLINE_WIDTH_FACTOR, 1);
+  const effectiveWidthPixels = OUTLINE_WIDTH_PIXELS * widthFactor;
+  const scalePerDepth = 2 * Math.tan(fov.radians / 2)
+    * effectiveWidthPixels / height;
   outlineScalePerDepthNode.value = Number.isFinite(scalePerDepth)
     ? scalePerDepth : 0;
   outlineViewportHeight = height;
-  outlineEffectiveFov = fovDegrees;
+  outlineEffectiveFov = fov.degrees;
+  outlineEffectiveWidthPixels = effectiveWidthPixels;
+  outlineProjectionSpan = currentSpan;
+  outlineProjectionRatio = ratio;
   return outlineScalePerDepthNode.value;
 }
 
@@ -127,10 +169,14 @@ export function getOutlineState(mesh) {
     visible: !!outline?.visible,
     globalEnabled: outlinesEnabled,
     widthPixels: OUTLINE_WIDTH_PIXELS,
-    scaleMode: 'view-depth',
+    effectiveWidthPixels: outlineEffectiveWidthPixels,
+    scaleMode: 'view-depth-adaptive',
     scalePerDepth: outlineScalePerDepthNode.value,
     viewportHeight: outlineViewportHeight,
     effectiveFov: outlineEffectiveFov,
+    projectionSpan: outlineProjectionSpan,
+    referenceProjectionSpan: outlineReferenceProjectionSpan,
+    projectionRatio: outlineProjectionRatio,
     suppressedByWireframe,
     suppressedByDebug,
   };

--- a/src/web/js/scene/outline-renderer.js
+++ b/src/web/js/scene/outline-renderer.js
@@ -10,7 +10,7 @@ import {
 } from 'three/tsl';
 import { requestRender } from './render-scheduler.js';
 
-const OUTLINE_WIDTH_PIXELS = 1.0;
+const OUTLINE_WIDTH_PIXELS = 1.5;
 const MIN_OUTLINE_WIDTH_FACTOR = 0.5;
 const outlineScalePerDepthNode = uniform(0);
 const outlineMaterial = new THREE.MeshBasicNodeMaterial({

--- a/src/web/js/scene/outline-renderer.js
+++ b/src/web/js/scene/outline-renderer.js
@@ -10,8 +10,9 @@ import {
 } from 'three/tsl';
 import { requestRender } from './render-scheduler.js';
 
-const OUTLINE_WIDTH_PIXELS = 1.5;
-const MIN_OUTLINE_WIDTH_FACTOR = 0.5;
+const REFERENCE_OUTLINE_WIDTH_PIXELS = 0.75;
+const MIN_OUTLINE_WIDTH_PIXELS = 0.5;
+const MAX_OUTLINE_WIDTH_PIXELS = 1.5;
 const outlineScalePerDepthNode = uniform(0);
 const outlineMaterial = new THREE.MeshBasicNodeMaterial({
   color: 0x111318,
@@ -33,7 +34,7 @@ let suppressedByWireframe = false;
 let suppressedByDebug = false;
 let outlineViewportHeight = 0;
 let outlineEffectiveFov = 0;
-let outlineEffectiveWidthPixels = OUTLINE_WIDTH_PIXELS;
+let outlineEffectiveWidthPixels = REFERENCE_OUTLINE_WIDTH_PIXELS;
 let outlineProjectionSpan = 0;
 let outlineReferenceProjectionSpan = 0;
 let outlineProjectionRatio = 1;
@@ -147,9 +148,10 @@ export function updateOutlineProjectionScale(camera, target, viewportHeight) {
   const referenceSpan = outlineReferenceProjectionSpan > 0
     ? outlineReferenceProjectionSpan : currentSpan;
   const ratio = referenceSpan / currentSpan;
-  const widthFactor = THREE.MathUtils.clamp(
-    Math.sqrt(ratio), MIN_OUTLINE_WIDTH_FACTOR, 1);
-  const effectiveWidthPixels = OUTLINE_WIDTH_PIXELS * widthFactor;
+  const effectiveWidthPixels = THREE.MathUtils.clamp(
+    REFERENCE_OUTLINE_WIDTH_PIXELS * Math.sqrt(ratio),
+    MIN_OUTLINE_WIDTH_PIXELS,
+    MAX_OUTLINE_WIDTH_PIXELS);
   const scalePerDepth = 2 * Math.tan(fov.radians / 2)
     * effectiveWidthPixels / height;
   outlineScalePerDepthNode.value = Number.isFinite(scalePerDepth)
@@ -168,7 +170,9 @@ export function getOutlineState(mesh) {
     attached: !!outline,
     visible: !!outline?.visible,
     globalEnabled: outlinesEnabled,
-    widthPixels: OUTLINE_WIDTH_PIXELS,
+    referenceWidthPixels: REFERENCE_OUTLINE_WIDTH_PIXELS,
+    minWidthPixels: MIN_OUTLINE_WIDTH_PIXELS,
+    maxWidthPixels: MAX_OUTLINE_WIDTH_PIXELS,
     effectiveWidthPixels: outlineEffectiveWidthPixels,
     scaleMode: 'view-depth-adaptive',
     scalePerDepth: outlineScalePerDepthNode.value,

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -6,7 +6,10 @@ import { createCameraFrame } from './camera-frame.js';
 import { createCharacterShadowController } from './character-shadow-controller.js';
 import { createEnvironmentController } from './environment.js';
 import { createKeyLightController } from './key-light-controller.js';
-import { updateOutlineProjectionScale } from './outline-renderer.js';
+import {
+  resetOutlineProjectionReference,
+  updateOutlineProjectionScale,
+} from './outline-renderer.js';
 import { setBCTextureCompression } from './renderer-capabilities.js';
 import { requestRender, setRenderCallback } from './render-scheduler.js';
 import { createViewportRenderPipeline } from './viewport-render-pipeline.js';
@@ -185,7 +188,8 @@ function renderFrame() {
   characterShadowController.update();
   cameraFrame.updateViewport();
   cameraFrame.updateClipping();
-  updateOutlineProjectionScale(camera, renderer.domElement.clientHeight);
+  updateOutlineProjectionScale(
+    camera, controls.target, renderer.domElement.clientHeight);
   viewGizmoController.updateAxes();
   viewportRenderPipeline.render();
   renderCount += 1;
@@ -235,11 +239,13 @@ export function getLightMode() {
 
 export function frameView(meshes = [], direction = null, targetYOffset = 0) {
   cameraFrame.frameView(meshes, direction, targetYOffset);
+  resetOutlineProjectionReference(camera, controls.target);
   requestRender();
 }
 
 export function resetView() {
   cameraFrame.resetView();
+  resetOutlineProjectionReference(camera, controls.target);
   characterShadowController.invalidateGeometry();
   viewportRenderPipeline.invalidateGeometry();
   requestRender();
@@ -255,6 +261,9 @@ export function adoptModelMeshes(meshes = []) {
 
 export function fitTo(meshes, options) {
   cameraFrame.fitTo(meshes, options);
+  if (!options?.preserveCamera) {
+    resetOutlineProjectionReference(camera, controls.target);
+  }
   characterShadowController.setMeshes(meshes);
   viewportRenderPipeline.setMeshes(meshes);
   requestRender();

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -6,7 +6,7 @@ import { createCameraFrame } from './camera-frame.js';
 import { createCharacterShadowController } from './character-shadow-controller.js';
 import { createEnvironmentController } from './environment.js';
 import { createKeyLightController } from './key-light-controller.js';
-import { updateOutlineCameraScale } from './outline-renderer.js';
+import { updateOutlineProjectionScale } from './outline-renderer.js';
 import { setBCTextureCompression } from './renderer-capabilities.js';
 import { requestRender, setRenderCallback } from './render-scheduler.js';
 import { createViewportRenderPipeline } from './viewport-render-pipeline.js';
@@ -185,8 +185,7 @@ function renderFrame() {
   characterShadowController.update();
   cameraFrame.updateViewport();
   cameraFrame.updateClipping();
-  updateOutlineCameraScale(camera, controls.target,
-    renderer.domElement.clientHeight);
+  updateOutlineProjectionScale(camera, renderer.domElement.clientHeight);
   viewGizmoController.updateAxes();
   viewportRenderPipeline.render();
   renderCount += 1;


### PR DESCRIPTION
## Summary
- replace camera-target world-space extrusion with per-vertex view-space depth scaling
- use 0.75 CSS px at fitted framing, grow close views with a square-root curve to a 1.5 px cap, and taper distant views to a 0.5 px floor
- retain the fitted projection reference through ordinary camera movement and preserve-camera reloads; reset it only for fit, reset, and explicit reframe operations
- keep the shared inverted hull, geometry, material, depth behavior, AO exclusion, and suppression lifecycle

## Regression coverage
- verify equal outline thickness across different mesh depths and object scales under one camera projection
- verify fitted view uses 0.75 px, 2x closer uses about 1.06 px, 4x closer reaches the 1.5 px cap, 2x farther uses about 0.53 px, and sufficiently distant views reach the 0.5 px floor
- verify FOV and camera zoom use the same adaptive curve while viewport resize preserves CSS-pixel behavior
- verify the outline child, shared material, geometry reference, and material version remain stable and rendering remains on demand