### PR TITLE
feat: open disabled mod INIs

### DIFF
--- a/src/app/bridge/api.py
+++ b/src/app/bridge/api.py
@@ -128,9 +128,9 @@ class ModViewerAPI:
 
     # -- Mod preview --------------------------------------------------------
 
-    def load_mod(self, folder_path):
+    def load_mod(self, folder_path, disabled_ini=False):
         self._asset_preview.clear_fill()
-        return self._mod_preview.load_mod(folder_path)
+        return self._mod_preview.load_mod(folder_path, disabled_ini)
 
     def get_present_state(self, folder_path):
         return self._mod_preview.get_present_state(folder_path)

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -46,11 +46,11 @@ class ModPreview:
 
         return register
 
-    def authoritative_context(self, folder_path):
-        """Load active INI documents while preserving the current session."""
+    def authoritative_context(self, folder_path, disabled_ini=False):
+        """Load selected INI documents while preserving the current session."""
         folder_path = self._access.mod_folder(folder_path)
         ini_paths = (edit_session.document_paths(folder_path)
-                     or discover_ini_paths(folder_path))
+                     or discover_ini_paths(folder_path, disabled=disabled_ini))
         edit_session.load_documents(folder_path, ini_paths)
         overrides = edit_session.overrides_for(folder_path)
         pending_new_sections = edit_session.new_sections_for(folder_path)
@@ -73,9 +73,9 @@ class ModPreview:
         traceback.print_exc()
         return {"error": "Unexpected backend error. See the application log for details."}
 
-    def load_mod(self, folder_path):
+    def load_mod(self, folder_path, disabled_ini=False):
         folder_path, overrides, pending_new_sections, context = \
-            self.authoritative_context(folder_path)
+            self.authoritative_context(folder_path, disabled_ini=disabled_ini)
         geometry = GeometryBlob()
         publication = server.begin_texture_publication(folder_path)
         try:
@@ -83,6 +83,11 @@ class ModPreview:
                 context=context, overrides=overrides,
                 pending_new_sections=pending_new_sections, geometry=geometry,
                 texture_source=publication.register)
+            if (disabled_ini and isinstance(result, dict)
+                    and not context.ini_paths
+                    and result.get("error") ==
+                    "No active .ini files found in this folder."):
+                result["error"] = "No disabled .ini files found in this folder."
             if not isinstance(result, dict) or result.get("error"):
                 publication.discard()
                 self._active_mesh_keys.pop(folder_path, None)

--- a/src/app/runtime/server.py
+++ b/src/app/runtime/server.py
@@ -501,6 +501,8 @@ def start():
         body_classes.append("feature-export-off")
     if not flags["modify_toggle"]:
         body_classes.append("feature-modify-toggle-off")
