### PR TITLE
Update material profiles without reloading the model

### DIFF
--- a/src/app/mods/loader.py
+++ b/src/app/mods/loader.py
@@ -121,14 +121,22 @@ def _structured_payload(meshes=None, textures=None, toggles=None, menu=None,
 
 
 def load_mesh_semantics(context, overrides=None, active_mesh_keys=None):
-    """Read draw visibility semantics without building geometry."""
+    """Read draw and material semantics without building geometry."""
     parsed = analyze_mod_inis(
         context.ini_paths, context.mod_dir, overrides, context.docs)
     _bindings, asset_resolution = enrich_mod_analysis(parsed, context)
+    mesh_payload = build_mesh_semantics(
+        parsed.groups, context.mod_dir, game_profile=parsed.game.game,
+        active_mesh_keys=active_mesh_keys)
+    # Keep semantic refresh on the same authoritative material-resolution
+    # chain as a full model load. Viewer-only choices affect evidence here but
+    # never edit the source INI.
+    from .metadata import hydrate_component_material_kinds
+    hydrate_component_material_kinds(mesh_payload, context.metadata)
+    material_profiles = _assign_material_profiles(mesh_payload, parsed.game)
     return {
-        "meshes": build_mesh_semantics(
-            parsed.groups, context.mod_dir, game_profile=parsed.game.game,
-            active_mesh_keys=active_mesh_keys),
+        "meshes": mesh_payload,
+        "material_profiles": material_profiles,
         "asset_resolution": asset_resolution,
     }
 

--- a/src/core/geometry/semantics.py
+++ b/src/core/geometry/semantics.py
@@ -129,6 +129,12 @@ def build_mesh_semantics(groups, mod_dir, max_draws=0, game_profile=None,
                         mod_dir, draw.texture_default("emission_map"),
                         "emission_map")),
             }
+            source = group.get("source")
+            component = group.get("display_name") or group.get("name")
+            if source:
+                entry["source"] = source
+            if component:
+                entry["component"] = component
             normal_key = _semantic_texture_key(
                 mod_dir, draw.texture_default("normal_map"), normal_role)
             normal_key = (_semantic_asset_key(

--- a/src/tests/app/mods/test_enrichment.py
+++ b/src/tests/app/mods/test_enrichment.py
@@ -70,7 +70,8 @@ def test_full_and_semantic_loads_share_enrichment_stage(tmp_path):
                              meshes={"Body-1": {}}, textures={})), \
             patch.object(loader, "_assign_material_profiles", return_value={}):
         semantic_result = loader.load_mesh_semantics(context)
-        assert semantic_result["meshes"] == {"Body-1": {}}
+        assert semantic_result["meshes"] == {
+            "Body-1": {"material_kind_override": None}}
         assert enrich.call_count == 1
 
         full_result = loader.load_mod(context=context)

--- a/src/tests/core/geometry/test_semantics.py
+++ b/src/tests/core/geometry/test_semantics.py
@@ -17,3 +17,16 @@ def test_mesh_semantics_does_not_read_buffers_or_publish_textures(tmp_path):
         result = build_mesh_semantics(groups, str(tmp_path))
 
     assert result["Body-1"]["tex_key"] == "diffuse::diffuse.dds"
+
+
+def test_mesh_semantics_preserves_group_source_and_component_identity(tmp_path):
+    draw = DrawCall(label="Body-1")
+    result = build_mesh_semantics([{
+        "name": "Body",
+        "display_name": "Body Display",
+        "source": "Root.ini",
+        "draws": [draw],
+    }], str(tmp_path))
+
+    assert result["Body-1"]["source"] == "Root.ini"
+    assert result["Body-1"]["component"] == "Body Display"

--- a/src/tests/integration/test_load_pipeline.py
+++ b/src/tests/integration/test_load_pipeline.py
@@ -163,6 +163,49 @@ def test_geometry_blob_bypasses_base64_intermediate():
         assert set(loaded["metadata"]["material_profiles"]) == {"none"}, ("profile metadata is deduplicated at payload scope")
 
 
+def test_full_and_semantic_material_resolution_are_in_parity(tmp_path):
+    from core.materials.game_profile import GameDetection
+
+    parsed = mod_loader.ParsedModAnalysis(
+        groups=[{"name": "Body", "draws": [SimpleNamespace()]}],
+        toggles={}, menu={}, defaults={}, state_rules=[], present={},
+        game=GameDetection(
+            game="wuwa", runtime="rabbitfx", texture_api="rabbitfx",
+            confidence="high", scores={}),
+    )
+    context = mod_loader.ModLoadContext(
+        str(tmp_path), [str(tmp_path / "Root.ini")], {}, {
+            "component_material_kinds": {"Root.ini": {"Body": "body"}},
+        })
+
+    def semantic_meshes(*_args, **_kwargs):
+        return {"Body-1": {"source": "Root.ini", "component": "Body"}}
+
+    with patch.object(mod_loader, "analyze_mod_inis", return_value=parsed), \
+            patch.object(mod_loader, "enrich_mod_analysis",
+                         return_value=([], {"index_status": "unavailable"})), \
+            patch.object(mod_loader, "build_mesh_semantics",
+                         side_effect=semantic_meshes), \
+            patch.object(mod_loader, "build_mesh_result",
+                         return_value=SimpleNamespace(
+                             meshes=semantic_meshes(), textures={})):
+        semantic_result = mod_loader.load_mesh_semantics(context)
+        full_result = mod_loader.load_mod(context=context)
+
+    semantic_mesh = semantic_result["meshes"]["Body-1"]
+    full_mesh = full_result["meshes"]["Body-1"]
+    for field in (
+            "material_kind", "material_kind_reliable",
+            "material_kind_reason", "material_kind_override",
+            "material_profile_id"):
+        assert semantic_mesh[field] == full_mesh[field]
+    profile_id = semantic_mesh["material_profile_id"]
+    assert semantic_result["material_profiles"][profile_id] == \
+        full_result["metadata"]["material_profiles"][profile_id]
+    assert not {"pos", "idx", "uv", "normal", "shape_targets"}.intersection(
+        semantic_mesh)
+
+
 def test_wuwa_candidates_reach_texture_pool_without_changing_draw_default(
         tmp_path):
     (tmp_path / "Components-0 t=candidate.dds").write_bytes(
@@ -285,10 +328,13 @@ def test_mesh_semantics_returns_asset_resolution_summary(tmp_path):
                          side_effect=resolve), \
             patch.object(mod_enrichment.asset_enrichment, "apply"), \
             patch.object(mod_loader, "build_mesh_semantics",
-                         return_value={"Body-1": {}}):
+                         return_value={"Body-1": {}}), \
+            patch.object(mod_loader, "_assign_material_profiles",
+                         return_value={}):
         result = mod_loader.load_mesh_semantics(context)
 
-    assert result["meshes"] == {"Body-1": {}}
+    assert result["meshes"] == {
+        "Body-1": {"material_kind_override": None}}
     assert result["asset_resolution"]["index_status"] == "ready"
     assert result["asset_resolution"]["exact_draws"] == 1
 

