### PR TITLE
Add selective emission bloom

### DIFF
--- a/src/app/bridge/asset_preview.py
+++ b/src/app/bridge/asset_preview.py
@@ -122,7 +122,8 @@ class AssetPreview:
         """Register a chosen Asset texture using the facade-owned window."""
         try:
             selected, entry, _index, _record = self._asset_selection(folder_path)
-            if texture_role not in (None, "normal_map", "light_map", "material_map"):
+            if texture_role not in (
+                    None, "normal_map", "light_map", "material_map", "emission_map"):
                 return {"error": "Unknown texture role."}
             result = window.create_file_dialog(
                 webview.FileDialog.OPEN, directory=selected,

--- a/src/app/mods/controls.py
+++ b/src/app/mods/controls.py
@@ -13,7 +13,7 @@ from app.mods.analysis import _ini_rel, analyze_mod_inis
 
 _VARIANT_FIELDS = (
     "texture_variants", "normal_map_variants", "normal_data_variants",
-    "light_map_variants", "material_map_variants",
+    "light_map_variants", "material_map_variants", "emission_map_variants",
 )
 
 

--- a/src/app/mods/metadata.py
+++ b/src/app/mods/metadata.py
@@ -295,7 +295,7 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
         option["tex_key"] = key
         option["file"] = relative_path
         for field in ("normal_map", "normal_data", "light_map",
-                      "material_map"):
+                      "material_map", "emission_map"):
             if field in option:
                 option[field] = _role_key(option[field], field)
         return option
@@ -313,7 +313,7 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
         _role, relative_path = split_texture_key(key)
         item = {"tex_key": key, "file": relative_path,
                 "label": label, "manual": manual}
-        fields = ("light_map", "material_map")
+        fields = ("light_map", "material_map", "emission_map")
         if not packed_normal_transport:
             fields = ("normal_map", "normal_data", *fields)
         for field in fields:
@@ -375,7 +375,7 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
                 pool.append(opt)
             else:
                 for field in ("normal_map", "normal_data", "light_map",
-                              "material_map"):
+                              "material_map", "emission_map"):
                     manual_key = f"{field}_manual"
                     if opt.get(manual_key):
                         old[manual_key] = True
@@ -412,6 +412,7 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
         ("normal_data", "normal_data"),
         ("light_map", "light_map"),
         ("material_map", "material_map"),
+        ("emission_map", "emission_map"),
     )
     for pool in texture_pools.values():
         for option in pool:

--- a/src/app/settings/paths.py
+++ b/src/app/settings/paths.py
@@ -62,5 +62,6 @@ def has_vendored_three():
         "three.tsl.js",
         os.path.join("addons", "controls", "ArcballControls.js"),
         os.path.join("addons", "tsl", "display", "GTAONode.js"),
+        os.path.join("addons", "tsl", "display", "BloomNode.js"),
     )
     return all(os.path.isfile(os.path.join(vendor_dir(), rel)) for rel in required)

--- a/src/build.py
+++ b/src/build.py
@@ -93,6 +93,10 @@ ASSET_FILES = {
         "url": f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/examples/jsm/tsl/display/GTAONode.js",
         "sha256": "516e86dc398b8e2d93f693a168144fdd7420f261a72aaa7da6eb7f110cc8e3ef",
     },
+    "addons/tsl/display/BloomNode.js": {
+        "url": f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/examples/jsm/tsl/display/BloomNode.js",
+        "sha256": "f80f40d013f4d94aa089c68c673cae6a8ab45fb290970a696bc1dded312e3fc8",
+    },
 }
 
 

--- a/src/core/geometry/draw_call.py
+++ b/src/core/geometry/draw_call.py
@@ -106,6 +106,8 @@ class DrawCall(MutableMapping):
     light_map_variants: list = field(default_factory=list)
     material_map_default_file: str | None = None
     material_map_variants: list = field(default_factory=list)
+    emission_map_default_file: str | None = None
+    emission_map_variants: list = field(default_factory=list)
     geometry_match: GeometryMatch | None = None
     slot_textures: list = field(default_factory=list)
     asset_binding: object | None = None
@@ -121,6 +123,7 @@ class DrawCall(MutableMapping):
         "normal_map": "normal_map",
         "light_map": "light_map",
         "material_map": "material_map",
+        "emission_map": "emission_map",
     }
     _NON_RENDER_FIELDS: ClassVar[frozenset[str]] = frozenset({
         "label", "conditions", "sources", "geometry_match",
@@ -137,6 +140,7 @@ class DrawCall(MutableMapping):
         "normal_map_default_file", "normal_map_variants",
         "light_map_default_file", "light_map_variants",
         "material_map_default_file", "material_map_variants",
+        "emission_map_default_file", "emission_map_variants",
         "asset_texture_defaults",
     )
 
@@ -230,7 +234,7 @@ class DrawCall(MutableMapping):
             raise KeyError(f"cannot delete required DrawCall field: {key}")
         if key in {"texture_variants", "texture_assignments",
                    "normal_map_variants", "light_map_variants",
-                   "material_map_variants"}:
+                   "material_map_variants", "emission_map_variants"}:
             setattr(self, key, [])
         elif key == "label":
             setattr(self, key, "")

--- a/src/core/geometry/semantics.py
+++ b/src/core/geometry/semantics.py
@@ -124,6 +124,10 @@ def build_mesh_semantics(groups, mod_dir, max_draws=0, game_profile=None,
                     draw, "material_map") or _semantic_texture_key(
                         mod_dir, draw.texture_default("material_map"),
                         "material_map")),
+                "emission_map_key": (_semantic_asset_key(
+                    draw, "emission_map") or _semantic_texture_key(
+                        mod_dir, draw.texture_default("emission_map"),
+                        "emission_map")),
             }
             normal_key = _semantic_texture_key(
                 mod_dir, draw.texture_default("normal_map"), normal_role)
@@ -138,7 +142,7 @@ def build_mesh_semantics(groups, mod_dir, max_draws=0, game_profile=None,
                 draw, mod_dir, "diffuse")
             if len(texture_variants) > 1:
                 entry["texture_variants"] = texture_variants
-            for channel in ("light_map", "material_map"):
+            for channel in ("light_map", "material_map", "emission_map"):
                 variants = _semantic_texture_variants(draw, mod_dir, channel)
                 if variants:
                     entry[f"{channel}_variants"] = variants

--- a/src/core/geometry/texture_bindings.py
+++ b/src/core/geometry/texture_bindings.py
@@ -113,7 +113,7 @@ def apply_draw_texture_bindings(entry, draw, texture_options, *, registry):
         normal_path, normal_role, identity=asset_normal.get("key"))
     if normal_key:
         entry[f"{normal_role}_key"] = normal_key
-    for channel in ("light_map", "material_map"):
+    for channel in ("light_map", "material_map", "emission_map"):
         asset_default = draw.asset_texture_defaults.get(channel) or {}
         key = registry.ensure(
             asset_default.get("path") or safe_resource_path(
@@ -132,7 +132,7 @@ def apply_draw_texture_bindings(entry, draw, texture_options, *, registry):
                        if item["tex_key"] == diffuse_key), None)
         if option:
             for channel in ("normal_map", "light_map", "normal_data",
-                            "material_map"):
+                            "material_map", "emission_map"):
                 key = entry.get(f"{channel}_key")
                 if key and not option.get(channel):
                     option[channel] = key
@@ -154,7 +154,7 @@ def apply_draw_texture_bindings(entry, draw, texture_options, *, registry):
         if len(variants) > 1:
             entry["texture_variants"] = variants
 
-    for channel in ("light_map", "material_map"):
+    for channel in ("light_map", "material_map", "emission_map"):
         rules = draw.texture_rules(channel)
         variants = []
         for variant in rules:

--- a/src/core/ini/draw_scan.py
+++ b/src/core/ini/draw_scan.py
@@ -10,7 +10,7 @@ from .menu import extract_menu_var_names
 from .state import extract_state_rules
 from .toggles import extract_toggle_var_names
 from .texture_roles import (
-    TextureOverrideIndex, _SEMANTIC_TEXTURE_ROLES,
+    TextureOverrideIndex,
     _collect_structural_slot_role_hints, _collect_texture_override_index,
     _effective_role_assignments, _legacy_texture_evidence,
     _semantic_texture_role,
@@ -362,24 +362,17 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                     geometry_match=geometry_match(info),
                     slot_textures=slot_snapshot(info),
                 ))
-            semantic_diffuse = re.match(
-                r"^Resource[\\/]"
-                r"(?:GIMI|ZZMI|RabbitFX|WWMI)[\\/]Diffuse\s*=\s*"
-                r"(?:ref\s+)?(\S+)", line, re.I)
-            if semantic_diffuse:
-                record_texture_assignment(
-                    info, "diffuse", semantic_diffuse.group(1), cond_stack,
-                    source="semantic")
-            semantic_aux = re.match(
-                r"^Resource[\\/]"
+            semantic = re.match(
+                r"^(Resource[\\/]"
                 r"(?:GIMI|ZZMI|RabbitFX|WWMI)[\\/]"
-                r"(NormalMap|LightMap|MaterialMap)\s*=\s*"
-                r"(?:ref\s+)?(\S+)", line, re.I)
-            if semantic_aux:
-                record_texture_assignment(
-                    info,
-                    _SEMANTIC_TEXTURE_ROLES[semantic_aux.group(1).casefold()],
-                    semantic_aux.group(2), cond_stack, source="semantic")
+                r"(?:Diffuse|NormalMap|LightMap|MaterialMap|GlowMap))"
+                r"\s*=\s*(?:ref\s+)?(\S+)", line, re.I)
+            if semantic:
+                role = _semantic_texture_role(semantic.group(1))
+                if role:
+                    record_texture_assignment(
+                        info, role, semantic.group(2), cond_stack,
+                        source="semantic")
             if re.match(r"run\s*=\s*(\S+)", line, re.I):
                 target_name = _run_target_name(line, section_lookup)
                 if target_name and target_name not in visiting:

--- a/src/core/ini/health.py
+++ b/src/core/ini/health.py
@@ -333,7 +333,7 @@ def _viewer_texture_paths(mod_dir):
             if not isinstance(state, dict):
                 continue
             for field in ("tex_key", "normal_map", "normal_data",
-                          "light_map", "material_map"):
+                          "light_map", "material_map", "emission_map"):
                 key = state.get(field)
                 _role, relative_path = split_texture_key(key)
                 resolved = safe_resource_path(mod_dir, relative_path)

