### PR TITLE
Consolidate mesh identity and Asset resolution metadata

### DIFF
--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -90,7 +90,7 @@ class ModPreview:
 
             saved_metadata = context.metadata
             result.setdefault("metadata", {})["mesh_names"] = \
-                saved_metadata.get("mesh_names", {})
+                metadata.hydrate_mesh_names(result, saved_metadata)
             game_metadata = result.get("metadata", {}).get("game", {})
             publication.set_game_profile(game_metadata.get("id"))
             metadata.hydrate_textures(

--- a/src/app/mods/analysis.py
+++ b/src/app/mods/analysis.py
@@ -114,6 +114,11 @@ def analyze_mod_inis(ini_paths, folder_path, overrides=None, documents=None):
             secs, resources=resources, var_prefix=var_prefix, source=source,
             seen=seen_labels)
         ini_groups = analysis.draw_groups
+        identity_source = _ini_rel(ini_path, folder_path)
+        for group in ini_groups:
+            # ``source`` is intentionally a compact UI grouping label. Keep
+            # the complete relative INI path separately for mesh identity.
+            group["identity_source"] = identity_source
         shape_sliders = analysis.shapes
         state_rules.extend(analysis.state_rules)
         game_evidence.extend(analysis.game_evidence)

--- a/src/app/mods/metadata.py
+++ b/src/app/mods/metadata.py
@@ -14,13 +14,25 @@ PRESENT_NAMES_KEY = "__all__"
 _LOCK = threading.RLock()
 
 
-def _mesh_key(name, entry):
+def _legacy_mesh_key(name, entry):
     component = entry.get("component")
     if not component:
         component = name.rsplit("-", 1)[0] if name.rsplit("-", 1)[-1].isdigit() else name
     draw = entry.get("drawindexed")
     draw_key = ",".join(str(value) for value in draw) if draw else "whole"
     return f"{component}::{draw_key}"
+
+
+def _mesh_metadata_keys(name, entry):
+    """Return canonical then legacy keys for one displayed mesh."""
+    identity = entry.get("identity") if isinstance(entry, dict) else None
+    canonical = identity.get("key") if isinstance(identity, dict) else None
+    if not isinstance(canonical, str) or not canonical:
+        canonical = None
+    legacy = _legacy_mesh_key(name, entry)
+    if canonical and canonical != legacy:
+        return canonical, legacy
+    return (canonical or legacy,)
 
 
 def load(folder_path):
@@ -54,6 +66,26 @@ def save_textures(folder_path, textures):
         data = load(folder_path)
         data["textures"] = textures if isinstance(textures, dict) else {}
         return _save(folder_path, data)
+
+
+def hydrate_mesh_names(payload, data=None):
+    """Project saved mesh names onto current canonical metadata keys."""
+    data = data if isinstance(data, dict) else {}
+    saved = data.get("mesh_names")
+    if not isinstance(saved, dict):
+        return {}
+    meshes = payload.get("meshes", {}) if isinstance(payload, dict) else {}
+    hydrated = {}
+    for name, entry in meshes.items():
+        if not isinstance(entry, dict) or entry.get("error"):
+            continue
+        keys = _mesh_metadata_keys(name, entry)
+        value = next((saved[key] for key in keys
+                      if isinstance(saved.get(key), str)
+                      and saved[key].strip()), None)
+        if value is not None:
+            hydrated[keys[0]] = value
+    return hydrated
 
 
 def _source_key(value):
@@ -344,8 +376,10 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
     for name, entry in meshes.items():
         if not isinstance(entry, dict) or entry.get("error"):
             continue
-        mesh_key = _mesh_key(name, entry)
-        state = highlighted.get(mesh_key)
+        keys = _mesh_metadata_keys(name, entry)
+        mesh_key = keys[0]
+        state = next((highlighted[key] for key in keys
+                      if key in highlighted), None)
         if state:
             restored[mesh_key] = state
             if state["manual"]:
@@ -360,7 +394,7 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
         group = (entry.get("source"), entry.get("component"))
         pool = pools.setdefault(group, [])
         candidates = list(entry.get("texture_options") or [])