--- a/src/tests/web/support.py
+++ b/src/tests/web/support.py
@@ -397,13 +397,30 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
               state.calls.meshSemantics.push(path);
               const payload = state.responses[path] || {};
               const meshes = payload.meshSemantics || Object.fromEntries(
-                Object.entries(payload.meshes || {}).map(([name, entry]) => [name, {
-                  conditions: entry.conditions || [],
-                  sources: entry.sources || [],
-                }])
+                Object.entries(payload.meshes || {}).map(([name, entry]) => {
+                  const semantic = {};
+                  for (const key of [
+                    'conditions', 'sources', 'source', 'component',
+                    'tex_key', 'texture_variants', 'normal_map_key',
+                    'normal_map_variants', 'normal_data_key',
+                    'normal_data_variants', 'light_map_key',
+                    'light_map_variants', 'material_map_key',
+                    'material_map_variants', 'emission_map_key',
+                    'emission_map_variants', 'asset_binding',
+                    'texture_resolution', 'asset_slot_evidence',
+                    'material_kind', 'material_kind_reliable',
+                    'material_kind_reason', 'material_kind_override',
+                    'material_profile_id',
+                  ]) {
+                    if (Object.hasOwn(entry, key)) semantic[key] = entry[key];
+                  }
+                  return [name, semantic];
+                })
               );
               return copy({
                 meshes,
+                material_profiles: payload.materialProfiles
+                  || payload.metadata?.material_profiles || {},
                 asset_resolution: payload.meshSemanticsAssetResolution
                   ?? payload.asset_resolution ?? null,
               });

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -3817,6 +3817,218 @@ def test_material_kind_refresh_hot_swaps_profile_without_reloading_model(
         context.close()
 
 
+def _skinning_material_transition_payload():
+    payload = _packed_material_payload("wuwa:rabbitfx")
+    mesh_name, entry = next(iter(payload["meshes"].items()))
+    entry["source"] = "Packed.ini"
+    initial_semantic = copy.deepcopy(entry)
+    initial_semantic.update({
+        "source": "Packed.ini",
+        "component": entry["component"],
+        "material_kind": "body",
+        "material_kind_reliable": False,
+        "material_kind_reason": "automatic detection",
+        "material_kind_override": None,
+        "material_profile_id": "wuwa:rabbitfx",
+    })
+    explicit_semantic = copy.deepcopy(initial_semantic)
+    explicit_semantic.update({
+        "material_kind": "body",
+        "material_kind_reliable": True,
+        "material_kind_reason": "viewer material-kind override",
+        "material_kind_override": "body",
+        "material_profile_id": "wuwa:rabbitfx:body",
+    })
+    payload["meshSemantics"] = {mesh_name: initial_semantic}
+    payload["metadata"]["material_profiles"]["wuwa:rabbitfx:body"] = \
+        material_profile_for("wuwa", "rabbitfx", "body").to_metadata()
+    return payload, mesh_name, explicit_semantic
+
+
+def test_material_hot_swap_updates_loaded_skinning_baseline(
+        edge_browser, frontend_url):
+    payload, mesh_name, explicit_semantic = \
+        _skinning_material_transition_payload()
+    context, page = _page(edge_browser, frontend_url, {"Packed": payload})
+    try:
+        _open(page, "Packed")
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0]?.material?.userData?.gameMaterial")
+        page.evaluate("""data => {
+          window.__fakeApi.responses.Packed.meshSemantics = {
+            [data.mesh]: data.semantic,
+          };
+        }""", {"mesh": mesh_name, "semantic": explicit_semantic})
+        result = page.evaluate("""async () => {
+          const mesh = window.modViewer.activeMeshes[0];
+          const bytes = new Uint8Array(48);
+          new Uint32Array(bytes.buffer).set([0, 1, 1, 2, 0, 2]);
+          new Float32Array(bytes.buffer, 24).set([.8, .2, .7, .3, .6, .4]);
+          const url = URL.createObjectURL(new Blob([bytes]));
+          window.pywebview.api.get_skinning_preview = async () => ({
+            status: 'ok', vertex_count: 3, influence_count: 2,
+            bone_ids: [0, 1, 2], encoding: 'test',
+            data: {
+              url, length: 48,
+              indices: {offset: 0, length: 24, type: 'u32'},
+              weights: {offset: 24, length: 24, type: 'f32'},
+            }, diagnostics: {},
+          });
+          const experiment = await import('./js/mesh/weight-experiment.js');
+          const {setControlValue} =
+            await import('./js/editing/control-state.js');
+          const {refreshMeshes} = await import('./js/mesh/mesh-state.js');
+          await experiment.loadSkinningWeights(mesh);
+          const oldMaterial = mesh.material;
+          let oldMaterialDisposals = 0;
+          oldMaterial.addEventListener('dispose',
+            () => oldMaterialDisposals += 1);
+          const refreshed = await window.modViewer.refreshMeshSemantics();
+          const afterSwap = experiment.getSkinningState(mesh);
+          const newMaterial = afterSwap.originalMaterial;
+          setControlValue('shape', '1');
+          refreshMeshes();
+          URL.revokeObjectURL(url);
+          return {
+            refreshed,
+            oldMaterialDisposals,
+            newProfile: newMaterial.userData.gameMaterial.profile.id,
+            originalTracksNew: afterSwap.originalMaterial === newMaterial,
+            stateDisposed: experiment.getSkinningState(mesh) === null,
+            activeMaterialIsNew: mesh.material === newMaterial,
+            activeProfile: mesh.material.userData.gameMaterial.profile.id,
+          };
+        }""")
+        assert result == {
+            "refreshed": True,
+            "oldMaterialDisposals": 1,
+            "newProfile": "wuwa:rabbitfx:body",
+            "originalTracksNew": True,
+            "stateDisposed": True,
+            "activeMaterialIsNew": True,
+            "activeProfile": "wuwa:rabbitfx:body",
+        }
+    finally:
+        context.close()
+
+
+def test_material_hot_swap_preserves_active_skinning_heatmap(
+        edge_browser, frontend_url):
+    payload, mesh_name, explicit_semantic = \
+        _skinning_material_transition_payload()
+    context, page = _page(edge_browser, frontend_url, {"Packed": payload})
+    try:
+        _open(page, "Packed")
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0]?.material?.userData?.gameMaterial")
+        page.evaluate("""data => {
+          window.__fakeApi.responses.Packed.meshSemantics = {
+            [data.mesh]: data.semantic,
+          };
+        }""", {"mesh": mesh_name, "semantic": explicit_semantic})
+        result = page.evaluate("""async () => {
+          const mesh = window.modViewer.activeMeshes[0];
+          const bytes = new Uint8Array(48);
+          new Uint32Array(bytes.buffer).set([0, 1, 1, 2, 0, 2]);
+          new Float32Array(bytes.buffer, 24).set([.8, .2, .7, .3, .6, .4]);
+          const url = URL.createObjectURL(new Blob([bytes]));
+          window.pywebview.api.get_skinning_preview = async () => ({
+            status: 'ok', vertex_count: 3, influence_count: 2,
+            bone_ids: [0, 1, 2], encoding: 'test',
+            data: {
+              url, length: 48,
+              indices: {offset: 0, length: 24, type: 'u32'},
+              weights: {offset: 24, length: 24, type: 'f32'},
+            }, diagnostics: {},
+          });
+          const experiment = await import('./js/mesh/weight-experiment.js');
+          await experiment.loadSkinningWeights(mesh);
+          const oldMaterial = mesh.material;
+          let oldMaterialDisposals = 0;
+          oldMaterial.addEventListener('dispose',
+            () => oldMaterialDisposals += 1);
+          experiment.setSkinningHeatmap(mesh, true);
+          const heatmapMaterial = mesh.material;
+          let heatmapDisposals = 0;
+          heatmapMaterial.addEventListener('dispose',
+            () => heatmapDisposals += 1);
+          const refreshed = await window.modViewer.refreshMeshSemantics();
+          const afterSwap = experiment.getSkinningState(mesh);
+          const newMaterial = afterSwap.originalMaterial;
+          const displayedAfterSwap = mesh.material === heatmapMaterial;
+          experiment.setSelectedBone(mesh, 1);
+          const selectedBoneKeepsHeatmap =
+            mesh.material === heatmapMaterial
+            && experiment.getSkinningState(mesh).debugMaterial === heatmapMaterial;
+          const disabled = experiment.setSkinningHeatmap(mesh, false);
+          URL.revokeObjectURL(url);
+          return {
+            refreshed,
+            oldMaterialDisposals,
+            heatmapDisposals,
+            displayedAfterSwap,
+            selectedBoneKeepsHeatmap,
+            originalTracksNew: afterSwap.originalMaterial === newMaterial,
+            newProfile: newMaterial.userData.gameMaterial.profile.id,
+            disabled,
+            restoredAfterDisable: mesh.material === newMaterial,
+            heatmapCleared: afterSwap.debugMaterial === null
+              && afterSwap.heatmapMode === null,
+            activeProfile: mesh.material.userData.gameMaterial.profile.id,
+          };
+        }""")
+        assert result == {
+            "refreshed": True,
+            "oldMaterialDisposals": 1,
+            "heatmapDisposals": 1,
+            "displayedAfterSwap": True,
+            "selectedBoneKeepsHeatmap": True,
+            "originalTracksNew": True,
+            "newProfile": "wuwa:rabbitfx:body",
+            "disabled": False,
+            "restoredAfterDisable": True,
+            "heatmapCleared": True,
+            "activeProfile": "wuwa:rabbitfx:body",
+        }
+    finally:
+        context.close()
+
+
+def test_material_kind_control_reverts_when_semantic_refresh_fails(
+        edge_browser, frontend_url):
+    payload = _packed_material_payload("wuwa:rabbitfx")
+    context, page = _page(edge_browser, frontend_url, {"Packed": payload})
+    try:
+        _open(page, "Packed")
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0]?.material?.userData?.gameMaterial")
+        page.locator("#inspector-tab").click()
+        page.locator(".group-hdr .group-name").first.click()
+        select = page.locator(".inspector-material-kind-control")
+        select.wait_for()
+        assert select.input_value() == "auto"
+        page.evaluate("""() => {
+          window.pywebview.api.save_component_material_kind =
+            async () => ({saved: true});
+          window.pywebview.api.get_mesh_semantics =
+            async () => ({error: 'semantic refresh failed'});
+        }""")
+
+        select.select_option("body")
+        page.locator("#dialog-backdrop.show").wait_for()
+        page.locator("#dialog-ok").click()
+        page.wait_for_function(
+            "() => document.querySelector('.inspector-material-kind-control')"
+            "?.value === 'auto'")
+        assert page.evaluate("window.modViewer.getMaterialState(0).profileId") == (
+            "wuwa:rabbitfx")
+        assert page.evaluate(
+            "window.modViewer.getMaterialState(0).materialKindOverride") is None
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["Packed"]
+    finally:
+        context.close()
+
+
 def test_each_mesh_resolves_its_own_profile_and_packed_source(
         edge_browser, frontend_url):
     payload = _packed_material_payload("zzz:zzmi")

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -3628,6 +3628,195 @@ def test_packed_material_profile_uses_tsl_nodes_and_stable_bindings(
     finally:
         context.close()
 
+def test_material_kind_refresh_hot_swaps_profile_without_reloading_model(
+        edge_browser, frontend_url):
+    payload = _packed_material_payload("wuwa:rabbitfx")
+    mesh_name, entry = next(iter(payload["meshes"].items()))
+    entry["source"] = "Packed.ini"
+    initial_semantic = copy.deepcopy(entry)
+    initial_semantic.update({
+        "source": "Packed.ini",
+        "component": entry["component"],
+        "material_kind": "body",
+        "material_kind_reliable": False,
+        "material_kind_reason": "automatic detection",
+        "material_kind_override": None,
+        "material_profile_id": "wuwa:rabbitfx",
+    })
+    explicit_semantic = copy.deepcopy(initial_semantic)
+    explicit_semantic.update({
+        "material_kind": "body",
+        "material_kind_reliable": True,
+        "material_kind_reason": "viewer material-kind override",
+        "material_kind_override": "body",
+        "material_profile_id": "wuwa:rabbitfx:body",
+    })
+    payload["meshSemantics"] = {mesh_name: initial_semantic}
+    payload["metadata"]["material_profiles"]["wuwa:rabbitfx:body"] = \
+        material_profile_for("wuwa", "rabbitfx", "body").to_metadata()
+
+    context, page = _page(edge_browser, frontend_url, {"Packed": payload})
+    try:
+        _open(page, "Packed")
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0]?.material?.userData?.gameMaterial")
+        page.locator("#inspector-tab").click()
+        page.locator(".group-hdr .group-name").first.click()
+        page.locator(".inspector-material-kind-control").wait_for()
+        page.locator(".draw-item").first.click()
+        page.evaluate("""async () => {
+          const {setManualTexOverride} =
+            await import('./js/mesh/mesh-state.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          setManualTexOverride(mesh, 'diffuse::Packed-two.png', {
+            notify: false,
+          });
+          document.querySelector('#wire-btn').click();
+          document.querySelector('#shading-btn').click();
+          document.querySelector('#glossy-btn').click();
+          document.querySelector('#toon-btn').click();
+          window.modViewer.setMaterialDebugMode('normal-data-b');
+          const game = mesh.material.userData.gameMaterial;
+          window.__materialHotSwapBefore = {
+            mesh,
+            geometry: mesh.geometry,
+            position: mesh.position.toArray(),
+            quaternion: mesh.quaternion.toArray(),
+            positionAttribute: mesh.geometry.getAttribute('position'),
+            shapeTargets: mesh.userData.shapeTargets,
+            material: mesh.material,
+            diffuseKey: mesh.userData.texKey,
+            normalDataKey: mesh.userData.normalDataKey,
+            manualTexOverride: mesh.userData.manualTexOverride,
+            normalDataBound: game.bindings.normal_data.enabledNode.value,
+            debugMode: window.modViewer.getMaterialState(0).debugMode,
+            selected: game.selectionEnabledNode.value,
+          };
+        }""")
+        page.evaluate("""data => {
+          const response = window.__fakeApi.responses.Packed;
+          window.__fakeApi.calls.materialKind = [];
+          window.pywebview.api.save_component_material_kind =
+            async (path, source, component, kind) => {
+              window.__fakeApi.calls.materialKind.push(
+                [path, source, component, kind]);
+              response.meshSemantics = {
+                [data.mesh]: kind === 'body'
+                  ? data.explicit : data.automatic,
+              };
+              return {saved: true};
+            };
+        }""", {
+            "mesh": mesh_name,
+            "automatic": initial_semantic,
+            "explicit": explicit_semantic,
+        })
+
+        page.locator(".inspector-material-kind-control").select_option("body")
+        page.wait_for_function(
+            "window.__fakeApi.calls.meshSemantics.length === 1")
+        switched = page.evaluate("""() => {
+          const before = window.__materialHotSwapBefore;
+          const mesh = window.modViewer.activeMeshes[0];
+          const game = mesh.material.userData.gameMaterial;
+          return {
+            sameMesh: mesh === before.mesh,
+            sameGeometry: mesh.geometry === before.geometry,
+            samePositionAttribute:
+              mesh.geometry.getAttribute('position') === before.positionAttribute,
+            sameShapeTargets: mesh.userData.shapeTargets === before.shapeTargets,
+            position: mesh.position.toArray(),
+            quaternion: mesh.quaternion.toArray(),
+            newMaterial: mesh.material !== before.material,
+            profileId: mesh.userData.materialProfileId,
+            materialKindOverride: mesh.userData.materialKindOverride,
+            manualTexOverride: mesh.userData.manualTexOverride,
+            diffuseKey: mesh.userData.texKey,
+            normalDataKey: mesh.userData.normalDataKey,
+            normalDataBound: game.bindings.normal_data.enabledNode.value,
+            normalSource: game.normalSource,
+            debugMode: window.modViewer.getMaterialState(0).debugMode,
+            selected: game.selectionEnabledNode.value,
+            wireframe: mesh.material.wireframe,
+            flatShading: mesh.material.flatShading,
+            roughness: mesh.material.roughness,
+            toon: game.toonEnabledNode.value,
+            rim: game.rimEnabledNode.value,
+          };
+        }""")
+        assert switched["sameMesh"]
+        assert switched["sameGeometry"]
+        assert switched["samePositionAttribute"]
+        assert switched["sameShapeTargets"]
+        assert switched["position"] == pytest.approx(
+            page.evaluate("window.__materialHotSwapBefore.position"))
+        assert switched["quaternion"] == pytest.approx(
+            page.evaluate("window.__materialHotSwapBefore.quaternion"))
+        assert switched["newMaterial"]
+        assert switched["profileId"] == "wuwa:rabbitfx:body"
+        assert switched["materialKindOverride"] == "body"
+        assert switched["manualTexOverride"] == "diffuse::Packed-two.png"
+        assert switched["diffuseKey"] == "diffuse::Packed-two.png"
+        assert switched["normalDataKey"] == initial_semantic["normal_data_key"]
+        assert switched["normalDataBound"]
+        assert switched["normalSource"] == "normal_data"
+        assert switched["debugMode"] == "normal-data-b"
+        assert switched["selected"]
+        assert switched["wireframe"]
+        assert switched["flatShading"]
+        assert switched["roughness"] == pytest.approx(0.2)
+        assert switched["toon"]
+        assert not switched["rim"]
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["Packed"]
+        assert page.evaluate("window.__fakeApi.calls.materialKind") == [[
+            "Packed", "Packed.ini", "Body Packed", "body"]]
+
+        page.locator(".inspector-material-kind-control").select_option("auto")
+        page.wait_for_function(
+            "window.__fakeApi.calls.meshSemantics.length === 2")
+        automatic = page.evaluate("""() => {
+          const mesh = window.modViewer.activeMeshes[0];
+          const game = mesh.material.userData.gameMaterial;
+          return {
+            sameMesh: mesh === window.__materialHotSwapBefore.mesh,
+            sameGeometry: mesh.geometry ===
+              window.__materialHotSwapBefore.geometry,
+            profileId: mesh.userData.materialProfileId,
+            materialKindOverride: mesh.userData.materialKindOverride,
+            manualTexOverride: mesh.userData.manualTexOverride,
+            debugMode: window.modViewer.getMaterialState(0).debugMode,
+            selected: game.selectionEnabledNode.value,
+            normalDataBound: game.bindings.normal_data.enabledNode.value,
+            wireframe: mesh.material.wireframe,
+            flatShading: mesh.material.flatShading,
+            roughness: mesh.material.roughness,
+            toon: game.toonEnabledNode.value,
+          };
+        }""")
+        assert automatic == {
+            "sameMesh": True,
+            "sameGeometry": True,
+            "profileId": "wuwa:rabbitfx",
+            "materialKindOverride": None,
+            "manualTexOverride": "diffuse::Packed-two.png",
+            "debugMode": "normal-data-b",
+            "selected": True,
+            "normalDataBound": True,
+            "wireframe": True,
+            "flatShading": True,
+            "roughness": pytest.approx(0.2),
+            "toon": True,
+        }
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["Packed"]
+        assert page.evaluate("window.__fakeApi.calls.materialKind") == [
+            ["Packed", "Packed.ini", "Body Packed", "body"],
+            ["Packed", "Packed.ini", "Body Packed", "auto"],
+        ]
+    finally:
+        context.close()
+
+
 def test_each_mesh_resolves_its_own_profile_and_packed_source(
         edge_browser, frontend_url):
     payload = _packed_material_payload("zzz:zzmi")