--- a/src/core/ini/texture_roles.py
+++ b/src/core/ini/texture_roles.py
@@ -68,11 +68,12 @@ _SEMANTIC_TEXTURE_ROLES = {
     "normalmap": "normal_map",
     "lightmap": "light_map",
     "materialmap": "material_map",
+    "glowmap": "emission_map",
 }
 _SEMANTIC_TEXTURE_RESOURCE_RE = re.compile(
     r"^Resource[\\/]"
-    r"(?:GIMI|ZZMI|RabbitFX|WWMI)[\\/]"
-    r"(?P<role>Diffuse|NormalMap|LightMap|MaterialMap)$", re.I)
+    r"(?P<namespace>GIMI|ZZMI|RabbitFX|WWMI)[\\/]"
+    r"(?P<role>Diffuse|NormalMap|LightMap|MaterialMap|GlowMap)$", re.I)
 _LEGACY_TEXTURE_RESOURCE_RE = re.compile(
     r"^Resource.+(?P<role>Diffuse|NormalMap|LightMap|MaterialMap)"
     r"(?P<variant>\.\d+)?$", re.I)
@@ -148,8 +149,12 @@ def _collect_texture_override_index(sections, toggle_vars, alias_map,
 def _semantic_texture_role(resource):
     """Return a role only for a framework-owned semantic resource name."""
     match = _SEMANTIC_TEXTURE_RESOURCE_RE.fullmatch(str(resource or ""))
-    return (_SEMANTIC_TEXTURE_ROLES[match.group("role").casefold()]
-            if match else None)
+    if not match:
+        return None
+    if (match.group("role").casefold() == "glowmap"
+            and match.group("namespace").casefold() != "rabbitfx"):
+        return None
+    return _SEMANTIC_TEXTURE_ROLES[match.group("role").casefold()]
 
 
 def _legacy_texture_evidence(resource, sections, section_lookup):

--- a/src/core/materials/game_profile.py
+++ b/src/core/materials/game_profile.py
@@ -49,10 +49,10 @@ class GameDetection:
 
 _RESOURCE_ROLE_RE = re.compile(
     r"^resource[\\/]([^\\/]+)[\\/]"
-    r"(diffuse|normalmap|lightmap|materialmap)\b", re.I)
+    r"(diffuse|normalmap|lightmap|materialmap|glowmap)\b", re.I)
 _RESOURCE_ASSIGN_RE = re.compile(
     r"^resource[\\/]([^\\/]+)[\\/]"
-    r"(diffuse|normalmap|lightmap|materialmap)\b\s*=", re.I)
+    r"(diffuse|normalmap|lightmap|materialmap|glowmap)\b\s*=", re.I)
 _COMMAND_TEXTURE_RE = re.compile(r"settextures", re.I)
 _SET_TEXTURES_RUN_RE = re.compile(
     r"^run\s*=\s*commandlist[\\/]([^\\/]+)[\\/]settextures\b", re.I)
@@ -144,7 +144,13 @@ def _command_texture_namespace(section):
 
 def _resource_namespace(value, pattern=_RESOURCE_ROLE_RE):
     match = pattern.match(str(value))
-    return match.group(1).lower() if match else None
+    if not match:
+        return None
+    namespace, role = match.groups()
+    # Only RabbitFX owns GlowMap as a semantic texture binding.
+    if role.lower() == "glowmap" and namespace.lower() != "rabbitfx":
+        return None
+    return namespace.lower()
 
 
 def _legacy_direct_texture_item(items, sections):

--- a/src/core/materials/profiles.py
+++ b/src/core/materials/profiles.py
@@ -94,6 +94,9 @@ class MaterialInterpretation:
     wuwa_specular_power: float = 1.0
     wuwa_toon_specular_cutoff: float = 0.1
     wuwa_specular_mask_cutoff: float = 0.5
+    # Emission is only enabled by an explicit, game-owned colour binding.
+    emission_source: str | None = None
+    emission_strength: float = 1.0
 
     def __post_init__(self):
         if self.material_kind not in MATERIAL_KINDS:
@@ -113,6 +116,8 @@ class MaterialInterpretation:
         if self.direct_specular_model not in (None, "wuwa_body"):
             raise ValueError(
                 f"Unknown direct specular model: {self.direct_specular_model}")
+        if self.emission_source not in (None, "emission_map_rgb"):
+            raise ValueError(f"Unknown emission source: {self.emission_source}")
 
     def to_metadata(self):
         result = {
@@ -164,6 +169,8 @@ class MaterialInterpretation:
             "wuwa_specular_power": self.wuwa_specular_power,
             "wuwa_toon_specular_cutoff": self.wuwa_toon_specular_cutoff,
             "wuwa_specular_mask_cutoff": self.wuwa_specular_mask_cutoff,
+            "emission_source": self.emission_source,
+            "emission_strength": self.emission_strength,
         }
         return result
 
@@ -225,6 +232,7 @@ def _base_profile_for(game, texture_api):
             kwargs.update(
                 shadow_mask=ChannelRef("light_map", "g"),
                 direct_shadow_model="wuwa_base",
+                emission_source="emission_map_rgb",
             )
         return MaterialInterpretation(
             id=f"wuwa:{texture_api}", game=game, texture_api=texture_api,

--- a/src/core/textures/pipeline.py
+++ b/src/core/textures/pipeline.py
@@ -15,7 +15,8 @@ from ..resource_paths import _canonical, safe_resource_path
 _TEXTURE_CACHE_LIMIT = 256 * 1024 * 1024
 _MAX_IMAGE_PIXELS = 100_000_000
 TEXTURE_ROLES = (
-    "diffuse", "normal_map", "normal_data", "light_map", "material_map")
+    "diffuse", "normal_map", "normal_data", "light_map", "material_map",
+    "emission_map")
 TEXTURE_TRANSFORMS = (
     "passthrough", "normal_xy_reconstruct",
 )

--- a/src/core/textures/profiles.py
+++ b/src/core/textures/profiles.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 
 
 TEXTURE_ROLES = (
-    "diffuse", "normal_map", "normal_data", "light_map", "material_map")
+    "diffuse", "normal_map", "normal_data", "light_map", "material_map",
+    "emission_map")
 
 
 @dataclass(frozen=True)

--- a/src/tests/core/ini/test_draw_groups.py
+++ b/src/tests/core/ini/test_draw_groups.py
@@ -99,6 +99,71 @@ filename = body-light-map.dds
             draws[0].geometry_match.index_count) == ("0123abcd", 9, 3)
 
 