+    if not flags["open_disabled_mod"]:
+        body_classes.append("feature-open-disabled-mod-off")
 
     template_vars = {
         "__THREE_URL__": three_url,

--- a/src/app/settings/features.py
+++ b/src/app/settings/features.py
@@ -1,7 +1,8 @@
 """Build-time feature flags: which optional UI actions a *built* exe exposes.
 
-The two flags (Export / Modify_Toggle) are configured via features.ini at the
-repo root, a build-time-only input never bundled into the exe. build.py reads
+The three flags (Export / Modify_Toggle / Open_Disabled_Mod) are configured via
+features.ini at the repo root, a build-time-only input never bundled into the
+exe. build.py reads
 it and bakes the resolved booleans into app/settings/_baked_features.py, a generated
 module compiled into the exe like any other app code, then deletes it again
 after PyInstaller has run — so there's no plain config file for an end user
@@ -14,11 +15,15 @@ checkout always shows every feature. This only ever hides a button in the UI
 
 from . import paths
 
-_DEFAULTS = {"export": True, "modify_toggle": True}
+_DEFAULTS = {
+    "export": True,
+    "modify_toggle": True,
+    "open_disabled_mod": True,
+}
 
 
 def get_features():
-    """Returns {"export": bool, "modify_toggle": bool}.
+    """Returns the resolved optional feature flags.
 
     Always all-True when not frozen. When frozen, a missing baked module or
     a missing constant both fall back to True -- a broken build should never
@@ -35,4 +40,5 @@ def get_features():
     return {
         "export": bool(getattr(baked, "EXPORT", True)),
         "modify_toggle": bool(getattr(baked, "MODIFY_TOGGLE", True)),
+        "open_disabled_mod": bool(getattr(baked, "OPEN_DISABLED_MOD", True)),
     }

--- a/src/build.py
+++ b/src/build.py
@@ -408,11 +408,15 @@ def verify_features():
         raise RuntimeError(f"missing feature-flags config: {FEATURES_FILE}")
 
 
-_FEATURE_DEFAULTS = {"export": True, "modify_toggle": True}
+_FEATURE_DEFAULTS = {
+    "export": True,
+    "modify_toggle": True,
+    "open_disabled_mod": True,
+}
 
 
 def resolve_features(ini_path):
-    """Parse features.ini into {"export": bool, "modify_toggle": bool}.
+    """Parse features.ini into the resolved optional feature flags.
 
     This is the one place that ini gets read — the resolved booleans are
     baked into the exe at build time (write_baked_features()) instead of
@@ -455,6 +459,7 @@ def write_baked_features(flags, path=BAKED_FEATURES_MODULE):
             "# a safety net should a build ever be interrupted first.\n"
             f"EXPORT = {flags['export']!r}\n"
             f"MODIFY_TOGGLE = {flags['modify_toggle']!r}\n"
+            f"OPEN_DISABLED_MOD = {flags['open_disabled_mod']!r}\n"
         )
 
 

--- a/src/core/mod_discovery.py
+++ b/src/core/mod_discovery.py
@@ -1,4 +1,4 @@
-"""Filesystem-only discovery of active INI files for a selected mod folder."""
+"""Filesystem-only discovery of selected INI files for a mod folder."""
 
 import os
 import re
@@ -11,15 +11,19 @@ _DRAW_RE = re.compile(r"^drawindexed\s*=", re.I)
 _IB_RE = re.compile(r"^ib\s*=", re.I)
 
 
-def _active_ini_names(folder):
+def _ini_names(folder, *, disabled=False):
     try:
         names = os.listdir(folder)
     except OSError:
         return []
-    return [name for name in sorted(names)
-            if not name.upper().startswith("DISABLED")
-            and name.lower().endswith(".ini")
-            and os.path.isfile(os.path.join(folder, name))]
+    selected = []
+    for name in sorted(names):
+        is_disabled = name.upper().startswith("DISABLED")
+        if is_disabled != disabled or not name.lower().endswith(".ini"):
+            continue
+        if os.path.isfile(os.path.join(folder, name)):
+            selected.append(name)
+    return selected
 
 
 def _has_geometry_sections(path):
@@ -52,15 +56,17 @@ def _has_geometry_sections(path):
     return has_draw or has_index
 
 
-def discover_ini_paths(mod_dir):
-    """Return active direct INIs and bounded nested INIs for ``mod_dir``.
+def discover_ini_paths(mod_dir, *, disabled=False):
+    """Return selected direct INIs and bounded nested INIs for ``mod_dir``.
 
     Direct files are always retained.  Nested files are considered only when
     a direct INI contains a geometry command, and are capped at two directory
-    levels and ten total files.  This keeps category/library folders from
-    accidentally combining unrelated nested mods.
+    levels and ten total files.  ``disabled`` selects only filenames beginning
+    with ``DISABLED`` (case-insensitively); active and disabled files are never
+    combined.
     """
-    direct = [os.path.join(mod_dir, name) for name in _active_ini_names(mod_dir)]
+    direct = [os.path.join(mod_dir, name)
+              for name in _ini_names(mod_dir, disabled=disabled)]
     if not any(_has_geometry_sections(path) for path in direct):
         return direct
 
@@ -73,7 +79,7 @@ def discover_ini_paths(mod_dir):
         dirs[:] = sorted(dirs) if depth < _MAX_INI_DEPTH else []
         if depth == 0:
             continue
-        for name in _active_ini_names(base):
+        for name in _ini_names(base, disabled=disabled):
             found.append(os.path.join(base, name))
             if len(found) >= _MAX_INI_FILES:
                 return found

--- a/src/features.ini
+++ b/src/features.ini
@@ -13,3 +13,4 @@
 [features]
 Export = 1
 Modify_Toggle = 1
+Open_Disabled_Mod = 0

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -107,3 +107,17 @@ def test_missing_asset_parts_preserves_unauthorized_folder_error(
         "status": "error",
         "error": "This folder was not selected through the native folder picker.",
     }
+
+
+def test_load_mod_forwards_disabled_ini_flag(monkeypatch):
+    api = ModViewerAPI()
+    calls = []
+    monkeypatch.setattr(api._asset_preview, "clear_fill", lambda: None)
+    monkeypatch.setattr(
+        api._mod_preview, "load_mod",
+        lambda path, disabled_ini=False: calls.append((path, disabled_ini))
+        or {"ok": True},
+    )
+
+    assert api.load_mod("mod", True) == {"ok": True}
+    assert calls == [("mod", True)]

--- a/src/tests/app/bridge/test_mod_preview.py
+++ b/src/tests/app/bridge/test_mod_preview.py
@@ -34,6 +34,56 @@ def _context():
     return SimpleNamespace(metadata={}, asset_folders=[])
 
 
+@pytest.mark.parametrize(
+    "disabled_ini, expected_name",
+    [(False, "Active.ini"), (True, "DISABLEDActive.ini")],
+)
+def test_authoritative_context_discovers_only_selected_ini_mode(
+        disabled_ini, expected_name, monkeypatch):
+    preview = ModPreview(_Access())
+    discovered = []
+    ini_path = f"mod/{expected_name}"
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.discover_ini_paths",
+        lambda folder, *, disabled=False: discovered.append(disabled)
+        or [ini_path],
+    )
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.edit_session.document_paths",
+        lambda _folder: [],
+    )
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.edit_session.load_documents",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.edit_session.overrides_for",
+        lambda _folder: {},
+    )
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.edit_session.new_sections_for",
+        lambda _folder: {},
+    )
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.edit_session.documents_for",
+        lambda _folder: {},
+    )
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.load",
+        lambda _folder: {},
+    )
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.asset_folders.load_registry",
+        lambda: [],
+    )
+
+    _folder, _overrides, _pending, context = preview.authoritative_context(
+        "mod", disabled_ini=disabled_ini)
+
+    assert discovered == [disabled_ini]
+    assert context.ini_paths == [ini_path]
+
+
 def test_model_skinning_preview_includes_validated_saved_bones(monkeypatch):
     preview = ModPreview(_Access())
     context = _context()