-        mesh_key = _mesh_key(name, entry)
+        mesh_key = _mesh_metadata_keys(name, entry)[0]
         if mesh_key in restored:
             state = restored[mesh_key]
             candidates.append({key: value for key, value in state.items()

--- a/src/app/mods/metadata.py
+++ b/src/app/mods/metadata.py
@@ -1,4 +1,5 @@
 """Viewer-only mesh labels and texture choices stored beside a mod."""
+from collections import Counter
 import json
 import os
 import threading
@@ -23,16 +24,43 @@ def _legacy_mesh_key(name, entry):
     return f"{component}::{draw_key}"
 
 
-def _mesh_metadata_keys(name, entry):
-    """Return canonical then legacy keys for one displayed mesh."""
+def _canonical_mesh_key(name, entry):
+    """Return the key used to expose state for one displayed mesh."""
     identity = entry.get("identity") if isinstance(entry, dict) else None
     canonical = identity.get("key") if isinstance(identity, dict) else None
     if not isinstance(canonical, str) or not canonical:
-        canonical = None
+        return _legacy_mesh_key(name, entry)
+    return canonical
+
+
+def _legacy_mesh_key_counts(meshes):
+    """Count legacy-key ownership among the current displayed meshes."""
+    counts = Counter()
+    for name, entry in meshes.items():
+        if not isinstance(entry, dict) or entry.get("error"):
+            continue
+        counts[_legacy_mesh_key(name, entry)] += 1
+    return counts
+
+
+def _mesh_metadata_keys(name, entry, legacy_key_counts=None):
+    """Return safe canonical and legacy read keys for one mesh."""
+    canonical = _canonical_mesh_key(name, entry)
+    identity = entry.get("identity") if isinstance(entry, dict) else None
+    has_canonical = isinstance(identity, dict) and isinstance(
+        identity.get("key"), str) and bool(identity.get("key"))
     legacy = _legacy_mesh_key(name, entry)
-    if canonical and canonical != legacy:
-        return canonical, legacy
-    return (canonical or legacy,)
+    if has_canonical:
+        if canonical == legacy:
+            return (canonical,)
+        if (legacy_key_counts is None
+                or legacy_key_counts.get(legacy, 0) == 1):
+            return canonical, legacy
+        return (canonical,)
+    if (legacy_key_counts is not None
+            and legacy_key_counts.get(legacy, 0) != 1):
+        return ()
+    return (legacy,)
 
 
 def load(folder_path):
@@ -75,11 +103,14 @@ def hydrate_mesh_names(payload, data=None):
     if not isinstance(saved, dict):
         return {}
     meshes = payload.get("meshes", {}) if isinstance(payload, dict) else {}
+    legacy_key_counts = _legacy_mesh_key_counts(meshes)
     hydrated = {}
     for name, entry in meshes.items():
         if not isinstance(entry, dict) or entry.get("error"):
             continue
-        keys = _mesh_metadata_keys(name, entry)
+        keys = _mesh_metadata_keys(name, entry, legacy_key_counts)
+        if not keys:
+            continue
         value = next((saved[key] for key in keys
                       if isinstance(saved.get(key), str)
                       and saved[key].strip()), None)
@@ -373,11 +404,12 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
         highlighted[name] = item
 
     restored = {}
+    legacy_key_counts = _legacy_mesh_key_counts(meshes)
     for name, entry in meshes.items():
         if not isinstance(entry, dict) or entry.get("error"):
             continue
-        keys = _mesh_metadata_keys(name, entry)
-        mesh_key = keys[0]
+        keys = _mesh_metadata_keys(name, entry, legacy_key_counts)
+        mesh_key = _canonical_mesh_key(name, entry)
         state = next((highlighted[key] for key in keys
                       if key in highlighted), None)
         if state:
@@ -394,7 +426,7 @@ def hydrate_textures(folder_path, payload, data=None, texture_source=None,
         group = (entry.get("source"), entry.get("component"))
         pool = pools.setdefault(group, [])
         candidates = list(entry.get("texture_options") or [])
-        mesh_key = _mesh_metadata_keys(name, entry)[0]
+        mesh_key = _canonical_mesh_key(name, entry)
         if mesh_key in restored:
             state = restored[mesh_key]
             candidates.append({key: value for key, value in state.items()

--- a/src/core/geometry/draw_call.py
+++ b/src/core/geometry/draw_call.py
@@ -12,7 +12,7 @@ from collections.abc import Iterator, Mapping, MutableMapping
 from dataclasses import dataclass, field, fields
 from typing import ClassVar
 
-from .identity import GeometryMatch
+from .identity import DrawOccurrence, GeometryMatch
 from .vertex_attributes import VertexAttributeSource
 from .skinning import SkinningSource
 
@@ -36,6 +36,7 @@ class AuthoredDrawCall:
     base: int
     conditions: list = field(default_factory=list)
     source: dict | None = None
+    occurrence: DrawOccurrence | tuple | None = None
     index_resource: str | None = None
     diffuse_variants: list = field(default_factory=list)
     diffuse_history: list = field(default_factory=list)
@@ -88,6 +89,9 @@ class DrawCall(MutableMapping):
     base: int = 0
     conditions: list = field(default_factory=list)
     sources: list = field(default_factory=list)
+    # Authored provenance used to distinguish separate displayed rows, not
+    # rendered output and therefore not part of render_identity().
+    occurrence: DrawOccurrence | tuple | None = None
 
     ib_file: str | None = None
     index_size: int | None = None
@@ -132,7 +136,7 @@ class DrawCall(MutableMapping):
         "emission_map": "emission_map",
     }
     _NON_RENDER_FIELDS: ClassVar[frozenset[str]] = frozenset({
-        "label", "conditions", "sources", "geometry_match",
+        "label", "conditions", "sources", "occurrence", "geometry_match",
         "slot_textures", "asset_binding", "texture_provenance",
         "asset_slot_evidence", "texture_hashes",
         "skinning_source", "skinning_error",

--- a/src/core/geometry/identity.py
+++ b/src/core/geometry/identity.py
@@ -19,6 +19,20 @@ class GeometryMatch:
     index_count: int | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class DrawOccurrence:
+    """Stable ordinal for one authored draw command in a section."""
+
+    section: str | None
+    ordinal: int | None
+
+    def key_value(self):
+        return [self.section or "", self.ordinal]
+
+    def to_dict(self):
+        return {"section": self.section, "ordinal": self.ordinal}
+
+
 def normalize_identity_source(value):
     """Normalize an authored source label without changing its spelling."""
     if value is None:
@@ -27,6 +41,25 @@ def normalize_identity_source(value):
     while source.startswith("./"):
         source = source[2:]
     return source or None
+
+
+def _draw_occurrence_value(value):
+    if isinstance(value, DrawOccurrence):
+        return value.key_value()
+    if isinstance(value, (tuple, list)) and len(value) == 2:
+        return [str(value[0]) if value[0] is not None else "", value[1]]
+    return None
+
+
+def _draw_occurrence_dict(value):
+    if isinstance(value, DrawOccurrence):
+        return value.to_dict()
+    if isinstance(value, (tuple, list)) and len(value) == 2:
+        return {
+            "section": value[0],
+            "ordinal": value[1],
+        }
+    return None
 
 
 @dataclass(frozen=True, slots=True)
@@ -104,11 +137,12 @@ class MeshIdentity:
     count: int | None
     start: int
     base: int
+    occurrence: DrawOccurrence | tuple | None = None
     geometry_state: MeshGeometryIdentity | None = None
 
     @property
     def version(self):
-        return 3
+        return 4
 
     @property
     def key(self):
@@ -123,6 +157,7 @@ class MeshIdentity:
             self.version,
             self.source or "",
             self.component or "",
+            _draw_occurrence_value(self.occurrence),
             geometry,
             [self.count, self.start, self.base],
             (self.geometry_state.key_value()
@@ -145,6 +180,7 @@ class MeshIdentity:
             "key": self.key,
             "source": self.source,
             "component": self.component,
+            "occurrence": _draw_occurrence_dict(self.occurrence),
             "geometry": geometry,
             "draw": {
                 "count": self.count,
@@ -165,6 +201,7 @@ def make_mesh_identity(draw, source=None, component=None):
         count=draw.count,
         start=draw.start,
         base=draw.base,
+        occurrence=getattr(draw, "occurrence", None),
         geometry_state=make_mesh_geometry_identity(draw),
     )
 

--- a/src/core/geometry/identity.py
+++ b/src/core/geometry/identity.py
@@ -1,6 +1,7 @@
-"""Shared, conservative geometry identity values."""
+"""Shared, conservative geometry and displayed-mesh identity values."""
 
 from dataclasses import dataclass
+import json
 import re
 
 
@@ -14,6 +15,85 @@ class GeometryMatch:
     hash: str
     first_index: int | None = None
     index_count: int | None = None
+
+
+def normalize_identity_source(value):
+    """Normalize an authored source label without changing its spelling."""
+    if value is None:
+        return None
+    source = str(value).replace("\\", "/")
+    while source.startswith("./"):
+        source = source[2:]
+    return source or None
+
+
+@dataclass(frozen=True, slots=True)
+class MeshIdentity:
+    """Stable identity for one displayed, authored mod draw."""
+
+    source: str | None
+    component: str | None
+    geometry: GeometryMatch | None
+    count: int | None
+    start: int
+    base: int
+
+    @property
+    def version(self):
+        return 2
+
+    @property
+    def key(self):
+        geometry = None
+        if self.geometry is not None:
+            geometry = [
+                self.geometry.hash,
+                self.geometry.first_index,
+                self.geometry.index_count,
+            ]
+        value = [
+            self.version,
+            self.source or "",
+            self.component or "",
+            geometry,
+            [self.count, self.start, self.base],
+        ]
+        return "mesh:" + json.dumps(
+            value, ensure_ascii=False, separators=(",", ":"))
+
+    def to_dict(self):
+        """Return the stable frontend/persistence projection."""
+        geometry = None
+        if self.geometry is not None:
+            geometry = {
+                "hash": self.geometry.hash,
+                "first_index": self.geometry.first_index,
+                "index_count": self.geometry.index_count,
+            }
+        return {
+            "version": self.version,
+            "key": self.key,
+            "source": self.source,
+            "component": self.component,
+            "geometry": geometry,
+            "draw": {
+                "count": self.count,
+                "start": self.start,
+                "base": self.base,
+            },
+        }
+
+
+def make_mesh_identity(draw, source=None, component=None):
+    """Build the canonical identity from an already-resolved draw record."""
+    return MeshIdentity(
+        source=normalize_identity_source(source),
+        component=component or None,
+        geometry=getattr(draw, "geometry_match", None),
+        count=draw.count,
+        start=draw.start,
+        base=draw.base,
+    )
 
 
 def normalize_geometry_hash(value):

--- a/src/core/geometry/identity.py
+++ b/src/core/geometry/identity.py
@@ -1,8 +1,10 @@
 """Shared, conservative geometry and displayed-mesh identity values."""
 
-from dataclasses import dataclass
 import json
 import re
+from dataclasses import dataclass
+
+from .vertex_attributes import VertexAttributeSource
 
 
 _GEOMETRY_HASH = re.compile(r"^[0-9a-fA-F]{8}$")
@@ -28,6 +30,71 @@ def normalize_identity_source(value):
 
 
 @dataclass(frozen=True, slots=True)
+class MeshGeometryIdentity:
+    """Effective geometry resources that distinguish rendered draws."""
+
+    ib_file: str | None
+    index_size: int | None
+    position_file: str | None
+    position_stride: int | None
+    texcoord_file: str | None
+    texcoord_stride: int | None
+    normal_source: VertexAttributeSource | None = None
+
+    def key_value(self):
+        normal = None
+        if self.normal_source is not None:
+            normal = [
+                normalize_identity_source(self.normal_source.file),
+                self.normal_source.stride,
+                self.normal_source.offset,
+                self.normal_source.encoding,
+            ]
+        return [
+            normalize_identity_source(self.ib_file),
+            self.index_size,
+            normalize_identity_source(self.position_file),
+            self.position_stride,
+            normalize_identity_source(self.texcoord_file),
+            self.texcoord_stride,
+            normal,
+        ]
+
+    def to_dict(self):
+        """Return the diagnostic projection of the effective resources."""
+        normal = None
+        if self.normal_source is not None:
+            normal = {
+                "file": normalize_identity_source(self.normal_source.file),
+                "stride": self.normal_source.stride,
+                "offset": self.normal_source.offset,
+                "encoding": self.normal_source.encoding,
+            }
+        return {
+            "ib_file": normalize_identity_source(self.ib_file),
+            "index_size": self.index_size,
+            "position_file": normalize_identity_source(self.position_file),
+            "position_stride": self.position_stride,
+            "texcoord_file": normalize_identity_source(self.texcoord_file),
+            "texcoord_stride": self.texcoord_stride,
+            "normal_source": normal,
+        }
+
+
+def make_mesh_geometry_identity(draw):
+    """Project only effective geometry state from a resolved draw."""
+    return MeshGeometryIdentity(
+        ib_file=draw.ib_file,
+        index_size=draw.index_size,
+        position_file=draw.position_file,
+        position_stride=draw.position_stride,
+        texcoord_file=draw.texcoord_file,
+        texcoord_stride=draw.texcoord_stride,
+        normal_source=draw.normal_source,
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class MeshIdentity:
     """Stable identity for one displayed, authored mod draw."""
 
@@ -37,10 +104,11 @@ class MeshIdentity:
     count: int | None
     start: int
     base: int
+    geometry_state: MeshGeometryIdentity | None = None
 
     @property
     def version(self):
-        return 2
+        return 3
 
     @property
     def key(self):
@@ -57,6 +125,8 @@ class MeshIdentity:
             self.component or "",
             geometry,
             [self.count, self.start, self.base],
+            (self.geometry_state.key_value()
+             if self.geometry_state is not None else None),
         ]
         return "mesh:" + json.dumps(
             value, ensure_ascii=False, separators=(",", ":"))
@@ -81,6 +151,8 @@ class MeshIdentity:
                 "start": self.start,
                 "base": self.base,
             },
+            "geometry_state": (self.geometry_state.to_dict()
+                                if self.geometry_state is not None else None),
         }
 
 
@@ -93,6 +165,7 @@ def make_mesh_identity(draw, source=None, component=None):
         count=draw.count,
         start=draw.start,
         base=draw.base,
+        geometry_state=make_mesh_geometry_identity(draw),
     )
 
 

--- a/src/core/geometry/identity.py
+++ b/src/core/geometry/identity.py
@@ -25,12 +25,21 @@ class DrawOccurrence:
 
     section: str | None
     ordinal: int | None
+    path: tuple = ()
 
     def key_value(self):
-        return [self.section or "", self.ordinal]
+        value = [self.section or "", self.ordinal]
+        path = _occurrence_path_value(self.path)
+        if path:
+            value.append(path)
+        return value
 
     def to_dict(self):
-        return {"section": self.section, "ordinal": self.ordinal}
+        return {
+            "section": self.section,
+            "ordinal": self.ordinal,
+            "path": _occurrence_path_value(self.path),
+        }
 
 
 def normalize_identity_source(value):
@@ -43,11 +52,25 @@ def normalize_identity_source(value):
     return source or None
 
 
+def _occurrence_path_value(path):
+    return [
+        [str(item[0]) if item[0] is not None else "", item[1]]
+        for item in (path or ())
+        if isinstance(item, (tuple, list)) and len(item) == 2
+    ]
+
+
 def _draw_occurrence_value(value):
     if isinstance(value, DrawOccurrence):
         return value.key_value()
     if isinstance(value, (tuple, list)) and len(value) == 2:
         return [str(value[0]) if value[0] is not None else "", value[1]]
+    if isinstance(value, (tuple, list)) and len(value) == 3:
+        return [
+            str(value[0]) if value[0] is not None else "",
+            value[1],
+            _occurrence_path_value(value[2]),
+        ]
     return None
 
 
@@ -58,6 +81,12 @@ def _draw_occurrence_dict(value):
         return {
             "section": value[0],
             "ordinal": value[1],
+        }
+    if isinstance(value, (tuple, list)) and len(value) == 3:
+        return {
+            "section": value[0],
+            "ordinal": value[1],
+            "path": _occurrence_path_value(value[2]),
         }
     return None
 
@@ -142,7 +171,7 @@ class MeshIdentity:
 
     @property
     def version(self):
-        return 4
+        return 5
 
     @property
     def key(self):

--- a/src/core/geometry/mesh_builder.py
+++ b/src/core/geometry/mesh_builder.py
@@ -69,6 +69,7 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
         index_size = group.get("index_size", INDEX_SIZE)
         component = group.get("display_name") or group.get("name")
         source = group.get("source")
+        identity_source = group.get("identity_source") or source
 
         if not all(path and os.path.exists(path)
                    for path in (pos_path, tc_path, ib_path)):
@@ -136,7 +137,7 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
             if component:
                 entry["component"] = component
             entry["identity"] = make_mesh_identity(
-                draw, source=source, component=component).to_dict()
+                draw, source=identity_source, component=component).to_dict()
             binding = draw.asset_binding
             if binding is not None and hasattr(binding, "to_dict"):
                 entry["asset_binding"] = binding.to_dict()

--- a/src/core/geometry/mesh_builder.py
+++ b/src/core/geometry/mesh_builder.py
@@ -18,6 +18,7 @@ from .texture_bindings import (
     TextureRegistry, apply_draw_texture_bindings, build_texture_options,
 )
 from .transport import GeometryBlob
+from .identity import make_mesh_identity
 from ..resource_paths import safe_resource_path
 
 
@@ -134,6 +135,8 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 entry["source"] = source
             if component:
                 entry["component"] = component
+            entry["identity"] = make_mesh_identity(
+                draw, source=source, component=component).to_dict()
             binding = draw.asset_binding
             if binding is not None and hasattr(binding, "to_dict"):
                 entry["asset_binding"] = binding.to_dict()

--- a/src/core/geometry/semantics.py
+++ b/src/core/geometry/semantics.py
@@ -131,13 +131,14 @@ def build_mesh_semantics(groups, mod_dir, max_draws=0, game_profile=None,
                         "emission_map")),
             }
             source = group.get("source")
+            identity_source = group.get("identity_source") or source
             component = group.get("display_name") or group.get("name")
             if source:
                 entry["source"] = source
             if component:
                 entry["component"] = component
             entry["identity"] = make_mesh_identity(
-                draw, source=source, component=component).to_dict()
+                draw, source=identity_source, component=component).to_dict()
             normal_key = _semantic_texture_key(
                 mod_dir, draw.texture_default("normal_map"), normal_role)
             normal_key = (_semantic_asset_key(

--- a/src/core/geometry/semantics.py
+++ b/src/core/geometry/semantics.py
@@ -3,6 +3,7 @@
 import os
 
 from .draw_call import DrawCall
+from .identity import make_mesh_identity
 from ..resource_paths import safe_resource_path
 from ..textures.pipeline import normalize_texture_role, texture_key
 
@@ -135,6 +136,8 @@ def build_mesh_semantics(groups, mod_dir, max_draws=0, game_profile=None,
                 entry["source"] = source
             if component:
                 entry["component"] = component
+            entry["identity"] = make_mesh_identity(
+                draw, source=source, component=component).to_dict()
             normal_key = _semantic_texture_key(
                 mod_dir, draw.texture_default("normal_map"), normal_role)
             normal_key = (_semantic_asset_key(

--- a/src/core/ini/draw_groups.py
+++ b/src/core/ini/draw_groups.py
@@ -4,6 +4,7 @@ import re
 
 from ..geometry.buffers import DEFAULT_UV_OFFSET, POSITION_STRIDE, _res_get
 from ..geometry.draw_call import AuthoredDrawCall, DrawCall, SlotTextureBinding
+from ..geometry.identity import DrawOccurrence
 from ..geometry.skinning import resolve_skinning_source
 from .draw_resources import (
     _collect_resource_copy_sources, _extract_hash, _ib_index_size,
@@ -218,6 +219,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             resolve_vertex_info)
         authored_draws = list(info["draws"]) or [AuthoredDrawCall(
             count=None, start=0, base=0, source=info["src"],
+            occurrence=DrawOccurrence(section_name, None),
             diffuse_variants=info.get("diffuse_variants_at_end") or [],
             diffuse_history=info.get("diffuse_history_at_end") or [],
             auxiliary_maps=info.get("aux_maps_at_end") or {},
@@ -234,6 +236,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                 start=authored.start, base=authored.base,
                 conditions=authored.conditions,
                 sources=[authored.source] if authored.source else [],
+                occurrence=authored.occurrence,
                 ib_file=ib_file, index_size=index_size,
                 position_file=position_file, position_stride=position_stride,
                 texcoord_file=texcoord_file, texcoord_stride=texcoord_stride,

--- a/src/core/ini/draw_scan.py
+++ b/src/core/ini/draw_scan.py
@@ -265,8 +265,10 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 result.pop(role, None)
         return result
 
-    def scan(lines, info, cond_stack, visiting, section_name):
+    def scan(lines, info, cond_stack, visiting, section_name,
+             execution_path=()):
         draw_ordinal = 0
+        run_ordinal = 0
         for raw in lines:
             line = raw.split(";")[0].strip()
             if not line:
@@ -345,7 +347,8 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 r"drawindexed\s*=\s*(\d+)\s*,\s*(\d+)\s*,\s*(-?\d+)\s*",
                 line, re.I)
             if match:
-                occurrence = DrawOccurrence(section_name, draw_ordinal)
+                occurrence = DrawOccurrence(
+                    section_name, draw_ordinal, execution_path)
                 draw_ordinal += 1
                 combined = DNF_TRUE
                 for frame in cond_stack:
@@ -378,12 +381,16 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                     record_texture_assignment(
                         info, role, semantic.group(2), cond_stack,
                         source="semantic")
-            if re.match(r"run\s*=\s*(\S+)", line, re.I):
+            run_match = re.match(r"run\s*=\s*(\S+)", line, re.I)
+            if run_match:
+                current_run = run_ordinal
+                run_ordinal += 1
                 target_name = _run_target_name(line, section_lookup)
                 if target_name and target_name not in visiting:
                     visiting.add(target_name)
                     scan(sections[target_name], info, cond_stack, visiting,
-                         target_name)
+                         target_name,
+                         execution_path + ((section_name, current_run),))
                     visiting.discard(target_name)
 
     scanned = _ScannedSections(texture_override_index=texture_override_index)

--- a/src/core/ini/draw_scan.py
+++ b/src/core/ini/draw_scan.py
@@ -3,7 +3,8 @@
 import re
 
 from ..geometry.draw_call import AuthoredDrawCall, SlotTextureBinding
-from ..geometry.identity import GeometryMatch, normalize_geometry_hash
+from ..geometry.identity import (DrawOccurrence, GeometryMatch,
+                                  normalize_geometry_hash)
 from .dnf import (DNF_TRUE, build_bool_alias_map, dnf_and, dnf_not, dnf_or,
                   normalize_dnf, parse_condition_dnf)
 from .menu import extract_menu_var_names
@@ -264,7 +265,8 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 result.pop(role, None)
         return result
 
-    def scan(lines, info, cond_stack, visiting):
+    def scan(lines, info, cond_stack, visiting, section_name):
+        draw_ordinal = 0
         for raw in lines:
             line = raw.split(";")[0].strip()
             if not line:
@@ -343,6 +345,8 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 r"drawindexed\s*=\s*(\d+)\s*,\s*(\d+)\s*,\s*(-?\d+)\s*",
                 line, re.I)
             if match:
+                occurrence = DrawOccurrence(section_name, draw_ordinal)
+                draw_ordinal += 1
                 combined = DNF_TRUE
                 for frame in cond_stack:
                     combined = dnf_and(combined, frame["cur"])
@@ -351,6 +355,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                     count=int(match.group(1)), start=int(match.group(2)),
                     base=int(match.group(3)), conditions=conditions,
                     source=line_source(raw),
+                    occurrence=occurrence,
                     index_resource=info.get("_cur_ib"),
                     diffuse_variants=_effective_role_assignments(
                         info.get("_cur_diffuse_variants") or []),
@@ -377,7 +382,8 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 target_name = _run_target_name(line, section_lookup)
                 if target_name and target_name not in visiting:
                     visiting.add(target_name)
-                    scan(sections[target_name], info, cond_stack, visiting)
+                    scan(sections[target_name], info, cond_stack, visiting,
+                         target_name)
                     visiting.discard(target_name)
 
     scanned = _ScannedSections(texture_override_index=texture_override_index)
@@ -398,7 +404,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             "_geometry_hash": None, "_match_first_index": None,
             "_match_index_count": None,
         }
-        scan(lines, info, [], {name})
+        scan(lines, info, [], {name}, name)
         info.pop("_cur_ib", None)
         info["diffuse_variants_at_end"] = _effective_role_assignments(
             info.get("_cur_diffuse_variants") or [])

--- a/src/tests/core/geometry/test_identity.py
+++ b/src/tests/core/geometry/test_identity.py
@@ -9,6 +9,7 @@ from core.geometry.draw_call import DrawCall
 from core.geometry.identity import (
     GeometryMatch, make_mesh_identity, normalize_identity_source,
 )
+from core.geometry.vertex_attributes import VertexAttributeSource
 
 
 @pytest.mark.parametrize("value, expected", [
@@ -39,10 +40,10 @@ def test_mesh_identity_is_deterministic_and_projects_all_authored_fields():
         _draw(), source=".\\Root.ini", component="Body:Main")
 
     assert identity.key == (
-        'mesh:[2,"Root.ini","Body:Main",["1234ABCD",8,120],'
-        '[120,4,-2]]')
+        'mesh:[3,"Root.ini","Body:Main",["1234ABCD",8,120],'
+        '[120,4,-2],[null,null,null,null,null,null,null]]')
     assert identity.to_dict() == {
-        "version": 2,
+        "version": 3,
         "key": identity.key,
         "source": "Root.ini",
         "component": "Body:Main",
@@ -52,6 +53,12 @@ def test_mesh_identity_is_deterministic_and_projects_all_authored_fields():
             "index_count": 120,
         },
         "draw": {"count": 120, "start": 4, "base": -2},
+        "geometry_state": {
+            "ib_file": None, "index_size": None,
+            "position_file": None, "position_stride": None,
+            "texcoord_file": None, "texcoord_stride": None,
+            "normal_source": None,
+        },
     }
     assert make_mesh_identity(
         _draw(), source=".\\Root.ini", component="Body:Main").key == identity.key
@@ -73,6 +80,36 @@ def test_mesh_identity_key_changes_for_structural_fields(field, value):
     assert replace(identity, **{field: value}).key != identity.key
 
 
+@pytest.mark.parametrize("field, value", [
+    ("ib_file", "other.ib"),
+    ("index_size", 2),
+    ("position_file", "other-position.buf"),
+    ("position_stride", 40),
+    ("texcoord_file", "other-texcoord.buf"),
+    ("texcoord_stride", 16),
+    ("normal_source", VertexAttributeSource(
+        "other-normals.buf", 8, 4, "snorm8x3")),
+])
+def test_mesh_identity_key_changes_for_geometry_resources(field, value):
+    first = make_mesh_identity(
+        _draw(), source="Root.ini", component="Body")
+    changed_draw = _draw(**{field: value})
+
+    assert make_mesh_identity(
+        changed_draw, source="Root.ini", component="Body").key != first.key
+
+
+def test_mesh_identity_normalizes_geometry_resource_paths():
+    first = make_mesh_identity(
+        _draw(position_file="variants\\Body.buf"),
+        source="Root.ini", component="Body")
+    second = make_mesh_identity(
+        _draw(position_file="variants/Body.buf"),
+        source="Root.ini", component="Body")
+
+    assert first.key == second.key
+
+
 def test_mesh_identity_keeps_asset_binding_and_render_state_out_of_key():
     draw = _draw()
     first = make_mesh_identity(draw, source="Root.ini", component="Body")
@@ -89,10 +126,17 @@ def test_mesh_identity_without_geometry_evidence_is_still_present():
         _draw(geometry_match=None), source=None, component=None)
 
     assert identity.to_dict() == {
-        "version": 2,
-        "key": 'mesh:[2,"","",null,[120,4,-2]]',
+        "version": 3,
+        "key": 'mesh:[3,"","",null,[120,4,-2],'
+                '[null,null,null,null,null,null,null]]',
         "source": None,
         "component": None,
         "geometry": None,
         "draw": {"count": 120, "start": 4, "base": -2},
+        "geometry_state": {
+            "ib_file": None, "index_size": None,
+            "position_file": None, "position_stride": None,
+            "texcoord_file": None, "texcoord_stride": None,
+            "normal_source": None,
+        },
     }

--- a/src/tests/core/geometry/test_identity.py
+++ b/src/tests/core/geometry/test_identity.py
@@ -1,0 +1,98 @@
+"""Canonical displayed-mesh identity regressions."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from core.geometry.draw_call import DrawCall
+from core.geometry.identity import (
+    GeometryMatch, make_mesh_identity, normalize_identity_source,
+)
+
+
+@pytest.mark.parametrize("value, expected", [
+    (None, None),
+    ("", None),
+    ("./Root.ini", "Root.ini"),
+    (".\\variants\\sub", "variants/sub"),
+    ("Variants/Body", "Variants/Body"),
+])
+def test_identity_source_normalization_preserves_authored_spelling(value,
+                                                                    expected):
+    assert normalize_identity_source(value) == expected
+
+
+def _draw(**changes):
+    values = {
+        "count": 120,
+        "start": 4,
+        "base": -2,
+        "geometry_match": GeometryMatch("1234ABCD", 8, 120),
+    }
+    values.update(changes)
+    return DrawCall(**values)
+
+
+def test_mesh_identity_is_deterministic_and_projects_all_authored_fields():
+    identity = make_mesh_identity(
+        _draw(), source=".\\Root.ini", component="Body:Main")
+
+    assert identity.key == (
+        'mesh:[2,"Root.ini","Body:Main",["1234ABCD",8,120],'
+        '[120,4,-2]]')
+    assert identity.to_dict() == {
+        "version": 2,
+        "key": identity.key,
+        "source": "Root.ini",
+        "component": "Body:Main",
+        "geometry": {
+            "hash": "1234ABCD",
+            "first_index": 8,
+            "index_count": 120,
+        },
+        "draw": {"count": 120, "start": 4, "base": -2},
+    }
+    assert make_mesh_identity(
+        _draw(), source=".\\Root.ini", component="Body:Main").key == identity.key
+
+
+@pytest.mark.parametrize("field, value", [
+    ("source", "Other.ini"),
+    ("component", "Other"),
+    ("geometry", GeometryMatch("abcdef12", 8, 120)),
+    ("geometry", GeometryMatch("1234abcd", 9, 120)),
+    ("geometry", GeometryMatch("1234abcd", 8, 121)),
+    ("count", 121),
+    ("start", 5),
+    ("base", -1),
+])
+def test_mesh_identity_key_changes_for_structural_fields(field, value):
+    identity = make_mesh_identity(
+        _draw(), source="Root.ini", component="Body")
+    assert replace(identity, **{field: value}).key != identity.key
+
+
+def test_mesh_identity_keeps_asset_binding_and_render_state_out_of_key():
+    draw = _draw()
+    first = make_mesh_identity(draw, source="Root.ini", component="Body")
+    draw.conditions = [[{"var": "toggle", "value": "1"}]]
+    draw.asset_binding = SimpleNamespace(status="exact")
+    draw.texture_default_file = "different.dds"
+    second = make_mesh_identity(draw, source="Root.ini", component="Body")
+
+    assert second.key == first.key
+
+
+def test_mesh_identity_without_geometry_evidence_is_still_present():
+    identity = make_mesh_identity(
+        _draw(geometry_match=None), source=None, component=None)
+
+    assert identity.to_dict() == {
+        "version": 2,
+        "key": 'mesh:[2,"","",null,[120,4,-2]]',
+        "source": None,
+        "component": None,
+        "geometry": None,
+        "draw": {"count": 120, "start": 4, "base": -2},
+    }

--- a/src/tests/core/geometry/test_identity.py
+++ b/src/tests/core/geometry/test_identity.py
@@ -7,7 +7,8 @@ import pytest
 
 from core.geometry.draw_call import DrawCall
 from core.geometry.identity import (
-    GeometryMatch, make_mesh_identity, normalize_identity_source,
+    DrawOccurrence, GeometryMatch, make_mesh_identity,
+    normalize_identity_source,
 )
 from core.geometry.vertex_attributes import VertexAttributeSource
 
@@ -40,13 +41,14 @@ def test_mesh_identity_is_deterministic_and_projects_all_authored_fields():
         _draw(), source=".\\Root.ini", component="Body:Main")
 
     assert identity.key == (
-        'mesh:[3,"Root.ini","Body:Main",["1234ABCD",8,120],'
-        '[120,4,-2],[null,null,null,null,null,null,null]]')
+        'mesh:[4,"Root.ini","Body:Main",null,["1234ABCD",8,120],'
+                '[120,4,-2],[null,null,null,null,null,null,null]]')
     assert identity.to_dict() == {
-        "version": 3,
+        "version": 4,
         "key": identity.key,
         "source": "Root.ini",
         "component": "Body:Main",
+        "occurrence": None,
         "geometry": {
             "hash": "1234ABCD",
             "first_index": 8,
@@ -67,6 +69,7 @@ def test_mesh_identity_is_deterministic_and_projects_all_authored_fields():
 @pytest.mark.parametrize("field, value", [
     ("source", "Other.ini"),
     ("component", "Other"),
+    ("occurrence", DrawOccurrence("TextureOverrideBody", 1)),
     ("geometry", GeometryMatch("abcdef12", 8, 120)),
     ("geometry", GeometryMatch("1234abcd", 9, 120)),
     ("geometry", GeometryMatch("1234abcd", 8, 121)),
@@ -121,16 +124,41 @@ def test_mesh_identity_keeps_asset_binding_and_render_state_out_of_key():
     assert second.key == first.key
 
 
+def test_mesh_identity_occurrence_distinguishes_texture_only_draws():
+    first = make_mesh_identity(
+        _draw(texture_default_file="red.dds",
+              occurrence=("TextureOverrideBody", 0)),
+        source="Root.ini", component="Body")
+    second = make_mesh_identity(
+        _draw(texture_default_file="blue.dds",
+              occurrence=("TextureOverrideBody", 1)),
+        source="Root.ini", component="Body")
+
+    assert first.key != second.key
+    assert first.to_dict()["occurrence"] == {
+        "section": "TextureOverrideBody", "ordinal": 0}
+    assert second.to_dict()["occurrence"] == {
+        "section": "TextureOverrideBody", "ordinal": 1}
+
+
+def test_draw_occurrence_is_not_render_identity():
+    first = _draw(occurrence=("TextureOverrideBody", 0))
+    second = _draw(occurrence=("TextureOverrideBody", 1))
+
+    assert first.render_identity() == second.render_identity()
+
+
 def test_mesh_identity_without_geometry_evidence_is_still_present():
     identity = make_mesh_identity(
         _draw(geometry_match=None), source=None, component=None)
 
     assert identity.to_dict() == {
-        "version": 3,
-        "key": 'mesh:[3,"","",null,[120,4,-2],'
+        "version": 4,
+        "key": 'mesh:[4,"","",null,null,[120,4,-2],'
                 '[null,null,null,null,null,null,null]]',
         "source": None,
         "component": None,
+        "occurrence": None,
         "geometry": None,
         "draw": {"count": 120, "start": 4, "base": -2},
         "geometry_state": {

--- a/src/tests/core/geometry/test_identity.py
+++ b/src/tests/core/geometry/test_identity.py
@@ -41,10 +41,10 @@ def test_mesh_identity_is_deterministic_and_projects_all_authored_fields():
         _draw(), source=".\\Root.ini", component="Body:Main")
 
     assert identity.key == (
-        'mesh:[4,"Root.ini","Body:Main",null,["1234ABCD",8,120],'
+        'mesh:[5,"Root.ini","Body:Main",null,["1234ABCD",8,120],'
                 '[120,4,-2],[null,null,null,null,null,null,null]]')
     assert identity.to_dict() == {
-        "version": 4,
+        "version": 5,
         "key": identity.key,
         "source": "Root.ini",
         "component": "Body:Main",
@@ -129,11 +129,16 @@ def test_mesh_identity_occurrence_distinguishes_texture_only_draws():
         _draw(texture_default_file="red.dds",
               occurrence=("TextureOverrideBody", 0)),
         source="Root.ini", component="Body")
+    same_occurrence = make_mesh_identity(
+        _draw(texture_default_file="red-v2.dds",
+              occurrence=("TextureOverrideBody", 0)),
+        source="Root.ini", component="Body")
     second = make_mesh_identity(
         _draw(texture_default_file="blue.dds",
               occurrence=("TextureOverrideBody", 1)),
         source="Root.ini", component="Body")
 
+    assert same_occurrence.key == first.key
     assert first.key != second.key
     assert first.to_dict()["occurrence"] == {
         "section": "TextureOverrideBody", "ordinal": 0}
@@ -153,8 +158,8 @@ def test_mesh_identity_without_geometry_evidence_is_still_present():
         _draw(geometry_match=None), source=None, component=None)
 
     assert identity.to_dict() == {
-        "version": 4,
-        "key": 'mesh:[4,"","",null,null,[120,4,-2],'
+        "version": 5,
+        "key": 'mesh:[5,"","",null,null,[120,4,-2],'
                 '[null,null,null,null,null,null,null]]',
         "source": None,
         "component": None,

--- a/src/tests/core/geometry/test_semantics.py
+++ b/src/tests/core/geometry/test_semantics.py
@@ -8,6 +8,7 @@ from app.assets.resolver import AssetComponentBinding
 from core.geometry.draw_call import DrawCall
 from core.geometry.identity import GeometryMatch
 from core.geometry.mesh_builder import build_mesh_semantics
+from core.geometry.semantics import deduplicate_draws
 
 
 def test_mesh_semantics_does_not_read_buffers_or_publish_textures(tmp_path):
@@ -36,14 +37,21 @@ def test_mesh_semantics_preserves_group_source_and_component_identity(tmp_path):
     assert result["Body-1"]["source"] == "Root.ini"
     assert result["Body-1"]["component"] == "Body Display"
     assert result["Body-1"]["identity"] == {
-        "version": 2,
-        "key": 'mesh:[2,"Root.ini","Body Display",'
-                '["1234abcd",0,3],[3,0,0]]',
+        "version": 3,
+        "key": 'mesh:[3,"Root.ini","Body Display",'
+                '["1234abcd",0,3],[3,0,0],'
+                '[null,null,null,null,null,null,null]]',
         "source": "Root.ini",
         "component": "Body Display",
         "geometry": {"hash": "1234abcd", "first_index": 0,
                      "index_count": 3},
         "draw": {"count": 3, "start": 0, "base": 0},
+        "geometry_state": {
+            "ib_file": None, "index_size": None,
+            "position_file": None, "position_stride": None,
+            "texcoord_file": None, "texcoord_stride": None,
+            "normal_source": None,
+        },
     }
 
 
@@ -84,5 +92,34 @@ def test_mesh_identity_survives_uncertain_asset_resolution(tmp_path, status):
     }], str(tmp_path))["Body-1"]
 
     assert result["identity"]["key"] == (
-        'mesh:[2,"Root.ini","Body",["1234abcd",0,3],[3,0,0]]')
+        'mesh:[3,"Root.ini","Body",["1234abcd",0,3],[3,0,0],'
+        '[null,null,null,null,null,null,null]]')
     assert result["asset_binding"]["status"] == status
+
+
+def test_distinct_geometry_resources_keep_distinct_mesh_identities(tmp_path):
+    geometry_match = GeometryMatch("1234abcd", 0, 3)
+    draws = [
+        DrawCall(
+            label="Body-1", count=3, start=0, base=0,
+            ib_file="body.ib", index_size=4,
+            position_file="body-a.buf", position_stride=12,
+            texcoord_file="body-uv.buf", texcoord_stride=8,
+            geometry_match=geometry_match),
+        DrawCall(
+            label="Body-2", count=3, start=0, base=0,
+            ib_file="body.ib", index_size=4,
+            position_file="body-b.buf", position_stride=12,
+            texcoord_file="body-uv.buf", texcoord_stride=8,
+            geometry_match=geometry_match),
+    ]
+    group = [{
+        "name": "Body", "display_name": "Body", "source": "Root.ini",
+        "draws": draws,
+    }]
+
+    assert len(deduplicate_draws(group[0])) == 2
+    result = build_mesh_semantics(group, str(tmp_path))
+
+    assert len(result) == 2
+    assert len({entry["identity"]["key"] for entry in result.values()}) == 2

--- a/src/tests/core/geometry/test_semantics.py
+++ b/src/tests/core/geometry/test_semantics.py
@@ -37,12 +37,13 @@ def test_mesh_semantics_preserves_group_source_and_component_identity(tmp_path):
     assert result["Body-1"]["source"] == "Root.ini"
     assert result["Body-1"]["component"] == "Body Display"
     assert result["Body-1"]["identity"] == {
-        "version": 3,
-        "key": 'mesh:[3,"Root.ini","Body Display",'
+        "version": 4,
+        "key": 'mesh:[4,"Root.ini","Body Display",null,'
                 '["1234abcd",0,3],[3,0,0],'
                 '[null,null,null,null,null,null,null]]',
         "source": "Root.ini",
         "component": "Body Display",
+        "occurrence": None,
         "geometry": {"hash": "1234abcd", "first_index": 0,
                      "index_count": 3},
         "draw": {"count": 3, "start": 0, "base": 0},
@@ -92,7 +93,7 @@ def test_mesh_identity_survives_uncertain_asset_resolution(tmp_path, status):
     }], str(tmp_path))["Body-1"]
 
     assert result["identity"]["key"] == (
-        'mesh:[3,"Root.ini","Body",["1234abcd",0,3],[3,0,0],'
+        'mesh:[4,"Root.ini","Body",null,["1234abcd",0,3],[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     assert result["asset_binding"]["status"] == status
 
@@ -123,3 +124,38 @@ def test_distinct_geometry_resources_keep_distinct_mesh_identities(tmp_path):
 
     assert len(result) == 2
     assert len({entry["identity"]["key"] for entry in result.values()}) == 2
+
+
+def test_texture_only_draws_keep_distinct_displayed_mesh_identities(tmp_path):
+    geometry_match = GeometryMatch("1234abcd", 0, 3)
+    draws = [
+        DrawCall(
+            label="Body-1", count=3, start=0, base=0,
+            ib_file="body.ib", index_size=4,
+            position_file="body.buf", position_stride=12,
+            texcoord_file="body-uv.buf", texcoord_stride=8,
+            texture_default_file="red.dds",
+            occurrence=("TextureOverrideBody", 0),
+            geometry_match=geometry_match),
+        DrawCall(
+            label="Body-2", count=3, start=0, base=0,
+            ib_file="body.ib", index_size=4,
+            position_file="body.buf", position_stride=12,
+            texcoord_file="body-uv.buf", texcoord_stride=8,
+            texture_default_file="blue.dds",
+            occurrence=("TextureOverrideBody", 1),
+            geometry_match=geometry_match),
+    ]
+    group = [{
+        "name": "Body", "display_name": "Body", "source": "Root.ini",
+        "draws": draws,
+    }]
+
+    assert len(deduplicate_draws(group[0])) == 2
+    result = build_mesh_semantics(group, str(tmp_path))
+    keys = [entry["identity"]["key"] for entry in result.values()]
+
+    assert len(result) == 2
+    assert len(keys) == len(set(keys)) == 2
+    assert {entry["identity"]["occurrence"]["ordinal"]
+            for entry in result.values()} == {0, 1}

--- a/src/tests/core/geometry/test_semantics.py
+++ b/src/tests/core/geometry/test_semantics.py
@@ -37,8 +37,8 @@ def test_mesh_semantics_preserves_group_source_and_component_identity(tmp_path):
     assert result["Body-1"]["source"] == "Root.ini"
     assert result["Body-1"]["component"] == "Body Display"
     assert result["Body-1"]["identity"] == {
-        "version": 4,
-        "key": 'mesh:[4,"Root.ini","Body Display",null,'
+        "version": 5,
+        "key": 'mesh:[5,"Root.ini","Body Display",null,'
                 '["1234abcd",0,3],[3,0,0],'
                 '[null,null,null,null,null,null,null]]',
         "source": "Root.ini",
@@ -93,7 +93,7 @@ def test_mesh_identity_survives_uncertain_asset_resolution(tmp_path, status):
     }], str(tmp_path))["Body-1"]
 
     assert result["identity"]["key"] == (
-        'mesh:[4,"Root.ini","Body",null,["1234abcd",0,3],[3,0,0],'
+        'mesh:[5,"Root.ini","Body",null,["1234abcd",0,3],[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     assert result["asset_binding"]["status"] == status
 

--- a/src/tests/core/geometry/test_semantics.py
+++ b/src/tests/core/geometry/test_semantics.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import patch
 
+import pytest
+
+from app.assets.resolver import AssetComponentBinding
 from core.geometry.draw_call import DrawCall
+from core.geometry.identity import GeometryMatch
 from core.geometry.mesh_builder import build_mesh_semantics
 
 
@@ -20,7 +24,8 @@ def test_mesh_semantics_does_not_read_buffers_or_publish_textures(tmp_path):
 
 
 def test_mesh_semantics_preserves_group_source_and_component_identity(tmp_path):
-    draw = DrawCall(label="Body-1")
+    draw = DrawCall(label="Body-1", count=3, start=0, base=0,
+                    geometry_match=GeometryMatch("1234abcd", 0, 3))
     result = build_mesh_semantics([{
         "name": "Body",
         "display_name": "Body Display",
@@ -30,3 +35,54 @@ def test_mesh_semantics_preserves_group_source_and_component_identity(tmp_path):
 
     assert result["Body-1"]["source"] == "Root.ini"
     assert result["Body-1"]["component"] == "Body Display"
+    assert result["Body-1"]["identity"] == {
+        "version": 2,
+        "key": 'mesh:[2,"Root.ini","Body Display",'
+                '["1234abcd",0,3],[3,0,0]]',
+        "source": "Root.ini",
+        "component": "Body Display",
+        "geometry": {"hash": "1234abcd", "first_index": 0,
+                     "index_count": 3},
+        "draw": {"count": 3, "start": 0, "base": 0},
+    }
+
+
+def test_mesh_identity_is_independent_of_optional_asset_binding(tmp_path):
+    draw = DrawCall(
+        label="Body-1", count=3, start=0, base=0,
+        geometry_match=GeometryMatch("1234abcd", 0, 3))
+    group = [{
+        "name": "Body", "display_name": "Body", "source": "Root.ini",
+        "draws": [draw],
+    }]
+
+    without_asset = build_mesh_semantics(group, str(tmp_path))["Body-1"]
+    draw.asset_binding = AssetComponentBinding(
+        status="exact", geometry_hash="1234abcd", first_index=0,
+        index_count=3)
+    with_asset = build_mesh_semantics(group, str(tmp_path))["Body-1"]
+
+    assert with_asset["identity"] == without_asset["identity"]
+    assert "asset_binding" in with_asset
+    assert with_asset["asset_binding"]["geometry_hash"] == \
+        with_asset["identity"]["geometry"]["hash"]
+    assert with_asset["asset_binding"]["first_index"] == \
+        with_asset["identity"]["geometry"]["first_index"]
+    assert with_asset["asset_binding"]["index_count"] == \
+        with_asset["identity"]["geometry"]["index_count"]
+
+
+@pytest.mark.parametrize("status", ["ambiguous", "not_found"])
+def test_mesh_identity_survives_uncertain_asset_resolution(tmp_path, status):
+    draw = DrawCall(
+        label="Body-1", count=3, start=0, base=0,
+        geometry_match=GeometryMatch("1234abcd", 0, 3),
+        asset_binding=AssetComponentBinding(status=status))
+    result = build_mesh_semantics([{
+        "name": "Body", "display_name": "Body", "source": "Root.ini",
+        "draws": [draw],
+    }], str(tmp_path))["Body-1"]
+
+    assert result["identity"]["key"] == (
+        'mesh:[2,"Root.ini","Body",["1234abcd",0,3],[3,0,0]]')
+    assert result["asset_binding"]["status"] == status

--- a/src/tests/integration/test_load_pipeline.py
+++ b/src/tests/integration/test_load_pipeline.py
@@ -357,10 +357,10 @@ def test_wuwa_candidates_reach_texture_pool_without_changing_draw_default(
 def test_metadata_texture_migration_prefers_identity_key_and_rekeys_legacy(
         tmp_path):
     identity_key = (
-        'mesh:[4,"Root.ini","Body",null,null,[3,0,0],'
+        'mesh:[5,"Root.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 4, "key": identity_key},
+        "identity": {"version": 5, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
         "texture_options": [],
     }}, "textures": {}}
@@ -384,10 +384,10 @@ def test_metadata_texture_migration_prefers_identity_key_and_rekeys_legacy(
 def test_metadata_texture_migration_reads_legacy_key_under_new_identity(
         tmp_path):
     identity_key = (
-        'mesh:[4,"Root.ini","Body",null,null,[3,0,0],'
+        'mesh:[5,"Root.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 4, "key": identity_key},
+        "identity": {"version": 5, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
         "texture_options": [],
     }}, "textures": {}}
@@ -405,16 +405,16 @@ def test_metadata_texture_migration_reads_legacy_key_under_new_identity(
 
 def test_metadata_texture_migration_skips_ambiguous_legacy_key(tmp_path):
     identity_a = (
-        'mesh:[4,"A.ini","Body",null,null,[3,0,0],'
+        'mesh:[5,"A.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     identity_b = (
-        'mesh:[4,"B.ini","Body",null,null,[3,0,0],'
+        'mesh:[5,"B.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {
-        "Body-1": {"identity": {"version": 4, "key": identity_a},
+        "Body-1": {"identity": {"version": 5, "key": identity_a},
                     "component": "Body", "drawindexed": [3, 0, 0],
                     "texture_options": []},
-        "Body_2-1": {"identity": {"version": 4, "key": identity_b},
+        "Body_2-1": {"identity": {"version": 5, "key": identity_b},
                       "component": "Body", "drawindexed": [3, 0, 0],
                       "texture_options": []},
     }, "textures": {}}
@@ -431,10 +431,10 @@ def test_metadata_texture_migration_skips_ambiguous_legacy_key(tmp_path):
 
 def test_metadata_mesh_name_migration_prefers_new_key_and_rekeys_legacy():
     identity_key = (
-        'mesh:[4,"Root.ini","Body",null,null,[3,0,0],'
+        'mesh:[5,"Root.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 4, "key": identity_key},
+        "identity": {"version": 5, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
     }}}
     data = {"mesh_names": {
@@ -449,10 +449,10 @@ def test_metadata_mesh_name_migration_prefers_new_key_and_rekeys_legacy():
 
 def test_metadata_mesh_name_migration_reads_legacy_key_under_new_identity():
     identity_key = (
-        'mesh:[4,"Root.ini","Body",null,null,[3,0,0],'
+        'mesh:[5,"Root.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 4, "key": identity_key},
+        "identity": {"version": 5, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
     }}}
     data = {"mesh_names": {"Body::3,0,0": "Legacy name"}}
@@ -464,15 +464,15 @@ def test_metadata_mesh_name_migration_reads_legacy_key_under_new_identity():
 
 def test_metadata_mesh_name_migration_skips_ambiguous_legacy_key():
     identity_a = (
-        'mesh:[4,"A.ini","Body",null,null,[3,0,0],'
+        'mesh:[5,"A.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     identity_b = (
-        'mesh:[4,"B.ini","Body",null,null,[3,0,0],'
+        'mesh:[5,"B.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {
-        "Body-1": {"identity": {"version": 4, "key": identity_a},
+        "Body-1": {"identity": {"version": 5, "key": identity_a},
                     "component": "Body", "drawindexed": [3, 0, 0]},
-        "Body_2-1": {"identity": {"version": 4, "key": identity_b},
+        "Body_2-1": {"identity": {"version": 5, "key": identity_b},
                       "component": "Body", "drawindexed": [3, 0, 0]},
     }}
     data = {"mesh_names": {"Body::3,0,0": "Legacy name"}}

--- a/src/tests/integration/test_load_pipeline.py
+++ b/src/tests/integration/test_load_pipeline.py
@@ -91,7 +91,8 @@ format = R32_UINT
         assert {entry["identity"]["source"] for entry in meshes} == {
             "root.ini", "nested/nested.ini",
         }
-        assert len({entry["identity"]["key"] for entry in meshes}) == 2
+        keys = [entry["identity"]["key"] for entry in meshes]
+        assert len(keys) == len(set(keys)) == 2
 
 
 def test_mesh_identity_uses_relative_ini_paths_not_ui_source_labels(tmp_path):
@@ -135,7 +136,8 @@ stride = 8
     assert {identity["source"] for identity in sibling_identities} == {
         "variants/A.ini", "variants/B.ini",
     }
-    assert len({identity["key"] for identity in sibling_identities}) == 2
+    sibling_keys = [identity["key"] for identity in sibling_identities]
+    assert len(sibling_keys) == len(set(sibling_keys)) == 2
 
     sibling_ini = tmp_path / "Sibling.ini"
     write_ini(sibling_ini)
@@ -165,7 +167,8 @@ def test_source_qualified_identity_avoids_legacy_metadata_collision(tmp_path):
 
     assert len({metadata._legacy_mesh_key(name, entry)
                 for name, entry in result.items()}) == 1
-    assert len({entry["identity"]["key"] for entry in entries}) == 2
+    keys = [entry["identity"]["key"] for entry in entries]
+    assert len(keys) == len(set(keys)) == 2
 
 
 def test_document_projection_keeps_authoritative_text_and_source():
@@ -354,10 +357,10 @@ def test_wuwa_candidates_reach_texture_pool_without_changing_draw_default(
 def test_metadata_texture_migration_prefers_identity_key_and_rekeys_legacy(
         tmp_path):
     identity_key = (
-        'mesh:[3,"Root.ini","Body",null,[3,0,0],'
+        'mesh:[4,"Root.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 3, "key": identity_key},
+        "identity": {"version": 4, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
         "texture_options": [],
     }}, "textures": {}}
@@ -381,10 +384,10 @@ def test_metadata_texture_migration_prefers_identity_key_and_rekeys_legacy(
 def test_metadata_texture_migration_reads_legacy_key_under_new_identity(
         tmp_path):
     identity_key = (
-        'mesh:[3,"Root.ini","Body",null,[3,0,0],'
+        'mesh:[4,"Root.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 3, "key": identity_key},
+        "identity": {"version": 4, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
         "texture_options": [],
     }}, "textures": {}}
@@ -402,16 +405,16 @@ def test_metadata_texture_migration_reads_legacy_key_under_new_identity(
 
 def test_metadata_texture_migration_skips_ambiguous_legacy_key(tmp_path):
     identity_a = (
-        'mesh:[3,"A.ini","Body",null,[3,0,0],'
+        'mesh:[4,"A.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     identity_b = (
-        'mesh:[3,"B.ini","Body",null,[3,0,0],'
+        'mesh:[4,"B.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {
-        "Body-1": {"identity": {"version": 3, "key": identity_a},
+        "Body-1": {"identity": {"version": 4, "key": identity_a},
                     "component": "Body", "drawindexed": [3, 0, 0],
                     "texture_options": []},
-        "Body_2-1": {"identity": {"version": 3, "key": identity_b},
+        "Body_2-1": {"identity": {"version": 4, "key": identity_b},
                       "component": "Body", "drawindexed": [3, 0, 0],
                       "texture_options": []},
     }, "textures": {}}
@@ -428,10 +431,10 @@ def test_metadata_texture_migration_skips_ambiguous_legacy_key(tmp_path):
 
 def test_metadata_mesh_name_migration_prefers_new_key_and_rekeys_legacy():
     identity_key = (
-        'mesh:[3,"Root.ini","Body",null,[3,0,0],'
+        'mesh:[4,"Root.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 3, "key": identity_key},
+        "identity": {"version": 4, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
     }}}
     data = {"mesh_names": {
@@ -446,10 +449,10 @@ def test_metadata_mesh_name_migration_prefers_new_key_and_rekeys_legacy():
 
 def test_metadata_mesh_name_migration_reads_legacy_key_under_new_identity():
     identity_key = (
-        'mesh:[3,"Root.ini","Body",null,[3,0,0],'
+        'mesh:[4,"Root.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 3, "key": identity_key},
+        "identity": {"version": 4, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
     }}}
     data = {"mesh_names": {"Body::3,0,0": "Legacy name"}}
@@ -461,15 +464,15 @@ def test_metadata_mesh_name_migration_reads_legacy_key_under_new_identity():
 
 def test_metadata_mesh_name_migration_skips_ambiguous_legacy_key():
     identity_a = (
-        'mesh:[3,"A.ini","Body",null,[3,0,0],'
+        'mesh:[4,"A.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     identity_b = (
-        'mesh:[3,"B.ini","Body",null,[3,0,0],'
+        'mesh:[4,"B.ini","Body",null,null,[3,0,0],'
         '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {
-        "Body-1": {"identity": {"version": 3, "key": identity_a},
+        "Body-1": {"identity": {"version": 4, "key": identity_a},
                     "component": "Body", "drawindexed": [3, 0, 0]},
-        "Body_2-1": {"identity": {"version": 3, "key": identity_b},
+        "Body_2-1": {"identity": {"version": 4, "key": identity_b},
                       "component": "Body", "drawindexed": [3, 0, 0]},
     }}
     data = {"mesh_names": {"Body::3,0,0": "Legacy name"}}

--- a/src/tests/integration/test_load_pipeline.py
+++ b/src/tests/integration/test_load_pipeline.py
@@ -78,6 +78,35 @@ format = R32_UINT
         }
         assert "nested/nested.ini" in source_inis
 
+        semantic = mod_loader.load_mesh_semantics(
+            mod_loader.ModLoadContext(
+                root, mod_loader.find_inis(root), {}, {}))
+        assert {
+            name: entry["identity"]
+            for name, entry in payload["meshes"].items()
+        } == {
+            name: entry["identity"]
+            for name, entry in semantic["meshes"].items()
+        }
+        assert len({entry["identity"]["key"] for entry in meshes}) == 2
+
+
+def test_source_qualified_identity_avoids_legacy_metadata_collision(tmp_path):
+    groups = [{
+        "name": "Body", "display_name": "Body", "source": "A.ini",
+        "draws": [DrawCall(label="Body-1", count=100, start=0, base=0)],
+    }, {
+        "name": "Body_2", "display_name": "Body", "source": "B.ini",
+        "draws": [DrawCall(label="Body_2-1", count=100, start=0, base=0)],
+    }]
+
+    result = build_mesh_semantics(groups, str(tmp_path))
+    entries = list(result.values())
+
+    assert len({metadata._legacy_mesh_key(name, entry)
+                for name, entry in result.items()}) == 1
+    assert len({entry["identity"]["key"] for entry in entries}) == 2
+
 
 def test_document_projection_keeps_authoritative_text_and_source():
     path = os.path.join(tempfile.gettempdir(), "staged-refactor.ini")
@@ -260,6 +289,80 @@ def test_wuwa_candidates_reach_texture_pool_without_changing_draw_default(
     assert entry["tex_key"] == "diffuse::existing.dds"
     assert [item["file"] for item in pool] == [
         "existing.dds", "Components-0 t=candidate.dds"]
+
+
+def test_metadata_texture_migration_prefers_identity_key_and_rekeys_legacy(
+        tmp_path):
+    identity_key = 'mesh:[2,"Root.ini","Body",null,[3,0,0]]'
+    payload = {"meshes": {"Body-1": {
+        "identity": {"version": 2, "key": identity_key},
+        "component": "Body", "drawindexed": [3, 0, 0],
+        "texture_options": [],
+    }}, "textures": {}}
+    data = {"textures": {
+        "Body::3,0,0": {
+            "tex_key": "legacy.png", "label": "Legacy", "manual": True,
+        },
+        identity_key: {
+            "tex_key": "canonical.png", "label": "Canonical", "manual": True,
+        },
+    }}
+
+    restored = metadata.hydrate_textures(str(tmp_path), payload, data)
+
+    assert set(restored) == {identity_key}
+    assert restored[identity_key]["label"] == "Canonical"
+    assert payload["meshes"]["Body-1"]["saved_texture_override"] == (
+        "diffuse::canonical.png")
+
+
+def test_metadata_texture_migration_reads_legacy_key_under_new_identity(
+        tmp_path):
+    identity_key = 'mesh:[2,"Root.ini","Body",null,[3,0,0]]'
+    payload = {"meshes": {"Body-1": {
+        "identity": {"version": 2, "key": identity_key},
+        "component": "Body", "drawindexed": [3, 0, 0],
+        "texture_options": [],
+    }}, "textures": {}}
+    data = {"textures": {
+        "Body::3,0,0": {
+            "tex_key": "legacy.png", "label": "Legacy", "manual": True,
+        },
+    }}
+
+    restored = metadata.hydrate_textures(str(tmp_path), payload, data)
+
+    assert set(restored) == {identity_key}
+    assert restored[identity_key]["label"] == "Legacy"
+
+
+def test_metadata_mesh_name_migration_prefers_new_key_and_rekeys_legacy():
+    identity_key = 'mesh:[2,"Root.ini","Body",null,[3,0,0]]'
+    payload = {"meshes": {"Body-1": {
+        "identity": {"version": 2, "key": identity_key},
+        "component": "Body", "drawindexed": [3, 0, 0],
+    }}}
+    data = {"mesh_names": {
+        "Body::3,0,0": "Legacy name",
+        identity_key: "Canonical name",
+    }}
+
+    assert metadata.hydrate_mesh_names(payload, data) == {
+        identity_key: "Canonical name",
+    }
+
+
+def test_metadata_mesh_name_migration_reads_legacy_key_under_new_identity():
+    identity_key = 'mesh:[2,"Root.ini","Body",null,[3,0,0]]'
+    payload = {"meshes": {"Body-1": {
+        "identity": {"version": 2, "key": identity_key},
+        "component": "Body", "drawindexed": [3, 0, 0],
+    }}}
+    data = {"mesh_names": {"Body::3,0,0": "Legacy name"}}
+
+    assert metadata.hydrate_mesh_names(payload, data) == {
+        identity_key: "Legacy name",
+    }
 
 
 def test_mesh_semantics_include_conditional_texture_roles_without_geometry(

--- a/src/tests/integration/test_load_pipeline.py
+++ b/src/tests/integration/test_load_pipeline.py
@@ -88,7 +88,67 @@ format = R32_UINT
             name: entry["identity"]
             for name, entry in semantic["meshes"].items()
         }
+        assert {entry["identity"]["source"] for entry in meshes} == {
+            "root.ini", "nested/nested.ini",
+        }
         assert len({entry["identity"]["key"] for entry in meshes}) == 2
+
+
+def test_mesh_identity_uses_relative_ini_paths_not_ui_source_labels(tmp_path):
+    ini = """[TextureOverrideBody]
+ib = ResourceBodyIB
+vb0 = ResourceBodyPosition
+vb1 = ResourceBodyTexcoord
+drawindexed = 3, 0, 0
+
+[ResourceBodyIB]
+filename = body.ib
+format = R32_UINT
+[ResourceBodyPosition]
+filename = body.buf
+stride = 12
+[ResourceBodyTexcoord]
+filename = body-uv.buf
+stride = 8
+"""
+
+    def write_ini(path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(ini, encoding="utf-8")
+
+    root_ini = tmp_path / "Root.ini"
+    write_ini(root_ini)
+    single = mod_analysis.analyze_mod_inis([str(root_ini)], str(tmp_path))
+    single_result = build_mesh_semantics(single.groups, str(tmp_path))
+    single_identity = next(iter(single_result.values()))["identity"]
+
+    variants = [tmp_path / "variants" / name for name in ("A.ini", "B.ini")]
+    for path in variants:
+        write_ini(path)
+    sibling_analysis = mod_analysis.analyze_mod_inis(
+        [str(path) for path in variants], str(tmp_path))
+    sibling_result = build_mesh_semantics(
+        sibling_analysis.groups, str(tmp_path))
+    sibling_identities = [
+        entry["identity"] for entry in sibling_result.values()]
+
+    assert {identity["source"] for identity in sibling_identities} == {
+        "variants/A.ini", "variants/B.ini",
+    }
+    assert len({identity["key"] for identity in sibling_identities}) == 2
+
+    sibling_ini = tmp_path / "Sibling.ini"
+    write_ini(sibling_ini)
+    with_sibling = mod_analysis.analyze_mod_inis(
+        [str(root_ini), str(sibling_ini)], str(tmp_path))
+    with_sibling_result = build_mesh_semantics(
+        with_sibling.groups, str(tmp_path))
+    root_identity = next(
+        entry["identity"] for entry in with_sibling_result.values()
+        if entry["identity"]["source"] == "Root.ini")
+
+    assert single_identity["source"] == "Root.ini"
+    assert root_identity == single_identity
 
 
 def test_source_qualified_identity_avoids_legacy_metadata_collision(tmp_path):
@@ -293,9 +353,11 @@ def test_wuwa_candidates_reach_texture_pool_without_changing_draw_default(
 
 def test_metadata_texture_migration_prefers_identity_key_and_rekeys_legacy(
         tmp_path):
-    identity_key = 'mesh:[2,"Root.ini","Body",null,[3,0,0]]'
+    identity_key = (
+        'mesh:[3,"Root.ini","Body",null,[3,0,0],'
+        '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 2, "key": identity_key},
+        "identity": {"version": 3, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
         "texture_options": [],
     }}, "textures": {}}
@@ -318,9 +380,11 @@ def test_metadata_texture_migration_prefers_identity_key_and_rekeys_legacy(
 
 def test_metadata_texture_migration_reads_legacy_key_under_new_identity(
         tmp_path):
-    identity_key = 'mesh:[2,"Root.ini","Body",null,[3,0,0]]'
+    identity_key = (
+        'mesh:[3,"Root.ini","Body",null,[3,0,0],'
+        '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 2, "key": identity_key},
+        "identity": {"version": 3, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
         "texture_options": [],
     }}, "textures": {}}
@@ -336,10 +400,38 @@ def test_metadata_texture_migration_reads_legacy_key_under_new_identity(
     assert restored[identity_key]["label"] == "Legacy"
 
 
+def test_metadata_texture_migration_skips_ambiguous_legacy_key(tmp_path):
+    identity_a = (
+        'mesh:[3,"A.ini","Body",null,[3,0,0],'
+        '[null,null,null,null,null,null,null]]')
+    identity_b = (
+        'mesh:[3,"B.ini","Body",null,[3,0,0],'
+        '[null,null,null,null,null,null,null]]')
+    payload = {"meshes": {
+        "Body-1": {"identity": {"version": 3, "key": identity_a},
+                    "component": "Body", "drawindexed": [3, 0, 0],
+                    "texture_options": []},
+        "Body_2-1": {"identity": {"version": 3, "key": identity_b},
+                      "component": "Body", "drawindexed": [3, 0, 0],
+                      "texture_options": []},
+    }, "textures": {}}
+    data = {"textures": {"Body::3,0,0": {
+        "tex_key": "legacy.png", "label": "Legacy", "manual": True,
+    }}}
+
+    restored = metadata.hydrate_textures(str(tmp_path), payload, data)
+
+    assert restored == {}
+    assert "saved_texture_override" not in payload["meshes"]["Body-1"]
+    assert "saved_texture_override" not in payload["meshes"]["Body_2-1"]
+
+
 def test_metadata_mesh_name_migration_prefers_new_key_and_rekeys_legacy():
-    identity_key = 'mesh:[2,"Root.ini","Body",null,[3,0,0]]'
+    identity_key = (
+        'mesh:[3,"Root.ini","Body",null,[3,0,0],'
+        '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 2, "key": identity_key},
+        "identity": {"version": 3, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
     }}}
     data = {"mesh_names": {
@@ -353,9 +445,11 @@ def test_metadata_mesh_name_migration_prefers_new_key_and_rekeys_legacy():
 
 
 def test_metadata_mesh_name_migration_reads_legacy_key_under_new_identity():
-    identity_key = 'mesh:[2,"Root.ini","Body",null,[3,0,0]]'
+    identity_key = (
+        'mesh:[3,"Root.ini","Body",null,[3,0,0],'
+        '[null,null,null,null,null,null,null]]')
     payload = {"meshes": {"Body-1": {
-        "identity": {"version": 2, "key": identity_key},
+        "identity": {"version": 3, "key": identity_key},
         "component": "Body", "drawindexed": [3, 0, 0],
     }}}
     data = {"mesh_names": {"Body::3,0,0": "Legacy name"}}
@@ -363,6 +457,24 @@ def test_metadata_mesh_name_migration_reads_legacy_key_under_new_identity():
     assert metadata.hydrate_mesh_names(payload, data) == {
         identity_key: "Legacy name",
     }
+
+
+def test_metadata_mesh_name_migration_skips_ambiguous_legacy_key():
+    identity_a = (
+        'mesh:[3,"A.ini","Body",null,[3,0,0],'
+        '[null,null,null,null,null,null,null]]')
+    identity_b = (
+        'mesh:[3,"B.ini","Body",null,[3,0,0],'
+        '[null,null,null,null,null,null,null]]')
+    payload = {"meshes": {
+        "Body-1": {"identity": {"version": 3, "key": identity_a},
+                    "component": "Body", "drawindexed": [3, 0, 0]},
+        "Body_2-1": {"identity": {"version": 3, "key": identity_b},
+                      "component": "Body", "drawindexed": [3, 0, 0]},
+    }}
+    data = {"mesh_names": {"Body::3,0,0": "Legacy name"}}
+
+    assert metadata.hydrate_mesh_names(payload, data) == {}
 
 
 def test_mesh_semantics_include_conditional_texture_roles_without_geometry(

--- a/src/tests/integration/test_resource_resolution.py
+++ b/src/tests/integration/test_resource_resolution.py
@@ -313,6 +313,13 @@ def test_run_inlines_nested_commandlist_draws():
               f"(got {len(draws)})")
         by_count = {d["count"]: d for d in draws}
         assert (100 in by_count and 50 in by_count), (f"both the direct and run=-chained draws are present (got {sorted(by_count)})")
+        assert {
+            (draw["occurrence"].section, draw["occurrence"].ordinal)
+            for draw in draws
+        } == {
+            ("TextureOverrideBodyBlend", 0),
+            ("CommandListTransparent", 0),
+        }
 
         chained = by_count[50]
         assert (visible(chained["conditions"], {"naked": "0", "flag": "0"})), ("chained draw visible when both naked==0 and flag==0")

--- a/src/tests/integration/test_resource_resolution.py
+++ b/src/tests/integration/test_resource_resolution.py
@@ -8,6 +8,7 @@ from tests.support.corpus import sample_mods
 from app.mods import loader as mod_loader
 from core.ini.parser import (_scan_sections_for_draws, build_draw_groups,
                              extract_resources, merge_sections, parse_sections)
+from core.geometry.semantics import deduplicate_draws, build_mesh_semantics
 from core.textures import encode_texture_file
 from tests.support.provenance import (build_mesh_fixture, geometry_values, visible,
                                  write)
@@ -322,6 +323,61 @@ def test_run_inlines_nested_commandlist_draws():
         }
 
         chained = by_count[50]
+        assert chained["occurrence"].path == (
+            ("TextureOverrideBodyBlend", 0),
+            ("CustomShaderOuter", 0),
+        )
         assert (visible(chained["conditions"], {"naked": "0", "flag": "0"})), ("chained draw visible when both naked==0 and flag==0")
         assert (not visible(chained["conditions"], {"naked": "1", "flag": "0"})), ("chained draw hidden when the caller's own gate (naked==0) fails")
         assert (not visible(chained["conditions"], {"naked": "0", "flag": "1"})), ("chained draw hidden when the callee's own gate (flag==0) fails")
+
+
+def test_repeated_commandlist_execution_has_distinct_occurrences(tmp_path):
+    ini = """[TextureOverrideBody]
+ib = ResourceBodyIB
+vb0 = ResourceBodyPosition
+vb1 = ResourceBodyTexcoord
+Resource\\GIMI\\Diffuse = ResourceRed
+run = CommandListDraw
+Resource\\GIMI\\Diffuse = ResourceBlue
+run = CommandListDraw
+
+[CommandListDraw]
+drawindexed = 3, 0, 0
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourceBodyPosition]
+filename = body.buf
+stride = 12
+
+[ResourceBodyTexcoord]
+filename = body-uv.buf
+stride = 8
+
+[ResourceRed]
+filename = red.dds
+
+[ResourceBlue]
+filename = blue.dds
+"""
+    path = write(tmp_path, "mod.ini", ini)
+    sections = merge_sections([path])
+    groups = build_draw_groups(sections, extract_resources(sections))
+
+    assert len(groups) == 1
+    draws = groups[0]["draws"]
+    assert len(draws) == 2
+    assert [draw.texture_default("diffuse") for draw in draws] == [
+        "red.dds", "blue.dds"]
+    assert [draw.occurrence.path for draw in draws] == [
+        (("TextureOverrideBody", 0),),
+        (("TextureOverrideBody", 1),),
+    ]
+    assert len(deduplicate_draws(groups[0])) == 2
+
+    semantics = build_mesh_semantics(groups, str(tmp_path))
+    keys = [entry["identity"]["key"] for entry in semantics.values()]
+    assert len(keys) == len(set(keys)) == 2

--- a/src/tests/web/support.py
+++ b/src/tests/web/support.py
@@ -401,6 +401,7 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                   const semantic = {};
                   for (const key of [
                     'conditions', 'sources', 'source', 'component',
+                    'identity',
                     'tex_key', 'texture_variants', 'normal_map_key',
                     'normal_map_variants', 'normal_data_key',
                     'normal_data_variants', 'light_map_key',

--- a/src/tests/web/test_app_flow.py
+++ b/src/tests/web/test_app_flow.py
@@ -413,7 +413,7 @@ def test_control_and_mesh_semantic_refreshes_preserve_existing_meshes(
     payload = _payload("Semantic")
     mesh_name = next(iter(payload["meshes"]))
     identity = {
-        "version": 4, "key": "mesh:[4,\"Semantic.ini\",\"Body\",null,null,[3,0,0],[null,null,null,null,null,null,null]]",
+        "version": 5, "key": "mesh:[5,\"Semantic.ini\",\"Body\",null,null,[3,0,0],[null,null,null,null,null,null,null]]",
         "source": "Semantic.ini", "component": "Body", "geometry": None,
         "draw": {"count": 3, "start": 0, "base": 0},
     }
@@ -481,8 +481,8 @@ def test_frontend_uses_backend_mesh_identity_for_metadata_key(
     payload = _payload("Identity")
     mesh_name, entry = next(iter(payload["meshes"].items()))
     entry["identity"] = {
-        "version": 4,
-        "key": "mesh:[4,\"Identity.ini\",\"Body\",null,null,[3,0,0],[null,null,null,null,null,null,null]]",
+        "version": 5,
+        "key": "mesh:[5,\"Identity.ini\",\"Body\",null,null,[3,0,0],[null,null,null,null,null,null,null]]",
         "source": "Identity.ini", "component": "Body", "geometry": None,
         "draw": {"count": 3, "start": 0, "base": 0},
     }
@@ -511,13 +511,13 @@ def test_semantic_refresh_rejects_identity_mismatch_without_mutation(
     payload = _payload("Mismatch")
     mesh_name, entry = next(iter(payload["meshes"].items()))
     identity_a = {
-        "version": 4, "key": "mesh:[4,\"Mismatch.ini\",\"Body\",null,null,[3,0,0],[null,null,null,null,null,null,null]]",
+        "version": 5, "key": "mesh:[5,\"Mismatch.ini\",\"Body\",null,null,[3,0,0],[null,null,null,null,null,null,null]]",
         "source": "Mismatch.ini", "component": "Body", "geometry": None,
         "draw": {"count": 3, "start": 0, "base": 0},
     }
     identity_b = {
         **identity_a,
-        "key": "mesh:[4,\"Mismatch.ini\",\"Body\",null,null,[4,0,0],[null,null,null,null,null,null,null]]",
+        "key": "mesh:[5,\"Mismatch.ini\",\"Body\",null,null,[4,0,0],[null,null,null,null,null,null,null]]",
         "draw": {"count": 4, "start": 0, "base": 0},
     }
     entry["identity"] = identity_a

--- a/src/tests/web/test_app_flow.py
+++ b/src/tests/web/test_app_flow.py
@@ -413,7 +413,7 @@ def test_control_and_mesh_semantic_refreshes_preserve_existing_meshes(
     payload = _payload("Semantic")
     mesh_name = next(iter(payload["meshes"]))
     identity = {
-        "version": 2, "key": "mesh:[2,\"Semantic.ini\",\"Body\",null,[3,0,0]]",
+        "version": 3, "key": "mesh:[3,\"Semantic.ini\",\"Body\",null,[3,0,0],[null,null,null,null,null,null,null]]",
         "source": "Semantic.ini", "component": "Body", "geometry": None,
         "draw": {"count": 3, "start": 0, "base": 0},
     }
@@ -481,8 +481,8 @@ def test_frontend_uses_backend_mesh_identity_for_metadata_key(
     payload = _payload("Identity")
     mesh_name, entry = next(iter(payload["meshes"].items()))
     entry["identity"] = {
-        "version": 2,
-        "key": "mesh:[2,\"Identity.ini\",\"Body\",null,[3,0,0]]",
+        "version": 3,
+        "key": "mesh:[3,\"Identity.ini\",\"Body\",null,[3,0,0],[null,null,null,null,null,null,null]]",
         "source": "Identity.ini", "component": "Body", "geometry": None,
         "draw": {"count": 3, "start": 0, "base": 0},
     }
@@ -511,13 +511,13 @@ def test_semantic_refresh_rejects_identity_mismatch_without_mutation(
     payload = _payload("Mismatch")
     mesh_name, entry = next(iter(payload["meshes"].items()))
     identity_a = {
-        "version": 2, "key": "mesh:[2,\"Mismatch.ini\",\"Body\",null,[3,0,0]]",
+        "version": 3, "key": "mesh:[3,\"Mismatch.ini\",\"Body\",null,[3,0,0],[null,null,null,null,null,null,null]]",
         "source": "Mismatch.ini", "component": "Body", "geometry": None,
         "draw": {"count": 3, "start": 0, "base": 0},
     }
     identity_b = {
         **identity_a,
-        "key": "mesh:[2,\"Mismatch.ini\",\"Body\",null,[4,0,0]]",
+        "key": "mesh:[3,\"Mismatch.ini\",\"Body\",null,[4,0,0],[null,null,null,null,null,null,null]]",
         "draw": {"count": 4, "start": 0, "base": 0},
     }
     entry["identity"] = identity_a

--- a/src/tests/web/test_app_flow.py
+++ b/src/tests/web/test_app_flow.py
@@ -412,8 +412,14 @@ def test_control_and_mesh_semantic_refreshes_preserve_existing_meshes(
         edge_browser, frontend_url):
     payload = _payload("Semantic")
     mesh_name = next(iter(payload["meshes"]))
+    identity = {
+        "version": 2, "key": "mesh:[2,\"Semantic.ini\",\"Body\",null,[3,0,0]]",
+        "source": "Semantic.ini", "component": "Body", "geometry": None,
+        "draw": {"count": 3, "start": 0, "base": 0},
+    }
+    payload["meshes"][mesh_name]["identity"] = identity
     payload["meshSemantics"] = {
-        mesh_name: {"conditions": [[{
+        mesh_name: {"identity": identity, "conditions": [[{
             "var": "toggle", "value": "1", "negate": False,
         }]], "sources": payload["meshes"][mesh_name]["sources"],
         "tex_key": "diffuse::Semantic-one.png",
@@ -466,6 +472,88 @@ def test_control_and_mesh_semantic_refreshes_preserve_existing_meshes(
         }
         assert page.evaluate("window.__fakeApi.calls.loadMod.length") == 1
         assert page.evaluate("window.__fakeApi.calls.meshSemantics") == ["Semantic"]
+    finally:
+        context.close()
+
+
+def test_frontend_uses_backend_mesh_identity_for_metadata_key(
+        edge_browser, frontend_url):
+    payload = _payload("Identity")
+    mesh_name, entry = next(iter(payload["meshes"].items()))
+    entry["identity"] = {
+        "version": 2,
+        "key": "mesh:[2,\"Identity.ini\",\"Body\",null,[3,0,0]]",
+        "source": "Identity.ini", "component": "Body", "geometry": None,
+        "draw": {"count": 3, "start": 0, "base": 0},
+    }
+    context, page = _page(edge_browser, frontend_url, {"Identity": payload})
+    try:
+        _open(page, "Identity")
+        page.locator(".draw-item").wait_for()
+        assert page.evaluate("""() => {
+          const mesh = window.modViewer.activeMeshes[0];
+          return {
+            key: mesh.userData.metadataKey,
+            identity: mesh.userData.identity,
+          };
+        }""") == {
+            "key": entry["identity"]["key"],
+            "identity": entry["identity"],
+        }
+        assert page.evaluate("window.modViewer.activeMeshes[0].userData.metadataKey") != (
+            "Body::3,0,0")
+    finally:
+        context.close()
+
+
+def test_semantic_refresh_rejects_identity_mismatch_without_mutation(
+        edge_browser, frontend_url):
+    payload = _payload("Mismatch")
+    mesh_name, entry = next(iter(payload["meshes"].items()))
+    identity_a = {
+        "version": 2, "key": "mesh:[2,\"Mismatch.ini\",\"Body\",null,[3,0,0]]",
+        "source": "Mismatch.ini", "component": "Body", "geometry": None,
+        "draw": {"count": 3, "start": 0, "base": 0},
+    }
+    identity_b = {
+        **identity_a,
+        "key": "mesh:[2,\"Mismatch.ini\",\"Body\",null,[4,0,0]]",
+        "draw": {"count": 4, "start": 0, "base": 0},
+    }
+    entry["identity"] = identity_a
+    payload["meshSemantics"] = {mesh_name: {"identity": identity_b}}
+    context, page = _page(edge_browser, frontend_url, {"Mismatch": payload})
+    try:
+        _open(page, "Mismatch")
+        page.locator(".draw-item").wait_for()
+        page.evaluate("""() => {
+          const mesh = window.modViewer.activeMeshes[0];
+          window.__identityBefore = {
+            mesh,
+            geometry: mesh.geometry,
+            material: mesh.material,
+            identity: mesh.userData.identity,
+          };
+          window.__identityRefresh = window.modViewer.refreshMeshSemantics();
+        }""")
+        page.locator("#dialog-backdrop.show").wait_for()
+        page.locator("#dialog-ok").click()
+        assert page.evaluate(
+            "async () => await window.__identityRefresh") is False
+        assert page.evaluate("""() => {
+          const mesh = window.modViewer.activeMeshes[0];
+          return {
+            sameMesh: mesh === window.__identityBefore.mesh,
+            sameGeometry: mesh.geometry === window.__identityBefore.geometry,
+            sameMaterial: mesh.material === window.__identityBefore.material,
+            identity: mesh.userData.identity,
+          };
+        }""") == {
+            "sameMesh": True,
+            "sameGeometry": True,
+            "sameMaterial": True,
+            "identity": identity_a,
+        }
     finally:
         context.close()
 

--- a/src/tests/web/test_app_flow.py
+++ b/src/tests/web/test_app_flow.py
@@ -413,7 +413,7 @@ def test_control_and_mesh_semantic_refreshes_preserve_existing_meshes(
     payload = _payload("Semantic")
     mesh_name = next(iter(payload["meshes"]))
     identity = {
-        "version": 3, "key": "mesh:[3,\"Semantic.ini\",\"Body\",null,[3,0,0],[null,null,null,null,null,null,null]]",
+        "version": 4, "key": "mesh:[4,\"Semantic.ini\",\"Body\",null,null,[3,0,0],[null,null,null,null,null,null,null]]",
         "source": "Semantic.ini", "component": "Body", "geometry": None,
         "draw": {"count": 3, "start": 0, "base": 0},
     }
@@ -481,8 +481,8 @@ def test_frontend_uses_backend_mesh_identity_for_metadata_key(
     payload = _payload("Identity")
     mesh_name, entry = next(iter(payload["meshes"].items()))
     entry["identity"] = {
-        "version": 3,
-        "key": "mesh:[3,\"Identity.ini\",\"Body\",null,[3,0,0],[null,null,null,null,null,null,null]]",
+        "version": 4,
+        "key": "mesh:[4,\"Identity.ini\",\"Body\",null,null,[3,0,0],[null,null,null,null,null,null,null]]",
         "source": "Identity.ini", "component": "Body", "geometry": None,
         "draw": {"count": 3, "start": 0, "base": 0},
     }
@@ -511,13 +511,13 @@ def test_semantic_refresh_rejects_identity_mismatch_without_mutation(
     payload = _payload("Mismatch")
     mesh_name, entry = next(iter(payload["meshes"].items()))
     identity_a = {
-        "version": 3, "key": "mesh:[3,\"Mismatch.ini\",\"Body\",null,[3,0,0],[null,null,null,null,null,null,null]]",
+        "version": 4, "key": "mesh:[4,\"Mismatch.ini\",\"Body\",null,null,[3,0,0],[null,null,null,null,null,null,null]]",
         "source": "Mismatch.ini", "component": "Body", "geometry": None,
         "draw": {"count": 3, "start": 0, "base": 0},
     }
     identity_b = {
         **identity_a,
-        "key": "mesh:[3,\"Mismatch.ini\",\"Body\",null,[4,0,0],[null,null,null,null,null,null,null]]",
+        "key": "mesh:[4,\"Mismatch.ini\",\"Body\",null,null,[4,0,0],[null,null,null,null,null,null,null]]",
         "draw": {"count": 4, "start": 0, "base": 0},
     }
     entry["identity"] = identity_a

--- a/src/web/js/mesh/mesh-state.js
+++ b/src/web/js/mesh/mesh-state.js
@@ -150,6 +150,7 @@ export function resetMeshVisibility() {
 
 const SEMANTIC_SNAPSHOT_FIELDS = [
   'conditions', 'sources', 'source', 'component',
+  'identity',
   'textureVariants', 'normalMapVariants', 'normalDataVariants',
   'lightMapVariants', 'materialMapVariants', 'emissionMapVariants',
   'defaultTexKey', 'defaultNormalMapKey', 'defaultNormalDataKey',
@@ -180,6 +181,14 @@ export function updateMeshSemantics(semantics, { materialProfiles = {} } = {}) {
   const keys = semanticMeshes.map(mesh => mesh.userData.semanticKey);
   if (keys.some(key => !next[key])
       || Object.keys(next).length !== keys.length) {
+    return {success: false, materialChangedMeshes: []};
+  }
+  const identityMismatch = semanticMeshes.some(mesh => {
+    const currentKey = mesh.userData.identity?.key;
+    const nextKey = next[mesh.userData.semanticKey]?.identity?.key;
+    return currentKey && nextKey && currentKey !== nextKey;
+  });
+  if (identityMismatch) {
     return {success: false, materialChangedMeshes: []};
   }
 
@@ -216,6 +225,9 @@ export function updateMeshSemantics(semantics, { materialProfiles = {} } = {}) {
       }
       if (Object.hasOwn(semantic, 'component')) {
         mesh.userData.component = semantic.component;
+      }
+      if (Object.hasOwn(semantic, 'identity')) {
+        mesh.userData.identity = semantic.identity || null;
       }
       const variants = [
         ['textureVariants', 'texture_variants'],

--- a/src/web/js/mesh/mesh-texture-state.js
+++ b/src/web/js/mesh/mesh-texture-state.js
@@ -9,7 +9,7 @@ export {
   registerTextureRunGroup, unregisterTextureRunGroup,
 } from './mesh-texture-runs.js';
 
-export function meshMetadataKey(name, entry) {
+export function legacyMeshMetadataKey(name, entry) {
   const component = entry.component || name.replace(/-\d+$/, '');
   const draw = entry.drawindexed ? entry.drawindexed.join(',') : 'whole';
   return `${component}::${draw}`;

--- a/src/web/js/panels/mesh-panel.js
+++ b/src/web/js/panels/mesh-panel.js
@@ -8,7 +8,7 @@ import {
   setManualTexOverride,
 } from '../mesh/mesh-state.js';
 import {
-  clearTextureRunGroups, meshMetadataKey, recomputeTextureRuns,
+  clearTextureRunGroups, legacyMeshMetadataKey, recomputeTextureRuns,
   registerTextureRunGroup, unregisterTextureRunGroup, saveTextureState,
 } from '../mesh/mesh-texture-state.js';
 import { bindMeshView, getMeshView } from '../mesh/mesh-view-bindings.js';
@@ -59,7 +59,8 @@ function syncMeshPanel() {
 function groupByComponent(names, meshes) {
   const grouped = {};
   for (const name of names) {
-    const explicit = meshes[name]?.component;
+    const explicit = meshes[name]?.identity?.component
+      || meshes[name]?.component;
     let key = explicit;
     if (!key) {
       const m = name.match(/^(.+)-\d+$/);
@@ -331,7 +332,7 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
         .map(n => meshes[n].material_kind_override)
         .find(Boolean) || null;
       const componentIdentity = names
-        .map(n => meshes[n].component)
+        .map(n => meshes[n].identity?.component || meshes[n].component)
         .find(Boolean) || null;
 
       const itemCbs = [], itemObjs = [];
@@ -422,7 +423,9 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
         const materialProfile = materialProfiles?.[entry.material_profile_id] || null;
         const mesh = buildMesh(name, entry, materialProfile);
         mesh.userData.semanticKey = name;
-        mesh.userData.metadataKey = meshMetadataKey(name, meshes[name]);
+        mesh.userData.identity = entry.identity || null;
+        mesh.userData.metadataKey = entry.identity?.key
+          || legacyMeshMetadataKey(name, entry);
         mesh.userData.texturePool = texturePool;
         mesh.userData.displayName = meshNames[mesh.userData.metadataKey]
           || entry.display_name || null;


### PR DESCRIPTION
## Summary
- Add a canonical source-qualified identity for displayed mod draws.
- Emit the identity consistently from full and semantic payloads while keeping Asset binding separate.
- Migrate viewer texture and mesh-name metadata with legacy fallback and guard semantic refresh mismatches.