--- a/src/web/js/app/semantic-refresh.js
+++ b/src/web/js/app/semantic-refresh.js
@@ -130,7 +130,10 @@ export async function refreshMeshSemantics(handlers = {}) {
       await alertDialog('Could not refresh mesh render semantics:\n\n' + result.error);
       return false;
     }
-    if (!updateMeshSemantics(result.meshes)) {
+    const update = updateMeshSemantics(result.meshes, {
+      materialProfiles: result.material_profiles || {},
+    });
+    if (!update.success) {
       await alertDialog('Could not refresh mesh render semantics:\n\n' +
         'The staged draw set no longer matches the displayed model.');
       return false;
@@ -138,7 +141,10 @@ export async function refreshMeshSemantics(handlers = {}) {
     const assetResolution = result.asset_resolution || null;
     refreshMeshAssetDiagnostics(assetResolution);
     setAssetResolution(assetResolution);
-    refreshAll({force: {visibility: true, textures: true}});
+    refreshAll({
+      force: {visibility: true, textures: true},
+      additionalMeshes: update.materialChangedMeshes,
+    });
     return true;
   } finally {
     await finishSemanticRefresh(path, epoch, callbacks);

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -61,7 +61,7 @@ function semanticHandlers() {
 
 function modelHandlers() {
   return {
-    onMaterialKindChanged: reloadCurrentMod,
+    onMaterialKindChanged: () => refreshMeshSemanticsFlow(semanticHandlers()),
     onPresentChange: handlePresentChange,
     onReload: reloadCurrentMod,
     onToggleChange: handleToggleChange,

--- a/src/web/js/mesh/material-profile.js
+++ b/src/web/js/mesh/material-profile.js
@@ -964,6 +964,22 @@ export function getMaterialDebugMode(material) {
     || 'off';
 }
 
+/** Capture viewer state that is owned by an individual material instance. */
+export function captureGameMaterialViewerState(material) {
+  const state = material?.userData?.gameMaterial;
+  return {
+    debugMode: getMaterialDebugMode(material),
+    selectionEnabled: state?.selectionEnabledNode?.value === true,
+  };
+}
+
+/** Restore per-material viewer state onto a newly-created material graph. */
+export function restoreGameMaterialViewerState(material, viewerState = {}) {
+  setMaterialDebugMode([material], viewerState.debugMode || 'off');
+  setGameMaterialSelectionEnabled(
+    material, viewerState.selectionEnabled === true);
+}
+
 /** Toggle viewer rim lighting without rebuilding the material node graph. */
 export function setGameMaterialRimEnabled(material, enabled) {
   const node = material?.userData?.gameMaterial?.rimEnabledNode;

--- a/src/web/js/mesh/mesh-factory.js
+++ b/src/web/js/mesh/mesh-factory.js
@@ -3,14 +3,12 @@
 import * as THREE from 'three';
 import { decodeF32, decodeU32 } from '../textures/decode.js';
 import {
-  captureGameMaterialViewerState, createGameMaterial, disposeGameMaterial,
-  getGameMaterialSources, restoreGameMaterialViewerState,
-  updateGameMaterialTextures, usesPackedNormal,
+  createGameMaterial, getGameMaterialSources, updateGameMaterialTextures,
+  usesPackedNormal,
 } from './material-profile.js';
 import { getMeshView } from './mesh-view-bindings.js';
 import { loadDDSTexture } from '../textures/dds-loader.js';
 import { requestRender } from '../scene/render-scheduler.js';
-import { initializeMeshRenderModes } from '../scene/render-modes.js';
 import { supportsBCTextureCompression } from '../scene/renderer-capabilities.js';
 import { splitTextureKey } from '../textures/texture-key.js';
 import { CHARACTER_AO_LAYER } from '../scene/viewer-layers.js';
@@ -277,93 +275,6 @@ export function setMeshTextureState(mesh, state, { render = true } = {}) {
   mesh.userData.materialMapKey = state.material_map || null;
   mesh.userData.emissionMapKey = state.emission_map || null;
   return refreshMeshTexture(mesh, { render });
-}
-
-const MATERIAL_METADATA_FIELDS = [
-  ['materialKind', 'material_kind'],
-  ['materialKindReliable', 'material_kind_reliable'],
-  ['materialKindReason', 'material_kind_reason'],
-  ['materialKindOverride', 'material_kind_override'],
-  ['materialProfileId', 'material_profile_id'],
-];
-
-export function updateMeshMaterialMetadata(mesh, metadata, profile) {
-  let changed = false;
-  for (const [target, source] of MATERIAL_METADATA_FIELDS) {
-    if (!Object.hasOwn(metadata, source)) continue;
-    const value = metadata[source];
-    let next;
-    if (target === 'materialKindReliable') {
-      next = value === true;
-    } else if (target === 'materialKindOverride') {
-      next = value || null;
-    } else if (target === 'materialProfileId') {
-      next = value || 'none';
-    } else if (target === 'materialKind') {
-      next = value || 'unknown';
-    } else {
-      next = value || '';
-    }
-    changed = !Object.is(mesh.userData[target], next) || changed;
-    mesh.userData[target] = next;
-  }
-  if (Object.hasOwn(metadata, 'material_profile_id')) {
-    mesh.userData.materialProfile = profile;
-  }
-  return changed;
-}
-
-/** Replace one mesh material without replacing its mesh or geometry. */
-export function replaceMeshMaterial(
-    mesh, profile, metadata = {}, { render = true, disposeOld = true } = {}) {
-  const oldMaterial = mesh.material;
-  const viewerState = captureGameMaterialViewerState(oldMaterial);
-  const previousMetadata = Object.fromEntries(
-    MATERIAL_METADATA_FIELDS.map(([target]) => [target, mesh.userData[target]])
-      .concat([['materialProfile', mesh.userData.materialProfile]]));
-  const textureStateFields = [
-    'texKey', 'normalMapKey', 'normalDataKey', 'lightMapKey',
-    'materialMapKey', 'emissionMapKey',
-  ];
-  const previousTextureState = Object.fromEntries(
-    textureStateFields.map(field => [field, mesh.userData[field]]));
-  const nextMaterial = createGameMaterial(
-    profile, mesh.userData.fallbackColor ?? 0xcccccc,
-    { hasUv: !!mesh.geometry?.attributes?.uv });
-  try {
-    mesh.material = nextMaterial;
-    initializeMeshRenderModes(mesh);
-    restoreGameMaterialViewerState(nextMaterial, viewerState);
-    updateMeshMaterialMetadata(mesh, metadata, profile);
-    setMeshTextureState(mesh, {
-      diffuse: mesh.userData.texKey,
-      // The applied normal-map key is intentionally not authoritative when
-      // the new profile consumes packed normal data instead.
-      normal_map: mesh.userData.resolvedNormalMapKey,
-      normal_data: mesh.userData.normalDataKey
-        || mesh.userData.resolvedNormalDataKey,
-      light_map: mesh.userData.lightMapKey,
-      material_map: mesh.userData.materialMapKey,
-      emission_map: mesh.userData.emissionMapKey,
-    }, { render: false });
-  } catch (error) {
-    mesh.material = oldMaterial;
-    for (const [target, value] of Object.entries(previousMetadata)) {
-      mesh.userData[target] = value;
-    }
-    for (const [field, value] of Object.entries(previousTextureState)) {
-      mesh.userData[field] = value;
-    }
-    disposeGameMaterial(nextMaterial);
-    nextMaterial.dispose();
-    throw error;
-  }
-  if (disposeOld) {
-    disposeGameMaterial(oldMaterial);
-    oldMaterial.dispose();
-  }
-  if (render) requestRender();
-  return disposeOld ? true : {material: nextMaterial, oldMaterial};
 }
 
 /** Colour for meshes with no texture, guessed from the component name. */

--- a/src/web/js/mesh/mesh-factory.js
+++ b/src/web/js/mesh/mesh-factory.js
@@ -3,12 +3,14 @@
 import * as THREE from 'three';
 import { decodeF32, decodeU32 } from '../textures/decode.js';
 import {
-  createGameMaterial, getGameMaterialSources, updateGameMaterialTextures,
-  usesPackedNormal,
+  captureGameMaterialViewerState, createGameMaterial, disposeGameMaterial,
+  getGameMaterialSources, restoreGameMaterialViewerState,
+  updateGameMaterialTextures, usesPackedNormal,
 } from './material-profile.js';
 import { getMeshView } from './mesh-view-bindings.js';
 import { loadDDSTexture } from '../textures/dds-loader.js';
 import { requestRender } from '../scene/render-scheduler.js';
+import { initializeMeshRenderModes } from '../scene/render-modes.js';
 import { supportsBCTextureCompression } from '../scene/renderer-capabilities.js';
 import { splitTextureKey } from '../textures/texture-key.js';
 import { CHARACTER_AO_LAYER } from '../scene/viewer-layers.js';
@@ -277,6 +279,91 @@ export function setMeshTextureState(mesh, state, { render = true } = {}) {
   return refreshMeshTexture(mesh, { render });
 }
 
+const MATERIAL_METADATA_FIELDS = [
+  ['materialKind', 'material_kind'],
+  ['materialKindReliable', 'material_kind_reliable'],
+  ['materialKindReason', 'material_kind_reason'],
+  ['materialKindOverride', 'material_kind_override'],
+  ['materialProfileId', 'material_profile_id'],
+];
+
+export function updateMeshMaterialMetadata(mesh, metadata, profile) {
+  let changed = false;
+  for (const [target, source] of MATERIAL_METADATA_FIELDS) {
+    if (!Object.hasOwn(metadata, source)) continue;
+    const value = metadata[source];
+    let next;
+    if (target === 'materialKindReliable') {
+      next = value === true;
+    } else if (target === 'materialKindOverride') {
+      next = value || null;
+    } else if (target === 'materialProfileId') {
+      next = value || 'none';
+    } else if (target === 'materialKind') {
+      next = value || 'unknown';
+    } else {
+      next = value || '';
+    }
+    changed = !Object.is(mesh.userData[target], next) || changed;
+    mesh.userData[target] = next;
+  }
+  if (Object.hasOwn(metadata, 'material_profile_id')) {
+    mesh.userData.materialProfile = profile;
+  }
+  return changed;
+}
+
+/** Replace one mesh material without replacing its mesh or geometry. */
+export function replaceMeshMaterial(
+    mesh, profile, metadata = {}, { render = true } = {}) {
+  const oldMaterial = mesh.material;
+  const viewerState = captureGameMaterialViewerState(oldMaterial);
+  const previousMetadata = Object.fromEntries(
+    MATERIAL_METADATA_FIELDS.map(([target]) => [target, mesh.userData[target]])
+      .concat([['materialProfile', mesh.userData.materialProfile]]));
+  const textureStateFields = [
+    'texKey', 'normalMapKey', 'normalDataKey', 'lightMapKey',
+    'materialMapKey', 'emissionMapKey',
+  ];
+  const previousTextureState = Object.fromEntries(
+    textureStateFields.map(field => [field, mesh.userData[field]]));
+  const nextMaterial = createGameMaterial(
+    profile, mesh.userData.fallbackColor ?? 0xcccccc,
+    { hasUv: !!mesh.geometry?.attributes?.uv });
+  try {
+    mesh.material = nextMaterial;
+    initializeMeshRenderModes(mesh);
+    restoreGameMaterialViewerState(nextMaterial, viewerState);
+    updateMeshMaterialMetadata(mesh, metadata, profile);
+    setMeshTextureState(mesh, {
+      diffuse: mesh.userData.texKey,
+      // The applied normal-map key is intentionally not authoritative when
+      // the new profile consumes packed normal data instead.
+      normal_map: mesh.userData.resolvedNormalMapKey,
+      normal_data: mesh.userData.normalDataKey
+        || mesh.userData.resolvedNormalDataKey,
+      light_map: mesh.userData.lightMapKey,
+      material_map: mesh.userData.materialMapKey,
+      emission_map: mesh.userData.emissionMapKey,
+    }, { render: false });
+  } catch (error) {
+    mesh.material = oldMaterial;
+    for (const [target, value] of Object.entries(previousMetadata)) {
+      mesh.userData[target] = value;
+    }
+    for (const [field, value] of Object.entries(previousTextureState)) {
+      mesh.userData[field] = value;
+    }
+    disposeGameMaterial(nextMaterial);
+    nextMaterial.dispose();
+    throw error;
+  }
+  disposeGameMaterial(oldMaterial);
+  oldMaterial.dispose();
+  if (render) requestRender();
+  return true;
+}
+
 /** Colour for meshes with no texture, guessed from the component name. */
 function fallbackColor(name) {
   const n = name.toLowerCase();
@@ -327,8 +414,9 @@ export function buildMesh(name, data, materialProfile = null) {
   // applyTextureVariant). Immutable; setMeshTextureState updates the stable
   // binding state without rebuilding the material.
   mesh.userData.defaultTexKey = data.tex_key || null;
+  const authoredNormalMapKey = data.normal_map_key || null;
   mesh.userData.normalMapKey = usesPackedNormal(mat)
-    ? null : (data.normal_map_key || null);
+    ? null : authoredNormalMapKey;
   mesh.userData.normalDataKey = data.normal_data_key || null;
   mesh.userData.lightMapKey = data.light_map_key || null;
   mesh.userData.materialMapKey = data.material_map_key || null;
@@ -343,7 +431,9 @@ export function buildMesh(name, data, materialProfile = null) {
   mesh.userData.normalMapEnabled = data.normal_map_enabled !== false;
   mesh.userData.normalMapYSign = Number.isFinite(data.normal_map_y_sign)
     ? data.normal_map_y_sign : -1;
-  mesh.userData.defaultNormalMapKey = mesh.userData.normalMapKey;
+  // Keep the authored normal-map default even while a packed profile hides
+  // it. A later profile swap may need to restore that role in place.
+  mesh.userData.defaultNormalMapKey = authoredNormalMapKey;
   mesh.userData.defaultNormalDataKey = mesh.userData.normalDataKey;
   mesh.userData.defaultLightMapKey = mesh.userData.lightMapKey;
   mesh.userData.defaultMaterialMapKey = mesh.userData.materialMapKey;

--- a/src/web/js/mesh/mesh-factory.js
+++ b/src/web/js/mesh/mesh-factory.js
@@ -315,7 +315,7 @@ export function updateMeshMaterialMetadata(mesh, metadata, profile) {
 
 /** Replace one mesh material without replacing its mesh or geometry. */
 export function replaceMeshMaterial(
-    mesh, profile, metadata = {}, { render = true } = {}) {
+    mesh, profile, metadata = {}, { render = true, disposeOld = true } = {}) {
   const oldMaterial = mesh.material;
   const viewerState = captureGameMaterialViewerState(oldMaterial);
   const previousMetadata = Object.fromEntries(
@@ -358,10 +358,12 @@ export function replaceMeshMaterial(
     nextMaterial.dispose();
     throw error;
   }
-  disposeGameMaterial(oldMaterial);
-  oldMaterial.dispose();
+  if (disposeOld) {
+    disposeGameMaterial(oldMaterial);
+    oldMaterial.dispose();
+  }
   if (render) requestRender();
-  return true;
+  return disposeOld ? true : {material: nextMaterial, oldMaterial};
 }
 
 /** Colour for meshes with no texture, guessed from the component name. */

--- a/src/web/js/mesh/mesh-material-state.js
+++ b/src/web/js/mesh/mesh-material-state.js
@@ -1,0 +1,96 @@
+// Runtime material replacement and metadata state for an existing mesh.
+
+import {
+  captureGameMaterialViewerState, createGameMaterial, disposeGameMaterial,
+  restoreGameMaterialViewerState,
+} from './material-profile.js';
+import { setMeshTextureState } from './mesh-factory.js';
+import { initializeMeshRenderModes } from '../scene/render-modes.js';
+import { requestRender } from '../scene/render-scheduler.js';
+
+const MATERIAL_METADATA_FIELDS = [
+  ['materialKind', 'material_kind'],
+  ['materialKindReliable', 'material_kind_reliable'],
+  ['materialKindReason', 'material_kind_reason'],
+  ['materialKindOverride', 'material_kind_override'],
+  ['materialProfileId', 'material_profile_id'],
+];
+
+export function updateMeshMaterialMetadata(mesh, metadata, profile) {
+  let changed = false;
+  for (const [target, source] of MATERIAL_METADATA_FIELDS) {
+    if (!Object.hasOwn(metadata, source)) continue;
+    const value = metadata[source];
+    let next;
+    if (target === 'materialKindReliable') {
+      next = value === true;
+    } else if (target === 'materialKindOverride') {
+      next = value || null;
+    } else if (target === 'materialProfileId') {
+      next = value || 'none';
+    } else if (target === 'materialKind') {
+      next = value || 'unknown';
+    } else {
+      next = value || '';
+    }
+    changed = !Object.is(mesh.userData[target], next) || changed;
+    mesh.userData[target] = next;
+  }
+  if (Object.hasOwn(metadata, 'material_profile_id')) {
+    mesh.userData.materialProfile = profile;
+  }
+  return changed;
+}
+
+/** Replace one mesh material without replacing its mesh or geometry. */
+export function replaceMeshMaterial(
+    mesh, profile, metadata = {}, { render = true, disposeOld = true } = {}) {
+  const oldMaterial = mesh.material;
+  const viewerState = captureGameMaterialViewerState(oldMaterial);
+  const previousMetadata = Object.fromEntries(
+    MATERIAL_METADATA_FIELDS.map(([target]) => [target, mesh.userData[target]])
+      .concat([['materialProfile', mesh.userData.materialProfile]]));
+  const textureStateFields = [
+    'texKey', 'normalMapKey', 'normalDataKey', 'lightMapKey',
+    'materialMapKey', 'emissionMapKey',
+  ];
+  const previousTextureState = Object.fromEntries(
+    textureStateFields.map(field => [field, mesh.userData[field]]));
+  const nextMaterial = createGameMaterial(
+    profile, mesh.userData.fallbackColor ?? 0xcccccc,
+    { hasUv: !!mesh.geometry?.attributes?.uv });
+  try {
+    mesh.material = nextMaterial;
+    initializeMeshRenderModes(mesh);
+    restoreGameMaterialViewerState(nextMaterial, viewerState);
+    updateMeshMaterialMetadata(mesh, metadata, profile);
+    setMeshTextureState(mesh, {
+      diffuse: mesh.userData.texKey,
+      // The applied normal-map key is intentionally not authoritative when
+      // the new profile consumes packed normal data instead.
+      normal_map: mesh.userData.resolvedNormalMapKey,
+      normal_data: mesh.userData.normalDataKey
+        || mesh.userData.resolvedNormalDataKey,
+      light_map: mesh.userData.lightMapKey,
+      material_map: mesh.userData.materialMapKey,
+      emission_map: mesh.userData.emissionMapKey,
+    }, { render: false });
+  } catch (error) {
+    mesh.material = oldMaterial;
+    for (const [target, value] of Object.entries(previousMetadata)) {
+      mesh.userData[target] = value;
+    }
+    for (const [field, value] of Object.entries(previousTextureState)) {
+      mesh.userData[field] = value;
+    }
+    disposeGameMaterial(nextMaterial);
+    nextMaterial.dispose();
+    throw error;
+  }
+  if (disposeOld) {
+    disposeGameMaterial(oldMaterial);
+    oldMaterial.dispose();
+  }
+  if (render) requestRender();
+  return disposeOld ? true : {material: nextMaterial, oldMaterial};
+}

--- a/src/web/js/mesh/mesh-state.js
+++ b/src/web/js/mesh/mesh-state.js
@@ -7,7 +7,10 @@ import {
 } from '../scene/scene.js';
 import { dnfSatisfied, getControlValue } from '../editing/control-state.js';
 import { disposeGameMaterial } from './material-profile.js';
-import { setMeshTextureState, updateGeometryNormals } from './mesh-factory.js';
+import {
+  replaceMeshMaterial, setMeshTextureState, updateGeometryNormals,
+  updateMeshMaterialMetadata,
+} from './mesh-factory.js';
 import { clearTextureRunGroups, recomputeAllTextureRuns } from './mesh-texture-runs.js';
 import { attachOutline, detachOutline } from '../scene/outline-renderer.js';
 import { initializeMeshRenderModes } from '../scene/render-modes.js';
@@ -142,53 +145,95 @@ export function resetMeshVisibility() {
   requestRender();
 }
 
-/** Replace draw visibility and texture semantics without applying rendering. */
-export function updateMeshSemantics(semantics) {
+/** Replace draw visibility, texture and material semantics without reloading. */
+export function updateMeshSemantics(semantics, { materialProfiles = {} } = {}) {
   const next = semantics || {};
   const semanticMeshes = activeMeshes.filter(
     mesh => mesh.userData.assetFill !== true);
   const keys = semanticMeshes.map(mesh => mesh.userData.semanticKey);
   if (keys.some(key => !next[key])
-      || Object.keys(next).length !== keys.length) return false;
-  semanticMeshes.forEach(mesh => {
+      || Object.keys(next).length !== keys.length) {
+    return {success: false, materialChangedMeshes: []};
+  }
+
+  const updates = semanticMeshes.map(mesh => {
     const semantic = next[mesh.userData.semanticKey];
-    mesh.userData.conditions = semantic.conditions || [];
-    mesh.userData.sources = semantic.sources || [];
-    const variants = [
-      ['textureVariants', 'texture_variants'],
-      ['normalMapVariants', 'normal_map_variants'],
-      ['normalDataVariants', 'normal_data_variants'],
-      ['lightMapVariants', 'light_map_variants'],
-      ['materialMapVariants', 'material_map_variants'],
-      ['emissionMapVariants', 'emission_map_variants'],
-    ];
-    for (const [target, source] of variants) {
-      mesh.userData[target] = semantic[source] || [];
+    if (!Object.hasOwn(semantic, 'material_profile_id')) {
+      return {mesh, semantic, material: null};
     }
-    const defaults = [
-      ['defaultTexKey', 'tex_key'],
-      ['defaultNormalMapKey', 'normal_map_key'],
-      ['defaultNormalDataKey', 'normal_data_key'],
-      ['defaultLightMapKey', 'light_map_key'],
-      ['defaultMaterialMapKey', 'material_map_key'],
-      ['defaultEmissionMapKey', 'emission_map_key'],
-    ];
-    for (const [target, source] of defaults) {
-      if (Object.hasOwn(semantic, source)) {
-        mesh.userData[target] = semantic[source] || null;
-      }
-    }
-    const assetEntry = mesh.userData.assetEntry || {};
-    for (const field of [
-      'asset_binding', 'texture_resolution', 'asset_slot_evidence',
-    ]) {
-      if (Object.hasOwn(semantic, field)) assetEntry[field] = semantic[field];
-      else delete assetEntry[field];
-    }
-    mesh.userData.assetEntry = assetEntry;
-    invalidateControlDependencies(mesh);
+    const profileId = semantic.material_profile_id || 'none';
+    const profile = materialProfiles?.[profileId] || null;
+    if (profileId !== 'none' && !profile) return null;
+    return {
+      mesh,
+      semantic,
+      material: {
+        profile,
+        changed: mesh.userData.materialProfileId !== profileId,
+      },
+    };
   });
-  return true;
+  if (updates.some(update => update === null)) {
+    return {success: false, materialChangedMeshes: []};
+  }
+
+  const materialChangedMeshes = [];
+  try {
+    updates.forEach(({mesh, semantic, material}) => {
+      mesh.userData.conditions = semantic.conditions || [];
+      mesh.userData.sources = semantic.sources || [];
+      if (Object.hasOwn(semantic, 'source')) {
+        mesh.userData.source = semantic.source;
+      }
+      if (Object.hasOwn(semantic, 'component')) {
+        mesh.userData.component = semantic.component;
+      }
+      const variants = [
+        ['textureVariants', 'texture_variants'],
+        ['normalMapVariants', 'normal_map_variants'],
+        ['normalDataVariants', 'normal_data_variants'],
+        ['lightMapVariants', 'light_map_variants'],
+        ['materialMapVariants', 'material_map_variants'],
+        ['emissionMapVariants', 'emission_map_variants'],
+      ];
+      for (const [target, source] of variants) {
+        mesh.userData[target] = semantic[source] || [];
+      }
+      const defaults = [
+        ['defaultTexKey', 'tex_key'],
+        ['defaultNormalMapKey', 'normal_map_key'],
+        ['defaultNormalDataKey', 'normal_data_key'],
+        ['defaultLightMapKey', 'light_map_key'],
+        ['defaultMaterialMapKey', 'material_map_key'],
+        ['defaultEmissionMapKey', 'emission_map_key'],
+      ];
+      for (const [target, source] of defaults) {
+        if (Object.hasOwn(semantic, source)) {
+          mesh.userData[target] = semantic[source] || null;
+        }
+      }
+      const assetEntry = mesh.userData.assetEntry || {};
+      for (const field of [
+        'asset_binding', 'texture_resolution', 'asset_slot_evidence',
+      ]) {
+        if (Object.hasOwn(semantic, field)) assetEntry[field] = semantic[field];
+        else delete assetEntry[field];
+      }
+      mesh.userData.assetEntry = assetEntry;
+      if (material?.changed) {
+        replaceMeshMaterial(mesh, material.profile, semantic, {render: false});
+        materialChangedMeshes.push(mesh);
+      } else if (material && updateMeshMaterialMetadata(
+          mesh, semantic, material.profile)) {
+        materialChangedMeshes.push(mesh);
+      }
+      invalidateControlDependencies(mesh);
+    });
+  } catch (error) {
+    console.error('Could not apply mesh semantic material update', error);
+    return {success: false, materialChangedMeshes};
+  }
+  return {success: true, materialChangedMeshes};
 }
 
 /** Pin or clear one mesh's highlighted diffuse. Ordered component propagation
@@ -335,6 +380,7 @@ export function refreshMeshes(options) {
   const {
     changedVariables = new Set(),
     force = {},
+    additionalMeshes = [],
   } = options || {};
   const changed = changedVariables instanceof Set
     ? changedVariables : new Set(changedVariables || []);
@@ -347,6 +393,9 @@ export function refreshMeshes(options) {
   const textureDirty = texturesForced || normalMeshes.some(mesh =>
     intersects(dependenciesFor(mesh).textures, changed));
   const changedMeshes = new Set();
+  for (const mesh of additionalMeshes || []) {
+    if (activeMeshes.includes(mesh)) changedMeshes.add(mesh);
+  }
   let visibilityChanged = false;
   let texturesChanged = false;
   let shapesChanged = false;
@@ -391,7 +440,8 @@ export function refreshMeshes(options) {
 
   const changedList = [...changedMeshes];
   if (changedList.length) notifyMeshStateChanged(changedList);
-  if (visibilityChanged || texturesChanged || shapesChanged) requestRender();
+  if (visibilityChanged || texturesChanged || shapesChanged
+      || (additionalMeshes?.length && changedMeshes.size)) requestRender();
   return {
     visibilityChanged,
     texturesChanged,

--- a/src/web/js/mesh/mesh-state.js
+++ b/src/web/js/mesh/mesh-state.js
@@ -8,9 +8,11 @@ import {
 import { dnfSatisfied, getControlValue } from '../editing/control-state.js';
 import { disposeGameMaterial } from './material-profile.js';
 import {
-  replaceMeshMaterial, setMeshTextureState, updateGeometryNormals,
-  updateMeshMaterialMetadata,
+  setMeshTextureState, updateGeometryNormals,
 } from './mesh-factory.js';
+import {
+  replaceMeshMaterial, updateMeshMaterialMetadata,
+} from './mesh-material-state.js';
 import { clearTextureRunGroups, recomputeAllTextureRuns } from './mesh-texture-runs.js';
 import { attachOutline, detachOutline } from '../scene/outline-renderer.js';
 import { initializeMeshRenderModes } from '../scene/render-modes.js';

--- a/src/web/js/mesh/mesh-state.js
+++ b/src/web/js/mesh/mesh-state.js
@@ -17,7 +17,8 @@ import { initializeMeshRenderModes } from '../scene/render-modes.js';
 import { requestRender } from '../scene/render-scheduler.js';
 import { notifyMeshStateChanged } from './mesh-state-events.js';
 import {
-  disposeSkinningExperiment, getSkinningState,
+  disposeSkinningExperiment, getSkinningBaseMaterial, getSkinningState,
+  withSkinningBaseMaterial,
 } from './weight-experiment.js';
 
 export const activeMeshes = [];
@@ -145,6 +146,30 @@ export function resetMeshVisibility() {
   requestRender();
 }
 
+const SEMANTIC_SNAPSHOT_FIELDS = [
+  'conditions', 'sources', 'source', 'component',
+  'textureVariants', 'normalMapVariants', 'normalDataVariants',
+  'lightMapVariants', 'materialMapVariants', 'emissionMapVariants',
+  'defaultTexKey', 'defaultNormalMapKey', 'defaultNormalDataKey',
+  'defaultLightMapKey', 'defaultMaterialMapKey', 'defaultEmissionMapKey',
+  'assetEntry', 'materialKind', 'materialKindReliable',
+  'materialKindReason', 'materialKindOverride', 'materialProfileId',
+  'materialProfile', 'texKey', 'normalMapKey', 'normalDataKey',
+  'lightMapKey', 'materialMapKey', 'emissionMapKey',
+];
+
+function snapshotMeshSemantics(mesh) {
+  const values = {};
+  for (const field of SEMANTIC_SNAPSHOT_FIELDS) {
+    values[field] = mesh.userData[field];
+  }
+  return {mesh, values};
+}
+
+function restoreMeshSemantics(snapshot) {
+  Object.assign(snapshot.mesh.userData, snapshot.values);
+}
+
 /** Replace draw visibility, texture and material semantics without reloading. */
 export function updateMeshSemantics(semantics, { materialProfiles = {} } = {}) {
   const next = semantics || {};
@@ -177,7 +202,9 @@ export function updateMeshSemantics(semantics, { materialProfiles = {} } = {}) {
     return {success: false, materialChangedMeshes: []};
   }
 
+  const snapshots = semanticMeshes.map(snapshotMeshSemantics);
   const materialChangedMeshes = [];
+  const replacements = [];
   try {
     updates.forEach(({mesh, semantic, material}) => {
       mesh.userData.conditions = semantic.conditions || [];
@@ -212,7 +239,7 @@ export function updateMeshSemantics(semantics, { materialProfiles = {} } = {}) {
           mesh.userData[target] = semantic[source] || null;
         }
       }
-      const assetEntry = mesh.userData.assetEntry || {};
+      const assetEntry = {...(mesh.userData.assetEntry || {})};
       for (const field of [
         'asset_binding', 'texture_resolution', 'asset_slot_evidence',
       ]) {
@@ -221,7 +248,14 @@ export function updateMeshSemantics(semantics, { materialProfiles = {} } = {}) {
       }
       mesh.userData.assetEntry = assetEntry;
       if (material?.changed) {
-        replaceMeshMaterial(mesh, material.profile, semantic, {render: false});
+        const replacement = withSkinningBaseMaterial(mesh, () =>
+          replaceMeshMaterial(mesh, material.profile, semantic, {
+            render: false, disposeOld: false,
+          }));
+        replacements.push({
+          mesh, oldMaterial: replacement.oldMaterial,
+          newMaterial: replacement.material,
+        });
         materialChangedMeshes.push(mesh);
       } else if (material && updateMeshMaterialMetadata(
           mesh, semantic, material.profile)) {
@@ -231,8 +265,25 @@ export function updateMeshSemantics(semantics, { materialProfiles = {} } = {}) {
     });
   } catch (error) {
     console.error('Could not apply mesh semantic material update', error);
-    return {success: false, materialChangedMeshes};
+    for (const {mesh, oldMaterial, newMaterial} of replacements.reverse()) {
+      const currentMaterial = getSkinningBaseMaterial(mesh);
+      const materialToDispose = currentMaterial === oldMaterial
+        ? newMaterial : currentMaterial;
+      if (materialToDispose && materialToDispose !== oldMaterial) {
+        disposeGameMaterial(materialToDispose);
+        materialToDispose.dispose();
+      }
+      withSkinningBaseMaterial(mesh, () => {
+        mesh.material = oldMaterial;
+      });
+    }
+    snapshots.forEach(restoreMeshSemantics);
+    return {success: false, materialChangedMeshes: []};
   }
+  replacements.forEach(({oldMaterial}) => {
+    disposeGameMaterial(oldMaterial);
+    oldMaterial.dispose();
+  });
   return {success: true, materialChangedMeshes};
 }
 

--- a/src/web/js/mesh/visibility.js
+++ b/src/web/js/mesh/visibility.js
@@ -46,7 +46,7 @@ export function syncCheckboxes() {
   syncView('mesh-panel');
 }
 
-export function refreshAll({ force = {} } = {}) {
+export function refreshAll({ force = {}, additionalMeshes = [] } = {}) {
   replayControlStateRules();
   const next = getControlState();
   const initialApplication = lastAppliedControlState === null;
@@ -55,6 +55,7 @@ export function refreshAll({ force = {} } = {}) {
     : changedControlVariables(lastAppliedControlState, next);
   const result = refreshMeshes({
     changedVariables,
+    additionalMeshes,
     force: initialApplication
       ? { visibility: true, textures: true, shapes: true }
       : force,

--- a/src/web/js/mesh/weight-experiment.js
+++ b/src/web/js/mesh/weight-experiment.js
@@ -143,6 +143,31 @@ export function getSkinningState(mesh) {
   return states.get(mesh) || null;
 }
 
+/** Return the game material owned by a loaded skinning experiment. */
+export function getSkinningBaseMaterial(mesh) {
+  const state = states.get(mesh);
+  return state ? (state.originalMaterial || mesh.material)
+    : mesh?.material;
+}
+
+/** Run a material operation against the game material, not the heatmap. */
+export function withSkinningBaseMaterial(mesh, operation) {
+  const state = states.get(mesh);
+  if (!state) return operation();
+
+  const heatmapActive = state.heatmapMode === 'bone'
+    && state.debugMaterial && mesh.material === state.debugMaterial;
+  const displayedMaterial = mesh.material;
+  if (heatmapActive) mesh.material = state.originalMaterial || mesh.material;
+  try {
+    const result = operation();
+    state.originalMaterial = mesh.material;
+    return result;
+  } finally {
+    if (heatmapActive) mesh.material = displayedMaterial;
+  }
+}
+
 function clearMotionDiagnostics(state) {
   state.lastRootAngularDelta = 0;
   state.lastProjectedAngularDelta = 0;

--- a/src/web/js/panels/mesh-panel.js
+++ b/src/web/js/panels/mesh-panel.js
@@ -349,6 +349,7 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
       const canPersist = !readOnlySource && !!modPath;
       const setMaterialKind = async kind => {
         if (!canPersist || !componentIdentity || materialKindInFlight) return false;
+        const previousKind = materialKind;
         materialKindInFlight = true;
         try {
           const result = await saveComponentMaterialKind(
@@ -357,9 +358,14 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
             throw new Error(result?.error || 'material kind was not saved');
           }
           materialKind = kind === 'auto' ? null : kind;
-          await options.onMaterialKindChanged?.();
+          const refreshed = await options.onMaterialKindChanged?.();
+          if (refreshed === false) {
+            materialKind = previousKind;
+            return false;
+          }
           return true;
         } catch (error) {
+          materialKind = previousKind;
           console.error(`Could not save material kind for ${groupName}`, error);
           return false;
         } finally {

--- a/src/web/js/panels/mesh-panel.js
+++ b/src/web/js/panels/mesh-panel.js
@@ -394,7 +394,8 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
         saveTextureState(modPath);
       };
       Object.assign(componentDescriptor, {
-        getMaterialKind: () => materialKind,
+        getMaterialKind: () => itemObjs[0]?.userData.materialKindOverride
+          || materialKind,
         setMaterialKind: canPersist ? setMaterialKind : undefined,
         openTextureManager: () => openTextureModal(
           groupName, texturePool, modPath, onPoolChange, texturePicker),


### PR DESCRIPTION
## Summary
- Return material resolution metadata from geometry-free mesh semantic refreshes.
- Replace changed profile materials in place while preserving mesh, geometry, texture bindings, and viewer state.
- Route Material Kind changes through semantic refresh and cover the lifecycle with backend and browser tests.