@@ -84,7 +134,7 @@ def test_load_commits_texture_publication_after_geometry(monkeypatch):
     preview = ModPreview(_Access())
     monkeypatch.setattr(
         preview, "authoritative_context",
-        lambda _folder: ("mod", {}, {}, _context()))
+        lambda _folder, **_kwargs: ("mod", {}, {}, _context()))
     monkeypatch.setattr(
         "app.bridge.mod_preview.server.begin_texture_publication",
         lambda _folder: publication)
@@ -113,6 +163,72 @@ def test_load_commits_texture_publication_after_geometry(monkeypatch):
     assert preview._active_mesh_keys == {"mod": {"Body-1"}}
 
 
+def test_load_forwards_disabled_mode_to_authoritative_context(monkeypatch):
+    publication = _Publication([])
+    preview = ModPreview(_Access())
+    context = _context()
+    context.ini_paths = ["mod/DISABLEDActive.ini"]
+    captured = {}
+
+    def authoritative_context(_folder, *, disabled_ini=False):
+        captured["disabled_ini"] = disabled_ini
+        return "mod", {}, {}, context
+
+    monkeypatch.setattr(preview, "authoritative_context", authoritative_context)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.begin_texture_publication",
+        lambda _folder: publication)
+
+    def load_model(**kwargs):
+        captured["context"] = kwargs["context"]
+        return {
+            "meshes": {"Body-1": {}},
+            "metadata": {"game": {"id": "genshin"}},
+            "controls": {"present": {}},
+        }
+
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.mod_loader.load_mod", load_model)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.hydrate_textures",
+        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.hydrate_present",
+        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.publish_payload_geometry",
+        lambda *_args, **_kwargs: None,
+    )
+
+    preview.load_mod("mod", disabled_ini=True)
+
+    assert captured["disabled_ini"] is True
+    assert captured["context"].ini_paths == ["mod/DISABLEDActive.ini"]
+
+
+def test_load_reports_disabled_ini_error_when_discovery_is_empty(monkeypatch):
+    publication = _Publication([])
+    preview = ModPreview(_Access())
+    context = _context()
+    context.ini_paths = []
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder, **_kwargs: ("mod", {}, {}, context))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.begin_texture_publication",
+        lambda _folder: publication)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.mod_loader.load_mod",
+        lambda **_kwargs: {
+            "error": "No active .ini files found in this folder.",
+        })
+
+    result = preview.load_mod("mod", disabled_ini=True)
+
+    assert result["error"] == "No disabled .ini files found in this folder."
+    assert publication.events == [("discard",)]
+
+
 def test_failed_load_discards_publication_and_clears_active_meshes(monkeypatch):
     events = []
     publication = _Publication(events)
