### PR TITLE
Avoid unnecessary mesh updates for control changes

### DIFF
--- a/src/tests/web/test_app_flow.py
+++ b/src/tests/web/test_app_flow.py
@@ -469,6 +469,53 @@ def test_control_and_mesh_semantic_refreshes_preserve_existing_meshes(
     finally:
         context.close()
 
+
+def test_mesh_semantic_refresh_forces_changed_rules_with_unchanged_controls(
+        edge_browser, frontend_url):
+    payload = _payload("SemanticForce")
+    mesh_name = next(iter(payload["meshes"]))
+    source = payload["meshes"][mesh_name]["sources"]
+    payload["meshSemantics"] = {
+        mesh_name: {
+            "conditions": [[{
+                "var": "menu", "value": "1", "negate": False,
+            }]],
+            "sources": source,
+            "tex_key": "diffuse::SemanticForce-one.png",
+            "texture_variants": [{
+                "conditions": [[{
+                    "var": "menu", "value": "0", "negate": False,
+                }]],
+                "tex_key": "diffuse::SemanticForce-two.png",
+            }],
+        },
+    }
+    context, page = _page(
+        edge_browser, frontend_url, {"SemanticForce": payload})
+    try:
+        _open(page, "SemanticForce")
+        page.locator(".draw-item").wait_for()
+        before = page.evaluate("""() => ({
+          value: window.modViewer.activeMeshes[0].visible,
+          texture: window.modViewer.activeMeshes[0].userData.resolvedTexKey,
+        })""")
+        assert before == {
+            "value": True, "texture": "diffuse::SemanticForce-one.png",
+        }
+        assert page.evaluate("window.modViewer.refreshMeshSemantics()") is True
+        after = page.evaluate("""() => ({
+          value: window.modViewer.activeMeshes[0].visible,
+          texture: window.modViewer.activeMeshes[0].userData.resolvedTexKey,
+        })""")
+        assert after == {
+            "value": False, "texture": "diffuse::SemanticForce-two.png",
+        }
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["SemanticForce"]
+        assert page.evaluate("window.__fakeApi.calls.meshSemantics") == [
+            "SemanticForce"]
+    finally:
+        context.close()
+
 def test_record_refreshes_controls_and_meshes_without_reloading_model(
         edge_browser, frontend_url):
     payload = _payload("Record")

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1101,6 +1101,243 @@ def test_skinning_load_is_invalidated_by_shape_change(
         context.close()
 
 
+def _invalidation_payload():
+    payload = _payload("Invalidation")
+    template = next(iter(payload["meshes"].values()))
+
+    def condition(variable, value):
+        return [[{"var": variable, "value": value, "negate": False}]]
+
+    def mesh(name, *, conditions=None, texture_variants=None, shape=None):
+        entry = copy.deepcopy(template)
+        entry["component"] = name
+        entry["conditions"] = conditions or []
+        entry["texture_variants"] = texture_variants or []
+        entry["shape_targets"] = [] if shape is None else [{
+            "var": shape,
+            "pos": _f32(0, 0, 0, 1.5, 0, 0, 0, 1.5, 0),
+        }]
+        return entry
+
+    alt_texture = payload["texture_pools"]["p0"][1]["tex_key"]
+    payload["meshes"] = {
+        "Mesh-A": mesh("Mesh A", conditions=condition("visibleA", "1"),
+                        shape="shapeA"),
+        "Mesh-B": mesh("Mesh B", texture_variants=[{
+            "conditions": condition("textureB", "1"),
+            "tex_key": alt_texture,
+        }], shape="shapeB"),
+        "Mesh-C": mesh("Mesh C"),
+    }
+    payload["controls"]["menu"] = {}
+    payload["state"]["defaults"].update({
+        "visibleA": "1", "textureB": "0", "shapeA": "0", "shapeB": "0",
+    })
+    return payload
+
+
+def test_control_dependency_and_snapshot_helpers(edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"Deps": _payload("Deps")})
+    try:
+        result = page.evaluate("""async () => {
+          const visibility = await import('./js/mesh/visibility.js');
+          const controls = await import('./js/editing/control-state.js');
+          const mesh = {userData: {
+            conditions: [[{var: 'A'}, {var: 'B'}], [{var: 'C'}]],
+            textureVariants: [{conditions: [[{var: 'D'}]]}],
+            normalMapVariants: [{conditions: [[{var: 'E'}]]}],
+            emissionMapVariants: [{conditions: [[{var: 'F'}]]}],
+            shapeTargets: [{var: 'ShapeA'}, {var: 'ShapeB'}, {var: 'ShapeA'}],
+          }};
+          const first = visibility.dependenciesFor(mesh);
+          const cached = visibility.dependenciesFor(mesh) === first;
+          mesh.userData.conditions = [[{var: 'NewVisibility'}]];
+          const beforeInvalidate = [...visibility.dependenciesFor(mesh).visibility];
+          visibility.invalidateControlDependencies(mesh);
+          const afterInvalidate = [...visibility.dependenciesFor(mesh).visibility];
+          const changed = [...controls.changedControlVariables(
+            {A: '0', B: '1'}, {A: '1', B: '1', C: '0'})];
+          const removed = [...controls.changedControlVariables(
+            {A: '1', B: '1'}, {A: '1'})];
+          return {
+            conditionVariables: [...visibility.variablesFromConditions(
+              mesh.userData.conditions)],
+            textureVariables: [...first.textures],
+            shapeVariables: [...first.shapes],
+            cached, beforeInvalidate, afterInvalidate, changed, removed,
+          };
+        }""")
+        assert result == {
+            "conditionVariables": ["NewVisibility"],
+            "textureVariables": ["D", "E", "F"],
+            "shapeVariables": ["ShapeA", "ShapeB"],
+            "cached": True,
+            "beforeInvalidate": ["A", "B", "C"],
+            "afterInvalidate": ["NewVisibility"],
+            "changed": ["A", "C"],
+            "removed": ["B"],
+        }
+    finally:
+        context.close()
+
+
+def test_control_refresh_updates_only_affected_mesh_categories(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"Invalidation": _invalidation_payload()})
+    try:
+        _open(page, "Invalidation")
+        page.locator(".draw-item").nth(2).wait_for()
+        page.wait_for_timeout(100)
+        result = page.evaluate("""async () => {
+          const {setControlValue} = await import('./js/editing/control-state.js');
+          const {refreshAll} = await import('./js/mesh/visibility.js');
+          const meshes = window.modViewer.activeMeshes;
+          const refs = meshes.map(mesh => ({
+            mesh, geometry: mesh.geometry, material: mesh.material,
+          }));
+          const capture = () => meshes.map(mesh => ({
+            name: mesh.userData.semanticKey,
+            visible: mesh.visible,
+            positionVersion: mesh.geometry.attributes.position.version,
+            resolved: mesh.userData.resolvedTexKey,
+          }));
+          const initial = capture();
+          const stable = refreshAll();
+          const noOp = capture();
+
+          setControlValue('visibleA', '0');
+          const visibility = refreshAll();
+          const afterVisibility = capture();
+
+          setControlValue('shapeA', '1');
+          const shape = refreshAll();
+          const afterShape = capture();
+
+          setControlValue('textureB', '1');
+          const texture = refreshAll();
+          const afterTexture = capture();
+          const sameObjects = refs.every((ref, index) =>
+            meshes[index] === ref.mesh && meshes[index].geometry === ref.geometry
+              && meshes[index].material === ref.material);
+          const names = result => result.changedMeshes.map(mesh => mesh.userData.semanticKey);
+          return {
+            stable: {
+              visibilityChanged: stable.visibilityChanged,
+              texturesChanged: stable.texturesChanged,
+              shapesChanged: stable.shapesChanged,
+              state: noOp,
+            },
+            visibility: {
+              names: names(visibility), state: afterVisibility,
+            },
+            shape: {names: names(shape), state: afterShape},
+            texture: {names: names(texture), state: afterTexture},
+            initial, sameObjects,
+          };
+        }""")
+        assert result["stable"] == {
+            "visibilityChanged": False, "texturesChanged": False,
+            "shapesChanged": False, "state": result["initial"],
+        }
+        assert result["visibility"]["names"] == ["Mesh-A"]
+        assert result["visibility"]["state"][0]["visible"] is False
+        assert [item["positionVersion"] for item in result["visibility"]["state"]] == [
+            item["positionVersion"] for item in result["initial"]]
+        assert result["shape"]["names"] == ["Mesh-A"]
+        assert result["shape"]["state"][0]["positionVersion"] > \
+            result["initial"][0]["positionVersion"]
+        assert [item["positionVersion"] for item in result["shape"]["state"][1:]] == [
+            item["positionVersion"] for item in result["initial"][1:]]
+        assert result["texture"]["names"] == ["Mesh-B"]
+        assert result["texture"]["state"][1]["resolved"] == \
+            "diffuse::Invalidation-two.png"
+        assert [item["positionVersion"] for item in result["texture"]["state"]] == [
+            item["positionVersion"] for item in result["shape"]["state"]]
+        assert result["sameObjects"]
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["Invalidation"]
+    finally:
+        context.close()
+
+
+def test_control_refresh_plans_all_final_values_from_derived_rules(
+        edge_browser, frontend_url):
+    payload = _invalidation_payload()
+    payload["state"]["defaults"].update({
+        "root": "0", "visibleA": "1", "shapeA": "0", "textureB": "0",
+    })
+    payload["state"]["rules"] = [
+        {"conditions": [[{"var": "root", "value": "1"}]],
+         "var": "visibleA", "value": "0"},
+        {"conditions": [[{"var": "visibleA", "value": "0"}]],
+         "var": "shapeA", "value": "1"},
+        {"conditions": [[{"var": "shapeA", "value": "1"}]],
+         "var": "textureB", "value": "1"},
+    ]
+    context, page = _page(
+        edge_browser, frontend_url, {"Derived": payload})
+    try:
+        _open(page, "Derived")
+        page.locator(".draw-item").nth(2).wait_for()
+        result = page.evaluate("""async () => {
+          const {setControlValue} = await import('./js/editing/control-state.js');
+          const {refreshAll} = await import('./js/mesh/visibility.js');
+          const before = window.modViewer.activeMeshes.map(mesh => ({
+            visible: mesh.visible,
+            positionVersion: mesh.geometry.attributes.position.version,
+            texture: mesh.userData.resolvedTexKey,
+          }));
+          setControlValue('root', '1');
+          const refresh = refreshAll();
+          const after = window.modViewer.activeMeshes.map(mesh => ({
+            visible: mesh.visible,
+            positionVersion: mesh.geometry.attributes.position.version,
+            texture: mesh.userData.resolvedTexKey,
+          }));
+          return {
+            changed: [...refresh.changedMeshes].map(mesh => mesh.userData.semanticKey),
+            visibilityChanged: refresh.visibilityChanged,
+            shapesChanged: refresh.shapesChanged,
+            texturesChanged: refresh.texturesChanged,
+            before, after,
+          };
+        }""")
+        assert result["changed"] == ["Mesh-A", "Mesh-B"]
+        assert result["visibilityChanged"]
+        assert result["shapesChanged"]
+        assert result["texturesChanged"]
+        assert not result["after"][0]["visible"]
+        assert result["after"][0]["positionVersion"] > \
+            result["before"][0]["positionVersion"]
+        assert result["after"][1]["texture"] == "diffuse::Invalidation-two.png"
+        assert result["after"][2] == result["before"][2]
+    finally:
+        context.close()
+
+
+def test_noop_control_refresh_does_not_request_render(edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"NoOp": _payload("NoOp")})
+    try:
+        _open(page, "NoOp")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_timeout(150)
+        before = page.evaluate("""() => ({
+          render: window.modViewer.getRenderCount(),
+          positions: window.modViewer.activeMeshes.map(mesh =>
+            mesh.geometry.attributes.position.version),
+        })""")
+        page.evaluate("import('./js/mesh/visibility.js').then(({refreshAll}) => refreshAll())")
+        page.wait_for_timeout(100)
+        after = page.evaluate("""() => ({
+          render: window.modViewer.getRenderCount(),
+          positions: window.modViewer.activeMeshes.map(mesh =>
+            mesh.geometry.attributes.position.version),
+        })""")
+        assert after == before
+    finally:
+        context.close()
+
+
 def test_skinning_angular_motion_follows_model_turn_and_ignores_camera(
         edge_browser, frontend_url):
     context, page = _page(

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1338,6 +1338,41 @@ def test_noop_control_refresh_does_not_request_render(edge_browser, frontend_url
         context.close()
 
 
+def test_clean_control_refresh_skips_texture_run_reconciliation(
+        edge_browser, frontend_url):
+    payload = _invalidation_payload()
+    context, page = _page(
+        edge_browser, frontend_url, {"TextureRuns": payload})
+    try:
+        _open(page, "TextureRuns")
+        page.locator(".draw-item").nth(2).wait_for()
+        result = page.evaluate("""async () => {
+          const {setControlValue} = await import('./js/editing/control-state.js');
+          const {refreshAll} = await import('./js/mesh/visibility.js');
+          const pool = window.modViewer.activeMeshes[0].userData.texturePool;
+          const marker = 'light::reconciliation-marker';
+          const markAndRefresh = () => {
+            pool[0].light_map = marker;
+            refreshAll();
+            return Object.hasOwn(pool[0], 'light_map');
+          };
+          const noOp = markAndRefresh();
+          setControlValue('visibleA', '0');
+          const visibility = markAndRefresh();
+          setControlValue('shapeA', '1');
+          const shape = markAndRefresh();
+          setControlValue('textureB', '1');
+          const texture = markAndRefresh();
+          return {noOp, visibility, shape, texture};
+        }""")
+        assert result == {
+            "noOp": True, "visibility": True, "shape": True,
+            "texture": False,
+        }
+    finally:
+        context.close()
+
+
 def test_skinning_angular_motion_follows_model_turn_and_ignores_camera(
         edge_browser, frontend_url):
     context, page = _page(

--- a/src/web/js/app/model-flow.js
+++ b/src/web/js/app/model-flow.js
@@ -8,7 +8,9 @@ import {
 import { setRightDockEnabled } from '../panels/right-dock.js';
 import { clearSelection } from '../scene/selection.js';
 import { clearInspector } from '../panels/inspector-panel.js';
-import { activeMeshes, reset, setStateRules } from '../mesh/visibility.js';
+import {
+  activeMeshes, refreshAll, reset, setStateRules,
+} from '../mesh/visibility.js';
 import { setTextures } from '../mesh/mesh-factory.js';
 import { buildMeshPanel } from '../panels/mesh-panel.js';
 import { setMeshesAvailable } from '../panels/left-dock.js';
@@ -208,6 +210,9 @@ export async function displayMeshPayload(payload, {
   buildMenuPanel(controls.menu);
   buildPresentPanel(controls.present, {
     modPath: viewerState.currentModPath, onChange: onPresentChange,
+  });
+  refreshAll({
+    force: { visibility: true, textures: true, shapes: true },
   });
   setMeshesAvailable(true);
   viewerState.rightDockEnabled = true;

--- a/src/web/js/app/semantic-refresh.js
+++ b/src/web/js/app/semantic-refresh.js
@@ -138,7 +138,7 @@ export async function refreshMeshSemantics(handlers = {}) {
     const assetResolution = result.asset_resolution || null;
     refreshMeshAssetDiagnostics(assetResolution);
     setAssetResolution(assetResolution);
-    refreshAll();
+    refreshAll({force: {visibility: true, textures: true}});
     return true;
   } finally {
     await finishSemanticRefresh(path, epoch, callbacks);

--- a/src/web/js/editing/control-state.js
+++ b/src/web/js/editing/control-state.js
@@ -20,6 +20,21 @@ export function getControlState() {
   return { ...values };
 }
 
+/** Return variables whose final values differ between two control snapshots. */
+export function changedControlVariables(previous, current) {
+  const changed = new Set();
+  const keys = new Set([
+    ...Object.keys(previous || {}),
+    ...Object.keys(current || {}),
+  ]);
+  for (const variable of keys) {
+    if (!Object.is(previous?.[variable], current?.[variable])) {
+      changed.add(variable);
+    }
+  }
+  return changed;
+}
+
 // True if an OR'd list of AND-groups ([[{var,value,negate}, ...], ...]) is
 // satisfied by the current control state.
 export function dnfSatisfied(condGroups) {

--- a/src/web/js/mesh/mesh-factory.js
+++ b/src/web/js/mesh/mesh-factory.js
@@ -209,7 +209,7 @@ function getTexture(mesh, key) {
 /** Bind whatever diffuse map the mesh currently wants, honouring the global
  * textures on/off switch. Falls back to the name-guessed flat colour, which is
  * also what an untextured mesh has always shown. */
-export function refreshMeshTexture(mesh) {
+export function refreshMeshTexture(mesh, { render = true } = {}) {
   const showDiffuse = textureMode !== 'none';
   const showMaterialMaps = textureMode === 'all';
   const showNormal = showMaterialMaps || textureMode === 'diffuse-normal';
@@ -239,9 +239,10 @@ export function refreshMeshTexture(mesh) {
     emission_map: emissionMap,
     normal_map_y_sign: mesh.userData.normalMapYSign ?? -1,
   });
-  if (!changed) return;
+  if (!changed) return false;
   getMeshView(mesh)?.onTextureChanged?.();
-  if (mesh.visible) requestRender();
+  if (render && mesh.visible) requestRender();
+  return true;
 }
 
 export function setTextureMode(mode) {
@@ -263,7 +264,7 @@ export function updateGeometryNormals(mesh, deformed) {
 }
 
 /** Update the complete resolved texture state with one material refresh. */
-export function setMeshTextureState(mesh, state) {
+export function setMeshTextureState(mesh, state, { render = true } = {}) {
   mesh.userData.texKey = state.diffuse || null;
   mesh.userData.normalMapKey = usesPackedNormal(mesh.material)
     ? null : (state.normal_map || null);
@@ -273,7 +274,7 @@ export function setMeshTextureState(mesh, state) {
   mesh.userData.lightMapKey = state.light_map || null;
   mesh.userData.materialMapKey = state.material_map || null;
   mesh.userData.emissionMapKey = state.emission_map || null;
-  refreshMeshTexture(mesh);
+  return refreshMeshTexture(mesh, { render });
 }
 
 /** Colour for meshes with no texture, guessed from the component name. */

--- a/src/web/js/mesh/mesh-state.js
+++ b/src/web/js/mesh/mesh-state.js
@@ -8,6 +8,7 @@ import {
 import { dnfSatisfied, getControlValue } from '../editing/control-state.js';
 import { disposeGameMaterial } from './material-profile.js';
 import { setMeshTextureState, updateGeometryNormals } from './mesh-factory.js';
+import { clearTextureRunGroups, recomputeAllTextureRuns } from './mesh-texture-runs.js';
 import { attachOutline, detachOutline } from '../scene/outline-renderer.js';
 import { initializeMeshRenderModes } from '../scene/render-modes.js';
 import { requestRender } from '../scene/render-scheduler.js';
@@ -74,6 +75,7 @@ export function resetMeshes({ preserveModelOrientation = false } = {}) {
     });
   });
   activeMeshes.length = 0;
+  clearTextureRunGroups();
   resetModelOrientation({ preserveRotation: preserveModelOrientation });
   resetCharacterShadows();
   requestRender();
@@ -379,6 +381,12 @@ export function refreshMeshes(options) {
         changedMeshes.add(mesh);
       }
     }
+  }
+
+  if (textureDirty) {
+    const runChangedMeshes = recomputeAllTextureRuns({ render: false });
+    for (const mesh of runChangedMeshes) changedMeshes.add(mesh);
+    texturesChanged = runChangedMeshes.size > 0 || texturesChanged;
   }
 
   const changedList = [...changedMeshes];

--- a/src/web/js/mesh/mesh-state.js
+++ b/src/web/js/mesh/mesh-state.js
@@ -17,6 +17,49 @@ import {
 } from './weight-experiment.js';
 
 export const activeMeshes = [];
+const controlDependencies = new WeakMap();
+
+/** Add every variable referenced by an existing DNF condition structure. */
+export function variablesFromConditions(conditions, variables = new Set()) {
+  for (const group of conditions || []) {
+    for (const condition of group || []) {
+      if (condition?.var) variables.add(condition.var);
+    }
+  }
+  return variables;
+}
+
+function variablesFromVariants(variants, variables) {
+  for (const variant of variants || []) {
+    variablesFromConditions(variant?.conditions, variables);
+  }
+}
+
+/** Lazily derive the control categories that can affect one mesh. */
+export function dependenciesFor(mesh) {
+  let dependencies = controlDependencies.get(mesh);
+  if (dependencies) return dependencies;
+
+  const visibility = variablesFromConditions(mesh.userData?.conditions);
+  const textures = new Set();
+  for (const field of [
+    'textureVariants', 'normalMapVariants', 'normalDataVariants',
+    'lightMapVariants', 'materialMapVariants', 'emissionMapVariants',
+  ]) {
+    variablesFromVariants(mesh.userData?.[field], textures);
+  }
+  const shapes = new Set(
+    (mesh.userData?.shapeTargets || [])
+      .map(target => target?.var)
+      .filter(Boolean));
+  dependencies = { visibility, textures, shapes };
+  controlDependencies.set(mesh, dependencies);
+  return dependencies;
+}
+
+export function invalidateControlDependencies(mesh) {
+  controlDependencies.delete(mesh);
+}
 
 export function resetMeshes({ preserveModelOrientation = false } = {}) {
   activeMeshes.forEach(mesh => {
@@ -97,7 +140,7 @@ export function resetMeshVisibility() {
   requestRender();
 }
 
-/** Replace draw visibility and texture semantics on the existing meshes. */
+/** Replace draw visibility and texture semantics without applying rendering. */
 export function updateMeshSemantics(semantics) {
   const next = semantics || {};
   const semanticMeshes = activeMeshes.filter(
@@ -141,7 +184,7 @@ export function updateMeshSemantics(semantics) {
       else delete assetEntry[field];
     }
     mesh.userData.assetEntry = assetEntry;
-    applyTextureVariant(mesh);
+    invalidateControlDependencies(mesh);
   });
   return true;
 }
@@ -159,7 +202,21 @@ export function conditionsSatisfied(mesh) {
   return dnfSatisfied(mesh.userData.conditions);
 }
 
-export function applyTextureVariant(mesh) {
+export function applyTextureVariant(mesh, { render = true } = {}) {
+  const previous = [
+    mesh.userData.resolvedTexKey,
+    mesh.userData.resolvedNormalMapKey,
+    mesh.userData.resolvedNormalDataKey,
+    mesh.userData.resolvedLightMapKey,
+    mesh.userData.resolvedMaterialMapKey,
+    mesh.userData.resolvedEmissionMapKey,
+    mesh.userData.texKey,
+    mesh.userData.normalMapKey,
+    mesh.userData.normalDataKey,
+    mesh.userData.lightMapKey,
+    mesh.userData.materialMapKey,
+    mesh.userData.emissionMapKey,
+  ];
   const resolve = (variants, fallback) => {
     variants = variants || [];
     const variant = variants.findLast
@@ -179,7 +236,7 @@ export function applyTextureVariant(mesh) {
     mesh.userData.materialMapVariants, mesh.userData.defaultMaterialMapKey);
   mesh.userData.resolvedEmissionMapKey = resolve(
     mesh.userData.emissionMapVariants, mesh.userData.defaultEmissionMapKey);
-  setMeshTextureState(mesh, {
+  const materialChanged = setMeshTextureState(mesh, {
     diffuse: mesh.userData.manualTexOverride !== undefined
       ? mesh.userData.manualTexOverride
       : mesh.userData.resolvedTexKey,
@@ -188,26 +245,43 @@ export function applyTextureVariant(mesh) {
     light_map: mesh.userData.resolvedLightMapKey,
     material_map: mesh.userData.resolvedMaterialMapKey,
     emission_map: mesh.userData.resolvedEmissionMapKey,
-  });
+  }, { render });
+  const next = [
+    mesh.userData.resolvedTexKey,
+    mesh.userData.resolvedNormalMapKey,
+    mesh.userData.resolvedNormalDataKey,
+    mesh.userData.resolvedLightMapKey,
+    mesh.userData.resolvedMaterialMapKey,
+    mesh.userData.resolvedEmissionMapKey,
+    mesh.userData.texKey,
+    mesh.userData.normalMapKey,
+    mesh.userData.normalDataKey,
+    mesh.userData.lightMapKey,
+    mesh.userData.materialMapKey,
+    mesh.userData.emissionMapKey,
+  ];
+  return materialChanged || next.some((value, index) => !Object.is(value, previous[index]));
 }
 
 // The MESHES control is the direct visibility source. Automatic refreshes
 // re-baseline visibility and clear any transient manual eye-click marker.
-export function applyMeshVisibility(mesh, { notify = true } = {}) {
+export function applyMeshVisibility(mesh, { notify = true, render = true } = {}) {
   const previous = mesh.visible;
   mesh.visible = mesh.userData.manualVisible !== false;
-  if (previous !== mesh.visible) invalidateCharacterShadowVisibility();
+  const changed = previous !== mesh.visible;
+  if (changed) invalidateCharacterShadowVisibility({ request: render });
   if (notify) notifyMeshStateChanged([mesh]);
-  requestRender();
+  if (render) requestRender();
+  return changed;
 }
 
-function applyShapeTargets(mesh) {
+function applyShapeTargets(mesh, { render = true } = {}) {
   const targets = mesh.userData.shapeTargets || [];
-  if (!targets.length) return;
+  if (!targets.length) return false;
   const controlValues = targets.map(target => getControlValue(target.var) ?? 0);
   const previous = mesh.userData.shapeControlValues;
   if (previous?.length === controlValues.length
-      && controlValues.every((value, index) => value === previous[index])) return;
+      && controlValues.every((value, index) => value === previous[index])) return false;
   const skinning = getSkinningState(mesh);
   if (skinning?.loaded || skinning?.loading || skinning?.promise) {
     disposeSkinningExperiment(mesh);
@@ -243,21 +317,77 @@ function applyShapeTargets(mesh) {
   updateGeometryNormals(mesh, deformed);
   mesh.geometry.computeBoundingBox();
   mesh.geometry.computeBoundingSphere();
-  invalidateCharacterShadowGeometry();
+  invalidateCharacterShadowGeometry({ request: render });
+  return true;
 }
 
-export function refreshMeshes() {
-  activeMeshes.forEach(mesh => {
-    mesh.userData.manualVisible = conditionsSatisfied(mesh);
-    mesh.userData.manuallyToggled = false;
-    applyMeshVisibility(mesh, { notify: false });
-    if (!mesh.userData.defaultCaptured) {
-      mesh.userData.loadedVisible = mesh.visible;
-      mesh.userData.defaultCaptured = true;
+function intersects(left, right) {
+  for (const value of left) if (right.has(value)) return true;
+  return false;
+}
+
+/** Apply only mesh categories affected by the final control-state diff. */
+export function refreshMeshes(options) {
+  // Keep direct low-level callers compatible with the former all-mesh API.
+  const legacyRefresh = options === undefined;
+  const {
+    changedVariables = new Set(),
+    force = {},
+  } = options || {};
+  const changed = changedVariables instanceof Set
+    ? changedVariables : new Set(changedVariables || []);
+  const effectiveForce = legacyRefresh
+    ? { visibility: true, textures: true, shapes: true } : force;
+  const visibilityForced = effectiveForce.visibility === true;
+  const texturesForced = effectiveForce.textures === true;
+  const shapesForced = effectiveForce.shapes === true;
+  const normalMeshes = activeMeshes.filter(mesh => mesh.userData.assetFill !== true);
+  const textureDirty = texturesForced || normalMeshes.some(mesh =>
+    intersects(dependenciesFor(mesh).textures, changed));
+  const changedMeshes = new Set();
+  let visibilityChanged = false;
+  let texturesChanged = false;
+  let shapesChanged = false;
+
+  for (const mesh of activeMeshes) {
+    const dependencies = dependenciesFor(mesh);
+    const needsVisibility = visibilityForced
+      || mesh.userData.manuallyToggled === true
+      || intersects(dependencies.visibility, changed);
+    if (needsVisibility) {
+      mesh.userData.manualVisible = conditionsSatisfied(mesh);
+      mesh.userData.manuallyToggled = false;
+      visibilityChanged = applyMeshVisibility(mesh, {
+        notify: false, render: false,
+      }) || visibilityChanged;
+      changedMeshes.add(mesh);
+      if (!mesh.userData.defaultCaptured) {
+        mesh.userData.loadedVisible = mesh.visible;
+        mesh.userData.defaultCaptured = true;
+      }
     }
-    applyTextureVariant(mesh);
-    applyShapeTargets(mesh);
-  });
-  notifyMeshStateChanged(activeMeshes);
-  requestRender();
+
+    if (textureDirty && mesh.userData.assetFill !== true) {
+      const changed = applyTextureVariant(mesh, { render: false });
+      texturesChanged = changed || texturesChanged;
+      if (changed) changedMeshes.add(mesh);
+    }
+
+    if (shapesForced || intersects(dependencies.shapes, changed)) {
+      if (applyShapeTargets(mesh, { render: false })) {
+        shapesChanged = true;
+        changedMeshes.add(mesh);
+      }
+    }
+  }
+
+  const changedList = [...changedMeshes];
+  if (changedList.length) notifyMeshStateChanged(changedList);
+  if (visibilityChanged || texturesChanged || shapesChanged) requestRender();
+  return {
+    visibilityChanged,
+    texturesChanged,
+    shapesChanged,
+    changedMeshes: changedList,
+  };
 }

--- a/src/web/js/mesh/mesh-texture-runs.js
+++ b/src/web/js/mesh/mesh-texture-runs.js
@@ -1,0 +1,103 @@
+// Ordered texture propagation belongs to mesh state, not panel rendering.
+
+import { setMeshTextureState } from './mesh-factory.js';
+import { usesPackedNormal } from './material-profile.js';
+
+const textureRunGroups = new Set();
+
+function normalMapsFor(mesh, option) {
+  if (usesPackedNormal(mesh.material)) {
+    return {
+      normal_map: null,
+      normal_data: option?.normal_data || null,
+    };
+  }
+  return {
+    normal_map: option?.normal_map || null,
+    normal_data: option?.normal_data || null,
+  };
+}
+
+export function registerTextureRunGroup(groupMeshes) {
+  if (groupMeshes) textureRunGroups.add(groupMeshes);
+}
+
+export function unregisterTextureRunGroup(groupMeshes) {
+  textureRunGroups.delete(groupMeshes);
+}
+
+export function clearTextureRunGroups() {
+  textureRunGroups.clear();
+}
+
+/** Reconcile one ordered component texture run after its texture state changes. */
+export function recomputeTextureRuns(groupMeshes, { render = true } = {}) {
+  let activeKey = null;
+  let activeMaps = null;
+  const changedMeshes = new Set();
+  for (const mesh of groupMeshes) {
+    if (mesh.userData.manualTexOverride !== undefined) {
+      activeKey = mesh.userData.manualTexOverride;
+      const option = (mesh.userData.texturePool || [])
+        .find(candidate => candidate.tex_key === activeKey);
+      activeMaps = option ? {
+        ...normalMapsFor(mesh, option),
+        light_map: option.light_map || null,
+        material_map: option.material_map || null,
+        emission_map: option.emission_map || null,
+      } : null;
+    } else if (mesh.userData.automaticTextureBoundary
+               && !mesh.userData.textureHighlightDisabled) {
+      // Automatic boundaries use the live resolved diffuse and propagate only
+      // until the next boundary in this ordered component.
+      activeKey = mesh.userData.resolvedTexKey;
+      const diffuseKeys = new Set([
+        activeKey,
+        mesh.userData.defaultTexKey,
+        ...(mesh.userData.textureVariants || []).map(variant => variant.tex_key),
+      ].filter(Boolean));
+      for (const option of (mesh.userData.texturePool || [])) {
+        if (!diffuseKeys.has(option.tex_key)) continue;
+        const resolvedMaps = {
+          ...normalMapsFor(mesh, {
+            normal_map: mesh.userData.resolvedNormalMapKey,
+            normal_data: mesh.userData.resolvedNormalDataKey,
+          }),
+          light_map: mesh.userData.resolvedLightMapKey,
+          material_map: mesh.userData.resolvedMaterialMapKey,
+          emission_map: mesh.userData.resolvedEmissionMapKey,
+        };
+        for (const [field, key] of Object.entries(resolvedMaps)) {
+          if (option[`${field}_manual`]) continue;
+          if (key) option[field] = key;
+          else delete option[field];
+        }
+      }
+      activeMaps = null;
+    }
+    const maps = activeMaps || {
+      ...normalMapsFor(mesh, {
+        normal_map: mesh.userData.resolvedNormalMapKey,
+        normal_data: mesh.userData.resolvedNormalDataKey,
+      }),
+      light_map: mesh.userData.resolvedLightMapKey,
+      material_map: mesh.userData.resolvedMaterialMapKey,
+      emission_map: mesh.userData.resolvedEmissionMapKey,
+    };
+    if (setMeshTextureState(mesh, { diffuse: activeKey, ...maps }, { render })) {
+      changedMeshes.add(mesh);
+    }
+  }
+  return changedMeshes;
+}
+
+/** Reconcile all registered component runs after a texture-dirty refresh. */
+export function recomputeAllTextureRuns({ render = true } = {}) {
+  const changedMeshes = new Set();
+  for (const groupMeshes of textureRunGroups) {
+    for (const mesh of recomputeTextureRuns(groupMeshes, { render })) {
+      changedMeshes.add(mesh);
+    }
+  }
+  return changedMeshes;
+}

--- a/src/web/js/mesh/mesh-texture-state.js
+++ b/src/web/js/mesh/mesh-texture-state.js
@@ -1,78 +1,13 @@
 // Component texture propagation, lazy loading and viewer-only persistence.
 
-import { setMeshTextureState } from './mesh-factory.js';
 import { activeMeshes } from './mesh-state.js';
 import { usesPackedNormal } from './material-profile.js';
 import { setHealthReport } from '../panels/health-report.js';
 
-function normalMapsFor(mesh, option) {
-  if (usesPackedNormal(mesh.material)) {
-    return {
-      normal_map: null,
-      normal_data: option?.normal_data || null,
-    };
-  }
-  return {
-    normal_map: option?.normal_map || null,
-    normal_data: option?.normal_data || null,
-  };
-}
-
-export function recomputeTextureRuns(groupMeshes) {
-  let activeKey = null;
-  let activeMaps = null;
-  for (const mesh of groupMeshes) {
-    if (mesh.userData.manualTexOverride !== undefined) {
-      activeKey = mesh.userData.manualTexOverride;
-      const option = (mesh.userData.texturePool || [])
-        .find(candidate => candidate.tex_key === activeKey);
-      activeMaps = option ? {
-        ...normalMapsFor(mesh, option),
-        light_map: option.light_map || null,
-        material_map: option.material_map || null,
-        emission_map: option.emission_map || null,
-      } : null;
-    } else if (mesh.userData.automaticTextureBoundary
-               && !mesh.userData.textureHighlightDisabled) {
-      // Automatic boundaries use the live resolved diffuse and propagate only
-      // until the next boundary in this ordered component.
-      activeKey = mesh.userData.resolvedTexKey;
-      const diffuseKeys = new Set([
-        activeKey,
-        mesh.userData.defaultTexKey,
-        ...(mesh.userData.textureVariants || []).map(variant => variant.tex_key),
-      ].filter(Boolean));
-      for (const option of (mesh.userData.texturePool || [])) {
-        if (!diffuseKeys.has(option.tex_key)) continue;
-        const resolvedMaps = {
-          ...normalMapsFor(mesh, {
-            normal_map: mesh.userData.resolvedNormalMapKey,
-            normal_data: mesh.userData.resolvedNormalDataKey,
-          }),
-          light_map: mesh.userData.resolvedLightMapKey,
-          material_map: mesh.userData.resolvedMaterialMapKey,
-          emission_map: mesh.userData.resolvedEmissionMapKey,
-        };
-        for (const [field, key] of Object.entries(resolvedMaps)) {
-          if (option[`${field}_manual`]) continue;
-          if (key) option[field] = key;
-          else delete option[field];
-        }
-      }
-      activeMaps = null;
-    }
-    const maps = activeMaps || {
-      ...normalMapsFor(mesh, {
-        normal_map: mesh.userData.resolvedNormalMapKey,
-        normal_data: mesh.userData.resolvedNormalDataKey,
-      }),
-      light_map: mesh.userData.resolvedLightMapKey,
-      material_map: mesh.userData.resolvedMaterialMapKey,
-      emission_map: mesh.userData.resolvedEmissionMapKey,
-    };
-    setMeshTextureState(mesh, { diffuse: activeKey, ...maps });
-  }
-}
+export {
+  clearTextureRunGroups, recomputeAllTextureRuns, recomputeTextureRuns,
+  registerTextureRunGroup, unregisterTextureRunGroup,
+} from './mesh-texture-runs.js';
 
 export function meshMetadataKey(name, entry) {
   const component = entry.component || name.replace(/-\d+$/, '');

--- a/src/web/js/mesh/visibility.js
+++ b/src/web/js/mesh/visibility.js
@@ -2,7 +2,8 @@
 
 import {
   getControlState, getControlValue, replayControlStateRules,
-  resetControlState, setControlStateRules, setControlValue,
+  changedControlVariables, resetControlState, setControlStateRules,
+  setControlValue,
 } from '../editing/control-state.js';
 import {
   activeMeshes, refreshMeshes, resetMeshes, resetMeshVisibility,
@@ -15,18 +16,23 @@ import { clearViewSyncs, syncView, syncViews } from '../scene/view-sync.js';
 
 export {
   activeMeshes, addMesh, applyMeshVisibility, conditionsSatisfied,
+  dependenciesFor, invalidateControlDependencies, variablesFromConditions,
   removeAssetFillMeshes, removeMesh, setManualTexOverride,
   updateMeshSemantics,
 } from './mesh-state.js';
+export { changedControlVariables } from '../editing/control-state.js';
 
 export const setToggleValue = setControlValue;
 export const getToggleValue = getControlValue;
 export const getToggleState = getControlState;
 export const setStateRules = setControlStateRules;
 
+let lastAppliedControlState = null;
+
 export function reset(options) {
   resetMeshes(options);
   resetControlState();
+  lastAppliedControlState = null;
   clearViewSyncs();
 }
 
@@ -40,10 +46,22 @@ export function syncCheckboxes() {
   syncView('mesh-panel');
 }
 
-export function refreshAll() {
+export function refreshAll({ force = {} } = {}) {
   replayControlStateRules();
-  refreshMeshes();
+  const next = getControlState();
+  const initialApplication = lastAppliedControlState === null;
+  const changedVariables = initialApplication
+    ? new Set(Object.keys(next))
+    : changedControlVariables(lastAppliedControlState, next);
+  const result = refreshMeshes({
+    changedVariables,
+    force: initialApplication
+      ? { visibility: true, textures: true, shapes: true }
+      : force,
+  });
+  lastAppliedControlState = next;
   syncViews();
+  return result;
 }
 
 export function toggleWireframe() {

--- a/src/web/js/panels/menu-panel.js
+++ b/src/web/js/panels/menu-panel.js
@@ -167,5 +167,4 @@ export function buildMenuPanel(menu) {
     }
   }
 
-  refreshAll();
 }

--- a/src/web/js/panels/mesh-panel.js
+++ b/src/web/js/panels/mesh-panel.js
@@ -8,7 +8,8 @@ import {
   setManualTexOverride,
 } from '../mesh/mesh-state.js';
 import {
-  meshMetadataKey, recomputeTextureRuns, saveTextureState,
+  clearTextureRunGroups, meshMetadataKey, recomputeTextureRuns,
+  registerTextureRunGroup, unregisterTextureRunGroup, saveTextureState,
 } from '../mesh/mesh-texture-state.js';
 import { bindMeshView, getMeshView } from '../mesh/mesh-view-bindings.js';
 import { registerViewSync } from '../scene/view-sync.js';
@@ -35,7 +36,6 @@ function saveComponentMaterialKind(modPath, source, component, kind) {
 
 function syncMeshPanel() {
   for (const group of groupsUI) {
-    group.applyTextureRuns?.();
     group.itemObjs.forEach((mesh, index) => {
       group.itemCbs[index].checked = mesh.visible;
       const binding = getMeshView(mesh);
@@ -296,6 +296,7 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
   if (replace) {
     list.innerHTML = '';
     groupsUI = [];
+    clearTextureRunGroups();
   }
   registerViewSync('mesh-panel', syncMeshPanel);
   const texturePools = options.texturePools || {};
@@ -464,6 +465,7 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
         });
       }
       recomputeTextureRuns(itemObjs);
+      registerTextureRunGroup(itemObjs);
 
       masterCb.addEventListener('change', () => {
         masterCb.indeterminate = false;
@@ -487,7 +489,6 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
         sourceHeader,
         assetFill: names.every(name => meshes[name]?.asset_fill === true),
         assetResolution: options.assetResolution || null,
-        applyTextureRuns: () => recomputeTextureRuns(itemObjs),
       });
     }
   }
@@ -517,10 +518,11 @@ export function removeAssetFillMeshPanel(targetMeshes = null) {
       }
     });
     if (!group.itemObjs.length) {
+      unregisterTextureRunGroup(group.itemObjs);
       group.header?.remove();
       group.itemsWrap?.remove();
     } else {
-      group.applyTextureRuns?.();
+      recomputeTextureRuns(group.itemObjs);
     }
   }
   groupsUI = groupsUI.filter(group => !group.assetFill || group.itemObjs.length);

--- a/src/web/js/panels/toggle-panel.js
+++ b/src/web/js/panels/toggle-panel.js
@@ -270,5 +270,4 @@ export function buildTogglePanel(toggles, ctx = {}) {
     }
   }
 
-  refreshAll();
 }

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -334,15 +334,15 @@ export function resetCharacterShadows() {
   viewportRenderPipeline.reset();
 }
 
-export function invalidateCharacterShadowGeometry() {
+export function invalidateCharacterShadowGeometry({ request = true } = {}) {
   characterShadowController.invalidateGeometry();
   viewportRenderPipeline.invalidateGeometry();
-  requestRender();
+  if (request) requestRender();
 }
 
-export function invalidateCharacterShadowVisibility() {
+export function invalidateCharacterShadowVisibility({ request = true } = {}) {
   characterShadowController.invalidateVisibility();
-  requestRender();
+  if (request) requestRender();
 }
 
 export function getCharacterShadowDebugState() {


### PR DESCRIPTION
## Summary
- Track final control-state changes after derived rule replay.
- Apply visibility, texture, and shape updates only to affected mesh state while preserving in-place objects and manual overrides.
- Keep staged mesh semantics data-only and retain full reload boundaries for structural edits.
- Add browser regressions for dependency planning, no-op refreshes, derived rules, and forced semantic updates.