+def test_rabbitfx_glow_map_flows_through_the_draw_scanner():
+    sections = parse_sections("sample.ini", text=r"""[TextureOverrideBody]
+ib = ResourceBodyIB
+vb0 = ResourceBodyPosition
+vb1 = ResourceBodyTexcoord
+Resource\RabbitFX\Diffuse = ref ResourceBodyDiffuse
+Resource\RabbitFX\GlowMap = ref ResourceBodyGlow
+drawindexed = 3, 0, 0
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourceBodyPosition]
+filename = body-position.buf
+stride = 12
+
+[ResourceBodyTexcoord]
+filename = body-texcoord.buf
+stride = 8
+
+[ResourceBodyDiffuse]
+filename = body-diffuse.dds
+
+[ResourceBodyGlow]
+filename = body-glow.dds
+""")
+    groups = build_draw_groups(sections, extract_resources(sections))
+
+    assert groups[0]["draws"][0].texture_default("emission_map") == (
+        "body-glow.dds")
+
+
+def test_non_rabbitfx_glow_map_is_not_recorded_as_emission():
+    sections = parse_sections("sample.ini", text=r"""[TextureOverrideBody]
+ib = ResourceBodyIB
+vb0 = ResourceBodyPosition
+vb1 = ResourceBodyTexcoord
+Resource\GIMI\Diffuse = ref ResourceBodyDiffuse
+Resource\GIMI\GlowMap = ref ResourceBodyGlow
+drawindexed = 3, 0, 0
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourceBodyPosition]
+filename = body-position.buf
+stride = 12
+
+[ResourceBodyTexcoord]
+filename = body-texcoord.buf
+stride = 8
+
+[ResourceBodyDiffuse]
+filename = body-diffuse.dds
+
+[ResourceBodyGlow]
+filename = body-glow.dds
+""")
+    groups = build_draw_groups(sections, extract_resources(sections))
+
+    assert groups[0]["draws"][0].texture_default("emission_map") is None
+
+
 def test_draw_groups_preserve_inline_run_snapshots_without_buffer_files():
     sections = parse_sections("sample.ini", text="""[TextureOverrideBody]
 ib = ResourceMissingIB

--- a/src/tests/core/ini/test_texture_roles.py
+++ b/src/tests/core/ini/test_texture_roles.py
@@ -1,6 +1,13 @@
 """Texture evidence precedence regressions."""
 
-from core.ini.texture_roles import _effective_role_assignments
+from core.ini.texture_roles import (_effective_role_assignments,
+                                    _semantic_texture_role)
+
+
+def test_only_rabbitfx_glowmap_is_an_explicit_emission_role():
+    assert _semantic_texture_role(r"Resource\RabbitFX\GlowMap") == "emission_map"
+    assert _semantic_texture_role(r"Resource\GIMI\GlowMap") is None
+    assert _semantic_texture_role(r"Resource\ZZMI\MaterialMap") == "material_map"
 
 
 def test_semantic_texture_evidence_subtracts_its_covered_condition():

--- a/src/tests/core/materials/test_profiles.py
+++ b/src/tests/core/materials/test_profiles.py
@@ -105,6 +105,14 @@ def test_wuwa_rabbitfx_alone_enables_validated_shadow_semantics():
 
     assert profile.shadow_mask == ChannelRef("light_map", "g")
     assert profile.direct_shadow_model == "wuwa_base"
+    assert profile.emission_source == "emission_map_rgb"
+    assert profile.emission_strength == 1.0
+    assert profile.to_metadata()["emission_source"] == "emission_map_rgb"
+
+
+def test_other_profiles_do_not_infer_emission_from_packed_channels():
+    assert material_profile_for("genshin", "gimi").emission_source is None
+    assert material_profile_for("zzz", "zzmi").emission_source is None
 
 
 def test_wuwa_rabbitfx_body_is_the_only_first_specialized_profile():

--- a/src/tests/web/test_app_flow.py
+++ b/src/tests/web/test_app_flow.py
@@ -8,12 +8,12 @@ def test_frontend_public_surface_and_lifecycle_events(edge_browser, frontend_url
     try:
         assert page.evaluate("Object.keys(window.modViewer).sort()") == sorted([
             "activeMeshes", "displayMeshPayload", "exportChanges",
-            "getAmbientOcclusionStrength", "getCurrentSource",
+            "getAmbientOcclusionStrength", "getBloomEnabled", "getCurrentSource",
             "getEnvironmentPreset", "getMaterialState",
             "getOutlineState", "getRenderCount", "openMod",
             "refreshControlSemantics", "refreshMeshSemantics",
             "refreshPresentState", "reloadCurrentMod", "setEnvironmentPreset",
-            "setMaterialDebugMode", "setOutlineEnabled", "switchAsset",
+            "setBloomEnabled", "setMaterialDebugMode", "setOutlineEnabled", "switchAsset",
             "setAmbientOcclusionStrength", "switchMod",
         ])
         page.evaluate("""() => {

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -571,7 +571,11 @@ def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
 
 def test_viewport_bloom_selects_only_its_required_render_graph(
         edge_browser, frontend_url):
-    context, page = _page(edge_browser, frontend_url, {"Bloom": _payload("Bloom")})
+    payload = _packed_material_payload("wuwa:rabbitfx")
+    payload["meshes"]["Body-Packed-0"]["emission_map_key"] = (
+        "emission_map::Packed-glow.png")
+    payload["textures"]["emission_map::Packed-glow.png"] = _PNG_URI
+    context, page = _page(edge_browser, frontend_url, {"Bloom": payload})
     try:
         _open(page, "Bloom")
         page.locator(".draw-item").wait_for()
@@ -652,6 +656,20 @@ def test_viewport_bloom_selects_only_its_required_render_graph(
             await import('./js/scene/scene.js');
           return getViewportRenderPipelineDebugState().activeRenderMode === 'bloom';
         }""")
+    finally:
+        context.close()
+
+
+def test_bloom_control_is_disabled_without_supported_emission(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Plain": _payload("Plain")})
+    try:
+        _open(page, "Plain")
+        page.locator(".draw-item").wait_for()
+        button = page.locator("#bloom-btn")
+        assert button.is_disabled()
+        assert button.get_attribute("aria-label") == (
+            "Emission bloom unavailable: no GlowMap detected")
     finally:
         context.close()
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -590,6 +590,7 @@ def test_viewport_bloom_selects_only_its_required_render_graph(
         assert not bloom_button.is_disabled()
         assert initial["activeRenderMode"] == "direct"
         assert not initial["bloomEnabled"]
+        assert initial["bloomAvailable"]
         assert initial["hasBloom"]
 
         page.locator("#bloom-btn").click()
@@ -605,6 +606,7 @@ def test_viewport_bloom_selects_only_its_required_render_graph(
           return getViewportRenderPipelineDebugState();
         }""")
         assert bloom_only["bloomEffective"]
+        assert bloom_only["bloomAvailable"]
         assert bloom_only["aoOnlyRenderCount"] == 0
         assert page.locator("#bloom-btn").get_attribute("aria-pressed") == "true"
 
@@ -672,8 +674,116 @@ def test_bloom_control_is_hidden_without_supported_emission(
         button = page.locator("#bloom-btn")
         assert button.is_hidden()
         assert button.is_disabled()
+        state = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert not state["bloomAvailable"]
+        assert not state["bloomEffective"]
         assert button.get_attribute("aria-label") == (
             "Emission bloom unavailable: no GlowMap detected")
+    finally:
+        context.close()
+
+
+def test_bloom_availability_suppresses_pipeline_and_restores_preference(
+        edge_browser, frontend_url):
+    supported = _packed_material_payload("wuwa:rabbitfx")
+    supported["meshes"]["Body-Packed-0"]["emission_map_key"] = (
+        "emission_map::Packed-glow.png")
+    supported["textures"]["emission_map::Packed-glow.png"] = _PNG_URI
+    context, page = _page(edge_browser, frontend_url, {
+        "Bloom": supported, "Plain": _payload("Plain"),
+    })
+    try:
+        _open(page, "Bloom")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 1")
+        page.evaluate("window.modViewer.setBloomEnabled(true)")
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return state.activeRenderMode === 'bloom'
+            && state.bloomAvailable && state.bloomEffective;
+        }""")
+        _set_ao_level(page, 100)
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState().activeRenderMode
+            === 'ao-bloom';
+        }""")
+
+        _open(page, "Plain")
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return window.modViewer.activeMeshes.length === 1
+            && !state.bloomAvailable
+            && !state.bloomEffective
+            && state.activeRenderMode === 'ao'
+            && state.aoOnlyRenderCount > 0;
+        }""")
+        unsupported = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert unsupported["bloomEnabled"]
+        assert not unsupported["bloomAvailable"]
+        assert not unsupported["bloomEffective"]
+        assert page.locator("#bloom-btn").is_hidden()
+
+        _open(page, "Bloom")
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return window.modViewer.activeMeshes.length === 1
+            && state.bloomAvailable
+            && state.bloomEffective
+            && state.activeRenderMode === 'ao-bloom';
+        }""")
+        button = page.locator("#bloom-btn")
+        assert not button.is_hidden()
+        assert not button.is_disabled()
+    finally:
+        context.close()
+
+
+def test_emission_variants_keep_bloom_available_without_active_map(
+        edge_browser, frontend_url):
+    payload = _packed_material_payload("wuwa:rabbitfx")
+    entry = payload["meshes"]["Body-Packed-0"]
+    entry["emission_map_variants"] = [{
+        "conditions": [[{"var": "menu", "value": "1", "negate": False}]],
+        "tex_key": "emission_map::Packed-conditional-glow.png",
+    }]
+    payload["textures"]["emission_map::Packed-conditional-glow.png"] = _PNG_URI
+    context, page = _page(edge_browser, frontend_url, {"Conditional": payload})
+    try:
+        _open(page, "Conditional")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 1")
+        state = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          const pipeline = getViewportRenderPipelineDebugState();
+          return {
+            variantCount: mesh.userData.emissionMapVariants.length,
+            resolvedEmissionMapKey: mesh.userData.resolvedEmissionMapKey,
+            bloomAvailable: pipeline.bloomAvailable,
+          };
+        }""")
+        assert state == {
+            "variantCount": 1,
+            "resolvedEmissionMapKey": None,
+            "bloomAvailable": True,
+        }
+        assert not page.locator("#bloom-btn").is_hidden()
+        assert not page.locator("#bloom-btn").is_disabled()
     finally:
         context.close()
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -585,6 +585,9 @@ def test_viewport_bloom_selects_only_its_required_render_graph(
             await import('./js/scene/scene.js');
           return getViewportRenderPipelineDebugState();
         }""")
+        bloom_button = page.locator("#bloom-btn")
+        assert not bloom_button.is_hidden()
+        assert not bloom_button.is_disabled()
         assert initial["activeRenderMode"] == "direct"
         assert not initial["bloomEnabled"]
         assert initial["hasBloom"]