@@ -120,7 +236,7 @@ def test_failed_load_discards_publication_and_clears_active_meshes(monkeypatch):
     preview._active_mesh_keys["mod"] = {"old"}
     monkeypatch.setattr(
         preview, "authoritative_context",
-        lambda _folder: ("mod", {}, {}, _context()))
+        lambda _folder, **_kwargs: ("mod", {}, {}, _context()))
     monkeypatch.setattr(
         "app.bridge.mod_preview.server.begin_texture_publication",
         lambda _folder: publication)

--- a/src/tests/app/runtime/test_server.py
+++ b/src/tests/app/runtime/test_server.py
@@ -6,18 +6,19 @@ import urllib.request
 from app.runtime import server as server
 
 
-def _read_index(tmp_path, monkeypatch):
+def _read_index(tmp_path, monkeypatch, feature_flags=None):
     web = tmp_path / "web"
     web.mkdir(parents=True)
     (web / "index.html").write_text(
-        '<script type="importmap" nonce="__CSP_NONCE__"></script>',
+        '<body class="__BODY_CLASS__"><script type="importmap" '
+        'nonce="__CSP_NONCE__"></script></body>',
         encoding="utf-8")
     monkeypatch.setattr(server.paths, "has_vendored_three", lambda: True)
     monkeypatch.setattr(server.paths, "web_dir", lambda: str(web))
     monkeypatch.setattr(server.paths, "vendor_dir", lambda: str(web))
     monkeypatch.setattr(server.features, "get_features", lambda: {
-        "export": True, "modify_toggle": True,
-    })
+        "export": True, "modify_toggle": True, "open_disabled_mod": True,
+    } if feature_flags is None else feature_flags)
 
     response = urllib.request.urlopen(server.start(), timeout=5)
     return response.headers, response.read().decode("utf-8")
@@ -40,3 +41,12 @@ def test_server_generates_fresh_nonce_and_applies_it_consistently(
         nonces.append(nonce)
 
     assert nonces[0] != nonces[1]
+
+
+def test_server_marks_disabled_mod_feature_as_hidden(tmp_path, monkeypatch):
+    _headers, body = _read_index(
+        tmp_path, monkeypatch,
+        {"export": True, "modify_toggle": True, "open_disabled_mod": False},
+    )
+
+    assert "feature-open-disabled-mod-off" in body

--- a/src/tests/app/settings/test_features.py
+++ b/src/tests/app/settings/test_features.py
@@ -2,7 +2,7 @@
 exposes), split across two seams that this file tests separately:
 
   - build.py's resolve_features(ini_path): reads features.ini at BUILD time
-    and resolves it to {"export": bool, "modify_toggle": bool}. This is now
+    and resolves it to the three feature booleans. This is now
     the only place that ever parses the ini file. write_baked_features()/
     clean_baked_features() round-trip those booleans through a tiny
     generated module (app/settings/_baked_features.py) so PyInstaller compiles them
@@ -14,7 +14,7 @@ exposes), split across two seams that this file tests separately:
     source checkout (paths.is_frozen()), regardless of any baked module
     present, so flags meant for a distributed build do not hide source
     features. When frozen, it imports app.settings._baked_features and reads
-    its EXPORT/MODIFY_TOGGLE constants, falling back to True for a flag if the
+    its baked constants, falling back to True for a flag if the
     module or the constant is missing (a broken/skipped bake should never
     silently hide a feature nobody deliberately disabled).
 
@@ -44,41 +44,56 @@ def _fixture(tmp, text, name="features.ini"):
 
 # ── build.py: resolve_features() / write_baked_features() ───────────────────
 
-_FLAG_CASES = [(False, True), (True, False)]
+_FLAG_CASES = [(False, True, False), (True, False, True)]
 
 
-def _run_feature_case(export, modify_toggle, tmp):
+def _run_feature_case(export, modify_toggle, open_disabled_mod, tmp):
     path = _fixture(
         tmp,
         "[features]\n"
         f"Export = {int(export)}\n"
-        f"Modify_Toggle = {int(modify_toggle)}\n",
+        f"Modify_Toggle = {int(modify_toggle)}\n"
+        f"Open_Disabled_Mod = {int(open_disabled_mod)}\n",
     )
     result = build.resolve_features(path)
-    assert result == {"export": export, "modify_toggle": modify_toggle}, f"feature flags resolve independently (got {result})"
+    assert result == {
+        "export": export,
+        "modify_toggle": modify_toggle,
+        "open_disabled_mod": open_disabled_mod,
+    }, f"feature flags resolve independently (got {result})"
 
 
-@pytest.mark.parametrize("export, modify_toggle", _FLAG_CASES)
-def test_resolve_features_flag_matrix(export, modify_toggle, tmp_path):
-    """Every pair of authored feature flags maps to the same booleans."""
-    _run_feature_case(export, modify_toggle, str(tmp_path))
+@pytest.mark.parametrize("export, modify_toggle, open_disabled_mod", _FLAG_CASES)
+def test_resolve_features_flag_matrix(
+        export, modify_toggle, open_disabled_mod, tmp_path):
+    """Every authored feature combination maps to the same booleans."""
+    _run_feature_case(
+        export, modify_toggle, open_disabled_mod, str(tmp_path))
 
 
 def test_missing_feature_config_defaults_enabled(tmp_path):
     result = build.resolve_features(str(tmp_path / "does_not_exist.ini"))
-    assert result == {"export": True, "modify_toggle": True}
+    assert result == {
+        "export": True, "modify_toggle": True, "open_disabled_mod": True,
+    }
 
 
 def test_write_baked_features_round_trips_through_import():
     with tempfile.TemporaryDirectory() as tmp:
         path = os.path.join(tmp, "_baked_features_test.py")
-        build.write_baked_features({"export": False, "modify_toggle": True}, path=path)
+        build.write_baked_features({
+            "export": False, "modify_toggle": True, "open_disabled_mod": False,
+        }, path=path)
         ns = {}
         with open(path, encoding="utf-8") as fh:
             exec(compile(fh.read(), path, "exec"), ns)
-        assert ns.get("EXPORT") is False and ns.get("MODIFY_TOGGLE") is True, (
+        assert (ns.get("EXPORT") is False
+                and ns.get("MODIFY_TOGGLE") is True
+                and ns.get("OPEN_DISABLED_MOD") is False), (
             f"the generated module's constants match the flags passed in "
-            f"(got EXPORT={ns.get('EXPORT')!r}, MODIFY_TOGGLE={ns.get('MODIFY_TOGGLE')!r})")
+            f"(got EXPORT={ns.get('EXPORT')!r}, "
+            f"MODIFY_TOGGLE={ns.get('MODIFY_TOGGLE')!r}, "
+            f"OPEN_DISABLED_MOD={ns.get('OPEN_DISABLED_MOD')!r})")
         build.clean_baked_features(path=path)
     assert not os.path.isfile(path), "clean_baked_features removes the generated module"
 