@@ -660,13 +663,14 @@ def test_viewport_bloom_selects_only_its_required_render_graph(
         context.close()
 
 
-def test_bloom_control_is_disabled_without_supported_emission(
+def test_bloom_control_is_hidden_without_supported_emission(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {"Plain": _payload("Plain")})
     try:
         _open(page, "Plain")
         page.locator(".draw-item").wait_for()
         button = page.locator("#bloom-btn")
+        assert button.is_hidden()
         assert button.is_disabled()
         assert button.get_attribute("aria-label") == (
             "Emission bloom unavailable: no GlowMap detected")

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -569,6 +569,93 @@ def test_viewport_ambient_occlusion_slider_selects_direct_or_gtao_path(
     finally:
         context.close()
 
+def test_viewport_bloom_selects_only_its_required_render_graph(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Bloom": _payload("Bloom")})
+    try:
+        _open(page, "Bloom")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function("window.modViewer.getRenderCount() > 0")
+        initial = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert initial["activeRenderMode"] == "direct"
+        assert not initial["bloomEnabled"]
+        assert initial["hasBloom"]
+
+        page.locator("#bloom-btn").click()
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return state.activeRenderMode === 'bloom' && state.bloomOnlyRenderCount > 0;
+        }""")
+        bloom_only = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert bloom_only["bloomEffective"]
+        assert bloom_only["aoOnlyRenderCount"] == 0
+        assert page.locator("#bloom-btn").get_attribute("aria-pressed") == "true"
+
+        _set_ao_level(page, 100)
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return state.activeRenderMode === 'ao-bloom' && state.aoBloomRenderCount > 0;
+        }""")
+        page.evaluate("window.modViewer.setBloomEnabled(false)")
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return state.activeRenderMode === 'ao' && state.aoOnlyRenderCount > 0;
+        }""")
+        _set_ao_level(page, 0)
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState().activeRenderMode === 'direct';
+        }""")
+
+        page.evaluate("window.modViewer.setBloomEnabled(true)")
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState().activeRenderMode === 'bloom';
+        }""")
+        page.locator("#wire-btn").click()
+        suppressed = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert suppressed["activeRenderMode"] == "direct"
+        assert suppressed["bloomEnabled"]
+        assert suppressed["bloomSuppressedByWireframe"]
+        page.locator("#wire-btn").click()
+        page.evaluate("window.modViewer.setMaterialDebugMode('material-id')")
+        debug_suppressed = page.evaluate("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState();
+        }""")
+        assert debug_suppressed["activeRenderMode"] == "direct"
+        assert debug_suppressed["bloomSuppressedByDebug"]
+        page.evaluate("window.modViewer.setMaterialDebugMode('off')")
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          return getViewportRenderPipelineDebugState().activeRenderMode === 'bloom';
+        }""")
+    finally:
+        context.close()
+
+
 @pytest.mark.parametrize("scale", [0.01, 1, 100])
 def test_viewport_gtao_radius_scales_with_model_bounds(edge_browser, frontend_url, scale):
     label = f"PipelineScale{scale}"
@@ -922,6 +1009,7 @@ def test_diffuse_normal_mode_keeps_only_color_and_normal_bindings(
             "normal_data": False,
             "light_map": False,
             "material_map": False,
+            "emission_map": False,
         }
         expected_bindings[normal_role] = True
         assert bindings == expected_bindings
@@ -1319,6 +1407,96 @@ def test_genshin_no_uv_keeps_a_and_b_out_of_conservative_material_graph(
             "lightingModel": "GenshinLightingModel",
         }
         assert not uv_messages, uv_messages
+    finally:
+        context.close()
+
+
+def test_rabbitfx_emission_binding_stays_stable_across_texture_replacement(
+        edge_browser, frontend_url):
+    payload = _packed_material_payload("wuwa:rabbitfx")
+    entry = payload["meshes"]["Body-Packed-0"]
+    entry["emission_map_key"] = "emission_map::Packed-glow.png"
+    payload["textures"]["emission_map::Packed-glow.png"] = _PNG_URI
+    context, page = _page(edge_browser, frontend_url, {"Emission": payload})
+    try:
+        _open(page, "Emission")
+        page.wait_for_function("""() => {
+          const game = window.modViewer.activeMeshes[0]?.material?.userData?.gameMaterial;
+          return game?.bindings?.emission_map?.enabledNode?.value === true;
+        }""")
+        state = page.evaluate("""async () => {
+          const {setMeshTextureState} = await import('./js/mesh/mesh-factory.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          const material = mesh.material;
+          const game = material.userData.gameMaterial;
+          const binding = game.bindings.emission_map;
+          const textureNode = binding.textureNode;
+          const enabledNode = binding.enabledNode;
+          const emissiveNode = material.emissiveNode;
+          const version = material.version;
+          setMeshTextureState(mesh, {
+            diffuse: mesh.userData.texKey,
+            normal_map: mesh.userData.normalMapKey,
+            normal_data: mesh.userData.normalDataKey,
+            light_map: mesh.userData.lightMapKey,
+            material_map: mesh.userData.materialMapKey,
+            emission_map: null,
+          });
+          const disabled = binding.enabledNode.value === false;
+          setMeshTextureState(mesh, {
+            diffuse: mesh.userData.texKey,
+            normal_map: mesh.userData.normalMapKey,
+            normal_data: mesh.userData.normalDataKey,
+            light_map: mesh.userData.lightMapKey,
+            material_map: mesh.userData.materialMapKey,
+            emission_map: 'emission_map::Packed-glow.png',
+          });
+          return {
+            profile: game.profile.emission_source,
+            rebound: binding.enabledNode.value === true,
+            disabled,
+            sameTextureNode: binding.textureNode === textureNode,
+            sameEnabledNode: binding.enabledNode === enabledNode,
+            sameEmissiveNode: material.emissiveNode === emissiveNode,
+            sameVersion: material.version === version,
+          };
+        }""")
+        assert state == {
+            "profile": "emission_map_rgb", "disabled": True, "rebound": True,
+            "sameTextureNode": True, "sameEnabledNode": True,
+            "sameEmissiveNode": True, "sameVersion": True,
+        }
+    finally:
+        context.close()
+
+
+def test_rabbitfx_emission_produces_selective_bloom_output(
+        edge_browser, frontend_url):
+    payload = _packed_material_payload("wuwa:rabbitfx")
+    entry = payload["meshes"]["Body-Packed-0"]
+    entry["pos"] = _f32(-1, -1, 0, 1, -1, 0, 1, 1, 0, -1, 1, 0)
+    entry["idx"] = _u32(0, 1, 2, 0, 2, 3)
+    entry["drawindexed"] = [6, 0, 0]
+    entry["emission_map_key"] = "emission_map::Packed-glow.png"
+    payload["textures"][entry["tex_key"]] = _flat_png_uri((0, 0, 0, 255))
+    payload["textures"]["emission_map::Packed-glow.png"] = _flat_png_uri(
+        (255, 255, 255, 255))
+    context, page = _page(edge_browser, frontend_url, {"EmissionBloom": payload})
+    try:
+        _open(page, "EmissionBloom")
+        page.wait_for_function("""() => window.modViewer.getMaterialState(0)
+          .emissionMapBound""")
+        canvas = page.locator("#canvas-container canvas")
+        without_bloom = Image.open(io.BytesIO(canvas.screenshot())).convert("RGB")
+        page.evaluate("window.modViewer.setBloomEnabled(true)")
+        page.wait_for_function("""async () => {
+          const {getViewportRenderPipelineDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getViewportRenderPipelineDebugState();
+          return state.activeRenderMode === 'bloom' && state.bloomOnlyRenderCount > 0;
+        }""")
+        with_bloom = Image.open(io.BytesIO(canvas.screenshot())).convert("RGB")
+        assert ImageChops.difference(without_bloom, with_bloom).getbbox()
     finally:
         context.close()
 

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -83,11 +83,12 @@ def test_mesh_row_selection_invalidates_on_demand_renderer(
           return window.modViewer.activeMeshes.map(mesh => ({
             emissive: mesh.material.emissive.getHex(),
             intensity: mesh.material.emissiveIntensity,
+            selected: mesh.material.userData.gameMaterial.selectionEnabledNode.value,
           }));
         }""")
         assert first_state == [
-            {"emissive": 0xffd60a, "intensity": 0.22},
-            {"emissive": 0x000000, "intensity": 1},
+            {"emissive": 0x000000, "intensity": 1, "selected": True},
+            {"emissive": 0x000000, "intensity": 1, "selected": False},
         ]
 
         selected_count = page.evaluate("window.modViewer.getRenderCount()")
@@ -101,11 +102,12 @@ def test_mesh_row_selection_invalidates_on_demand_renderer(
           return window.modViewer.activeMeshes.map(mesh => ({
             emissive: mesh.material.emissive.getHex(),
             intensity: mesh.material.emissiveIntensity,
+            selected: mesh.material.userData.gameMaterial.selectionEnabledNode.value,
           }));
         }""")
         assert second_state == [
-            {"emissive": 0x000000, "intensity": 1},
-            {"emissive": 0xffd60a, "intensity": 0.22},
+            {"emissive": 0x000000, "intensity": 1, "selected": False},
+            {"emissive": 0x000000, "intensity": 1, "selected": True},
         ]
 
         final_count = page.evaluate("window.modViewer.getRenderCount()")

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -362,6 +362,7 @@ body.asset-preview-mode #toolbar-overflow [data-toolbar-target="export-btn"] {
   font-size: 20px; line-height: 1;
   display: flex; align-items: center; justify-content: center;
 }
+.tool-btn[hidden] { display: none !important; }
 .mesh-state-btn { width: 22px; height: 22px; min-height: 22px; padding: 0; border: 0; background: transparent; color: var(--text); cursor: pointer; flex-shrink: 0; }
 .mesh-state-btn .ui-icon { width: 16px; height: 16px; }
 .mesh-state-btn.state-hidden { color: var(--text-muted); opacity: .7; }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -224,6 +224,7 @@
       <button id="outline-btn" class="tool-btn" title="Silhouette outlines: off" aria-label="Silhouette outlines: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-outline"></use></svg></button>
       <button id="ao-btn" class="tool-btn" title="Ambient occlusion: 0%" aria-label="Ambient occlusion: 0%"
               aria-expanded="false" aria-controls="ao-popover"><svg class="ui-icon" aria-hidden="true"><use href="#icon-ao"></use></svg></button>
+      <button id="bloom-btn" class="tool-btn off" title="Emission bloom: off" aria-label="Emission bloom: off" aria-pressed="false">B</button>
       <button id="glossy-btn" class="tool-btn off" title="Glossy materials: off" aria-label="Glossy materials: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-glossy"></use></svg></button>
       <button id="toon-btn" class="tool-btn off" title="Toon shadows: off" aria-label="Toon shadows: off" aria-pressed="false"><svg class="ui-icon" aria-hidden="true"><use href="#icon-toon"></use></svg></button>
       <button id="grid-btn" class="tool-btn" title="Grid visibility: on" aria-label="Grid visibility: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-grid"></use></svg></button>

--- a/src/web/js/app/model-flow.js
+++ b/src/web/js/app/model-flow.js
@@ -2,7 +2,9 @@
 
 import { viewerState, samePath } from './state.js';
 import { resetAssetFillState, updateAssetFillButton } from './asset-fill.js';
-import { fitTo, isRendererAvailable } from '../scene/scene.js';
+import {
+  fitTo, isRendererAvailable, setBloomSuppressedByDebug,
+} from '../scene/scene.js';
 import { setRightDockEnabled } from '../panels/right-dock.js';
 import { clearSelection } from '../scene/selection.js';
 import { clearInspector } from '../panels/inspector-panel.js';
@@ -64,6 +66,7 @@ export function clearScene({ preserveModelOrientation = false } = {}) {
   // suppression in the same lifecycle rather than carrying stale state onto
   // the next mod's normal materials.
   setOutlineSuppressedByDebug(false);
+  setBloomSuppressedByDebug(false);
   resetAssetFillState();
   setTextures(null);
   setGeometryBlob(null);

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -4,7 +4,8 @@ import {
   getAmbientOcclusionStrength, getBloomEnabled, getEnvironmentPreset, getRenderCount,
   isRendererAvailable, rendererReady,
   resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
-  setAmbientOcclusionStrength, setBloomEnabled, setBloomSuppressedByDebug,
+  setAmbientOcclusionStrength, setBloomAvailable, setBloomEnabled,
+  setBloomSuppressedByDebug,
   toggleGrid, toggleTrackballGizmo,
 } from './scene/scene.js';
 import {
@@ -114,17 +115,21 @@ function exportChanges() {
   return exportChangesFlow();
 }
 
-function hasUsableEmission() {
+function hasEmissionCapability() {
   return activeMeshes.some(mesh => {
     const game = mesh.material?.userData?.gameMaterial;
-    return game?.profile?.emission_source === 'emission_map_rgb'
-      && !!mesh.userData.emissionMapKey;
+    if (game?.profile?.emission_source !== 'emission_map_rgb') return false;
+    return !!mesh.userData.emissionMapKey
+      || !!mesh.userData.defaultEmissionMapKey
+      || !!mesh.userData.resolvedEmissionMapKey
+      || (mesh.userData.emissionMapVariants?.length ?? 0) > 0;
   });
 }
 
 function syncBloomControl() {
   const button = $('bloom-btn');
-  const available = hasUsableEmission();
+  const available = hasEmissionCapability();
+  setBloomAvailable(available);
   const enabled = available && getBloomEnabled();
   button.hidden = !available;
   button.disabled = !available;
@@ -172,6 +177,7 @@ rendererReady.then(ready => {
   for (const eventName of [
     'mod-viewer-mod-load-started', 'mod-viewer-mod-loaded',
     'mod-viewer-asset-load-started', 'mod-viewer-asset-loaded',
+    'mod-viewer-mesh-state-changed',
   ]) {
     window.addEventListener(eventName, syncBloomControl);
   }

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -126,6 +126,7 @@ function syncBloomControl() {
   const button = $('bloom-btn');
   const available = hasUsableEmission();
   const enabled = available && getBloomEnabled();
+  button.hidden = !available;
   button.disabled = !available;
   button.classList.toggle('off', !enabled);
   button.classList.toggle('active', enabled);

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -1,10 +1,11 @@
 // Entry point: composes frontend application flows and initializes the UI.
 
 import {
-  getAmbientOcclusionStrength, getEnvironmentPreset, getRenderCount,
+  getAmbientOcclusionStrength, getBloomEnabled, getEnvironmentPreset, getRenderCount,
   isRendererAvailable, rendererReady,
   resetView, rotateModelHorizontalQuarterTurn, rotateModelQuarterTurn,
-  setAmbientOcclusionStrength, toggleGrid, toggleTrackballGizmo,
+  setAmbientOcclusionStrength, setBloomEnabled, setBloomSuppressedByDebug,
+  toggleGrid, toggleTrackballGizmo,
 } from './scene/scene.js';
 import {
   activeMeshes, resetMeshState,
@@ -133,11 +134,27 @@ rendererReady.then(ready => {
     button.setAttribute('aria-pressed', String(enabled));
     button.setAttribute('aria-label', `Silhouette outlines: ${enabled ? 'on' : 'off'}`);
   });
+  const syncBloomControl = () => {
+    const enabled = getBloomEnabled();
+    const button = $('bloom-btn');
+    button.classList.toggle('off', !enabled);
+    button.classList.toggle('active', enabled);
+    button.setAttribute('aria-pressed', String(enabled));
+    const label = `Emission bloom: ${enabled ? 'on' : 'off'}`;
+    button.title = label;
+    button.setAttribute('aria-label', label);
+    return enabled;
+  };
+  $('bloom-btn').addEventListener('click', () => {
+    setBloomEnabled(!getBloomEnabled());
+    syncBloomControl();
+  });
   $('grid-btn').addEventListener('click', toggleGrid);
   $('shading-btn').addEventListener('click', toggleSmoothShading);
   $('toon-btn').addEventListener('click', toggleToonShading);
   $('glossy-btn').addEventListener('click', toggleGlossy);
   const syncAmbientOcclusionControl = initToolPopovers();
+  syncBloomControl();
   $('reset-state-btn').addEventListener('click', event => {
     event.stopPropagation();
     resetMeshState();
@@ -216,6 +233,8 @@ rendererReady.then(ready => {
       normalDataBound: !!game?.bindings?.normal_data?.enabledNode?.value,
       lightMapBound: !!game?.bindings?.light_map?.enabledNode?.value,
       materialMapBound: !!game?.bindings?.material_map?.enabledNode?.value,
+      emissionMapBound: !!game?.bindings?.emission_map?.enabledNode?.value,
+      emissionSource: game?.profile?.emission_source || null,
       supportedDebugModes: game?.supportedDebugModes || [],
       debugMode: getMaterialDebugMode(mesh?.material),
     };
@@ -223,6 +242,7 @@ rendererReady.then(ready => {
   const setMaterialDebugModeForMeshes = mode => {
     const normalized = setMaterialDebugMode(activeMeshes, mode);
     setOutlineSuppressedByDebug(normalized !== 'off');
+    setBloomSuppressedByDebug(normalized !== 'off');
     // Diagnostics use the same stable packed bindings as normal rendering.
     // WuWa's packed normal is already resident when debug mode changes, so a
     // B/A view only changes the diagnostic uniform and binding selection.
@@ -243,6 +263,12 @@ rendererReady.then(ready => {
     setAmbientOcclusionStrength: value => {
       const changed = setAmbientOcclusionStrength(value);
       syncAmbientOcclusionControl?.();
+      return changed;
+    },
+    getBloomEnabled,
+    setBloomEnabled: value => {
+      const changed = setBloomEnabled(value);
+      syncBloomControl();
       return changed;
     },
     getMaterialState,

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -114,6 +114,30 @@ function exportChanges() {
   return exportChangesFlow();
 }
 
+function hasUsableEmission() {
+  return activeMeshes.some(mesh => {
+    const game = mesh.material?.userData?.gameMaterial;
+    return game?.profile?.emission_source === 'emission_map_rgb'
+      && !!mesh.userData.emissionMapKey;
+  });
+}
+
+function syncBloomControl() {
+  const button = $('bloom-btn');
+  const available = hasUsableEmission();
+  const enabled = available && getBloomEnabled();
+  button.disabled = !available;
+  button.classList.toggle('off', !enabled);
+  button.classList.toggle('active', enabled);
+  button.setAttribute('aria-pressed', String(enabled));
+  const label = available
+    ? `Emission bloom: ${enabled ? 'on' : 'off'}`
+    : 'Emission bloom unavailable: no GlowMap detected';
+  button.title = label;
+  button.setAttribute('aria-label', label);
+  return enabled;
+}
+
 initToolbarOverflow();
 initPanelOpacityControl();
 
@@ -134,17 +158,6 @@ rendererReady.then(ready => {
     button.setAttribute('aria-pressed', String(enabled));
     button.setAttribute('aria-label', `Silhouette outlines: ${enabled ? 'on' : 'off'}`);
   });
-  const syncBloomControl = () => {
-    const enabled = getBloomEnabled();
-    const button = $('bloom-btn');
-    button.classList.toggle('off', !enabled);
-    button.classList.toggle('active', enabled);
-    button.setAttribute('aria-pressed', String(enabled));
-    const label = `Emission bloom: ${enabled ? 'on' : 'off'}`;
-    button.title = label;
-    button.setAttribute('aria-label', label);
-    return enabled;
-  };
   $('bloom-btn').addEventListener('click', () => {
     setBloomEnabled(!getBloomEnabled());
     syncBloomControl();
@@ -155,6 +168,12 @@ rendererReady.then(ready => {
   $('glossy-btn').addEventListener('click', toggleGlossy);
   const syncAmbientOcclusionControl = initToolPopovers();
   syncBloomControl();
+  for (const eventName of [
+    'mod-viewer-mod-load-started', 'mod-viewer-mod-loaded',
+    'mod-viewer-asset-load-started', 'mod-viewer-asset-loaded',
+  ]) {
+    window.addEventListener(eventName, syncBloomControl);
+  }
   $('reset-state-btn').addEventListener('click', event => {
     event.stopPropagation();
     resetMeshState();

--- a/src/web/js/mesh/material-profile.js
+++ b/src/web/js/mesh/material-profile.js
@@ -92,6 +92,7 @@ const PLACEHOLDERS = Object.freeze({
   normal_data: PACKED_PLACEHOLDER,
   light_map: PACKED_PLACEHOLDER,
   material_map: PACKED_PLACEHOLDER,
+  emission_map: PACKED_PLACEHOLDER,
 });
 
 function validRef(ref) {
@@ -184,6 +185,7 @@ function createBindings(hasUv) {
     normal_data: createBinding('normal_data', primaryUv),
     light_map: createBinding('light_map', primaryUv),
     material_map: createBinding('material_map', primaryUv),
+    emission_map: createBinding('emission_map', primaryUv),
   };
 }
 
@@ -310,6 +312,7 @@ function setStableMaterialNodes(material, state, fallbackColor) {
     material.normalNode = fallbackNormal;
   }
   material.colorNode = createDebugOutputNode(state, baseColor);
+  material.emissiveNode = state.emissionNode;
 
   if (!state.packedResponse) return;
 
@@ -346,8 +349,25 @@ function applyViewerRim(state, result) {
   return vec4(result.rgb.add(tint.mul(amount)), result.a);
 }
 
+function applyViewerSelection(state, result) {
+  if (!state?.selectionEnabledNode || !state?.selectionStrengthNode) {
+    return result;
+  }
+  const highlighted = mix(result.rgb, color(0xffd60a), state.selectionStrengthNode);
+  return vec4(
+    mix(result.rgb, highlighted, state.selectionEnabledNode), result.a);
+}
+
 function applyViewerOutput(state, result) {
-  return applyDebugOverride(state, applyViewerRim(state, result));
+  return applyDebugOverride(
+    state, applyViewerSelection(state, applyViewerRim(state, result)));
+}
+
+function createEmissionNode(profile, bindings, hasUv) {
+  if (!hasUv || profile?.emission_source !== 'emission_map_rgb') return vec3(0);
+  const strength = clamp(float(numericOr(profile.emission_strength, 1)), 0, 1);
+  return bindings.emission_map.enabledNode.select(
+    bindings.emission_map.textureNode.rgb.mul(strength), vec3(0));
 }
 
 function physicalLightingFlags(material) {
@@ -801,6 +821,8 @@ export function configureGameMaterial(material, profile, options = {}) {
     rimEnabledNode: uniform(true),
     rimStrengthNode: uniform(0.075),
     rimPowerNode: uniform(4.0),
+    selectionEnabledNode: uniform(false),
+    selectionStrengthNode: uniform(0.22),
     hasMaterialId,
     hasSpecularArea,
     hasShadowMask,
@@ -831,6 +853,8 @@ export function configureGameMaterial(material, profile, options = {}) {
   state.metalRouteNode = validRef(resolvedProfile.metal_route)
     ? createRawChannelNode(resolvedProfile.metal_route, state.bindings)
     : float(0);
+  state.emissionNode = createEmissionNode(
+    resolvedProfile, state.bindings, hasUv);
   state.sources = state.bindings;
   state.nodes = {
     diffuse: state.bindings.diffuse,
@@ -838,6 +862,7 @@ export function configureGameMaterial(material, profile, options = {}) {
     normalData: state.bindings.normal_data,
     lightMap: state.bindings.light_map,
     materialMap: state.bindings.material_map,
+    emissionMap: state.bindings.emission_map,
   };
   material.userData.gameMaterial = state;
   setStableMaterialNodes(material, state, options.fallbackColor ?? material.color);
@@ -865,6 +890,7 @@ export function updateGameMaterialTextures(mesh, maps = {}, options = {}) {
     normal_data: maps.normal_data,
     light_map: maps.light_map,
     material_map: maps.material_map,
+    emission_map: maps.emission_map,
   };
   for (const [role, value] of Object.entries(values)) {
     if (!Object.hasOwn(maps, role)) continue;
@@ -899,6 +925,9 @@ export function getGameMaterialSources(material) {
   const sources = new Set(profileRenderSources(state.profile));
   for (const source of profileNormalSources(state.profile)) {
     sources.add(source);
+  }
+  if (state.profile?.emission_source === 'emission_map_rgb') {
+    sources.add('emission_map');
   }
   const debugSource = profileDebugSource(
     state.profile, getMaterialDebugMode(material));
@@ -946,6 +975,14 @@ export function setGameMaterialRimEnabled(material, enabled) {
 /** Toggle profile-driven toon direct diffuse without rebuilding the material. */
 export function setGameMaterialToonEnabled(material, enabled) {
   const node = material?.userData?.gameMaterial?.toonEnabledNode;
+  if (!node) return false;
+  node.value = enabled === true;
+  return true;
+}
+
+/** Keep selection out of material emissive so MRT bloom sees authored light only. */
+export function setGameMaterialSelectionEnabled(material, enabled) {
+  const node = material?.userData?.gameMaterial?.selectionEnabledNode;
   if (!node) return false;
   node.value = enabled === true;
   return true;

--- a/src/web/js/mesh/mesh-factory.js
+++ b/src/web/js/mesh/mesh-factory.js
@@ -230,10 +230,13 @@ export function refreshMeshTexture(mesh) {
     ? getTexture(mesh, mesh.userData.lightMapKey) : null;
   const materialMap = usePackedSource('material_map')
     ? getTexture(mesh, mesh.userData.materialMapKey) : null;
+  const emissionMap = usePackedSource('emission_map')
+    ? getTexture(mesh, mesh.userData.emissionMapKey) : null;
   const changed = updateGameMaterialTextures(mesh, {
     diffuse: map,
     normal_map: normalMap,
     normal_data: normalData, light_map: lightMap, material_map: materialMap,
+    emission_map: emissionMap,
     normal_map_y_sign: mesh.userData.normalMapYSign ?? -1,
   });
   if (!changed) return;
@@ -269,6 +272,7 @@ export function setMeshTextureState(mesh, state) {
   }
   mesh.userData.lightMapKey = state.light_map || null;
   mesh.userData.materialMapKey = state.material_map || null;
+  mesh.userData.emissionMapKey = state.emission_map || null;
   refreshMeshTexture(mesh);
 }
 
@@ -327,6 +331,7 @@ export function buildMesh(name, data, materialProfile = null) {
   mesh.userData.normalDataKey = data.normal_data_key || null;
   mesh.userData.lightMapKey = data.light_map_key || null;
   mesh.userData.materialMapKey = data.material_map_key || null;
+  mesh.userData.emissionMapKey = data.emission_map_key || null;
   mesh.userData.materialKind = data.material_kind || 'unknown';
   mesh.userData.materialKindReliable = data.material_kind_reliable === true;
   mesh.userData.materialKindReason = data.material_kind_reason || '';
@@ -341,6 +346,7 @@ export function buildMesh(name, data, materialProfile = null) {
   mesh.userData.defaultNormalDataKey = mesh.userData.normalDataKey;
   mesh.userData.defaultLightMapKey = mesh.userData.lightMapKey;
   mesh.userData.defaultMaterialMapKey = mesh.userData.materialMapKey;
+  mesh.userData.defaultEmissionMapKey = mesh.userData.emissionMapKey;
   mesh.userData.fallbackColor = fallback;
   refreshMeshTexture(mesh);
   mesh.castShadow = mesh.receiveShadow = true;

--- a/src/web/js/mesh/mesh-state.js
+++ b/src/web/js/mesh/mesh-state.js
@@ -43,6 +43,7 @@ export function addMesh(mesh, conditions, sources, textureVariants, materialVari
   mesh.userData.normalDataVariants = materialVariants.normal_data || [];
   mesh.userData.lightMapVariants = materialVariants.light_map || [];
   mesh.userData.materialMapVariants = materialVariants.material_map || [];
+  mesh.userData.emissionMapVariants = materialVariants.emission_map || [];
   // The texture selected by the INI under the current control state. Ordered
   // component texture runs may still make a following mesh inherit it.
   mesh.userData.resolvedTexKey = mesh.userData.defaultTexKey;
@@ -109,6 +110,7 @@ export function updateMeshSemantics(semantics) {
       ['normalDataVariants', 'normal_data_variants'],
       ['lightMapVariants', 'light_map_variants'],
       ['materialMapVariants', 'material_map_variants'],
+      ['emissionMapVariants', 'emission_map_variants'],
     ];
     for (const [target, source] of variants) {
       mesh.userData[target] = semantic[source] || [];
@@ -119,6 +121,7 @@ export function updateMeshSemantics(semantics) {
       ['defaultNormalDataKey', 'normal_data_key'],
       ['defaultLightMapKey', 'light_map_key'],
       ['defaultMaterialMapKey', 'material_map_key'],
+      ['defaultEmissionMapKey', 'emission_map_key'],
     ];
     for (const [target, source] of defaults) {
       if (Object.hasOwn(semantic, source)) {
@@ -169,6 +172,8 @@ export function applyTextureVariant(mesh) {
     mesh.userData.lightMapVariants, mesh.userData.defaultLightMapKey);
   mesh.userData.resolvedMaterialMapKey = resolve(
     mesh.userData.materialMapVariants, mesh.userData.defaultMaterialMapKey);
+  mesh.userData.resolvedEmissionMapKey = resolve(
+    mesh.userData.emissionMapVariants, mesh.userData.defaultEmissionMapKey);
   setMeshTextureState(mesh, {
     diffuse: mesh.userData.manualTexOverride !== undefined
       ? mesh.userData.manualTexOverride
@@ -177,6 +182,7 @@ export function applyTextureVariant(mesh) {
     normal_data: mesh.userData.resolvedNormalDataKey,
     light_map: mesh.userData.resolvedLightMapKey,
     material_map: mesh.userData.resolvedMaterialMapKey,
+    emission_map: mesh.userData.resolvedEmissionMapKey,
   });
 }
 

--- a/src/web/js/mesh/mesh-texture-state.js
+++ b/src/web/js/mesh/mesh-texture-state.js
@@ -30,6 +30,7 @@ export function recomputeTextureRuns(groupMeshes) {
         ...normalMapsFor(mesh, option),
         light_map: option.light_map || null,
         material_map: option.material_map || null,
+        emission_map: option.emission_map || null,
       } : null;
     } else if (mesh.userData.automaticTextureBoundary
                && !mesh.userData.textureHighlightDisabled) {
@@ -50,6 +51,7 @@ export function recomputeTextureRuns(groupMeshes) {
           }),
           light_map: mesh.userData.resolvedLightMapKey,
           material_map: mesh.userData.resolvedMaterialMapKey,
+          emission_map: mesh.userData.resolvedEmissionMapKey,
         };
         for (const [field, key] of Object.entries(resolvedMaps)) {
           if (option[`${field}_manual`]) continue;
@@ -66,6 +68,7 @@ export function recomputeTextureRuns(groupMeshes) {
       }),
       light_map: mesh.userData.resolvedLightMapKey,
       material_map: mesh.userData.resolvedMaterialMapKey,
+      emission_map: mesh.userData.resolvedEmissionMapKey,
     };
     setMeshTextureState(mesh, { diffuse: activeKey, ...maps });
   }
@@ -102,9 +105,11 @@ export function saveTextureState(modPath) {
       normal_data: option.normal_data || null,
       light_map: option.light_map || null,
       material_map: option.material_map || null,
+      emission_map: option.emission_map || null,
       normal_data_manual: !!option.normal_data_manual,
       light_map_manual: !!option.light_map_manual,
       material_map_manual: !!option.material_map_manual,
+      emission_map_manual: !!option.emission_map_manual,
     };
     if (!usesPackedNormal(mesh.material)) {
       savedState.normal_map = option.normal_map || null;

--- a/src/web/js/panels/mesh-panel.js
+++ b/src/web/js/panels/mesh-panel.js
@@ -431,6 +431,7 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
             normal_data: meshes[name].normal_data_variants,
             light_map: meshes[name].light_map_variants,
             material_map: meshes[name].material_map_variants,
+            emission_map: meshes[name].emission_map_variants,
           });
         // addMesh establishes the automatic defaults; restore persisted
         // viewer choices only after that initialization has completed.

--- a/src/web/js/scene/render-modes.js
+++ b/src/web/js/scene/render-modes.js
@@ -6,7 +6,10 @@ import {
 } from '../mesh/material-profile.js';
 import { setOutlineSuppressedByWireframe } from './outline-renderer.js';
 import { requestRender } from './render-scheduler.js';
-import { setAmbientOcclusionSuppressedByWireframe } from './scene.js';
+import {
+  setAmbientOcclusionSuppressedByWireframe,
+  setBloomSuppressedByWireframe,
+} from './scene.js';
 
 let wireframe = false;
 let smoothShading = true;
@@ -39,6 +42,7 @@ export function toggleWireframeMode(meshes) {
   wireframe = !wireframe;
   setOutlineSuppressedByWireframe(wireframe);
   setAmbientOcclusionSuppressedByWireframe(wireframe);
+  setBloomSuppressedByWireframe(wireframe);
   const button = document.getElementById('wire-btn');
   button.classList.toggle('active', wireframe);
   button.setAttribute('aria-pressed', String(wireframe));

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -325,6 +325,12 @@ export function setBloomEnabled(value) {
   return changed;
 }
 
+export function setBloomAvailable(value) {
+  const changed = viewportRenderPipeline.setBloomAvailable(value);
+  if (changed) requestRender();
+  return changed;
+}
+
 export function getBloomEnabled() {
   return viewportRenderPipeline.getBloomEnabled();
 }

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -319,6 +319,26 @@ export function setAmbientOcclusionSuppressedByWireframe(value) {
   requestRender();
 }
 
+export function setBloomEnabled(value) {
+  const changed = viewportRenderPipeline.setBloomEnabled(value);
+  if (changed) requestRender();
+  return changed;
+}
+
+export function getBloomEnabled() {
+  return viewportRenderPipeline.getBloomEnabled();
+}
+
+export function setBloomSuppressedByWireframe(value) {
+  viewportRenderPipeline.setBloomSuppressedByWireframe(value);
+  requestRender();
+}
+
+export function setBloomSuppressedByDebug(value) {
+  viewportRenderPipeline.setBloomSuppressedByDebug(value);
+  requestRender();
+}
+
 export function rotateModelQuarterTurn(meshes = []) {
   cameraFrame.rotateModelQuarterTurn(meshes);
   characterShadowController.invalidateGeometry();

--- a/src/web/js/scene/selection.js
+++ b/src/web/js/scene/selection.js
@@ -7,18 +7,16 @@ import * as THREE from 'three';
 import { camera, renderer } from './scene.js';
 import { activeMeshes } from '../mesh/visibility.js';
 import { getMeshView } from '../mesh/mesh-view-bindings.js';
+import { setGameMaterialSelectionEnabled } from '../mesh/material-profile.js';
 import { requestRender } from './render-scheduler.js';
 
-const HIGHLIGHT_COLOR = 0xffd60a; // selection yellow
-const HIGHLIGHT_INTENSITY = 0.22;  // kept low so the mesh's own texture reads through
 const raycaster = new THREE.Raycaster();
 const pointer = new THREE.Vector2();
 
 let selected = null; // currently selected mesh, or null
 
 function setHighlight(mesh, on) {
-  mesh.material.emissive.setHex(on ? HIGHLIGHT_COLOR : 0x000000);
-  mesh.material.emissiveIntensity = on ? HIGHLIGHT_INTENSITY : 1;
+  setGameMaterialSelectionEnabled(mesh.material, on);
 }
 
 function setRowSelected(mesh, on) {

--- a/src/web/js/scene/viewport-render-pipeline.js
+++ b/src/web/js/scene/viewport-render-pipeline.js
@@ -90,6 +90,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
   let modelSize = MIN_MODEL_SIZE;
   let configuredStrength = 0;
   let bloomEnabled = false;
+  let bloomAvailable = false;
   let suppressedByWireframe = false;
   let bloomSuppressedByWireframe = false;
   let bloomSuppressedByDebug = false;
@@ -103,8 +104,8 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
 
   const isAmbientOcclusionEnabled = () => configuredStrength > 0;
   const shouldRenderAO = () => isAmbientOcclusionEnabled() && !suppressedByWireframe;
-  const shouldRenderBloom = () => bloomEnabled && !bloomSuppressedByWireframe
-    && !bloomSuppressedByDebug;
+  const shouldRenderBloom = () => bloomEnabled && bloomAvailable
+    && !bloomSuppressedByWireframe && !bloomSuppressedByDebug;
   const renderMode = () => shouldRenderAO()
     ? (shouldRenderBloom() ? 'ao-bloom' : 'ao')
     : (shouldRenderBloom() ? 'bloom' : 'direct');
@@ -162,8 +163,10 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     meshes = [];
     modelSize = MIN_MODEL_SIZE;
     modelSizeDirty = false;
+    bloomAvailable = false;
     aoPass.radius.value = MIN_AO_RADIUS;
     aoPass.thickness.value = MIN_AO_RADIUS * AO_THICKNESS_RADIUS_RATIO;
+    configureRenderGraph();
   }
   function setAmbientOcclusionStrength(value) {
     if (!Number.isFinite(value)) return false;
@@ -184,6 +187,13 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     const next = value === true;
     const changed = next !== bloomEnabled;
     bloomEnabled = next;
+    configureRenderGraph();
+    return changed;
+  }
+  function setBloomAvailable(value) {
+    const next = value === true;
+    const changed = next !== bloomAvailable;
+    bloomAvailable = next;
     configureRenderGraph();
     return changed;
   }
@@ -223,7 +233,8 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     return {
       enabled: isAmbientOcclusionEnabled(), radiusFactor: AO_RADIUS_FACTOR,
       strength: configuredStrength, effectiveStrength: effectiveStrength(),
-      suppressedByWireframe, bloomEnabled, bloomEffective: shouldRenderBloom(),
+      suppressedByWireframe, bloomEnabled, bloomAvailable,
+      bloomEffective: shouldRenderBloom(),
       bloomSuppressedByWireframe, bloomSuppressedByDebug,
       bloomStrength: BLOOM_STRENGTH, bloomRadius: BLOOM_RADIUS,
       bloomThreshold: BLOOM_THRESHOLD, bloomResolutionScale: bloomPass.getResolutionScale(),
@@ -259,7 +270,7 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     render, setMeshes, adoptMeshes, forgetMeshes, invalidateGeometry, reset,
     getAmbientOcclusionStrength: () => configuredStrength, isAmbientOcclusionEnabled,
     setAmbientOcclusionStrength, setAmbientOcclusionSuppressedByWireframe,
-    getBloomEnabled: () => bloomEnabled, setBloomEnabled,
+    getBloomEnabled: () => bloomEnabled, setBloomEnabled, setBloomAvailable,
     setBloomSuppressedByWireframe, setBloomSuppressedByDebug, getDebugState, dispose,
   };
 }

--- a/src/web/js/scene/viewport-render-pipeline.js
+++ b/src/web/js/scene/viewport-render-pipeline.js
@@ -1,20 +1,9 @@
-// WebGPU-native viewport post-processing and character-only ambient occlusion.
+// WebGPU-native viewport post-processing for character AO and emission bloom.
 
 import * as THREE from 'three/webgpu';
-import {
-  builtinAOContext,
-  float,
-  mix,
-  mrt,
-  normalView,
-  packNormalToRGB,
-  pass,
-  sample,
-  screenUV,
-  uniform,
-  unpackRGBToNormal,
-} from 'three/tsl';
+import { builtinAOContext, emissive, float, mix, mrt, normalView, output, packNormalToRGB, pass, sample, screenUV, uniform, unpackRGBToNormal } from 'three/tsl';
 import { ao } from 'three/addons/tsl/display/GTAONode.js';
+import { bloom } from 'three/addons/tsl/display/BloomNode.js';
 import { computeModelBounds } from './model-bounds.js';
 import { CHARACTER_AO_LAYER } from './viewer-layers.js';
 
@@ -22,119 +11,126 @@ const AO_RESOLUTION_SCALE = 0.5;
 const AO_SAMPLES = 8;
 const AO_RADIUS_FACTOR = 0.005;
 const AO_THICKNESS_RADIUS_RATIO = 4;
+const BLOOM_STRENGTH = 0.35;
+const BLOOM_RADIUS = 0.2;
+const BLOOM_THRESHOLD = 0;
+const BLOOM_RESOLUTION_SCALE = 0.5;
 const MIN_MODEL_SIZE = 0.001;
 const MIN_AO_RADIUS = MIN_MODEL_SIZE * AO_RADIUS_FACTOR;
 let nextPipelineId = 0;
 
-function finitePositive(value) {
-  return Number.isFinite(value) && value > 0;
-}
-
+function finitePositive(value) { return Number.isFinite(value) && value > 0; }
 function readUniformValue(node, fallback = 0) {
   return Number.isFinite(node?.value) ? node.value : fallback;
 }
-
 function readResolution(node) {
   const value = node?.value;
-  if (!value || !Number.isFinite(value.x) || !Number.isFinite(value.y)) {
-    return null;
-  }
-  return [value.x, value.y];
+  return value && Number.isFinite(value.x) && Number.isFinite(value.y)
+    ? [value.x, value.y] : null;
 }
 
 /** Create the one viewport render pipeline used by the scene renderer. */
 export function createViewportRenderPipeline({ renderer, scene, camera }) {
   const aoLayers = new THREE.Layers();
   aoLayers.set(CHARACTER_AO_LAYER);
-
   const renderPipeline = new THREE.RenderPipeline(renderer);
   const pipelineId = ++nextPipelineId;
-  // RenderPipeline evaluates scene passes from inside the fullscreen quad.
-  // Keep the beauty pass on the camera owned by ArcballControls. Only the
-  // character pre-pass needs an isolated camera because it changes layers.
   const prePassCamera = camera.clone();
-
-  function syncCameraCoordinateSystem() {
+  const syncCameraCoordinateSystem = () => {
     if (camera.coordinateSystem !== renderer.coordinateSystem) {
       camera.coordinateSystem = renderer.coordinateSystem;
       camera.updateProjectionMatrix();
     }
-  }
-
-  function syncPrePassCamera() {
+  };
+  const syncPrePassCamera = () => {
     syncCameraCoordinateSystem();
     prePassCamera.copy(camera, false);
-  }
+  };
 
-  // The pre-pass renders only character meshes. Its packed normal attachment
-  // is deliberately 8-bit; depth remains the pass's depth texture.
   const prePass = pass(scene, prePassCamera, { samples: 1 });
   prePass.setResolutionScale(AO_RESOLUTION_SCALE);
   prePass.name = 'Character AO pre-pass';
   prePass.transparent = false;
   prePass.setLayers(aoLayers);
   prePass.setMRT(mrt({ output: packNormalToRGB(normalView) }));
-  const normalTexture = prePass.getTexture('output');
-  normalTexture.type = THREE.UnsignedByteType;
-
+  prePass.getTexture('output').type = THREE.UnsignedByteType;
   const prePassNormal = sample(uv =>
     unpackRGBToNormal(prePass.getTextureNode().sample(uv)));
-  const prePassDepth = prePass.getTextureNode('depth');
-  const aoPass = ao(prePassDepth, prePassNormal, camera);
+  const aoPass = ao(prePass.getTextureNode('depth'), prePassNormal, camera);
   aoPass.resolutionScale = AO_RESOLUTION_SCALE;
   aoPass.samples.value = AO_SAMPLES;
   aoPass.useTemporalFiltering = false;
-
   const aoStrengthNode = uniform(0);
-  const aoSample = aoPass.getTextureNode().sample(screenUV).r;
-  const effectiveAO = mix(float(1), aoSample, aoStrengthNode);
+  const effectiveAO = mix(
+    float(1), aoPass.getTextureNode().sample(screenUV).r, aoStrengthNode);
 
-  // The beauty pass retains the whole presentation scene. AO enters through
-  // the lighting context so direct light, shadows, rim and debug outputs are
-  // not multiplied as a final screen-space color operation.
-  const scenePass = pass(scene, camera);
-  scenePass.name = 'Viewport beauty pass';
-  scenePass.contextNode = builtinAOContext(effectiveAO);
-  renderPipeline.outputNode = scenePass;
+  // Each output graph has only the work it needs: bloom-only deliberately has
+  // no AO context, so it cannot schedule GTAO's depth/normal pre-pass.
+  const aoScenePass = pass(scene, camera);
+  aoScenePass.name = 'Viewport AO beauty pass';
+  aoScenePass.contextNode = builtinAOContext(effectiveAO);
+  const bloomScenePass = pass(scene, camera);
+  bloomScenePass.name = 'Viewport emission beauty pass';
+  bloomScenePass.setMRT(mrt({ output, emissive }));
+  const bloomPass = bloom(bloomScenePass.getTextureNode('emissive'),
+    BLOOM_STRENGTH, BLOOM_RADIUS, BLOOM_THRESHOLD);
+  bloomPass.setResolutionScale(BLOOM_RESOLUTION_SCALE);
+  const bloomOutput = bloomScenePass.getTextureNode('output').add(bloomPass);
+  const aoBloomScenePass = pass(scene, camera);
+  aoBloomScenePass.name = 'Viewport AO emission beauty pass';
+  aoBloomScenePass.contextNode = builtinAOContext(effectiveAO);
+  aoBloomScenePass.setMRT(mrt({ output, emissive }));
+  const aoBloomPass = bloom(aoBloomScenePass.getTextureNode('emissive'),
+    BLOOM_STRENGTH, BLOOM_RADIUS, BLOOM_THRESHOLD);
+  aoBloomPass.setResolutionScale(BLOOM_RESOLUTION_SCALE);
+  const aoBloomOutput = aoBloomScenePass.getTextureNode('output').add(aoBloomPass);
 
   let meshes = [];
   let modelSizeDirty = true;
   let modelSize = MIN_MODEL_SIZE;
   let configuredStrength = 0;
+  let bloomEnabled = false;
   let suppressedByWireframe = false;
+  let bloomSuppressedByWireframe = false;
+  let bloomSuppressedByDebug = false;
+  let activeRenderMode = 'direct';
   let renderCount = 0;
   let directRenderCount = 0;
   let aoRenderCount = 0;
+  let aoOnlyRenderCount = 0;
+  let bloomOnlyRenderCount = 0;
+  let aoBloomRenderCount = 0;
 
-  function isAmbientOcclusionEnabled() {
-    return configuredStrength > 0;
+  const isAmbientOcclusionEnabled = () => configuredStrength > 0;
+  const shouldRenderAO = () => isAmbientOcclusionEnabled() && !suppressedByWireframe;
+  const shouldRenderBloom = () => bloomEnabled && !bloomSuppressedByWireframe
+    && !bloomSuppressedByDebug;
+  const renderMode = () => shouldRenderAO()
+    ? (shouldRenderBloom() ? 'ao-bloom' : 'ao')
+    : (shouldRenderBloom() ? 'bloom' : 'direct');
+  const effectiveStrength = () => shouldRenderAO() ? configuredStrength : 0;
+  const applyStrength = () => { aoStrengthNode.value = effectiveStrength(); };
+  function configureRenderGraph() {
+    const next = renderMode();
+    if (next === activeRenderMode) return false;
+    activeRenderMode = next;
+    if (next === 'ao') renderPipeline.outputNode = aoScenePass;
+    else if (next === 'bloom') renderPipeline.outputNode = bloomOutput;
+    else if (next === 'ao-bloom') renderPipeline.outputNode = aoBloomOutput;
+    if (next !== 'direct') renderPipeline.needsUpdate = true;
+    return true;
   }
-
-  function shouldRenderAO() {
-    return isAmbientOcclusionEnabled() && !suppressedByWireframe;
-  }
-
-  function effectiveStrength() {
-    return shouldRenderAO() ? configuredStrength : 0;
-  }
-
-  function applyStrength() {
-    aoStrengthNode.value = effectiveStrength();
-  }
-
   function updateModelSize() {
     if (!modelSizeDirty) return;
     const bounds = computeModelBounds(meshes);
-    if (bounds.isEmpty()) {
-      modelSize = MIN_MODEL_SIZE;
-    } else {
+    if (bounds.isEmpty()) modelSize = MIN_MODEL_SIZE;
+    else {
       const diagonal = bounds.getSize(new THREE.Vector3()).length();
       modelSize = finitePositive(diagonal) ? Math.max(diagonal, MIN_MODEL_SIZE)
         : MIN_MODEL_SIZE;
     }
     modelSizeDirty = false;
   }
-
   function updateSpatialParameters() {
     if (!isAmbientOcclusionEnabled()) {
       aoPass.radius.value = MIN_AO_RADIUS;
@@ -142,37 +138,26 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
       return;
     }
     updateModelSize();
-    const radius = modelSize * AO_RADIUS_FACTOR;
-    aoPass.radius.value = radius;
-    aoPass.thickness.value = radius * AO_THICKNESS_RADIUS_RATIO;
+    aoPass.radius.value = modelSize * AO_RADIUS_FACTOR;
+    aoPass.thickness.value = aoPass.radius.value * AO_THICKNESS_RADIUS_RATIO;
   }
-
-  function invalidateGeometry() {
-    modelSizeDirty = true;
-  }
-
+  const invalidateGeometry = () => { modelSizeDirty = true; };
   function setMeshes(nextMeshes = []) {
     meshes = [...new Set(nextMeshes.filter(Boolean))];
     invalidateGeometry();
   }
-
   function adoptMeshes(nextMeshes = []) {
     const known = new Set(meshes);
     const added = nextMeshes.filter(mesh => mesh && !known.has(mesh));
-    if (added.length) {
-      meshes.push(...added);
-      invalidateGeometry();
-    }
+    if (added.length) { meshes.push(...added); invalidateGeometry(); }
     return added;
   }
-
   function forgetMeshes(nextMeshes = []) {
     const removed = new Set(nextMeshes);
     const before = meshes.length;
     meshes = meshes.filter(mesh => !removed.has(mesh));
     if (meshes.length !== before) invalidateGeometry();
   }
-
   function reset() {
     meshes = [];
     modelSize = MIN_MODEL_SIZE;
@@ -180,7 +165,6 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     aoPass.radius.value = MIN_AO_RADIUS;
     aoPass.thickness.value = MIN_AO_RADIUS * AO_THICKNESS_RADIUS_RATIO;
   }
-
   function setAmbientOcclusionStrength(value) {
     if (!Number.isFinite(value)) return false;
     const next = THREE.MathUtils.clamp(value, 0, 1);
@@ -188,97 +172,94 @@ export function createViewportRenderPipeline({ renderer, scene, camera }) {
     configuredStrength = next;
     updateSpatialParameters();
     applyStrength();
+    configureRenderGraph();
     return changed;
   }
-
   function setAmbientOcclusionSuppressedByWireframe(value) {
     suppressedByWireframe = !!value;
     applyStrength();
+    configureRenderGraph();
   }
-
+  function setBloomEnabled(value) {
+    const next = value === true;
+    const changed = next !== bloomEnabled;
+    bloomEnabled = next;
+    configureRenderGraph();
+    return changed;
+  }
+  function setBloomSuppressedByWireframe(value) {
+    bloomSuppressedByWireframe = !!value;
+    configureRenderGraph();
+  }
+  function setBloomSuppressedByDebug(value) {
+    bloomSuppressedByDebug = !!value;
+    configureRenderGraph();
+  }
   function render() {
-    const useAmbientOcclusion = shouldRenderAO();
-    if (useAmbientOcclusion) {
+    const mode = renderMode();
+    if (mode === 'ao' || mode === 'ao-bloom') {
       updateSpatialParameters();
       syncPrePassCamera();
-    } else {
-      syncCameraCoordinateSystem();
-    }
+    } else syncCameraCoordinateSystem();
     renderer.outputColorSpace = THREE.SRGBColorSpace;
     renderer.toneMapping = THREE.NoToneMapping;
     try {
-      if (useAmbientOcclusion) {
-        renderPipeline.render();
-        aoRenderCount += 1;
-      } else {
+      if (mode === 'direct') {
         renderer.render(scene, camera);
         directRenderCount += 1;
+      } else {
+        renderPipeline.render();
+        if (mode === 'ao') { aoRenderCount += 1; aoOnlyRenderCount += 1; }
+        else if (mode === 'bloom') bloomOnlyRenderCount += 1;
+        else { aoRenderCount += 1; aoBloomRenderCount += 1; }
       }
     } finally {
-      // RenderPipeline temporarily switches to working color space while its
-      // internal passes execute. Keep the renderer contract visible to the
-      // rest of the viewer after the pipeline returns as well.
       renderer.outputColorSpace = THREE.SRGBColorSpace;
       renderer.toneMapping = THREE.NoToneMapping;
     }
     renderCount += 1;
   }
-
   function getDebugState() {
     return {
-      enabled: isAmbientOcclusionEnabled(),
-      radiusFactor: AO_RADIUS_FACTOR,
-      strength: configuredStrength,
-      effectiveStrength: effectiveStrength(),
-      suppressedByWireframe,
-      pipelineId,
-      resolutionScale: aoPass.resolutionScale,
-      resolution: readResolution(aoPass.resolution),
-      samples: readUniformValue(aoPass.samples),
-      radius: readUniformValue(aoPass.radius),
-      thickness: readUniformValue(aoPass.thickness),
-      modelSize,
-      renderCount,
-      directRenderCount,
-      aoRenderCount,
-      pipelineNeedsUpdate: renderPipeline.needsUpdate,
-      hasRenderPipeline: !!renderPipeline,
-      hasPrePass: !!prePass,
-      hasGTAO: !!aoPass,
+      enabled: isAmbientOcclusionEnabled(), radiusFactor: AO_RADIUS_FACTOR,
+      strength: configuredStrength, effectiveStrength: effectiveStrength(),
+      suppressedByWireframe, bloomEnabled, bloomEffective: shouldRenderBloom(),
+      bloomSuppressedByWireframe, bloomSuppressedByDebug,
+      bloomStrength: BLOOM_STRENGTH, bloomRadius: BLOOM_RADIUS,
+      bloomThreshold: BLOOM_THRESHOLD, bloomResolutionScale: bloomPass.getResolutionScale(),
+      activeRenderMode, pipelineId, resolutionScale: aoPass.resolutionScale,
+      resolution: readResolution(aoPass.resolution), samples: readUniformValue(aoPass.samples),
+      radius: readUniformValue(aoPass.radius), thickness: readUniformValue(aoPass.thickness),
+      modelSize, renderCount, directRenderCount, aoRenderCount, aoOnlyRenderCount,
+      bloomOnlyRenderCount, aoBloomRenderCount, pipelineNeedsUpdate: renderPipeline.needsUpdate,
+      hasRenderPipeline: !!renderPipeline, hasPrePass: !!prePass, hasGTAO: !!aoPass,
+      hasBloom: !!bloomPass && !!aoBloomPass,
       temporalFiltering: aoPass.useTemporalFiltering === true,
       prePassLayerMask: prePass.getLayers()?.mask ?? 0,
       prePassSamples: prePass.renderTarget?.samples ?? 0,
       prePassResolutionScale: prePass.getResolutionScale(),
-      beautyCameraIsSource: scenePass.camera === camera,
+      beautyCameraIsSource: aoScenePass.camera === camera
+        && bloomScenePass.camera === camera && aoBloomScenePass.camera === camera,
       prePassCameraIsClone: prePass.camera !== camera,
       cameraCoordinateSystem: camera.coordinateSystem,
       rendererCoordinateSystem: renderer.coordinateSystem,
       characterAOLayer: CHARACTER_AO_LAYER,
     };
   }
-
   function dispose() {
-    aoPass.dispose?.();
+    aoPass.dispose?.(); bloomPass.dispose?.(); aoBloomPass.dispose?.();
     renderPipeline.dispose?.();
-    prePass.renderTarget?.dispose?.();
-    scenePass.renderTarget?.dispose?.();
+    prePass.renderTarget?.dispose?.(); aoScenePass.renderTarget?.dispose?.();
+    bloomScenePass.renderTarget?.dispose?.();
+    aoBloomScenePass.renderTarget?.dispose?.();
   }
-
   updateSpatialParameters();
   applyStrength();
-
   return {
-    render,
-    setMeshes,
-    adoptMeshes,
-    forgetMeshes,
-    invalidateGeometry,
-    reset,
-    getAmbientOcclusionStrength: () => configuredStrength,
-    isAmbientOcclusionEnabled,
-    setAmbientOcclusionStrength,
-    setAmbientOcclusionSuppressedByWireframe,
-    getDebugState,
-    dispose,
+    render, setMeshes, adoptMeshes, forgetMeshes, invalidateGeometry, reset,
+    getAmbientOcclusionStrength: () => configuredStrength, isAmbientOcclusionEnabled,
+    setAmbientOcclusionStrength, setAmbientOcclusionSuppressedByWireframe,
+    getBloomEnabled: () => bloomEnabled, setBloomEnabled,
+    setBloomSuppressedByWireframe, setBloomSuppressedByDebug, getDebugState, dispose,
   };
 }

--- a/src/web/js/textures/texture-key.js
+++ b/src/web/js/textures/texture-key.js
@@ -6,6 +6,7 @@ export const TEXTURE_ROLES = new Set([
   'normal_data',
   'light_map',
   'material_map',
+  'emission_map',
 ]);
 
 export function splitTextureKey(key) {


### PR DESCRIPTION
## Summary
- add the explicit RabbitFX GlowMap emission role and stable material emission nodes
- add a toggleable selective Bloom pipeline with direct, AO-only, bloom-only, and combined modes
- keep selection, debug, and wireframe suppression out of authored bloom

## Coverage
- add core and browser regressions for role selection, stable texture replacement, render modes, and selective bloom output