@@ -88,10 +103,18 @@ def test_write_baked_features_round_trips_through_import():
 @pytest.mark.parametrize(
     "frozen, baked, expected",
     [
-        (False, (False, False), {"export": True, "modify_toggle": True}),
-        (True, (False, True), {"export": False, "modify_toggle": True}),
-        (True, None, {"export": True, "modify_toggle": True}),
-        (True, (False, None), {"export": False, "modify_toggle": True}),
+        (False, (False, False, False), {
+            "export": True, "modify_toggle": True, "open_disabled_mod": True,
+        }),
+        (True, (False, True, False), {
+            "export": False, "modify_toggle": True, "open_disabled_mod": False,
+        }),
+        (True, None, {
+            "export": True, "modify_toggle": True, "open_disabled_mod": True,
+        }),
+        (True, (False, None, True), {
+            "export": False, "modify_toggle": True, "open_disabled_mod": True,
+        }),
     ],
     ids=["source-ignores-baked", "frozen-reads-baked",
          "frozen-missing-module", "frozen-missing-attribute"],
@@ -107,6 +130,8 @@ def test_runtime_feature_resolution(frozen, baked, expected, monkeypatch):
             module.EXPORT = baked[0]
         if baked[1] is not None:
             module.MODIFY_TOGGLE = baked[1]
+        if baked[2] is not None:
+            module.OPEN_DISABLED_MOD = baked[2]
         monkeypatch.setitem(sys.modules, module_name, module)
 
     assert features.get_features() == expected

--- a/src/tests/core/test_mod_discovery.py
+++ b/src/tests/core/test_mod_discovery.py
@@ -1,0 +1,68 @@
+"""INI discovery keeps active and disabled selections separate."""
+
+import os
+
+import pytest
+
+from core.mod_discovery import discover_ini_paths
+
+
+_GEOMETRY_INI = "[TextureOverrideRoot]\ndrawindexed = 3, 0, 0\n"
+_PLAIN_INI = "[Constants]\n$Value = 1\n"
+
+
+def _write(root, relative, text=_PLAIN_INI):
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _relative_paths(root, paths):
+    return [os.path.relpath(path, root).replace(os.sep, "/")
+            for path in paths]
+
+
+def test_discovery_filters_selected_files_and_preserves_bounded_nested_rules(
+        tmp_path):
+    _write(tmp_path, "Active.ini", _GEOMETRY_INI)
+    _write(tmp_path, "active-extra.ini")
+    _write(tmp_path, "DISABLEDActive.ini", _GEOMETRY_INI)
+    _write(tmp_path, "disabled-extra.ini")
+    _write(tmp_path, "ignored.txt")
+    _write(tmp_path, "nested/Child.ini")
+    _write(tmp_path, "nested/DISABLEDChild.ini")
+    _write(tmp_path, "nested/deeper/Deep.ini")
+    _write(tmp_path, "nested/deeper/DISABLEDDeep.ini")
+    _write(tmp_path, "nested/deeper/too-deep/TooDeep.ini")
+    _write(tmp_path, "nested/deeper/too-deep/DISABLEDTooDeep.ini")
+
+    assert _relative_paths(tmp_path, discover_ini_paths(tmp_path)) == [
+        "Active.ini", "active-extra.ini", "nested/Child.ini",
+        "nested/deeper/Deep.ini",
+    ]
+    assert _relative_paths(
+        tmp_path, discover_ini_paths(tmp_path, disabled=True)) == [
+        "DISABLEDActive.ini", "disabled-extra.ini", "nested/DISABLEDChild.ini",
+        "nested/deeper/DISABLEDDeep.ini",
+    ]
+
+    no_disabled = tmp_path / "no-disabled"
+    _write(no_disabled, "Active.ini", _GEOMETRY_INI)
+    assert discover_ini_paths(no_disabled, disabled=True) == []
+
+
+@pytest.mark.parametrize("disabled, prefix", [(False, ""), (True, "DISABLED")])
+def test_discovery_applies_ini_count_cap_to_selected_nested_files(
+        disabled, prefix, tmp_path):
+    _write(tmp_path, f"{prefix}Root.ini", _GEOMETRY_INI)
+    for index in range(12):
+        _write(tmp_path, f"nested/{prefix}{index:02}.ini")
+    _write(tmp_path, "nested/other-mode.ini" if disabled else
+           "nested/DISABLEDother-mode.ini")
+
+    paths = discover_ini_paths(tmp_path, disabled=disabled)
+
+    assert len(paths) == 10
+    assert all(
+        ("DISABLED" in os.path.basename(path).upper()) == disabled
+        for path in paths)

--- a/src/tests/web/support.py
+++ b/src/tests/web/support.py
@@ -322,7 +322,7 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
             "summary": {"issues": 0, "errors": 0}, "files": {}, "issues": []},
         "panelOpacity": panel_opacity,
         "panelOpacityApi": panel_opacity_api,
-        "calls": {"loadMod": [], "loadAsset": [], "listSubfolders": [],
+        "calls": {"loadMod": [], "loadModArgs": [], "loadAsset": [], "listSubfolders": [],
                    "listAssetSubfolders": [],
                    "selectAssetFolder": [],
                    "rebuildAssetIndex": [],
@@ -357,8 +357,9 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
               state.calls.selectAssetFolder.push(path);
               return path;
             },
-            load_mod: async path => {
+            load_mod: async (path, disabledIni = false) => {
               state.calls.loadMod.push(path);
+              state.calls.loadModArgs.push([path, disabledIni]);
               if (state.blockLoads?.[path]) {
                 await new Promise(resolve => {
                   (loadWaiters[path] ||= []).push(resolve);

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -59,6 +59,24 @@ def test_right_dock_tabs_toggle_without_reopening_on_refresh(edge_browser, front
     finally:
         context.close()
 
+def test_reload_current_mod_does_not_read_disabled_ini_checkbox(
+        edge_browser, frontend_url):
+    path = "ReloadCheckbox"
+    context, page = _page(edge_browser, frontend_url, {path: _payload(path)})
+    try:
+        _open(page, path)
+        page.locator(".draw-item").wait_for()
+        page.locator("#open-disabled-mod").check()
+        page.evaluate("window.modViewer.reloadCurrentMod()")
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadModArgs.length === 2")
+
+        assert page.evaluate("window.__fakeApi.calls.loadModArgs") == [
+            [path, False], [path, False],
+        ]
+    finally:
+        context.close()
+
 def test_mesh_row_selection_invalidates_on_demand_renderer(
         edge_browser, frontend_url):
     payload = _payload("Selection")
@@ -227,12 +245,15 @@ def test_feature_flag_css_keeps_cycle_preview_and_core_invariants(
             "No key or menu toggle is available for PRESENT.")
         assert page.locator("#present-action-btn").is_enabled()
         page.evaluate("""
-          document.body.classList.add('feature-export-off', 'feature-modify-toggle-off')
+          document.body.classList.add(
+            'feature-export-off', 'feature-modify-toggle-off',
+            'feature-open-disabled-mod-off')
         """)
         assert page.locator("#export-btn").is_hidden()
         assert page.locator("#toggle-add-btn").is_hidden()
         assert page.locator("#toggle-list .toggle-actions").is_hidden()
         assert page.locator("#toggle-list .toggle-cycle-btn").is_visible()
+        assert page.locator("#open-disabled-mod").is_hidden()
 
         css = (paths.web_dir() + "/css/app.css")
         with open(css, encoding="utf-8") as handle:
@@ -242,6 +263,63 @@ def test_feature_flag_css_keeps_cycle_preview_and_core_invariants(
             html = handle.read()
         assert "https://cdn" not in html.lower()
         assert "http://" not in html.lower()
+    finally:
+        context.close()
+
+
+def test_open_disabled_checkbox_controls_direct_and_library_loads(
+        edge_browser, frontend_url):
+    direct_unchecked = "DirectUnchecked"
+    direct_checked = "DirectChecked"
+    library_unchecked = "LibraryUnchecked"
+    library_checked = "LibraryChecked"
+    context, page = _page(
+        edge_browser, frontend_url,
+        {path: _payload(path) for path in (
+            direct_unchecked, direct_checked,
+            library_unchecked, library_checked)},
+        mod_folders=[
+            {"name": "Library Unchecked", "path": library_unchecked,
+             "exists": True},
+            {"name": "Library Checked", "path": library_checked,
+             "exists": True},
+        ],
+    )
+    try:
+        checkbox = page.locator("#open-disabled-mod")
+        assert checkbox.is_visible()
+        assert checkbox.get_attribute("title") == "Open disabled mod"
+        assert checkbox.get_attribute("aria-label") == "Open disabled mod"
+        assert not checkbox.is_checked()
+        assert checkbox.evaluate("element => element.labels.length") == 0
+        assert "Open disabled mod" not in page.locator("#toolbar").inner_text()
+
+        _open(page, direct_unchecked)
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadModArgs.length === 1")
+        checkbox.check()
+        _open(page, direct_checked)
+        page.locator(".draw-item").wait_for()
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadModArgs.length === 2")
+
+        checkbox.uncheck()
+        _open_library(page)
+        page.locator(".mod-folder-select", has_text="Library Unchecked").click()
+        page.locator(".draw-item").wait_for(state="attached")
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadModArgs.length === 3")
+        checkbox.check()
+        page.locator(".mod-folder-select", has_text="Library Checked").click()
+        page.locator(".draw-item").wait_for(state="attached")
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadModArgs.length === 4")
+
+        assert page.evaluate("window.__fakeApi.calls.loadModArgs") == [
+            [direct_unchecked, False], [direct_checked, True],
+            [library_unchecked, False], [library_checked, True],
+        ]
     finally:
         context.close()
 

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -66,6 +66,11 @@ body {
 }
 #open-btn:hover:not(:disabled) { background: var(--success-hover); }
 #open-btn:disabled { opacity: .45; cursor: default; }
+#open-disabled-mod {
+  width: 14px; height: 14px; margin: 0 -4px 0 0; accent-color: var(--success);
+  cursor: pointer;
+}
+#open-disabled-mod:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .pending-indicator {
   display: none; font-size: 11px; color: var(--warning); background: #2b2111;
   border: 1px solid #4d3a14; border-radius: 6px; padding: 4px 8px; white-space: nowrap;
@@ -856,6 +861,7 @@ body.feature-modify-toggle-off #toggle-add-btn { display: none; }
 body.feature-modify-toggle-off .toggle-actions { display: none; }
 body.feature-modify-toggle-off #present-action-btn { display: none; }
 body.feature-modify-toggle-off .present-author-actions { display: none; }
+body.feature-open-disabled-mod-off #open-disabled-mod { display: none; }
 .menu-slider-item {
   gap: 7px;
 }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -47,6 +47,8 @@
   <span class="app-title">Mod Viewer</span>
   <span id="mod-path">No mod loaded</span>
   <span id="pending-indicator" class="pending-indicator" role="status">Edited</span>
+  <input id="open-disabled-mod" type="checkbox" title="Open disabled mod"
+         aria-label="Open disabled mod">
   <button id="open-btn" class="ui-button" disabled>Open Mod</button>
   <div class="ini-view-wrap toolbar-secondary">
     <button id="ini-view-btn" class="ui-button" disabled>View INI</button>

--- a/src/web/js/app/model-flow.js
+++ b/src/web/js/app/model-flow.js
@@ -229,14 +229,16 @@ export async function displayMeshPayload(payload, {
   showLoading(false);
 }
 
-async function loadModAt(path, handlers = {}) {
+async function loadModAt(path, disabledIni, handlers = {}) {
   const preserveViewerPose = samePath(viewerState.displayedModPath, path);
   beginModLoad(path, 'Loading Model…', {
     preserveModelOrientation: preserveViewerPose,
     onReload: handlers.onReload,
   });
 
-  const data = await window.pywebview.api.load_mod(path);
+  const data = disabledIni === undefined
+    ? await window.pywebview.api.load_mod(path)
+    : await window.pywebview.api.load_mod(path, disabledIni);
   setHealthReport(data?.health, data?.asset_resolution);
   if (data && data.error) {
     showLoading(false);
@@ -323,7 +325,8 @@ async function performModSwitch(path, handlers = {}) {
     await window.pywebview.api.discard_changes(viewerState.currentModPath);
   }
 
-  return await loadModAt(path, handlers);
+  const disabledIni = $('open-disabled-mod')?.checked === true;
+  return await loadModAt(path, disabledIni, handlers);
 }
 
 async function confirmLeaveCurrentModIfDirty() {
@@ -397,7 +400,7 @@ export async function reloadCurrentMod(handlers = {}) {
   if (!viewerState.currentModPath) return false;
   return await runModTransition(async () => {
     try {
-      return await loadModAt(viewerState.currentModPath, handlers);
+      return await loadModAt(viewerState.currentModPath, undefined, handlers);
     } catch (error) {
       showLoading(false);
       await alertDialog('Unexpected error while reloading:\n\n' + error);


### PR DESCRIPTION
## Summary
- Add the build-time `Open_Disabled_Mod` feature flag and developer-only checkbox.
- Route Open Mod and Mod Library selections through the existing load pipeline with disabled-INI selection.
- Filter shared discovery to `DISABLED*.ini` while preserving existing discovery limits and add regression coverage.

## Testing
- `pytest -q`