### PR TITLE
feat: add procedural IBL and continuous key lighting

### DIFF
--- a/src/app/settings/paths.py
+++ b/src/app/settings/paths.py
@@ -61,6 +61,7 @@ def has_vendored_three():
         "three.webgpu.js",
         "three.tsl.js",
         os.path.join("addons", "controls", "ArcballControls.js"),
+        os.path.join("addons", "objects", "SkyMesh.js"),
         os.path.join("addons", "tsl", "display", "GTAONode.js"),
         os.path.join("addons", "tsl", "display", "BloomNode.js"),
     )

--- a/src/build.py
+++ b/src/build.py
@@ -89,6 +89,10 @@ ASSET_FILES = {
         "url": f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/examples/jsm/controls/ArcballControls.js",
         "sha256": "f80db7fe66685fc7f5438e3be44fed6684aed33a7b92b2442fe6958291156fb3",
     },
+    "addons/objects/SkyMesh.js": {
+        "url": f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/examples/jsm/objects/SkyMesh.js",
+        "sha256": "a44cb7c543d04b2690b0079b8b473da9a36660629b2eb091f7eab8b4111d7b7a",
+    },
     "addons/tsl/display/GTAONode.js": {
         "url": f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/examples/jsm/tsl/display/GTAONode.js",
         "sha256": "516e86dc398b8e2d93f693a168144fdd7420f261a72aaa7da6eb7f110cc8e3ef",

--- a/src/tests/build/test_security.py
+++ b/src/tests/build/test_security.py
@@ -99,6 +99,16 @@ def test_build_minimum_python_excludes_unsupported_versions():
     assert build.MIN_PYTHON == (3, 10, 1)
 
 
+def test_sky_mesh_is_pinned_in_the_vendor_manifest():
+    spec = build.ASSET_FILES["addons/objects/SkyMesh.js"]
+
+    assert spec["url"] == (
+        "https://cdn.jsdelivr.net/npm/three@0.185.0/"
+        "examples/jsm/objects/SkyMesh.js")
+    assert spec["sha256"] == (
+        "a44cb7c543d04b2690b0079b8b473da9a36660629b2eb091f7eab8b4111d7b7a")
+
+
 def test_verify_web_uses_refactored_frontend_paths(tmp_path, monkeypatch):
     for relative_path in (
         "index.html",

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -55,6 +55,19 @@ def _set_test_key_light(page, x=1.0, z=0.25):
     page.wait_for_timeout(400)
 
 
+def _wait_for_environment_preparation(page):
+    page.wait_for_function("""async () => {
+      const {rendererReady, getEnvironmentDebugState} =
+        await import('./js/scene/scene.js');
+      await rendererReady;
+      const state = getEnvironmentDebugState();
+      const resources = Object.values(state.resources || {});
+      return resources.length === 2
+        && resources.every(resource => resource.attempted)
+        && !state.preparationInFlight;
+    }""")
+
+
 def _outline_payload():
     payload = _payload("Outline")
     positions = (
@@ -214,40 +227,33 @@ def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
         context.close()
 
 
-def test_outdoor_environment_uses_one_cached_pmrem_and_restores_original(
+def test_environment_ibl_resources_are_cached_and_presets_restore_original(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {})
     try:
-        page.wait_for_function("""async () => {
-          const {rendererReady, getEnvironmentDebugState} =
-            await import('./js/scene/scene.js');
-          await rendererReady;
-          return getEnvironmentDebugState().prepared;
-        }""")
+        _wait_for_environment_preparation(page)
         initial = page.evaluate("""async () => {
           const {scene, getEnvironmentDebugState} =
             await import('./js/scene/scene.js');
-          const state = getEnvironmentDebugState();
-          const ambient = scene.children.find(object => object.isAmbientLight);
-          const hemisphere = scene.children.find(
-            object => object.isHemisphereLight);
-          let accent = null;
-          scene.traverse(object => {
-            if (object.isDirectionalLight && object !== scene.children.find(
-                candidate => candidate.isDirectionalLight)) accent = object;
-          });
-          return {...state,
+          return {...getEnvironmentDebugState(),
             environmentId: scene.environment?.uuid || null,
             hasVisibleSky: scene.getObjectByProperty('isSkyMesh', true) != null,
-            ambientIntensity: ambient?.intensity,
-            hemisphereIntensity: hemisphere?.intensity,
-            accentIntensity: accent?.intensity,
           };
         }""")
-        assert initial["outdoorIblAvailable"]
-        assert initial["pmremGenerationCount"] == 1
+        assert initial["activeIblPreset"] is None
         assert not initial["environmentActive"]
         assert not initial["hasVisibleSky"]
+        assert initial["resources"] == {
+            "outdoor": {
+                "attempted": True, "available": True,
+                "generationCount": 1, "error": None,
+            },
+            "indoor": {
+                "attempted": True, "available": True,
+                "generationCount": 1, "error": None,
+            },
+        }
+        assert initial["totalPmremGenerationCount"] == 2
 
         def select_preset(preset):
             before = page.evaluate("window.modViewer.getRenderCount()")
@@ -272,37 +278,57 @@ def test_outdoor_environment_uses_one_cached_pmrem_and_restores_original(
               });
               return {...getEnvironmentDebugState(),
                 environmentId: scene.environment?.uuid || null,
+                backgroundIsCanvas: scene.background?.isCanvasTexture === true,
+                hasVisibleSky: scene.getObjectByProperty('isSkyMesh', true) != null,
                 ambientIntensity: ambient?.intensity,
                 hemisphereIntensity: hemisphere?.intensity,
                 accentIntensity: accent?.intensity};
             }""")
 
+        indoor = select_preset("indoor")
+        assert indoor["activeIblPreset"] == "indoor"
+        assert indoor["environmentActive"]
+        assert indoor["environmentIntensity"] == pytest.approx(0.15)
+        assert indoor["ambientIntensity"] == pytest.approx(0.05)
+        assert indoor["hemisphereIntensity"] == pytest.approx(0.1)
+        assert indoor["accentIntensity"] == pytest.approx(0.3)
+        assert indoor["environmentId"] is not None
+        assert indoor["environmentId"] != initial["environmentId"]
+        assert indoor["backgroundIsCanvas"]
+        assert not indoor["hasVisibleSky"]
+
         outdoor = select_preset("outdoor")
-        assert outdoor["environmentIsOutdoor"]
+        assert outdoor["activeIblPreset"] == "outdoor"
         assert outdoor["environmentActive"]
         assert outdoor["environmentIntensity"] == pytest.approx(0.1)
         assert outdoor["ambientIntensity"] == pytest.approx(0.04)
         assert outdoor["hemisphereIntensity"] == pytest.approx(0.08)
         assert outdoor["accentIntensity"] == pytest.approx(0.4)
-        assert outdoor["environmentId"] is not None
-
-        studio = select_preset("studio")
-        assert not studio["environmentIsOutdoor"]
-        assert not studio["environmentActive"]
-        assert studio["environmentIntensity"] == initial["environmentIntensity"]
-
-        indoor = select_preset("indoor")
-        assert not indoor["environmentIsOutdoor"]
-        assert not indoor["environmentActive"]
-        assert indoor["environmentIntensity"] == initial["environmentIntensity"]
-
-        outdoor_again = select_preset("outdoor")
-        assert outdoor_again["environmentIsOutdoor"]
-        assert outdoor_again["environmentId"] == outdoor["environmentId"]
-        assert outdoor_again["pmremGenerationCount"] == 1
-        assert outdoor_again["sunDirection"] == pytest.approx(
+        assert outdoor["environmentId"] not in (None, indoor["environmentId"])
+        assert outdoor["backgroundIsCanvas"]
+        assert not outdoor["hasVisibleSky"]
+        assert outdoor["sunDirection"] == pytest.approx(
             [-6 / math.sqrt(172), 10 / math.sqrt(172), 6 / math.sqrt(172)],
         )
+
+        studio = select_preset("studio")
+        assert studio["activeIblPreset"] is None
+        assert not studio["environmentActive"]
+        assert studio["environmentId"] == initial["environmentId"]
+        assert studio["environmentIntensity"] == initial["environmentIntensity"]
+
+        indoor_again = select_preset("indoor")
+        outdoor_again = select_preset("outdoor")
+        default = select_preset("default")
+        indoor_third = select_preset("indoor")
+        assert indoor_again["environmentId"] == indoor["environmentId"]
+        assert outdoor_again["environmentId"] == outdoor["environmentId"]
+        assert default["activeIblPreset"] is None
+        assert default["environmentId"] == initial["environmentId"]
+        assert default["environmentIntensity"] == initial["environmentIntensity"]
+        assert indoor_third["environmentId"] == indoor["environmentId"]
+        assert indoor_third["resources"] == initial["resources"]
+        assert indoor_third["totalPmremGenerationCount"] == 2
 
         idle_count = page.evaluate("window.modViewer.getRenderCount()")
         page.wait_for_timeout(200)
@@ -315,24 +341,29 @@ def test_environment_controller_prepare_is_single_flight(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {})
     try:
+        _wait_for_environment_preparation(page)
         result = page.evaluate("""async () => {
           const THREE = await import('three/webgpu');
-          const {renderer, rendererReady, getEnvironmentDebugState} =
+          const {renderer, rendererReady} =
             await import('./js/scene/scene.js');
           const {createEnvironmentController} =
             await import('./js/scene/environment.js');
           await rendererReady;
-          for (let attempts = 0; attempts < 100; attempts += 1) {
-            const state = getEnvironmentDebugState();
-            if (state.prepared || state.preparationError) break;
-            await new Promise(resolve => setTimeout(resolve, 10));
-          }
 
           const originalFromScene = THREE.PMREMGenerator.prototype.fromScene;
           let generationCalls = 0;
+          let targetDisposals = 0;
+          const generationOrder = [];
           THREE.PMREMGenerator.prototype.fromScene = function (...args) {
             generationCalls += 1;
-            return originalFromScene.apply(this, args);
+            generationOrder.push(args[0].userData.iblPresetId);
+            const target = originalFromScene.apply(this, args);
+            const originalDispose = target.dispose.bind(target);
+            target.dispose = () => {
+              targetDisposals += 1;
+              originalDispose();
+            };
+            return target;
           };
           const testScene = new THREE.Scene();
           const ambient = new THREE.AmbientLight(0xffffff, 0.55);
@@ -347,9 +378,11 @@ def test_environment_controller_prepare_is_single_flight(
             const first = controller.prepare();
             const second = controller.prepare();
             const [firstResult, secondResult] = await Promise.all([first, second]);
+            const debug = controller.getDebugState();
+            controller.dispose();
             return {
-              firstResult, secondResult, generationCalls,
-              debug: controller.getDebugState(),
+              firstResult, secondResult, generationCalls, generationOrder,
+              targetDisposals, debug,
             };
           } finally {
             THREE.PMREMGenerator.prototype.fromScene = originalFromScene;
@@ -358,9 +391,15 @@ def test_environment_controller_prepare_is_single_flight(
         }""")
         assert result["firstResult"] is True
         assert result["secondResult"] is True
-        assert result["generationCalls"] == 1
-        assert result["debug"]["pmremGenerationCount"] == 1
-        assert result["debug"]["prepared"] is True
+        assert result["generationCalls"] == 2
+        assert result["generationOrder"] == ["outdoor", "indoor"]
+        assert result["targetDisposals"] == 2
+        assert result["debug"]["resources"]["outdoor"][
+            "generationCount"] == 1
+        assert result["debug"]["resources"]["indoor"][
+            "generationCount"] == 1
+        assert result["debug"]["totalPmremGenerationCount"] == 2
+        assert result["debug"]["preparationInFlight"] is False
     finally:
         context.close()
 
@@ -369,18 +408,14 @@ def test_environment_controller_dispose_cancels_pending_preparation(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {})
     try:
+        _wait_for_environment_preparation(page)
         result = page.evaluate("""async () => {
           const THREE = await import('three/webgpu');
-          const {renderer, rendererReady, getEnvironmentDebugState} =
+          const {renderer, rendererReady} =
             await import('./js/scene/scene.js');
           const {createEnvironmentController} =
             await import('./js/scene/environment.js');
           await rendererReady;
-          for (let attempts = 0; attempts < 100; attempts += 1) {
-            const state = getEnvironmentDebugState();
-            if (state.prepared || state.preparationError) break;
-            await new Promise(resolve => setTimeout(resolve, 10));
-          }
 
           const originalFromScene = THREE.PMREMGenerator.prototype.fromScene;
           let generationCalls = 0;
@@ -411,81 +446,238 @@ def test_environment_controller_dispose_cancels_pending_preparation(
         }""")
         assert result["prepared"] is False
         assert result["generationCalls"] == 0
-        assert result["debug"]["pmremGenerationCount"] == 0
-        assert result["debug"]["outdoorIblAvailable"] is False
-        assert result["debug"]["prepared"] is False
+        assert result["debug"]["totalPmremGenerationCount"] == 0
+        assert result["debug"]["resources"] == {
+            "outdoor": {
+                "attempted": False, "available": False,
+                "generationCount": 0, "error": None,
+            },
+            "indoor": {
+                "attempted": False, "available": False,
+                "generationCount": 0, "error": None,
+            },
+        }
     finally:
         context.close()
 
 
-def test_environment_controller_uses_legacy_lighting_when_pmrem_fails(
-        edge_browser, frontend_url):
+@pytest.mark.parametrize("failed_profile", ["outdoor", "indoor"])
+def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
+        edge_browser, frontend_url, failed_profile):
     context, page = _page(edge_browser, frontend_url, {})
     try:
-        result = page.evaluate("""async () => {
+        _wait_for_environment_preparation(page)
+        result = page.evaluate("""async failedProfile => {
           const THREE = await import('three/webgpu');
-          const {renderer, rendererReady, getEnvironmentDebugState} =
+          const {renderer, rendererReady} =
             await import('./js/scene/scene.js');
           const {createEnvironmentController} =
             await import('./js/scene/environment.js');
           const rendererReadyResult = await rendererReady;
-          for (let attempts = 0; attempts < 100; attempts += 1) {
-            const state = getEnvironmentDebugState();
-            if (state.prepared || state.preparationError) break;
-            await new Promise(resolve => setTimeout(resolve, 10));
-          }
 
           const originalFromScene = THREE.PMREMGenerator.prototype.fromScene;
           const testScene = new THREE.Scene();
-          testScene.environment = null;
+          const originalEnvironment = new THREE.Texture();
+          testScene.environment = originalEnvironment;
           testScene.environmentIntensity = 1;
           const ambient = new THREE.AmbientLight(0xffffff, 0.55);
           const hemisphere = new THREE.HemisphereLight(0xffffff, 0x30343f, 0.35);
           const lightTarget = new THREE.Object3D();
           let controller = null;
           try {
-            THREE.PMREMGenerator.prototype.fromScene = () => {
-              throw new Error('simulated Outdoor PMREM failure');
+            THREE.PMREMGenerator.prototype.fromScene = function (...args) {
+              const id = args[0].userData.iblPresetId;
+              if (id === failedProfile) {
+                throw new Error(`simulated ${id} PMREM failure`);
+              }
+              return originalFromScene.apply(this, args);
             };
             controller = createEnvironmentController({
               renderer, scene: testScene, ambientLight: ambient,
               hemisphereLight: hemisphere, lightTarget,
             });
             const prepared = await controller.prepare();
-            controller.setPreset('outdoor');
-            const outdoor = controller.getDebugState();
-            const outdoorLighting = {
-              backgroundChanged: testScene.background !== null,
+            const snapshot = () => ({
+              state: controller.getDebugState(),
+              environmentIsOriginal: testScene.environment === originalEnvironment,
+              environmentId: testScene.environment?.uuid || null,
               ambient: ambient.intensity,
               hemisphere: hemisphere.intensity,
               accent: lightTarget.children.find(
                 object => object.isDirectionalLight)?.intensity,
               accentVisible: lightTarget.children.some(
                 object => object.isDirectionalLight && object.visible),
-            };
+            });
+            controller.setPreset(failedProfile);
+            const failed = snapshot();
+            const workingProfile = failedProfile === 'outdoor'
+              ? 'indoor' : 'outdoor';
+            controller.setPreset(workingProfile);
+            const working = snapshot();
             return {
               rendererReady: rendererReadyResult,
-              prepared, outdoor, outdoorLighting,
+              prepared, failedProfile, workingProfile, failed, working,
+            };
+          } finally {
+            THREE.PMREMGenerator.prototype.fromScene = originalFromScene;
+            controller?.dispose();
+            originalEnvironment.dispose();
+          }
+        }""", failed_profile)
+        assert result["rendererReady"]
+        assert result["prepared"] is False
+        failed = result["failed"]
+        working = result["working"]
+        failed_resource = failed["state"]["resources"][failed_profile]
+        working_profile = result["workingProfile"]
+        working_resource = failed["state"]["resources"][working_profile]
+        assert failed_resource["attempted"] is True
+        assert failed_resource["available"] is False
+        assert failed_resource["generationCount"] == 0
+        assert f"simulated {failed_profile} PMREM failure" in failed_resource[
+            "error"]
+        assert working_resource == {
+            "attempted": True, "available": True,
+            "generationCount": 1, "error": None,
+        }
+        assert failed["state"]["totalPmremGenerationCount"] == 1
+        assert failed["state"]["activeIblPreset"] is None
+        assert failed["environmentIsOriginal"] is True
+        fallback = {
+            "outdoor": {"ambient": 0.26, "hemisphere": 0.45, "accent": 0.7},
+            "indoor": {"ambient": 0.32, "hemisphere": 0.38, "accent": 0.45},
+        }[failed_profile]
+        assert {key: failed[key] for key in fallback} == fallback
+        assert failed["accentVisible"] is True
+
+        assert working["state"]["activeIblPreset"] == working_profile
+        assert working["environmentIsOriginal"] is False
+        enhanced = {
+            "outdoor": {"ambient": 0.04, "hemisphere": 0.08, "accent": 0.4},
+            "indoor": {"ambient": 0.05, "hemisphere": 0.1, "accent": 0.3},
+        }[working_profile]
+        assert {key: working[key] for key in enhanced} == enhanced
+        assert working["accentVisible"] is True
+    finally:
+        context.close()
+
+
+def test_environment_disposal_between_resources_stops_later_generation(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {})
+    try:
+        _wait_for_environment_preparation(page)
+        result = page.evaluate("""async () => {
+          const THREE = await import('three/webgpu');
+          const {renderer, rendererReady} = await import('./js/scene/scene.js');
+          const {createEnvironmentController} =
+            await import('./js/scene/environment.js');
+          await rendererReady;
+          const originalFromScene = THREE.PMREMGenerator.prototype.fromScene;
+          const generationOrder = [];
+          THREE.PMREMGenerator.prototype.fromScene = function (...args) {
+            generationOrder.push(args[0].userData.iblPresetId);
+            return originalFromScene.apply(this, args);
+          };
+          const testScene = new THREE.Scene();
+          const ambient = new THREE.AmbientLight(0xffffff, 0.55);
+          const hemisphere = new THREE.HemisphereLight(0xffffff, 0x30343f, 0.35);
+          const lightTarget = new THREE.Object3D();
+          const visualChanges = [];
+          let controller = null;
+          try {
+            controller = createEnvironmentController({
+              renderer, scene: testScene, ambientLight: ambient,
+              hemisphereLight: hemisphere, lightTarget,
+              onVisualChange: () => {
+                visualChanges.push(controller.getPreset().id);
+                controller.dispose();
+              },
+            });
+            controller.setPreset('outdoor');
+            const prepared = await controller.prepare();
+            return {
+              prepared, generationOrder, visualChanges,
+              debug: controller.getDebugState(),
             };
           } finally {
             THREE.PMREMGenerator.prototype.fromScene = originalFromScene;
             controller?.dispose();
           }
         }""")
-        assert result["rendererReady"]
         assert result["prepared"] is False
-        assert result["outdoor"]["outdoorIblAvailable"] is False
-        assert result["outdoor"]["environmentActive"] is False
-        assert result["outdoor"]["pmremGenerationCount"] == 0
-        assert "simulated Outdoor PMREM failure" in result["outdoor"][
-            "preparationError"]
-        assert result["outdoorLighting"] == {
-            "backgroundChanged": True,
-            "ambient": 0.26,
-            "hemisphere": 0.45,
-            "accent": 0.7,
-            "accentVisible": True,
-        }
+        assert result["generationOrder"] == ["outdoor"]
+        assert result["visualChanges"] == ["outdoor"]
+        assert result["debug"]["resources"]["outdoor"][
+            "generationCount"] == 1
+        assert result["debug"]["resources"]["indoor"]["attempted"] is False
+        assert result["debug"]["resources"]["indoor"][
+            "generationCount"] == 0
+    finally:
+        context.close()
+
+
+@pytest.mark.parametrize(("active_preset", "expected_visual_changes"), [
+    ("default", []),
+    ("outdoor", ["outdoor"]),
+    ("indoor", ["indoor"]),
+])
+def test_environment_preparation_notifies_only_for_active_visual_upgrade(
+        edge_browser, frontend_url, active_preset, expected_visual_changes):
+    context, page = _page(edge_browser, frontend_url, {})
+    try:
+        _wait_for_environment_preparation(page)
+        result = page.evaluate("""async activePreset => {
+          const THREE = await import('three/webgpu');
+          const {renderer, rendererReady} = await import('./js/scene/scene.js');
+          const {createEnvironmentController} =
+            await import('./js/scene/environment.js');
+          await rendererReady;
+          const testScene = new THREE.Scene();
+          const ambient = new THREE.AmbientLight(0xffffff, 0.55);
+          const hemisphere = new THREE.HemisphereLight(0xffffff, 0x30343f, 0.35);
+          const lightTarget = new THREE.Object3D();
+          const visualChanges = [];
+          let controller = null;
+          try {
+            controller = createEnvironmentController({
+              renderer, scene: testScene, ambientLight: ambient,
+              hemisphereLight: hemisphere, lightTarget,
+              onVisualChange: () => visualChanges.push(controller.getPreset().id),
+            });
+            controller.setPreset(activePreset);
+            const before = {
+              state: controller.getDebugState(),
+              ambient: ambient.intensity,
+              hemisphere: hemisphere.intensity,
+              accent: lightTarget.children.find(
+                object => object.isDirectionalLight)?.intensity,
+            };
+            const prepared = await controller.prepare();
+            return {
+              prepared, visualChanges, before,
+              debug: controller.getDebugState(),
+            };
+          } finally {
+            controller?.dispose();
+          }
+        }""", active_preset)
+        assert result["prepared"] is True
+        assert result["visualChanges"] == expected_visual_changes
+        assert result["debug"]["totalPmremGenerationCount"] == 2
+        assert result["before"]["state"]["activeIblPreset"] is None
+        if active_preset != "default":
+            fallback = {
+                "outdoor": {
+                    "ambient": 0.26, "hemisphere": 0.45, "accent": 0.7,
+                },
+                "indoor": {
+                    "ambient": 0.32, "hemisphere": 0.38, "accent": 0.45,
+                },
+            }[active_preset]
+            assert {
+                key: result["before"][key] for key in fallback
+            } == fallback
     finally:
         context.close()
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -61,9 +61,8 @@ def _wait_for_environment_preparation(page):
         await import('./js/scene/scene.js');
       await rendererReady;
       const state = getEnvironmentDebugState();
-      const resources = Object.values(state.resources || {});
-      return resources.length === 2
-        && resources.every(resource => resource.attempted)
+      const expected = ['outdoor', 'indoor', 'studio'];
+      return expected.every(id => state.resources?.[id]?.attempted === true)
         && !state.preparationInFlight;
     }""")
 
@@ -253,8 +252,12 @@ def test_environment_ibl_resources_are_cached_and_presets_restore_original(
                 "attempted": True, "available": True,
                 "generationCount": 1, "error": None,
             },
+            "studio": {
+                "attempted": True, "available": True,
+                "generationCount": 1, "error": None,
+            },
         }
-        assert initial["totalPmremGenerationCount"] == 2
+        assert initial["totalPmremGenerationCount"] == 3
 
         def select_preset(preset):
             before = page.evaluate("window.modViewer.getRenderCount()")
@@ -332,25 +335,46 @@ def test_environment_ibl_resources_are_cached_and_presets_restore_original(
         assert "sunDirection" not in outdoor
 
         studio = select_preset("studio")
-        assert studio["activeIblPreset"] is None
-        assert studio["activeDominantDirection"] is None
-        assert not studio["environmentActive"]
-        assert studio["environmentId"] == initial["environmentId"]
-        assert studio["environmentIntensity"] == initial["environmentIntensity"]
+        assert studio["activeIblPreset"] == "studio"
+        assert studio["environmentActive"]
+        assert studio["environmentIntensity"] == pytest.approx(0.15)
+        assert studio["ambientColor"] == 0xf5f7fa
+        assert studio["ambientIntensity"] == pytest.approx(0.03)
+        assert studio["hemisphereColor"] == 0xe1e9f3
+        assert studio["hemisphereGroundColor"] == 0x454b55
+        assert studio["hemisphereIntensity"] == pytest.approx(0.06)
+        assert studio["accentColor"] == 0xffffff
+        assert studio["accentPosition"] == [4, 8, 6]
+        assert studio["accentIntensity"] == pytest.approx(0.2)
+        assert studio["activeDominantDirection"] == pytest.approx(
+            [4 / math.sqrt(116), 8 / math.sqrt(116), 6 / math.sqrt(116)],
+        )
+        assert studio["environmentId"] not in (
+            None, indoor["environmentId"], outdoor["environmentId"],
+        )
+        assert studio["backgroundIsCanvas"]
+        assert not studio["hasVisibleSky"]
 
         indoor_again = select_preset("indoor")
         outdoor_again = select_preset("outdoor")
         default = select_preset("default")
+        studio_again = select_preset("studio")
+        outdoor_third = select_preset("outdoor")
         indoor_third = select_preset("indoor")
+        studio_third = select_preset("studio")
         assert indoor_again["environmentId"] == indoor["environmentId"]
         assert outdoor_again["environmentId"] == outdoor["environmentId"]
+        assert studio_again["environmentId"] == studio["environmentId"]
+        assert outdoor_third["environmentId"] == outdoor["environmentId"]
         assert default["activeIblPreset"] is None
         assert default["activeDominantDirection"] is None
         assert default["environmentId"] == initial["environmentId"]
         assert default["environmentIntensity"] == initial["environmentIntensity"]
         assert indoor_third["environmentId"] == indoor["environmentId"]
+        assert studio_third["environmentId"] == studio["environmentId"]
         assert indoor_third["resources"] == initial["resources"]
-        assert indoor_third["totalPmremGenerationCount"] == 2
+        assert studio_again["totalPmremGenerationCount"] == 3
+        assert indoor_third["totalPmremGenerationCount"] == 3
 
         idle_count = page.evaluate("window.modViewer.getRenderCount()")
         page.wait_for_timeout(200)
@@ -418,14 +442,16 @@ def test_environment_controller_prepare_is_single_flight(
         }""")
         assert result["firstResult"] is True
         assert result["secondResult"] is True
-        assert result["generationCalls"] == 2
-        assert result["generationOrder"] == ["outdoor", "indoor"]
-        assert result["targetDisposals"] == 2
+        assert result["generationCalls"] == 3
+        assert result["generationOrder"] == ["outdoor", "indoor", "studio"]
+        assert result["targetDisposals"] == 3
         assert result["debug"]["resources"]["outdoor"][
             "generationCount"] == 1
         assert result["debug"]["resources"]["indoor"][
             "generationCount"] == 1
-        assert result["debug"]["totalPmremGenerationCount"] == 2
+        assert result["debug"]["resources"]["studio"][
+            "generationCount"] == 1
+        assert result["debug"]["totalPmremGenerationCount"] == 3
         assert result["debug"]["preparationInFlight"] is False
         assert result["dominantDirections"]["default"] is None
         assert result["dominantDirections"]["indoor"] == pytest.approx(
@@ -434,7 +460,9 @@ def test_environment_controller_prepare_is_single_flight(
         assert result["dominantDirections"]["outdoor"] == pytest.approx(
             [-6 / math.sqrt(172), 10 / math.sqrt(172), 6 / math.sqrt(172)],
         )
-        assert result["dominantDirections"]["studio"] is None
+        assert result["dominantDirections"]["studio"] == pytest.approx(
+            [4 / math.sqrt(116), 8 / math.sqrt(116), 6 / math.sqrt(116)],
+        )
     finally:
         context.close()
 
@@ -491,12 +519,16 @@ def test_environment_controller_dispose_cancels_pending_preparation(
                 "attempted": False, "available": False,
                 "generationCount": 0, "error": None,
             },
+            "studio": {
+                "attempted": False, "available": False,
+                "generationCount": 0, "error": None,
+            },
         }
     finally:
         context.close()
 
 
-@pytest.mark.parametrize("failed_profile", ["outdoor", "indoor"])
+@pytest.mark.parametrize("failed_profile", ["outdoor", "indoor", "studio"])
 def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
         edge_browser, frontend_url, failed_profile):
     context, page = _page(edge_browser, frontend_url, {})
@@ -545,13 +577,16 @@ def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
             });
             controller.setPreset(failedProfile);
             const failed = snapshot();
-            const workingProfile = failedProfile === 'outdoor'
-              ? 'indoor' : 'outdoor';
-            controller.setPreset(workingProfile);
-            const working = snapshot();
+            const workingProfiles = ['outdoor', 'indoor', 'studio']
+              .filter(id => id !== failedProfile);
+            const working = {};
+            for (const profile of workingProfiles) {
+              controller.setPreset(profile);
+              working[profile] = snapshot();
+            }
             return {
-              rendererReady: rendererReadyResult,
-              prepared, failedProfile, workingProfile, failed, working,
+              rendererReady: rendererReadyResult, prepared, failedProfile,
+              workingProfiles, failed, working,
             };
           } finally {
             THREE.PMREMGenerator.prototype.fromScene = originalFromScene;
@@ -562,37 +597,50 @@ def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
         assert result["rendererReady"]
         assert result["prepared"] is False
         failed = result["failed"]
-        working = result["working"]
         failed_resource = failed["state"]["resources"][failed_profile]
-        working_profile = result["workingProfile"]
-        working_resource = failed["state"]["resources"][working_profile]
+        working_profiles = result["workingProfiles"]
+        assert working_profiles == [
+            profile for profile in ["outdoor", "indoor", "studio"]
+            if profile != failed_profile
+        ]
         assert failed_resource["attempted"] is True
         assert failed_resource["available"] is False
         assert failed_resource["generationCount"] == 0
         assert f"simulated {failed_profile} PMREM failure" in failed_resource[
             "error"]
-        assert working_resource == {
-            "attempted": True, "available": True,
-            "generationCount": 1, "error": None,
-        }
-        assert failed["state"]["totalPmremGenerationCount"] == 1
+        for profile in working_profiles:
+            assert failed["state"]["resources"][profile] == {
+                "attempted": True, "available": True,
+                "generationCount": 1, "error": None,
+            }
+        assert failed["state"]["totalPmremGenerationCount"] == 2
         assert failed["state"]["activeIblPreset"] is None
         assert failed["environmentIsOriginal"] is True
         fallback = {
             "outdoor": {"ambient": 0.26, "hemisphere": 0.45, "accent": 0.7},
             "indoor": {"ambient": 0.32, "hemisphere": 0.38, "accent": 0.45},
+            "studio": {"ambient": 0.38, "hemisphere": 0.42, "accent": 0.18},
         }[failed_profile]
         assert {key: failed[key] for key in fallback} == fallback
         assert failed["accentVisible"] is True
 
-        assert working["state"]["activeIblPreset"] == working_profile
-        assert working["environmentIsOriginal"] is False
-        enhanced = {
-            "outdoor": {"ambient": 0.04, "hemisphere": 0.08, "accent": 0.4},
-            "indoor": {"ambient": 0.05, "hemisphere": 0.1, "accent": 0.3},
-        }[working_profile]
-        assert {key: working[key] for key in enhanced} == enhanced
-        assert working["accentVisible"] is True
+        for working_profile in working_profiles:
+            working = result["working"][working_profile]
+            assert working["state"]["activeIblPreset"] == working_profile
+            assert working["environmentIsOriginal"] is False
+            expected = {
+                "outdoor": {
+                    "ambient": 0.04, "hemisphere": 0.08, "accent": 0.4,
+                },
+                "indoor": {
+                    "ambient": 0.05, "hemisphere": 0.1, "accent": 0.3,
+                },
+                "studio": {
+                    "ambient": 0.03, "hemisphere": 0.06, "accent": 0.2,
+                },
+            }[working_profile]
+            assert {key: working[key] for key in expected} == expected
+            assert working["accentVisible"] is True
     finally:
         context.close()
 
@@ -626,10 +674,10 @@ def test_environment_disposal_between_resources_stops_later_generation(
               hemisphereLight: hemisphere, lightTarget,
               onVisualChange: () => {
                 visualChanges.push(controller.getPreset().id);
-                controller.dispose();
+                if (controller.getPreset().id === 'indoor') controller.dispose();
               },
             });
-            controller.setPreset('outdoor');
+            controller.setPreset('indoor');
             const prepared = await controller.prepare();
             return {
               prepared, generationOrder, visualChanges,
@@ -641,12 +689,14 @@ def test_environment_disposal_between_resources_stops_later_generation(
           }
         }""")
         assert result["prepared"] is False
-        assert result["generationOrder"] == ["outdoor"]
-        assert result["visualChanges"] == ["outdoor"]
+        assert result["generationOrder"] == ["outdoor", "indoor"]
+        assert result["visualChanges"] == ["indoor"]
         assert result["debug"]["resources"]["outdoor"][
             "generationCount"] == 1
-        assert result["debug"]["resources"]["indoor"]["attempted"] is False
         assert result["debug"]["resources"]["indoor"][
+            "generationCount"] == 1
+        assert result["debug"]["resources"]["studio"]["attempted"] is False
+        assert result["debug"]["resources"]["studio"][
             "generationCount"] == 0
     finally:
         context.close()
@@ -656,6 +706,7 @@ def test_environment_disposal_between_resources_stops_later_generation(
     ("default", []),
     ("outdoor", ["outdoor"]),
     ("indoor", ["indoor"]),
+    ("studio", ["studio"]),
 ])
 def test_environment_preparation_notifies_only_for_active_visual_upgrade(
         edge_browser, frontend_url, active_preset, expected_visual_changes):
@@ -699,7 +750,7 @@ def test_environment_preparation_notifies_only_for_active_visual_upgrade(
         }""", active_preset)
         assert result["prepared"] is True
         assert result["visualChanges"] == expected_visual_changes
-        assert result["debug"]["totalPmremGenerationCount"] == 2
+        assert result["debug"]["totalPmremGenerationCount"] == 3
         assert result["before"]["state"]["activeIblPreset"] is None
         if active_preset != "default":
             fallback = {
@@ -708,6 +759,9 @@ def test_environment_preparation_notifies_only_for_active_visual_upgrade(
                 },
                 "indoor": {
                     "ambient": 0.32, "hemisphere": 0.38, "accent": 0.45,
+                },
+                "studio": {
+                    "ambient": 0.38, "hemisphere": 0.42, "accent": 0.18,
                 },
             }[active_preset]
             assert {

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -564,17 +564,21 @@ def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
               hemisphereLight: hemisphere, lightTarget,
             });
             const prepared = await controller.prepare();
-            const snapshot = () => ({
-              state: controller.getDebugState(),
-              environmentIsOriginal: testScene.environment === originalEnvironment,
-              environmentId: testScene.environment?.uuid || null,
-              ambient: ambient.intensity,
-              hemisphere: hemisphere.intensity,
-              accent: lightTarget.children.find(
-                object => object.isDirectionalLight)?.intensity,
-              accentVisible: lightTarget.children.some(
-                object => object.isDirectionalLight && object.visible),
-            });
+            const snapshot = () => {
+              const accentLight = lightTarget.children.find(
+                object => object.isDirectionalLight);
+              return {
+                state: controller.getDebugState(),
+                environmentIsOriginal: testScene.environment === originalEnvironment,
+                environmentId: testScene.environment?.uuid || null,
+                ambient: ambient.intensity,
+                hemisphere: hemisphere.intensity,
+                accent: accentLight?.intensity,
+                accentVisible: accentLight?.visible === true,
+                dominantLightIsAccent:
+                  controller.getDominantLight() === accentLight,
+              };
+            };
             controller.setPreset(failedProfile);
             const failed = snapshot();
             const workingProfiles = ['outdoor', 'indoor', 'studio']
@@ -623,6 +627,7 @@ def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
         }[failed_profile]
         assert {key: failed[key] for key in fallback} == fallback
         assert failed["accentVisible"] is True
+        assert failed["dominantLightIsAccent"] is True
 
         for working_profile in working_profiles:
             working = result["working"][working_profile]
@@ -641,6 +646,7 @@ def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
             }[working_profile]
             assert {key: working[key] for key in expected} == expected
             assert working["accentVisible"] is True
+            assert working["dominantLightIsAccent"] is True
     finally:
         context.close()
 
@@ -6432,6 +6438,175 @@ def test_key_light_mode_changes_restore_ground_without_refitting_shadows(
         assert off["shadowUpdateCount"] == before["shadowUpdateCount"]
         assert restored["fitCount"] == before["fitCount"]
         assert restored["shadowUpdateCount"] == before["shadowUpdateCount"]
+    finally:
+        context.close()
+
+
+def test_environment_presets_own_world_space_character_shadows(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"ShadowSource": _payload("ShadowSource")})
+    try:
+        _open(page, "ShadowSource")
+        page.locator(".draw-item").wait_for()
+        _wait_for_environment_preparation(page)
+        page.wait_for_function("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return getCharacterShadowDebugState().groundVisible;
+        }""")
+
+        def snapshot():
+            return page.evaluate("""async () => {
+              const {
+                getCharacterShadowDebugState, getLightMode, scene,
+              } = await import('./js/scene/scene.js');
+              const lights = [];
+              scene.traverse(object => {
+                if (object.isDirectionalLight) lights.push(object);
+              });
+              const key = scene.children.find(object => object.isDirectionalLight);
+              const accent = lights.find(object => object !== key);
+              return {
+                debug: getCharacterShadowDebugState(),
+                keyUuid: key.uuid,
+                accentUuid: accent.uuid,
+                keyCastsShadow: key.castShadow,
+                accentCastsShadow: accent.castShadow,
+                castingCount: lights.filter(object => object.castShadow).length,
+                keyMode: getLightMode(),
+              };
+            }""")
+
+        def select_preset(preset):
+            before = page.evaluate("window.modViewer.getRenderCount()")
+            assert page.evaluate(
+                "preset => window.modViewer.setEnvironmentPreset(preset)",
+                preset,
+            )
+            page.wait_for_function(
+                "count => window.modViewer.getRenderCount() > count", arg=before)
+            return snapshot()
+
+        def assert_single_source(state, source):
+            debug = state["debug"]
+            assert state["castingCount"] == 1
+            assert debug["activeLightCastsShadow"] is True
+            if source == "key":
+                assert debug["activeLightUuid"] == state["keyUuid"]
+                assert state["keyCastsShadow"] is True
+                assert state["accentCastsShadow"] is False
+            else:
+                assert debug["activeLightUuid"] == state["accentUuid"]
+                assert state["keyCastsShadow"] is False
+                assert state["accentCastsShadow"] is True
+
+        default = snapshot()
+        assert_single_source(default, "key")
+
+        studio = select_preset("studio")
+        assert_single_source(studio, "accent")
+        assert studio["debug"]["activeLightDirection"] == pytest.approx(
+            [-4 / math.sqrt(116), -8 / math.sqrt(116), -6 / math.sqrt(116)],
+        )
+        assert studio["debug"]["fitCount"] == default["debug"]["fitCount"] + 1
+
+        indoor = select_preset("indoor")
+        assert_single_source(indoor, "accent")
+        assert indoor["accentUuid"] == studio["accentUuid"]
+        assert indoor["debug"]["activeLightDirection"] == pytest.approx(
+            [-4 / math.sqrt(105), -8 / math.sqrt(105), -5 / math.sqrt(105)],
+        )
+        assert indoor["debug"]["fitCount"] == studio["debug"]["fitCount"] + 1
+
+        outdoor = select_preset("outdoor")
+        assert_single_source(outdoor, "accent")
+        assert outdoor["accentUuid"] == studio["accentUuid"]
+        assert outdoor["debug"]["activeLightDirection"] == pytest.approx(
+            [6 / math.sqrt(172), -10 / math.sqrt(172), -6 / math.sqrt(172)],
+        )
+        assert outdoor["debug"]["fitCount"] == indoor["debug"]["fitCount"] + 1
+        assert outdoor["debug"]["shadowUpdateCount"] > indoor["debug"][
+            "shadowUpdateCount"]
+
+        before_target_move = outdoor["debug"]
+        render_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.evaluate("""async () => {
+          const THREE = await import('three');
+          const {controls} = await import('./js/scene/scene.js');
+          const {requestRender} = await import('./js/scene/render-scheduler.js');
+          controls.target.add(new THREE.Vector3(1.25, 0.5, -0.75));
+          requestRender();
+        }""")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=render_count)
+        target_moved = snapshot()
+        assert target_moved["debug"]["fitCount"] == (
+            before_target_move["fitCount"] + 1)
+        assert target_moved["debug"]["activeLightDirection"] == pytest.approx(
+            before_target_move["activeLightDirection"])
+        expected_delta = [1.25, 0.5, -0.75]
+        assert [
+            current - previous for current, previous in zip(
+                target_moved["debug"]["activeLightPosition"],
+                before_target_move["activeLightPosition"],
+            )
+        ] == pytest.approx(expected_delta)
+        assert [
+            current - previous for current, previous in zip(
+                target_moved["debug"]["activeLightTarget"],
+                before_target_move["activeLightTarget"],
+            )
+        ] == pytest.approx(expected_delta)
+
+        render_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.evaluate("""async () => {
+          const THREE = await import('three');
+          const {scene} = await import('./js/scene/scene.js');
+          const {requestRender} = await import('./js/scene/render-scheduler.js');
+          const key = scene.children.find(object => object.isDirectionalLight);
+          key.position.add(new THREE.Vector3(3, 0, -2));
+          requestRender();
+        }""")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=render_count)
+        key_moved = snapshot()
+        assert_single_source(key_moved, "accent")
+        assert key_moved["debug"]["activeLightDirection"] == pytest.approx(
+            target_moved["debug"]["activeLightDirection"])
+        assert key_moved["debug"]["fitCount"] == target_moved["debug"]["fitCount"]
+        assert key_moved["debug"]["shadowUpdateCount"] == target_moved["debug"][
+            "shadowUpdateCount"]
+
+        render_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.evaluate("""async () => {
+          const {setLightMode} = await import('./js/scene/scene.js');
+          setLightMode('off');
+        }""")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count", arg=render_count)
+        outdoor_key_off = snapshot()
+        assert_single_source(outdoor_key_off, "accent")
+        assert outdoor_key_off["debug"]["groundVisible"] is True
+        assert outdoor_key_off["debug"]["fitCount"] == key_moved["debug"]["fitCount"]
+
+        default_key_off = select_preset("default")
+        assert_single_source(default_key_off, "key")
+        assert default_key_off["keyMode"] == "off"
+        assert default_key_off["debug"]["groundVisible"] is False
+
+        render_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.evaluate("""async () => {
+          const {setLightMode} = await import('./js/scene/scene.js');
+          setLightMode('current');
+        }""")
+        page.wait_for_function("""async state => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          return window.modViewer.getRenderCount() > state.renderCount
+            && getCharacterShadowDebugState().groundVisible;
+        }""", arg={"renderCount": render_count})
+        restored = snapshot()
+        assert_single_source(restored, "key")
+        assert restored["keyMode"] == "current"
     finally:
         context.close()
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -575,8 +575,8 @@ def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
                 hemisphere: hemisphere.intensity,
                 accent: accentLight?.intensity,
                 accentVisible: accentLight?.visible === true,
-                dominantLightIsAccent:
-                  controller.getDominantLight() === accentLight,
+                dominantLightDirection:
+                  controller.getDominantLightDirection(),
               };
             };
             controller.setPreset(failedProfile);
@@ -627,7 +627,7 @@ def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
         }[failed_profile]
         assert {key: failed[key] for key in fallback} == fallback
         assert failed["accentVisible"] is True
-        assert failed["dominantLightIsAccent"] is True
+        assert len(failed["dominantLightDirection"]) == 3
 
         for working_profile in working_profiles:
             working = result["working"][working_profile]
@@ -646,7 +646,7 @@ def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
             }[working_profile]
             assert {key: working[key] for key in expected} == expected
             assert working["accentVisible"] is True
-            assert working["dominantLightIsAccent"] is True
+            assert len(working["dominantLightDirection"]) == 3
     finally:
         context.close()
 
@@ -6402,47 +6402,82 @@ def test_wireframe_toggles_rim_uniform_without_rebuilding_material(
         context.close()
 
 
-def test_key_light_mode_changes_restore_ground_without_refitting_shadows(
+def test_key_light_intensity_controls_marker_and_ground_without_refitting_shadows(
         edge_browser, frontend_url):
-    context, page = _page(edge_browser, frontend_url, {"LightMode": _payload("LightMode")})
+    context, page = _page(edge_browser, frontend_url, {"LightIntensity": _payload("LightIntensity")})
     try:
-        _open(page, "LightMode")
+        _open(page, "LightIntensity")
         page.locator(".draw-item").wait_for()
         page.wait_for_function("""async () => {
           const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
           return getCharacterShadowDebugState().groundVisible;
         }""")
-        before = page.evaluate("""async () => {
-          const {getCharacterShadowDebugState, setLightMode} = await import('./js/scene/scene.js');
-          setLightMode('off');
-          return getCharacterShadowDebugState();
+
+        def snapshot():
+            return page.evaluate("""async () => {
+              const {
+                getCharacterShadowDebugState, getKeyLightIntensity, scene,
+              } = await import('./js/scene/scene.js');
+              const handle = scene.children.find(object => object.isSprite);
+              const debug = getCharacterShadowDebugState();
+              return {
+                intensity: getKeyLightIntensity(),
+                visible: handle.visible,
+                scale: handle.scale.x,
+                debug,
+              };
+            }""")
+
+        initial = snapshot()
+        assert initial["intensity"] == pytest.approx(1.0)
+        assert initial["visible"] is True
+        levels = [(0, 0.0), (33, 0.495), (67, 1.005), (100, 1.5)]
+        states = []
+        for level, expected in levels:
+            before_render = page.evaluate("window.modViewer.getRenderCount()")
+            page.evaluate("""async value => {
+              const {setKeyLightIntensity} = await import('./js/scene/scene.js');
+              setKeyLightIntensity(value);
+            }""", expected)
+            page.wait_for_function(
+                "count => window.modViewer.getRenderCount() > count",
+                arg=before_render,
+            )
+            state = snapshot()
+            states.append(state)
+            assert state["intensity"] == pytest.approx(expected)
+            assert state["visible"] is (level > 0)
+            assert state["debug"]["groundVisible"] is (level > 0)
+
+        assert states[0]["scale"] < states[1]["scale"] < states[2]["scale"] < states[3]["scale"]
+        assert states[1]["debug"]["fitCount"] == states[2]["debug"]["fitCount"]
+        assert states[2]["debug"]["shadowUpdateCount"] == states[3]["debug"]["shadowUpdateCount"]
+
+        before_noop = page.evaluate("window.modViewer.getRenderCount()")
+        changed = page.evaluate("""async () => {
+          const {setKeyLightIntensity} = await import('./js/scene/scene.js');
+          return setKeyLightIntensity(1.5);
         }""")
-        page.wait_for_function("""async () => {
-          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
-          return !getCharacterShadowDebugState().groundVisible;
-        }""")
-        off = page.evaluate("""async () => {
-          const {getCharacterShadowDebugState, setLightMode} = await import('./js/scene/scene.js');
-          setLightMode('current');
-          return getCharacterShadowDebugState();
-        }""")
-        page.wait_for_function("""async () => {
-          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
-          return getCharacterShadowDebugState().groundVisible;
-        }""")
-        restored = page.evaluate("""async () => {
-          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
-          return getCharacterShadowDebugState();
-        }""")
-        assert off["fitCount"] == before["fitCount"]
-        assert off["shadowUpdateCount"] == before["shadowUpdateCount"]
-        assert restored["fitCount"] == before["fitCount"]
-        assert restored["shadowUpdateCount"] == before["shadowUpdateCount"]
+        assert changed is False
+        page.wait_for_timeout(100)
+        assert page.evaluate("window.modViewer.getRenderCount()") == before_noop
+
+        for value, expected in [(-1, 0.0), (2, 1.5)]:
+            before_render = page.evaluate("window.modViewer.getRenderCount()")
+            page.evaluate("""async intensity => {
+              const {setKeyLightIntensity} = await import('./js/scene/scene.js');
+              setKeyLightIntensity(intensity);
+            }""", value)
+            page.wait_for_function(
+                "count => window.modViewer.getRenderCount() > count",
+                arg=before_render,
+            )
+            assert snapshot()["intensity"] == pytest.approx(expected)
     finally:
         context.close()
 
 
-def test_environment_presets_own_world_space_character_shadows(
+def test_environment_presets_keep_key_light_as_character_shadow_source(
         edge_browser, frontend_url):
     context, page = _page(
         edge_browser, frontend_url, {"ShadowSource": _payload("ShadowSource")})
@@ -6458,7 +6493,7 @@ def test_environment_presets_own_world_space_character_shadows(
         def snapshot():
             return page.evaluate("""async () => {
               const {
-                getCharacterShadowDebugState, getLightMode, scene,
+                getCharacterShadowDebugState, scene,
               } = await import('./js/scene/scene.js');
               const lights = [];
               scene.traverse(object => {
@@ -6473,7 +6508,8 @@ def test_environment_presets_own_world_space_character_shadows(
                 keyCastsShadow: key.castShadow,
                 accentCastsShadow: accent.castShadow,
                 castingCount: lights.filter(object => object.castShadow).length,
-                keyMode: getLightMode(),
+                keyPosition: key.position.toArray(),
+                keyTarget: key.target.position.toArray(),
               };
             }""")
 
@@ -6487,126 +6523,68 @@ def test_environment_presets_own_world_space_character_shadows(
                 "count => window.modViewer.getRenderCount() > count", arg=before)
             return snapshot()
 
-        def assert_single_source(state, source):
+        def assert_single_source(state):
             debug = state["debug"]
             assert state["castingCount"] == 1
-            assert debug["activeLightCastsShadow"] is True
-            if source == "key":
-                assert debug["activeLightUuid"] == state["keyUuid"]
-                assert state["keyCastsShadow"] is True
-                assert state["accentCastsShadow"] is False
-            else:
-                assert debug["activeLightUuid"] == state["accentUuid"]
-                assert state["keyCastsShadow"] is False
-                assert state["accentCastsShadow"] is True
+            assert state["keyCastsShadow"] is True
+            assert state["accentCastsShadow"] is False
 
         default = snapshot()
-        assert_single_source(default, "key")
+        assert_single_source(default)
 
-        studio = select_preset("studio")
-        assert_single_source(studio, "accent")
-        assert studio["debug"]["activeLightDirection"] == pytest.approx(
-            [-4 / math.sqrt(116), -8 / math.sqrt(116), -6 / math.sqrt(116)],
-        )
-        assert studio["debug"]["fitCount"] == default["debug"]["fitCount"] + 1
+        previous = default
+        for preset in ("studio", "indoor", "outdoor", "default"):
+            current = select_preset(preset)
+            assert_single_source(current)
+            assert current["keyUuid"] == default["keyUuid"]
+            assert current["accentUuid"] == default["accentUuid"]
+            assert current["keyPosition"] == pytest.approx(previous["keyPosition"])
+            assert current["keyTarget"] == pytest.approx(previous["keyTarget"])
+            assert current["debug"]["fitCount"] == previous["debug"]["fitCount"]
 
-        indoor = select_preset("indoor")
-        assert_single_source(indoor, "accent")
-        assert indoor["accentUuid"] == studio["accentUuid"]
-        assert indoor["debug"]["activeLightDirection"] == pytest.approx(
-            [-4 / math.sqrt(105), -8 / math.sqrt(105), -5 / math.sqrt(105)],
-        )
-        assert indoor["debug"]["fitCount"] == studio["debug"]["fitCount"] + 1
-
-        outdoor = select_preset("outdoor")
-        assert_single_source(outdoor, "accent")
-        assert outdoor["accentUuid"] == studio["accentUuid"]
-        assert outdoor["debug"]["activeLightDirection"] == pytest.approx(
-            [6 / math.sqrt(172), -10 / math.sqrt(172), -6 / math.sqrt(172)],
-        )
-        assert outdoor["debug"]["fitCount"] == indoor["debug"]["fitCount"] + 1
-        assert outdoor["debug"]["shadowUpdateCount"] > indoor["debug"][
-            "shadowUpdateCount"]
-
-        before_target_move = outdoor["debug"]
-        render_count = page.evaluate("window.modViewer.getRenderCount()")
-        page.evaluate("""async () => {
-          const THREE = await import('three');
-          const {controls} = await import('./js/scene/scene.js');
-          const {requestRender} = await import('./js/scene/render-scheduler.js');
-          controls.target.add(new THREE.Vector3(1.25, 0.5, -0.75));
-          requestRender();
-        }""")
-        page.wait_for_function(
-            "count => window.modViewer.getRenderCount() > count", arg=render_count)
-        target_moved = snapshot()
-        assert target_moved["debug"]["fitCount"] == (
-            before_target_move["fitCount"] + 1)
-        assert target_moved["debug"]["activeLightDirection"] == pytest.approx(
-            before_target_move["activeLightDirection"])
-        expected_delta = [1.25, 0.5, -0.75]
-        assert [
-            current - previous for current, previous in zip(
-                target_moved["debug"]["activeLightPosition"],
-                before_target_move["activeLightPosition"],
+            render_count = page.evaluate("window.modViewer.getRenderCount()")
+            page.evaluate("""async () => {
+              const THREE = await import('three');
+              const {scene} = await import('./js/scene/scene.js');
+              const {requestRender} = await import('./js/scene/render-scheduler.js');
+              const key = scene.children.find(object => object.isDirectionalLight);
+              key.position.add(new THREE.Vector3(3, 0, -2));
+              requestRender();
+            }""")
+            page.wait_for_function(
+                "count => window.modViewer.getRenderCount() > count",
+                arg=render_count,
             )
-        ] == pytest.approx(expected_delta)
-        assert [
-            current - previous for current, previous in zip(
-                target_moved["debug"]["activeLightTarget"],
-                before_target_move["activeLightTarget"],
+            moved = snapshot()
+            assert_single_source(moved)
+            assert moved["debug"]["fitCount"] == current["debug"]["fitCount"] + 1
+            assert moved["debug"]["shadowUpdateCount"] > current["debug"]["shadowUpdateCount"]
+
+            render_count = page.evaluate("window.modViewer.getRenderCount()")
+            page.evaluate("""async () => {
+              const {setKeyLightIntensity} = await import('./js/scene/scene.js');
+              setKeyLightIntensity(0);
+            }""")
+            page.wait_for_function(
+                "count => window.modViewer.getRenderCount() > count",
+                arg=render_count,
             )
-        ] == pytest.approx(expected_delta)
+            off = snapshot()
+            assert_single_source(off)
+            assert off["debug"]["groundVisible"] is False
+            assert off["debug"]["fitCount"] == moved["debug"]["fitCount"]
 
-        render_count = page.evaluate("window.modViewer.getRenderCount()")
-        page.evaluate("""async () => {
-          const THREE = await import('three');
-          const {scene} = await import('./js/scene/scene.js');
-          const {requestRender} = await import('./js/scene/render-scheduler.js');
-          const key = scene.children.find(object => object.isDirectionalLight);
-          key.position.add(new THREE.Vector3(3, 0, -2));
-          requestRender();
-        }""")
-        page.wait_for_function(
-            "count => window.modViewer.getRenderCount() > count", arg=render_count)
-        key_moved = snapshot()
-        assert_single_source(key_moved, "accent")
-        assert key_moved["debug"]["activeLightDirection"] == pytest.approx(
-            target_moved["debug"]["activeLightDirection"])
-        assert key_moved["debug"]["fitCount"] == target_moved["debug"]["fitCount"]
-        assert key_moved["debug"]["shadowUpdateCount"] == target_moved["debug"][
-            "shadowUpdateCount"]
-
-        render_count = page.evaluate("window.modViewer.getRenderCount()")
-        page.evaluate("""async () => {
-          const {setLightMode} = await import('./js/scene/scene.js');
-          setLightMode('off');
-        }""")
-        page.wait_for_function(
-            "count => window.modViewer.getRenderCount() > count", arg=render_count)
-        outdoor_key_off = snapshot()
-        assert_single_source(outdoor_key_off, "accent")
-        assert outdoor_key_off["debug"]["groundVisible"] is True
-        assert outdoor_key_off["debug"]["fitCount"] == key_moved["debug"]["fitCount"]
-
-        default_key_off = select_preset("default")
-        assert_single_source(default_key_off, "key")
-        assert default_key_off["keyMode"] == "off"
-        assert default_key_off["debug"]["groundVisible"] is False
-
-        render_count = page.evaluate("window.modViewer.getRenderCount()")
-        page.evaluate("""async () => {
-          const {setLightMode} = await import('./js/scene/scene.js');
-          setLightMode('current');
-        }""")
-        page.wait_for_function("""async state => {
-          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
-          return window.modViewer.getRenderCount() > state.renderCount
-            && getCharacterShadowDebugState().groundVisible;
-        }""", arg={"renderCount": render_count})
-        restored = snapshot()
-        assert_single_source(restored, "key")
-        assert restored["keyMode"] == "current"
+            render_count = page.evaluate("window.modViewer.getRenderCount()")
+            page.evaluate("""async () => {
+              const {setKeyLightIntensity} = await import('./js/scene/scene.js');
+              setKeyLightIntensity(1);
+            }""")
+            page.wait_for_function("""async state => {
+              const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+              return window.modViewer.getRenderCount() > state.renderCount
+                && getCharacterShadowDebugState().groundVisible;
+            }""", arg={"renderCount": render_count})
+            previous = snapshot()
     finally:
         context.close()
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -337,15 +337,15 @@ def test_environment_ibl_resources_are_cached_and_presets_restore_original(
         studio = select_preset("studio")
         assert studio["activeIblPreset"] == "studio"
         assert studio["environmentActive"]
-        assert studio["environmentIntensity"] == pytest.approx(0.15)
+        assert studio["environmentIntensity"] == pytest.approx(0.18)
         assert studio["ambientColor"] == 0xf5f7fa
-        assert studio["ambientIntensity"] == pytest.approx(0.03)
+        assert studio["ambientIntensity"] == pytest.approx(0.04)
         assert studio["hemisphereColor"] == 0xe1e9f3
         assert studio["hemisphereGroundColor"] == 0x454b55
-        assert studio["hemisphereIntensity"] == pytest.approx(0.06)
+        assert studio["hemisphereIntensity"] == pytest.approx(0.08)
         assert studio["accentColor"] == 0xffffff
         assert studio["accentPosition"] == [4, 8, 6]
-        assert studio["accentIntensity"] == pytest.approx(0.2)
+        assert studio["accentIntensity"] == pytest.approx(0.24)
         assert studio["activeDominantDirection"] == pytest.approx(
             [4 / math.sqrt(116), 8 / math.sqrt(116), 6 / math.sqrt(116)],
         )
@@ -636,7 +636,7 @@ def test_environment_ibl_failure_is_isolated_and_uses_legacy_lighting(
                     "ambient": 0.05, "hemisphere": 0.1, "accent": 0.3,
                 },
                 "studio": {
-                    "ambient": 0.03, "hemisphere": 0.06, "accent": 0.2,
+                    "ambient": 0.04, "hemisphere": 0.08, "accent": 0.24,
                 },
             }[working_profile]
             assert {key: working[key] for key in expected} == expected

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -365,6 +365,59 @@ def test_environment_controller_prepare_is_single_flight(
         context.close()
 
 
+def test_environment_controller_dispose_cancels_pending_preparation(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {})
+    try:
+        result = page.evaluate("""async () => {
+          const THREE = await import('three/webgpu');
+          const {renderer, rendererReady, getEnvironmentDebugState} =
+            await import('./js/scene/scene.js');
+          const {createEnvironmentController} =
+            await import('./js/scene/environment.js');
+          await rendererReady;
+          for (let attempts = 0; attempts < 100; attempts += 1) {
+            const state = getEnvironmentDebugState();
+            if (state.prepared || state.preparationError) break;
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+
+          const originalFromScene = THREE.PMREMGenerator.prototype.fromScene;
+          let generationCalls = 0;
+          THREE.PMREMGenerator.prototype.fromScene = function (...args) {
+            generationCalls += 1;
+            return originalFromScene.apply(this, args);
+          };
+          const testScene = new THREE.Scene();
+          const ambient = new THREE.AmbientLight(0xffffff, 0.55);
+          const hemisphere = new THREE.HemisphereLight(0xffffff, 0x30343f, 0.35);
+          const lightTarget = new THREE.Object3D();
+          const controller = createEnvironmentController({
+            renderer, scene: testScene, ambientLight: ambient,
+            hemisphereLight: hemisphere, lightTarget,
+          });
+          try {
+            const pending = controller.prepare();
+            controller.dispose();
+            return {
+              prepared: await pending,
+              generationCalls,
+              debug: controller.getDebugState(),
+            };
+          } finally {
+            THREE.PMREMGenerator.prototype.fromScene = originalFromScene;
+            controller.dispose();
+          }
+        }""")
+        assert result["prepared"] is False
+        assert result["generationCalls"] == 0
+        assert result["debug"]["pmremGenerationCount"] == 0
+        assert result["debug"]["outdoorIblAvailable"] is False
+        assert result["debug"]["prepared"] is False
+    finally:
+        context.close()
+
+
 def test_environment_controller_uses_legacy_lighting_when_pmrem_fails(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {})

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -228,9 +228,20 @@ def test_outdoor_environment_uses_one_cached_pmrem_and_restores_original(
           const {scene, getEnvironmentDebugState} =
             await import('./js/scene/scene.js');
           const state = getEnvironmentDebugState();
+          const ambient = scene.children.find(object => object.isAmbientLight);
+          const hemisphere = scene.children.find(
+            object => object.isHemisphereLight);
+          let accent = null;
+          scene.traverse(object => {
+            if (object.isDirectionalLight && object !== scene.children.find(
+                candidate => candidate.isDirectionalLight)) accent = object;
+          });
           return {...state,
             environmentId: scene.environment?.uuid || null,
             hasVisibleSky: scene.getObjectByProperty('isSkyMesh', true) != null,
+            ambientIntensity: ambient?.intensity,
+            hemisphereIntensity: hemisphere?.intensity,
+            accentIntensity: accent?.intensity,
           };
         }""")
         assert initial["outdoorIblAvailable"]
@@ -251,23 +262,39 @@ def test_outdoor_environment_uses_one_cached_pmrem_and_restores_original(
             return page.evaluate("""async () => {
               const {scene, getEnvironmentDebugState} =
                 await import('./js/scene/scene.js');
+              const ambient = scene.children.find(object => object.isAmbientLight);
+              const hemisphere = scene.children.find(
+                object => object.isHemisphereLight);
+              let accent = null;
+              scene.traverse(object => {
+                if (object.isDirectionalLight && object !== scene.children.find(
+                    candidate => candidate.isDirectionalLight)) accent = object;
+              });
               return {...getEnvironmentDebugState(),
-                environmentId: scene.environment?.uuid || null};
+                environmentId: scene.environment?.uuid || null,
+                ambientIntensity: ambient?.intensity,
+                hemisphereIntensity: hemisphere?.intensity,
+                accentIntensity: accent?.intensity};
             }""")
 
         outdoor = select_preset("outdoor")
         assert outdoor["environmentIsOutdoor"]
         assert outdoor["environmentActive"]
-        assert outdoor["environmentIntensity"] == pytest.approx(0.7)
+        assert outdoor["environmentIntensity"] == pytest.approx(0.1)
+        assert outdoor["ambientIntensity"] == pytest.approx(0.04)
+        assert outdoor["hemisphereIntensity"] == pytest.approx(0.08)
+        assert outdoor["accentIntensity"] == pytest.approx(0.4)
         assert outdoor["environmentId"] is not None
 
         studio = select_preset("studio")
         assert not studio["environmentIsOutdoor"]
         assert not studio["environmentActive"]
+        assert studio["environmentIntensity"] == initial["environmentIntensity"]
 
         indoor = select_preset("indoor")
         assert not indoor["environmentIsOutdoor"]
         assert not indoor["environmentActive"]
+        assert indoor["environmentIntensity"] == initial["environmentIntensity"]
 
         outdoor_again = select_preset("outdoor")
         assert outdoor_again["environmentIsOutdoor"]
@@ -284,16 +311,76 @@ def test_outdoor_environment_uses_one_cached_pmrem_and_restores_original(
         context.close()
 
 
-def test_outdoor_environment_generation_failure_keeps_viewer_usable(
+def test_environment_controller_prepare_is_single_flight(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {})
     try:
         result = page.evaluate("""async () => {
           const THREE = await import('three/webgpu');
-          const {renderer, rendererReady} = await import('./js/scene/scene.js');
+          const {renderer, rendererReady, getEnvironmentDebugState} =
+            await import('./js/scene/scene.js');
+          const {createEnvironmentController} =
+            await import('./js/scene/environment.js');
+          await rendererReady;
+          for (let attempts = 0; attempts < 100; attempts += 1) {
+            const state = getEnvironmentDebugState();
+            if (state.prepared || state.preparationError) break;
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
+
+          const originalFromScene = THREE.PMREMGenerator.prototype.fromScene;
+          let generationCalls = 0;
+          THREE.PMREMGenerator.prototype.fromScene = function (...args) {
+            generationCalls += 1;
+            return originalFromScene.apply(this, args);
+          };
+          const testScene = new THREE.Scene();
+          const ambient = new THREE.AmbientLight(0xffffff, 0.55);
+          const hemisphere = new THREE.HemisphereLight(0xffffff, 0x30343f, 0.35);
+          const lightTarget = new THREE.Object3D();
+          let controller = null;
+          try {
+            controller = createEnvironmentController({
+              renderer, scene: testScene, ambientLight: ambient,
+              hemisphereLight: hemisphere, lightTarget,
+            });
+            const first = controller.prepare();
+            const second = controller.prepare();
+            const [firstResult, secondResult] = await Promise.all([first, second]);
+            return {
+              firstResult, secondResult, generationCalls,
+              debug: controller.getDebugState(),
+            };
+          } finally {
+            THREE.PMREMGenerator.prototype.fromScene = originalFromScene;
+            controller?.dispose();
+          }
+        }""")
+        assert result["firstResult"] is True
+        assert result["secondResult"] is True
+        assert result["generationCalls"] == 1
+        assert result["debug"]["pmremGenerationCount"] == 1
+        assert result["debug"]["prepared"] is True
+    finally:
+        context.close()
+
+
+def test_environment_controller_uses_legacy_lighting_when_pmrem_fails(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {})
+    try:
+        result = page.evaluate("""async () => {
+          const THREE = await import('three/webgpu');
+          const {renderer, rendererReady, getEnvironmentDebugState} =
+            await import('./js/scene/scene.js');
           const {createEnvironmentController} =
             await import('./js/scene/environment.js');
           const rendererReadyResult = await rendererReady;
+          for (let attempts = 0; attempts < 100; attempts += 1) {
+            const state = getEnvironmentDebugState();
+            if (state.prepared || state.preparationError) break;
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
 
           const originalFromScene = THREE.PMREMGenerator.prototype.fromScene;
           const testScene = new THREE.Scene();
@@ -318,6 +405,8 @@ def test_outdoor_environment_generation_failure_keeps_viewer_usable(
               backgroundChanged: testScene.background !== null,
               ambient: ambient.intensity,
               hemisphere: hemisphere.intensity,
+              accent: lightTarget.children.find(
+                object => object.isDirectionalLight)?.intensity,
               accentVisible: lightTarget.children.some(
                 object => object.isDirectionalLight && object.visible),
             };
@@ -339,8 +428,9 @@ def test_outdoor_environment_generation_failure_keeps_viewer_usable(
             "preparationError"]
         assert result["outdoorLighting"] == {
             "backgroundChanged": True,
-            "ambient": 0.12,
-            "hemisphere": 0.2,
+            "ambient": 0.26,
+            "hemisphere": 0.45,
+            "accent": 0.7,
             "accentVisible": True,
         }
     finally:
@@ -4291,7 +4381,15 @@ def test_each_mesh_resolves_its_own_profile_and_packed_source(
         page.wait_for_function(
             "window.modViewer.activeMeshes.length === 2 && "
             "window.modViewer.activeMeshes.every(mesh => "
-            "mesh.material.userData.gameMaterial)")
+            "mesh.material.userData.gameMaterial) && "
+            "window.modViewer.activeMeshes[0].material.userData.gameMaterial"
+            ".bindings.light_map.enabledNode.value === true && "
+            "window.modViewer.activeMeshes[0].material.userData.gameMaterial"
+            ".bindings.material_map.enabledNode.value === true && "
+            "window.modViewer.activeMeshes[1].material.userData.gameMaterial"
+            ".bindings.light_map.enabledNode.value === true && "
+            "window.modViewer.activeMeshes[1].material.userData.gameMaterial"
+            ".bindings.material_map.enabledNode.value === false")
         states = page.evaluate("""() => window.modViewer.activeMeshes.map(mesh => ({
           profileId: mesh.userData.materialProfileId,
           kind: mesh.userData.materialKind,
@@ -5880,7 +5978,8 @@ def test_character_shadows_are_on_demand_and_visibility_keeps_stable_ground(
         page.locator(".draw-item").wait_for()
         page.wait_for_function("""async () => {
           const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
-          return getCharacterShadowDebugState().shadowUpdateCount > 0;
+          const state = getCharacterShadowDebugState();
+          return state.modelBounds !== null && state.casterBounds !== null;
         }""")
         initial = page.evaluate("""async () => {
           const {getCharacterShadowDebugState, renderer, scene} =
@@ -6013,6 +6112,11 @@ def test_shadow_fit_and_bias_scale_with_model_size(edge_browser, frontend_url, s
     try:
         _open(page, label)
         page.locator(".draw-item").wait_for()
+        page.wait_for_function("""async () => {
+          const {getCharacterShadowDebugState} = await import('./js/scene/scene.js');
+          const state = getCharacterShadowDebugState();
+          return state.modelBounds !== null && state.casterBounds !== null;
+        }""")
         state = page.evaluate("""async () => {
           const {getCharacterShadowDebugState, scene} = await import('./js/scene/scene.js');
           const light = scene.children.find(object => object.isDirectionalLight);

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -213,6 +213,140 @@ def test_webgpu_startup_uses_actual_webgpu_backend(edge_browser, frontend_url):
     finally:
         context.close()
 
+
+def test_outdoor_environment_uses_one_cached_pmrem_and_restores_original(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {})
+    try:
+        page.wait_for_function("""async () => {
+          const {rendererReady, getEnvironmentDebugState} =
+            await import('./js/scene/scene.js');
+          await rendererReady;
+          return getEnvironmentDebugState().prepared;
+        }""")
+        initial = page.evaluate("""async () => {
+          const {scene, getEnvironmentDebugState} =
+            await import('./js/scene/scene.js');
+          const state = getEnvironmentDebugState();
+          return {...state,
+            environmentId: scene.environment?.uuid || null,
+            hasVisibleSky: scene.getObjectByProperty('isSkyMesh', true) != null,
+          };
+        }""")
+        assert initial["outdoorIblAvailable"]
+        assert initial["pmremGenerationCount"] == 1
+        assert not initial["environmentActive"]
+        assert not initial["hasVisibleSky"]
+
+        def select_preset(preset):
+            before = page.evaluate("window.modViewer.getRenderCount()")
+            assert page.evaluate(
+                "preset => window.modViewer.setEnvironmentPreset(preset)",
+                preset,
+            )
+            page.wait_for_function(
+                "count => window.modViewer.getRenderCount() > count",
+                arg=before,
+            )
+            return page.evaluate("""async () => {
+              const {scene, getEnvironmentDebugState} =
+                await import('./js/scene/scene.js');
+              return {...getEnvironmentDebugState(),
+                environmentId: scene.environment?.uuid || null};
+            }""")
+
+        outdoor = select_preset("outdoor")
+        assert outdoor["environmentIsOutdoor"]
+        assert outdoor["environmentActive"]
+        assert outdoor["environmentIntensity"] == pytest.approx(0.7)
+        assert outdoor["environmentId"] is not None
+
+        studio = select_preset("studio")
+        assert not studio["environmentIsOutdoor"]
+        assert not studio["environmentActive"]
+
+        indoor = select_preset("indoor")
+        assert not indoor["environmentIsOutdoor"]
+        assert not indoor["environmentActive"]
+
+        outdoor_again = select_preset("outdoor")
+        assert outdoor_again["environmentIsOutdoor"]
+        assert outdoor_again["environmentId"] == outdoor["environmentId"]
+        assert outdoor_again["pmremGenerationCount"] == 1
+        assert outdoor_again["sunDirection"] == pytest.approx(
+            [-6 / math.sqrt(172), 10 / math.sqrt(172), 6 / math.sqrt(172)],
+        )
+
+        idle_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.wait_for_timeout(200)
+        assert page.evaluate("window.modViewer.getRenderCount()") == idle_count
+    finally:
+        context.close()
+
+
+def test_outdoor_environment_generation_failure_keeps_viewer_usable(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {})
+    try:
+        result = page.evaluate("""async () => {
+          const THREE = await import('three/webgpu');
+          const {renderer, rendererReady} = await import('./js/scene/scene.js');
+          const {createEnvironmentController} =
+            await import('./js/scene/environment.js');
+          const rendererReadyResult = await rendererReady;
+
+          const originalFromScene = THREE.PMREMGenerator.prototype.fromScene;
+          const testScene = new THREE.Scene();
+          testScene.environment = null;
+          testScene.environmentIntensity = 1;
+          const ambient = new THREE.AmbientLight(0xffffff, 0.55);
+          const hemisphere = new THREE.HemisphereLight(0xffffff, 0x30343f, 0.35);
+          const lightTarget = new THREE.Object3D();
+          let controller = null;
+          try {
+            THREE.PMREMGenerator.prototype.fromScene = () => {
+              throw new Error('simulated Outdoor PMREM failure');
+            };
+            controller = createEnvironmentController({
+              renderer, scene: testScene, ambientLight: ambient,
+              hemisphereLight: hemisphere, lightTarget,
+            });
+            const prepared = await controller.prepare();
+            controller.setPreset('outdoor');
+            const outdoor = controller.getDebugState();
+            const outdoorLighting = {
+              backgroundChanged: testScene.background !== null,
+              ambient: ambient.intensity,
+              hemisphere: hemisphere.intensity,
+              accentVisible: lightTarget.children.some(
+                object => object.isDirectionalLight && object.visible),
+            };
+            return {
+              rendererReady: rendererReadyResult,
+              prepared, outdoor, outdoorLighting,
+            };
+          } finally {
+            THREE.PMREMGenerator.prototype.fromScene = originalFromScene;
+            controller?.dispose();
+          }
+        }""")
+        assert result["rendererReady"]
+        assert result["prepared"] is False
+        assert result["outdoor"]["outdoorIblAvailable"] is False
+        assert result["outdoor"]["environmentActive"] is False
+        assert result["outdoor"]["pmremGenerationCount"] == 0
+        assert "simulated Outdoor PMREM failure" in result["outdoor"][
+            "preparationError"]
+        assert result["outdoorLighting"] == {
+            "backgroundChanged": True,
+            "ambient": 0.12,
+            "hemisphere": 0.2,
+            "accentVisible": True,
+        }
+    finally:
+        context.close()
+
+
 def test_skinning_physics_solver_uses_true_3d_vectors_and_quaternions(
         edge_browser, frontend_url):
     context, page = _page(

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -241,6 +241,7 @@ def test_environment_ibl_resources_are_cached_and_presets_restore_original(
           };
         }""")
         assert initial["activeIblPreset"] is None
+        assert initial["activeDominantDirection"] is None
         assert not initial["environmentActive"]
         assert not initial["hasVisibleSky"]
         assert initial["resources"] == {
@@ -280,8 +281,13 @@ def test_environment_ibl_resources_are_cached_and_presets_restore_original(
                 environmentId: scene.environment?.uuid || null,
                 backgroundIsCanvas: scene.background?.isCanvasTexture === true,
                 hasVisibleSky: scene.getObjectByProperty('isSkyMesh', true) != null,
+                ambientColor: ambient?.color.getHex(),
                 ambientIntensity: ambient?.intensity,
+                hemisphereColor: hemisphere?.color.getHex(),
+                hemisphereGroundColor: hemisphere?.groundColor.getHex(),
                 hemisphereIntensity: hemisphere?.intensity,
+                accentColor: accent?.color.getHex(),
+                accentPosition: accent?.position.toArray(),
                 accentIntensity: accent?.intensity};
             }""")
 
@@ -289,9 +295,17 @@ def test_environment_ibl_resources_are_cached_and_presets_restore_original(
         assert indoor["activeIblPreset"] == "indoor"
         assert indoor["environmentActive"]
         assert indoor["environmentIntensity"] == pytest.approx(0.15)
+        assert indoor["ambientColor"] == 0xffd4af
         assert indoor["ambientIntensity"] == pytest.approx(0.05)
+        assert indoor["hemisphereColor"] == 0xffd3a6
+        assert indoor["hemisphereGroundColor"] == 0x2b3440
         assert indoor["hemisphereIntensity"] == pytest.approx(0.1)
+        assert indoor["accentColor"] == 0xffb36b
+        assert indoor["accentPosition"] == [4, 8, 5]
         assert indoor["accentIntensity"] == pytest.approx(0.3)
+        assert indoor["activeDominantDirection"] == pytest.approx(
+            [4 / math.sqrt(105), 8 / math.sqrt(105), 5 / math.sqrt(105)],
+        )
         assert indoor["environmentId"] is not None
         assert indoor["environmentId"] != initial["environmentId"]
         assert indoor["backgroundIsCanvas"]
@@ -301,18 +315,25 @@ def test_environment_ibl_resources_are_cached_and_presets_restore_original(
         assert outdoor["activeIblPreset"] == "outdoor"
         assert outdoor["environmentActive"]
         assert outdoor["environmentIntensity"] == pytest.approx(0.1)
+        assert outdoor["ambientColor"] == 0xdbeaff
         assert outdoor["ambientIntensity"] == pytest.approx(0.04)
+        assert outdoor["hemisphereColor"] == 0x78b5ed
+        assert outdoor["hemisphereGroundColor"] == 0x667068
         assert outdoor["hemisphereIntensity"] == pytest.approx(0.08)
+        assert outdoor["accentColor"] == 0xffe6bd
+        assert outdoor["accentPosition"] == [-6, 10, 6]
         assert outdoor["accentIntensity"] == pytest.approx(0.4)
         assert outdoor["environmentId"] not in (None, indoor["environmentId"])
         assert outdoor["backgroundIsCanvas"]
         assert not outdoor["hasVisibleSky"]
-        assert outdoor["sunDirection"] == pytest.approx(
+        assert outdoor["activeDominantDirection"] == pytest.approx(
             [-6 / math.sqrt(172), 10 / math.sqrt(172), 6 / math.sqrt(172)],
         )
+        assert "sunDirection" not in outdoor
 
         studio = select_preset("studio")
         assert studio["activeIblPreset"] is None
+        assert studio["activeDominantDirection"] is None
         assert not studio["environmentActive"]
         assert studio["environmentId"] == initial["environmentId"]
         assert studio["environmentIntensity"] == initial["environmentIntensity"]
@@ -324,6 +345,7 @@ def test_environment_ibl_resources_are_cached_and_presets_restore_original(
         assert indoor_again["environmentId"] == indoor["environmentId"]
         assert outdoor_again["environmentId"] == outdoor["environmentId"]
         assert default["activeIblPreset"] is None
+        assert default["activeDominantDirection"] is None
         assert default["environmentId"] == initial["environmentId"]
         assert default["environmentIntensity"] == initial["environmentIntensity"]
         assert indoor_third["environmentId"] == indoor["environmentId"]
@@ -379,10 +401,15 @@ def test_environment_controller_prepare_is_single_flight(
             const second = controller.prepare();
             const [firstResult, secondResult] = await Promise.all([first, second]);
             const debug = controller.getDebugState();
+            const dominantDirections = {};
+            for (const id of ['default', 'indoor', 'outdoor', 'studio']) {
+              controller.setPreset(id);
+              dominantDirections[id] = controller.getDominantLightDirection();
+            }
             controller.dispose();
             return {
               firstResult, secondResult, generationCalls, generationOrder,
-              targetDisposals, debug,
+              targetDisposals, debug, dominantDirections,
             };
           } finally {
             THREE.PMREMGenerator.prototype.fromScene = originalFromScene;
@@ -400,6 +427,14 @@ def test_environment_controller_prepare_is_single_flight(
             "generationCount"] == 1
         assert result["debug"]["totalPmremGenerationCount"] == 2
         assert result["debug"]["preparationInFlight"] is False
+        assert result["dominantDirections"]["default"] is None
+        assert result["dominantDirections"]["indoor"] == pytest.approx(
+            [4 / math.sqrt(105), 8 / math.sqrt(105), 5 / math.sqrt(105)],
+        )
+        assert result["dominantDirections"]["outdoor"] == pytest.approx(
+            [-6 / math.sqrt(172), 10 / math.sqrt(172), 6 / math.sqrt(172)],
+        )
+        assert result["dominantDirections"]["studio"] is None
     finally:
         context.close()
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -708,6 +708,63 @@ def test_environment_disposal_between_resources_stops_later_generation(
         context.close()
 
 
+def test_environment_dispose_restores_default_logical_state(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {})
+    try:
+        result = page.evaluate("""async () => {
+          const THREE = await import('three/webgpu');
+          const {renderer, rendererReady} = await import('./js/scene/scene.js');
+          const {createEnvironmentController} =
+            await import('./js/scene/environment.js');
+          await rendererReady;
+          const originalBackground = new THREE.Color(0x123456);
+          const originalEnvironment = new THREE.Texture();
+          const testScene = new THREE.Scene();
+          testScene.background = originalBackground;
+          testScene.environment = originalEnvironment;
+          testScene.environmentIntensity = 0.7;
+          const ambient = new THREE.AmbientLight(0xffffff, 0.55);
+          const hemisphere = new THREE.HemisphereLight(0xffffff, 0x30343f, 0.35);
+          const lightTarget = new THREE.Object3D();
+          const controller = createEnvironmentController({
+            renderer, scene: testScene, ambientLight: ambient,
+            hemisphereLight: hemisphere, lightTarget,
+          });
+          controller.setPreset('indoor');
+          const indoorDirection = controller.getDominantLightDirection();
+          controller.dispose();
+          const debug = controller.getDebugState();
+          return {
+            indoorDirection,
+            preset: controller.getPreset().id,
+            direction: controller.getDominantLightDirection(),
+            debugPreset: debug.preset,
+            activeDominantDirection: debug.activeDominantDirection,
+            environmentRestored: testScene.environment === originalEnvironment,
+            backgroundRestored: testScene.background === originalBackground,
+            environmentIntensity: testScene.environmentIntensity,
+            ambient: ambient.intensity,
+            hemisphere: hemisphere.intensity,
+            accentCount: lightTarget.children.filter(
+              object => object.isDirectionalLight).length,
+          };
+        }""")
+        assert len(result["indoorDirection"]) == 3
+        assert result["preset"] == "default"
+        assert result["direction"] is None
+        assert result["debugPreset"] == "default"
+        assert result["activeDominantDirection"] is None
+        assert result["environmentRestored"] is True
+        assert result["backgroundRestored"] is True
+        assert result["environmentIntensity"] == pytest.approx(0.7)
+        assert result["ambient"] == pytest.approx(0.55)
+        assert result["hemisphere"] == pytest.approx(0.35)
+        assert result["accentCount"] == 0
+    finally:
+        context.close()
+
+
 @pytest.mark.parametrize(("active_preset", "expected_visual_changes"), [
     ("default", []),
     ("outdoor", ["outdoor"]),
@@ -6419,11 +6476,14 @@ def test_key_light_intensity_controls_marker_and_ground_without_refitting_shadow
                 getCharacterShadowDebugState, getKeyLightIntensity, scene,
               } = await import('./js/scene/scene.js');
               const handle = scene.children.find(object => object.isSprite);
+              const ground = scene.children.find(
+                object => object.userData.isViewerGround);
               const debug = getCharacterShadowDebugState();
               return {
                 intensity: getKeyLightIntensity(),
                 visible: handle.visible,
                 scale: handle.scale.x,
+                opacity: ground.material.opacity,
                 debug,
               };
             }""")
@@ -6431,6 +6491,25 @@ def test_key_light_intensity_controls_marker_and_ground_without_refitting_shadow
         initial = snapshot()
         assert initial["intensity"] == pytest.approx(1.0)
         assert initial["visible"] is True
+        assert initial["opacity"] == pytest.approx(0.32)
+        initial_fit_count = initial["debug"]["fitCount"]
+        initial_shadow_update_count = initial["debug"]["shadowUpdateCount"]
+        for expected, opacity in [(0.0, 0.0), (0.5, 0.16),
+                                  (1.0, 0.32), (1.5, 0.32)]:
+            before_render = page.evaluate("window.modViewer.getRenderCount()")
+            page.evaluate("""async intensity => {
+              const {setKeyLightIntensity} = await import('./js/scene/scene.js');
+              setKeyLightIntensity(intensity);
+            }""", expected)
+            page.wait_for_function(
+                "count => window.modViewer.getRenderCount() > count",
+                arg=before_render,
+            )
+            state = snapshot()
+            assert state["opacity"] == pytest.approx(opacity)
+            assert state["debug"]["fitCount"] == initial_fit_count
+            assert state["debug"]["shadowUpdateCount"] == initial_shadow_update_count
+
         levels = [(0, 0.0), (33, 0.495), (67, 1.005), (100, 1.5)]
         states = []
         for level, expected in levels:
@@ -6446,6 +6525,7 @@ def test_key_light_intensity_controls_marker_and_ground_without_refitting_shadow
             state = snapshot()
             states.append(state)
             assert state["intensity"] == pytest.approx(expected)
+            assert state["opacity"] == pytest.approx(min(expected, 1.0) * 0.32)
             assert state["visible"] is (level > 0)
             assert state["debug"]["groundVisible"] is (level > 0)
 

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -993,17 +993,42 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
           };
         }""")
         assert light_position == {"above": True, "within": True}
-        assert page.locator("#light-popover .ui-popover-option").all_inner_texts() == [
-            "Bright", "Normal", "Off"]
-        page.locator("#light-popover .ui-popover-option", has_text="Normal").click()
-        assert page.locator("#light-popover").is_hidden()
-        assert page.locator("#light-btn").get_attribute("aria-expanded") == "false"
-        assert page.locator("#light-btn").get_attribute("aria-label").startswith("Key light: normal")
-
-        page.locator("#light-btn").click()
-        page.locator("#light-popover:not([hidden])").wait_for()
-        assert page.locator("#light-popover .ui-popover-option").all_inner_texts() == [
-            "Bright", "Normal", "Off"]
+        assert page.locator("#light-btn").get_attribute("aria-haspopup") == "dialog"
+        assert page.locator("#light-btn").get_attribute("aria-controls") == "light-popover"
+        assert page.locator("#light-btn").get_attribute("aria-label") == "Key light: 67%"
+        slider = page.locator("#light-slider")
+        assert slider.get_attribute("min") == "0"
+        assert slider.get_attribute("max") == "100"
+        assert slider.get_attribute("step") == "1"
+        assert slider.input_value() == "67"
+        assert page.locator("#light-btn").get_attribute("aria-expanded") == "true"
+        assert page.evaluate("document.activeElement.id") == "light-slider"
+        for level in (0, 33, 67, 100):
+            before = page.evaluate("window.modViewer.getRenderCount()")
+            page.evaluate("""value => {
+              const slider = document.querySelector('#light-slider');
+              slider.value = String(value);
+              slider.dispatchEvent(new Event('input', {bubbles: true}));
+            }""", level)
+            page.wait_for_function(
+                "count => window.modViewer.getRenderCount() > count", arg=before)
+            assert slider.input_value() == str(level)
+            assert page.locator("#light-value").text_content() == f"{level}%"
+            expected_label = "Key light: Off" if level == 0 else f"Key light: {level}%"
+            assert page.locator("#light-btn").get_attribute("aria-label") == expected_label
+            assert page.locator("#light-btn").get_attribute("title") == expected_label
+            assert page.locator("#light-btn").evaluate(
+                "(button, level) => button.classList.contains('active') === (level > 0)",
+                level,
+            )
+            assert page.locator("#light-btn").evaluate(
+                "(button, level) => button.classList.contains('off') === (level === 0)",
+                level,
+            )
+            assert page.evaluate("""async () => {
+              const {getKeyLightIntensity} = await import('./js/scene/scene.js');
+              return getKeyLightIntensity();
+            }""") == pytest.approx(level / 100 * 1.5)
         page.locator("#light-btn").click()
         assert page.locator("#light-popover").is_hidden()
 

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -927,6 +927,20 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
         assert toon_button.get_attribute("aria-pressed") == "false"
         assert toon_button.evaluate(
             "button => button.classList.contains('off')")
+        active_colors = page.evaluate("""() => {
+          const color = selector => getComputedStyle(
+            document.querySelector(selector)).backgroundColor;
+          return {
+            grid: color('#grid-btn'),
+            light: color('#light-btn'),
+          };
+        }""")
+        assert active_colors == {
+            "grid": "rgba(31, 111, 235, 0.22)",
+            "light": "rgba(227, 179, 65, 0.18)",
+        }
+        assert page.locator("#light-btn").evaluate(
+            "button => button.classList.contains('partial')")
         tool_order = page.evaluate(
             "() => [...document.querySelectorAll('#tool-buttons > .tool-btn')]"
             ".map(button => button.id)")
@@ -979,6 +993,9 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
             "Textures: diffuse only")
         assert page.locator("#texture-btn").get_attribute("aria-expanded") == "false"
         assert page.locator("#texture-popover").is_hidden()
+        assert page.evaluate(
+            "getComputedStyle(document.querySelector('#texture-btn')).backgroundColor"
+        ) == "rgba(227, 179, 65, 0.18)"
 
         page.locator("#light-btn").click()
         page.locator("#light-popover:not([hidden])").wait_for()
@@ -1018,7 +1035,11 @@ def test_viewport_toolbar_popovers_and_responsive_overflow(
             assert page.locator("#light-btn").get_attribute("aria-label") == expected_label
             assert page.locator("#light-btn").get_attribute("title") == expected_label
             assert page.locator("#light-btn").evaluate(
-                "(button, level) => button.classList.contains('active') === (level > 0)",
+                "(button, level) => button.classList.contains('active') === (level === 100)",
+                level,
+            )
+            assert page.locator("#light-btn").evaluate(
+                "(button, level) => button.classList.contains('partial') === (level > 0 && level < 100)",
                 level,
             )
             assert page.locator("#light-btn").evaluate(

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -391,11 +391,11 @@ body.asset-preview-mode #toolbar-overflow [data-toolbar-target="export-btn"] {
 #trackball-btn.off { background: var(--bg-control); }
 .tool-btn.active,
 #grid-btn:not(.off), #shading-btn:not(.off), #toon-btn:not(.off), #glossy-btn:not(.off),
-#texture-btn:not(.off), #trackball-btn:not(.off),
-#texture-btn.diffuse-normal, #texture-btn.diffuse-only {
-  background: rgba(227,179,65,.18); border-color: var(--warning); color: #f2cc72;
+#texture-btn:not(.off), #trackball-btn:not(.off) {
+  background: rgba(31,111,235,.22); border-color: var(--accent-soft); color: var(--accent-soft);
 }
-#ao-btn.partial {
+#texture-btn.diffuse-normal, #texture-btn.diffuse-only, #ao-btn.partial,
+#light-btn.partial {
   background: rgba(227,179,65,.18); border-color: var(--warning); color: #f2cc72;
 }
 .nav-gizmo-icon { width: 24px; height: 24px; overflow: visible; }

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -386,18 +386,13 @@ body.asset-preview-mode #toolbar-overflow [data-toolbar-target="export-btn"] {
 #texture-btn { background: var(--accent); }
 #texture-btn.diffuse-normal, #texture-btn.diffuse-only { background: #9a6700; }
 #texture-btn.off { background: var(--bg-control); }
-#light-btn.double { background: var(--accent); color: #fff; }
-#light-btn.current { background: #9a6700; color: #fff3b0; }
 #light-btn.off { background: var(--bg-control); color: var(--text); }
 #trackball-btn { background: var(--accent); }
 #trackball-btn.off { background: var(--bg-control); }
 .tool-btn.active,
 #grid-btn:not(.off), #shading-btn:not(.off), #toon-btn:not(.off), #glossy-btn:not(.off),
 #texture-btn:not(.off), #trackball-btn:not(.off),
-#light-btn.double, #light-btn.current {
-  background: rgba(31,111,235,.22); border-color: var(--accent-soft); color: var(--accent-soft);
-}
-#texture-btn.diffuse-normal, #texture-btn.diffuse-only, #light-btn.current {
+#texture-btn.diffuse-normal, #texture-btn.diffuse-only {
   background: rgba(227,179,65,.18); border-color: var(--warning); color: #f2cc72;
 }
 #ao-btn.partial {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -232,7 +232,7 @@
       <button id="grid-btn" class="tool-btn" title="Grid visibility: on" aria-label="Grid visibility: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-grid"></use></svg></button>
       <button id="shading-btn" class="tool-btn" title="Smooth shading: on" aria-label="Smooth shading: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-shading"></use></svg></button>
       <button id="texture-btn" class="tool-btn" title="Textures: all maps" aria-label="Textures: all maps"><svg class="ui-icon" aria-hidden="true"><use href="#icon-texture"></use></svg></button>
-      <button id="light-btn" class="tool-btn active" title="Key light: 67%" aria-label="Key light: 67%"
+      <button id="light-btn" class="tool-btn partial" title="Key light: 67%" aria-label="Key light: 67%"
               aria-expanded="false" aria-controls="light-popover"><svg class="ui-icon" aria-hidden="true"><use href="#icon-light"></use></svg></button>
       <button id="trackball-btn" class="tool-btn active" title="Toggle navigation gizmo: on" aria-label="Toggle navigation gizmo: on" aria-pressed="true">
         <svg class="nav-gizmo-icon" viewBox="0 0 24 24" aria-hidden="true">

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -232,7 +232,8 @@
       <button id="grid-btn" class="tool-btn" title="Grid visibility: on" aria-label="Grid visibility: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-grid"></use></svg></button>
       <button id="shading-btn" class="tool-btn" title="Smooth shading: on" aria-label="Smooth shading: on" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-shading"></use></svg></button>
       <button id="texture-btn" class="tool-btn" title="Textures: all maps" aria-label="Textures: all maps"><svg class="ui-icon" aria-hidden="true"><use href="#icon-texture"></use></svg></button>
-      <button id="light-btn" class="tool-btn double" title="Key light: double brightness and handle size" aria-label="Key light: double" aria-pressed="true"><svg class="ui-icon" aria-hidden="true"><use href="#icon-light"></use></svg></button>
+      <button id="light-btn" class="tool-btn active" title="Key light: 67%" aria-label="Key light: 67%"
+              aria-expanded="false" aria-controls="light-popover"><svg class="ui-icon" aria-hidden="true"><use href="#icon-light"></use></svg></button>
       <button id="trackball-btn" class="tool-btn active" title="Toggle navigation gizmo: on" aria-label="Toggle navigation gizmo: on" aria-pressed="true">
         <svg class="nav-gizmo-icon" viewBox="0 0 24 24" aria-hidden="true">
           <path class="nav-x" d="M12 12L20 15"/><path class="nav-y" d="M12 12V3"/><path class="nav-z" d="M12 12L5 18"/>
@@ -301,7 +302,15 @@
   </div>
   </div>
   <div id="texture-popover" class="ui-popover tool-popover" role="menu" aria-label="Texture display options" hidden></div>
-  <div id="light-popover" class="ui-popover tool-popover" role="menu" aria-label="Light options" hidden></div>
+  <div id="light-popover" class="ui-popover tool-popover range-popover" role="dialog"
+       aria-label="Key light" hidden>
+    <div class="range-control-row">
+      <label for="light-slider">Key light</label>
+      <output id="light-value" class="range-control-value" for="light-slider">67%</output>
+    </div>
+    <input id="light-slider" class="range-control-slider" type="range"
+           min="0" max="100" step="1" value="67"/>
+  </div>
   <div id="ao-popover" class="ui-popover tool-popover range-popover" role="dialog"
        aria-label="Ambient occlusion" hidden>
     <div class="range-control-row">

--- a/src/web/js/scene/character-shadow-controller.js
+++ b/src/web/js/scene/character-shadow-controller.js
@@ -43,19 +43,9 @@ export function createCharacterShadowController({ renderer, scene, light }) {
 
   renderer.shadowMap.enabled = true;
   if (THREE.PCFShadowMap !== undefined) renderer.shadowMap.type = THREE.PCFShadowMap;
-
-  function activateShadowLight(nextLight) {
-    nextLight.castShadow = true;
-    nextLight.shadow.autoUpdate = false;
-    nextLight.shadow.mapSize.set(2048, 2048);
-  }
-
-  function deactivateShadowLight(previousLight) {
-    previousLight.castShadow = false;
-  }
-
-  let activeLight = light;
-  activateShadowLight(activeLight);
+  light.castShadow = true;
+  light.shadow.autoUpdate = false;
+  light.shadow.mapSize.set(2048, 2048);
 
   let meshes = [];
   let modelBoundsDirty = true;
@@ -63,39 +53,11 @@ export function createCharacterShadowController({ renderer, scene, light }) {
   let shadowMapDirty = true;
   let modelBounds = new THREE.Box3();
   let casterBounds = new THREE.Box3();
-  let lastLightWorldPosition = null;
-  let lastTargetWorldPosition = null;
+  let lastLightPosition = null;
+  let lastLightTarget = null;
   let groundAvailable = false;
   let fitCount = 0;
   let shadowUpdateCount = 0;
-  const lightWorldPosition = new THREE.Vector3();
-  const targetWorldPosition = new THREE.Vector3();
-  const lightDirection = new THREE.Vector3();
-
-  function readLightWorldState() {
-    activeLight.updateWorldMatrix(true, false);
-    activeLight.target.updateWorldMatrix(true, false);
-    activeLight.getWorldPosition(lightWorldPosition);
-    activeLight.target.getWorldPosition(targetWorldPosition);
-    lightDirection.subVectors(targetWorldPosition, lightWorldPosition);
-    if (lightDirection.lengthSq() < 0.00000001) {
-      lightDirection.set(0, -1, 0);
-    } else {
-      lightDirection.normalize();
-    }
-  }
-
-  function setLight(nextLight) {
-    if (!nextLight || nextLight === activeLight) return false;
-    deactivateShadowLight(activeLight);
-    activeLight = nextLight;
-    activateShadowLight(activeLight);
-    lastLightWorldPosition = null;
-    lastTargetWorldPosition = null;
-    shadowFitDirty = true;
-    shadowMapDirty = true;
-    return true;
-  }
 
   function invalidateGeometry() {
     modelBoundsDirty = true;
@@ -163,6 +125,9 @@ export function createCharacterShadowController({ renderer, scene, light }) {
     }
 
     const modelSize = Math.max(modelBounds.getSize(new THREE.Vector3()).length(), MIN_SIZE);
+    const lightDirection = light.target.position.clone().sub(light.position);
+    if (lightDirection.lengthSq() < 0.00000001) lightDirection.set(0, -1, 0);
+    lightDirection.normalize();
     const casterCorners = boxCorners(casterBounds);
     const footprint = projectGroundFootprint(
       casterCorners, modelBounds.min.y, modelSize, lightDirection);
@@ -179,11 +144,13 @@ export function createCharacterShadowController({ renderer, scene, light }) {
       Math.max(footprintSize.z + groundMargin * 2, MIN_SIZE), 1,
     );
 
-    const shadowCamera = activeLight.shadow.camera;
-    shadowCamera.position.copy(lightWorldPosition);
+    const shadowCamera = light.shadow.camera;
+    light.updateWorldMatrix(true, false);
+    light.target.updateWorldMatrix(true, false);
+    shadowCamera.position.copy(light.position);
     shadowCamera.up.set(0, 1, 0);
     if (Math.abs(lightDirection.dot(shadowCamera.up)) > 0.98) shadowCamera.up.set(0, 0, 1);
-    shadowCamera.lookAt(targetWorldPosition);
+    shadowCamera.lookAt(light.target.position);
     shadowCamera.updateMatrixWorld(true);
     const lightSpace = footprint.map(point => point.clone().applyMatrix4(shadowCamera.matrixWorldInverse));
     const lightBox = new THREE.Box3().setFromPoints(lightSpace);
@@ -204,10 +171,10 @@ export function createCharacterShadowController({ renderer, scene, light }) {
     shadowCamera.near = Math.max(MIN_SIZE, -lightBox.max.z - marginDepth);
     shadowCamera.far = Math.max(shadowCamera.near + MIN_SIZE, -lightBox.min.z + marginDepth);
     shadowCamera.updateProjectionMatrix();
-    activeLight.shadow.bias = -0.00002;
-    activeLight.shadow.normalBias = modelSize * NORMAL_BIAS_SCALE;
+    light.shadow.bias = -0.00002;
+    light.shadow.normalBias = modelSize * NORMAL_BIAS_SCALE;
     groundAvailable = true;
-    ground.visible = activeLight.intensity > 0;
+    ground.visible = light.intensity > 0;
     shadowFitDirty = false;
     fitCount += 1;
     addWeightPhysicsPerformance('shadowFitCount');
@@ -215,24 +182,22 @@ export function createCharacterShadowController({ renderer, scene, light }) {
   }
 
   function update() {
-    readLightWorldState();
-    const changedLight = !sameVector(
-      lastLightWorldPosition, lightWorldPosition)
-      || !sameVector(lastTargetWorldPosition, targetWorldPosition);
+    const changedLight = !sameVector(lastLightPosition, light.position)
+      || !sameVector(lastLightTarget, light.target.position);
     if (changedLight) {
-      lastLightWorldPosition = lightWorldPosition.clone();
-      lastTargetWorldPosition = targetWorldPosition.clone();
+      lastLightPosition = light.position.clone();
+      lastLightTarget = light.target.position.clone();
       shadowFitDirty = true;
       shadowMapDirty = true;
     }
-    if (activeLight.intensity <= 0) {
+    if (light.intensity <= 0) {
       ground.visible = false;
       return;
     }
     if (shadowFitDirty) fitShadow();
     else ground.visible = groundAvailable;
     if (shadowMapDirty) {
-      activeLight.shadow.needsUpdate = true;
+      light.shadow.needsUpdate = true;
       renderer.shadowMap.needsUpdate = true;
       shadowMapDirty = false;
       shadowUpdateCount += 1;
@@ -246,14 +211,13 @@ export function createCharacterShadowController({ renderer, scene, light }) {
     modelBoundsDirty = false;
     shadowFitDirty = false;
     shadowMapDirty = false;
-    lastLightWorldPosition = null;
-    lastTargetWorldPosition = null;
+    lastLightPosition = null;
+    lastLightTarget = null;
     groundAvailable = false;
     ground.visible = false;
   }
 
   function getDebugState() {
-    readLightWorldState();
     const serialize = box => finiteBox(box) ? {
       min: box.min.toArray(), max: box.max.toArray(),
     } : null;
@@ -263,18 +227,12 @@ export function createCharacterShadowController({ renderer, scene, light }) {
       fitCount,
       shadowUpdateCount,
       groundVisible: ground.visible,
-      normalBias: activeLight.shadow.normalBias,
-      activeLightUuid: activeLight.uuid,
-      activeLightIntensity: activeLight.intensity,
-      activeLightPosition: lightWorldPosition.toArray(),
-      activeLightTarget: targetWorldPosition.toArray(),
-      activeLightDirection: lightDirection.toArray(),
-      activeLightCastsShadow: activeLight.castShadow,
+      normalBias: light.shadow.normalBias,
     };
   }
 
   return {
-    setLight, setMeshes, adoptMeshes, forgetMeshes,
+    setMeshes, adoptMeshes, forgetMeshes,
     invalidateGeometry, invalidateVisibility, invalidateMap,
     update, reset, getDebugState,
   };

--- a/src/web/js/scene/character-shadow-controller.js
+++ b/src/web/js/scene/character-shadow-controller.js
@@ -43,9 +43,19 @@ export function createCharacterShadowController({ renderer, scene, light }) {
 
   renderer.shadowMap.enabled = true;
   if (THREE.PCFShadowMap !== undefined) renderer.shadowMap.type = THREE.PCFShadowMap;
-  light.castShadow = true;
-  light.shadow.autoUpdate = false;
-  light.shadow.mapSize.set(2048, 2048);
+
+  function activateShadowLight(nextLight) {
+    nextLight.castShadow = true;
+    nextLight.shadow.autoUpdate = false;
+    nextLight.shadow.mapSize.set(2048, 2048);
+  }
+
+  function deactivateShadowLight(previousLight) {
+    previousLight.castShadow = false;
+  }
+
+  let activeLight = light;
+  activateShadowLight(activeLight);
 
   let meshes = [];
   let modelBoundsDirty = true;
@@ -53,11 +63,39 @@ export function createCharacterShadowController({ renderer, scene, light }) {
   let shadowMapDirty = true;
   let modelBounds = new THREE.Box3();
   let casterBounds = new THREE.Box3();
-  let lastLightPosition = null;
-  let lastLightTarget = null;
+  let lastLightWorldPosition = null;
+  let lastTargetWorldPosition = null;
   let groundAvailable = false;
   let fitCount = 0;
   let shadowUpdateCount = 0;
+  const lightWorldPosition = new THREE.Vector3();
+  const targetWorldPosition = new THREE.Vector3();
+  const lightDirection = new THREE.Vector3();
+
+  function readLightWorldState() {
+    activeLight.updateWorldMatrix(true, false);
+    activeLight.target.updateWorldMatrix(true, false);
+    activeLight.getWorldPosition(lightWorldPosition);
+    activeLight.target.getWorldPosition(targetWorldPosition);
+    lightDirection.subVectors(targetWorldPosition, lightWorldPosition);
+    if (lightDirection.lengthSq() < 0.00000001) {
+      lightDirection.set(0, -1, 0);
+    } else {
+      lightDirection.normalize();
+    }
+  }
+
+  function setLight(nextLight) {
+    if (!nextLight || nextLight === activeLight) return false;
+    deactivateShadowLight(activeLight);
+    activeLight = nextLight;
+    activateShadowLight(activeLight);
+    lastLightWorldPosition = null;
+    lastTargetWorldPosition = null;
+    shadowFitDirty = true;
+    shadowMapDirty = true;
+    return true;
+  }
 
   function invalidateGeometry() {
     modelBoundsDirty = true;
@@ -125,9 +163,6 @@ export function createCharacterShadowController({ renderer, scene, light }) {
     }
 
     const modelSize = Math.max(modelBounds.getSize(new THREE.Vector3()).length(), MIN_SIZE);
-    const lightDirection = light.target.position.clone().sub(light.position);
-    if (lightDirection.lengthSq() < 0.00000001) lightDirection.set(0, -1, 0);
-    lightDirection.normalize();
     const casterCorners = boxCorners(casterBounds);
     const footprint = projectGroundFootprint(
       casterCorners, modelBounds.min.y, modelSize, lightDirection);
@@ -144,13 +179,11 @@ export function createCharacterShadowController({ renderer, scene, light }) {
       Math.max(footprintSize.z + groundMargin * 2, MIN_SIZE), 1,
     );
 
-    const shadowCamera = light.shadow.camera;
-    light.updateWorldMatrix(true, false);
-    light.target.updateWorldMatrix(true, false);
-    shadowCamera.position.copy(light.position);
+    const shadowCamera = activeLight.shadow.camera;
+    shadowCamera.position.copy(lightWorldPosition);
     shadowCamera.up.set(0, 1, 0);
     if (Math.abs(lightDirection.dot(shadowCamera.up)) > 0.98) shadowCamera.up.set(0, 0, 1);
-    shadowCamera.lookAt(light.target.position);
+    shadowCamera.lookAt(targetWorldPosition);
     shadowCamera.updateMatrixWorld(true);
     const lightSpace = footprint.map(point => point.clone().applyMatrix4(shadowCamera.matrixWorldInverse));
     const lightBox = new THREE.Box3().setFromPoints(lightSpace);
@@ -171,10 +204,10 @@ export function createCharacterShadowController({ renderer, scene, light }) {
     shadowCamera.near = Math.max(MIN_SIZE, -lightBox.max.z - marginDepth);
     shadowCamera.far = Math.max(shadowCamera.near + MIN_SIZE, -lightBox.min.z + marginDepth);
     shadowCamera.updateProjectionMatrix();
-    light.shadow.bias = -0.00002;
-    light.shadow.normalBias = modelSize * NORMAL_BIAS_SCALE;
+    activeLight.shadow.bias = -0.00002;
+    activeLight.shadow.normalBias = modelSize * NORMAL_BIAS_SCALE;
     groundAvailable = true;
-    ground.visible = light.intensity > 0;
+    ground.visible = activeLight.intensity > 0;
     shadowFitDirty = false;
     fitCount += 1;
     addWeightPhysicsPerformance('shadowFitCount');
@@ -182,22 +215,24 @@ export function createCharacterShadowController({ renderer, scene, light }) {
   }
 
   function update() {
-    const changedLight = !sameVector(lastLightPosition, light.position)
-      || !sameVector(lastLightTarget, light.target.position);
+    readLightWorldState();
+    const changedLight = !sameVector(
+      lastLightWorldPosition, lightWorldPosition)
+      || !sameVector(lastTargetWorldPosition, targetWorldPosition);
     if (changedLight) {
-      lastLightPosition = light.position.clone();
-      lastLightTarget = light.target.position.clone();
+      lastLightWorldPosition = lightWorldPosition.clone();
+      lastTargetWorldPosition = targetWorldPosition.clone();
       shadowFitDirty = true;
       shadowMapDirty = true;
     }
-    if (light.intensity <= 0) {
+    if (activeLight.intensity <= 0) {
       ground.visible = false;
       return;
     }
     if (shadowFitDirty) fitShadow();
     else ground.visible = groundAvailable;
     if (shadowMapDirty) {
-      light.shadow.needsUpdate = true;
+      activeLight.shadow.needsUpdate = true;
       renderer.shadowMap.needsUpdate = true;
       shadowMapDirty = false;
       shadowUpdateCount += 1;
@@ -211,13 +246,14 @@ export function createCharacterShadowController({ renderer, scene, light }) {
     modelBoundsDirty = false;
     shadowFitDirty = false;
     shadowMapDirty = false;
-    lastLightPosition = null;
-    lastLightTarget = null;
+    lastLightWorldPosition = null;
+    lastTargetWorldPosition = null;
     groundAvailable = false;
     ground.visible = false;
   }
 
   function getDebugState() {
+    readLightWorldState();
     const serialize = box => finiteBox(box) ? {
       min: box.min.toArray(), max: box.max.toArray(),
     } : null;
@@ -227,12 +263,18 @@ export function createCharacterShadowController({ renderer, scene, light }) {
       fitCount,
       shadowUpdateCount,
       groundVisible: ground.visible,
-      normalBias: light.shadow.normalBias,
+      normalBias: activeLight.shadow.normalBias,
+      activeLightUuid: activeLight.uuid,
+      activeLightIntensity: activeLight.intensity,
+      activeLightPosition: lightWorldPosition.toArray(),
+      activeLightTarget: targetWorldPosition.toArray(),
+      activeLightDirection: lightDirection.toArray(),
+      activeLightCastsShadow: activeLight.castShadow,
     };
   }
 
   return {
-    setMeshes, adoptMeshes, forgetMeshes,
+    setLight, setMeshes, adoptMeshes, forgetMeshes,
     invalidateGeometry, invalidateVisibility, invalidateMap,
     update, reset, getDebugState,
   };

--- a/src/web/js/scene/character-shadow-controller.js
+++ b/src/web/js/scene/character-shadow-controller.js
@@ -8,6 +8,8 @@ const FIT_MARGIN = 0.12;
 const MAX_GROUND_REACH = 2.5;
 const NORMAL_BIAS_SCALE = 0.0015;
 const MIN_SIZE = 0.001;
+const SHADOW_OPACITY = 0.32;
+const SHADOW_REFERENCE_INTENSITY = 1.0;
 
 function finiteBox(box) {
   return !box.isEmpty() && [
@@ -29,10 +31,19 @@ function sameVector(left, right) {
   return !!left && left.distanceToSquared(right) < 0.0000000001;
 }
 
+function shadowOpacityForIntensity(intensity) {
+  return SHADOW_OPACITY * THREE.MathUtils.clamp(
+    intensity / SHADOW_REFERENCE_INTENSITY, 0, 1);
+}
+
 export function createCharacterShadowController({ renderer, scene, light }) {
+  const groundMaterial = new THREE.ShadowMaterial({
+    color: 0x000000, opacity: shadowOpacityForIntensity(light.intensity),
+    transparent: true, depthWrite: false,
+  });
   const ground = new THREE.Mesh(
     new THREE.PlaneGeometry(1, 1),
-    new THREE.ShadowMaterial({ color: 0x000000, opacity: 0.32, transparent: true, depthWrite: false }),
+    groundMaterial,
   );
   ground.rotation.x = -Math.PI / 2;
   ground.receiveShadow = true;
@@ -182,6 +193,7 @@ export function createCharacterShadowController({ renderer, scene, light }) {
   }
 
   function update() {
+    groundMaterial.opacity = shadowOpacityForIntensity(light.intensity);
     const changedLight = !sameVector(lastLightPosition, light.position)
       || !sameVector(lastLightTarget, light.target.position);
     if (changedLight) {

--- a/src/web/js/scene/environment.js
+++ b/src/web/js/scene/environment.js
@@ -7,8 +7,6 @@ import { SkyMesh } from 'three/addons/objects/SkyMesh.js';
 const BACKGROUND_WIDTH = 512;
 const BACKGROUND_HEIGHT = 256;
 const freeze = Object.freeze;
-const OUTDOOR_PMREM_SIZE = 256;
-const OUTDOOR_ENVIRONMENT_INTENSITY = 0.1;
 const OUTDOOR_SKY = freeze({
   turbidity: 2.5,
   rayleigh: 0.8,
@@ -17,6 +15,45 @@ const OUTDOOR_SKY = freeze({
   cloudCoverage: 0,
   cloudDensity: 0,
   cloudElevation: 0.5,
+});
+const INDOOR_CAPTURE = freeze({
+  room: freeze({
+    color: 0x29231f,
+    size: freeze([18, 12, 18]),
+    position: freeze([0, 1, 0]),
+  }),
+  floor: freeze({
+    color: 0x151312,
+    size: freeze([18, 18]),
+    position: freeze([0, -4.95, 0]),
+  }),
+  mainCard: freeze({
+    color: 0xffbd82,
+    intensity: 3.5,
+    distance: 6,
+    size: freeze([4.5, 3.2]),
+  }),
+  ceilingCard: freeze({
+    color: 0xffe0c2,
+    intensity: 1.25,
+    position: freeze([0, 4.75, 0]),
+    size: freeze([5.5, 3.5]),
+    target: freeze([0, 0, 0]),
+  }),
+  fillCard: freeze({
+    color: 0xb9cee2,
+    intensity: 0.45,
+    position: freeze([-4.5, 1.5, -5]),
+    size: freeze([3.2, 2.4]),
+    target: freeze([0, 0, 0]),
+  }),
+  roomLight: freeze({
+    color: 0xffbd82,
+    intensity: 35,
+    distance: 12,
+    decay: 2,
+    distanceFromOrigin: 2.5,
+  }),
 });
 
 const makeStops = (entries) => freeze(
@@ -46,11 +83,6 @@ const makeHemisphere = (color, groundColor, intensity) => freeze({
 });
 const makeAccent = (color, intensity, position) => freeze({
   color, intensity, position: freeze(position),
-});
-const OUTDOOR_IBL_LIGHTING = freeze({
-  ambient: makeAmbient(0xdbeaff, 0.04),
-  hemisphere: makeHemisphere(0x78b5ed, 0x667068, 0.08),
-  accent: makeAccent(0xffe6bd, 0.4, [-6, 10, 6]),
 });
 const makePreset = (id, label, background, ambient, hemisphere, accent) => freeze({
   id,
@@ -104,6 +136,137 @@ export const ENVIRONMENT_PRESETS = freeze({
     makeAccent(0xffe6bd, 0.7, [-6, 10, 6]),
   ),
 });
+
+const OUTDOOR_SUN_DIRECTION = new THREE.Vector3()
+  .fromArray(ENVIRONMENT_PRESETS.outdoor.accent.position)
+  .normalize();
+const INDOOR_KEY_DIRECTION = new THREE.Vector3()
+  .fromArray(ENVIRONMENT_PRESETS.indoor.accent.position)
+  .normalize();
+const DEFAULT_PMREM = freeze({size: 256, sigma: 0, near: 0.1, far: 100});
+
+function configureOutdoorSky(sky) {
+  sky.scale.setScalar(10000);
+  sky.turbidity.value = OUTDOOR_SKY.turbidity;
+  sky.rayleigh.value = OUTDOOR_SKY.rayleigh;
+  sky.mieCoefficient.value = OUTDOOR_SKY.mieCoefficient;
+  sky.mieDirectionalG.value = OUTDOOR_SKY.mieDirectionalG;
+  sky.cloudCoverage.value = OUTDOOR_SKY.cloudCoverage;
+  sky.cloudDensity.value = OUTDOOR_SKY.cloudDensity;
+  sky.cloudElevation.value = OUTDOOR_SKY.cloudElevation;
+  sky.sunPosition.value.copy(OUTDOOR_SUN_DIRECTION);
+  sky.showSunDisc.value = false;
+}
+
+function createOutdoorCaptureScene() {
+  const captureScene = new THREE.Scene();
+  captureScene.userData.iblPresetId = 'outdoor';
+  const sky = new SkyMesh();
+  configureOutdoorSky(sky);
+  captureScene.add(sky);
+  return captureScene;
+}
+
+function createLightCard({color, intensity, position, size, target}) {
+  const card = new THREE.Mesh(
+    new THREE.PlaneGeometry(1, 1),
+    new THREE.MeshLambertMaterial({
+      color: 0x000000,
+      emissive: color,
+      emissiveIntensity: intensity,
+      side: THREE.DoubleSide,
+    }),
+  );
+  card.position.fromArray(position);
+  card.scale.set(size[0], size[1], 1);
+  card.lookAt(new THREE.Vector3().fromArray(target || [0, 0, 0]));
+  return card;
+}
+
+function createIndoorCaptureScene() {
+  const captureScene = new THREE.Scene();
+  captureScene.userData.iblPresetId = 'indoor';
+  const room = new THREE.Mesh(
+    new THREE.BoxGeometry(...INDOOR_CAPTURE.room.size),
+    new THREE.MeshStandardMaterial({
+      color: INDOOR_CAPTURE.room.color,
+      roughness: 1,
+      metalness: 0,
+      side: THREE.BackSide,
+    }),
+  );
+  room.position.fromArray(INDOOR_CAPTURE.room.position);
+
+  const floor = new THREE.Mesh(
+    new THREE.PlaneGeometry(...INDOOR_CAPTURE.floor.size),
+    new THREE.MeshStandardMaterial({
+      color: INDOOR_CAPTURE.floor.color,
+      roughness: 1,
+      metalness: 0,
+    }),
+  );
+  floor.rotation.x = -Math.PI / 2;
+  floor.position.fromArray(INDOOR_CAPTURE.floor.position);
+
+  const mainPosition = INDOOR_KEY_DIRECTION.clone()
+    .multiplyScalar(INDOOR_CAPTURE.mainCard.distance)
+    .toArray();
+  const mainCard = createLightCard({
+    ...INDOOR_CAPTURE.mainCard,
+    position: mainPosition,
+    target: [0, 0, 0],
+  });
+  const ceilingCard = createLightCard(INDOOR_CAPTURE.ceilingCard);
+  const fillCard = createLightCard(INDOOR_CAPTURE.fillCard);
+
+  const roomLight = new THREE.PointLight(
+    INDOOR_CAPTURE.roomLight.color,
+    INDOOR_CAPTURE.roomLight.intensity,
+    INDOOR_CAPTURE.roomLight.distance,
+    INDOOR_CAPTURE.roomLight.decay,
+  );
+  roomLight.position.copy(INDOOR_KEY_DIRECTION)
+    .multiplyScalar(INDOOR_CAPTURE.roomLight.distanceFromOrigin);
+  captureScene.add(room, floor, mainCard, ceilingCard, fillCard, roomLight);
+  return captureScene;
+}
+
+const IBL_PROFILES = freeze({
+  outdoor: freeze({
+    environmentIntensity: 0.1,
+    lighting: freeze({
+      ambient: makeAmbient(0xdbeaff, 0.04),
+      hemisphere: makeHemisphere(0x78b5ed, 0x667068, 0.08),
+      accent: makeAccent(0xffe6bd, 0.4, [-6, 10, 6]),
+    }),
+    pmrem: DEFAULT_PMREM,
+    createCaptureScene: createOutdoorCaptureScene,
+  }),
+  indoor: freeze({
+    environmentIntensity: 0.15,
+    lighting: freeze({
+      ambient: makeAmbient(0xffd4af, 0.05),
+      hemisphere: makeHemisphere(0xffd3a6, 0x2b3440, 0.1),
+      accent: makeAccent(0xffb36b, 0.3, [4, 8, 5]),
+    }),
+    pmrem: DEFAULT_PMREM,
+    createCaptureScene: createIndoorCaptureScene,
+  }),
+});
+
+function disposeCaptureScene(captureScene) {
+  if (!captureScene) return;
+  const resources = new Set();
+  captureScene.traverse(object => {
+    if (object.geometry) resources.add(object.geometry);
+    const materials = Array.isArray(object.material)
+      ? object.material
+      : object.material ? [object.material] : [];
+    for (const material of materials) resources.add(material);
+  });
+  for (const resource of resources) resource.dispose?.();
+  captureScene.clear();
+}
 
 function createBackgroundTexture() {
   const canvas = document.createElement('canvas');
@@ -173,6 +336,7 @@ export function createEnvironmentController({
   ambientLight,
   hemisphereLight,
   lightTarget,
+  onVisualChange = null,
 }) {
   if (!renderer || !scene || !ambientLight || !hemisphereLight || !lightTarget) {
     throw new Error('EnvironmentController needs a renderer, scene, viewer lights and target.');
@@ -191,20 +355,20 @@ export function createEnvironmentController({
   // movable key light updates this target whenever the model is reframed.
   lightTarget.add(accentLight);
 
-  const sunDirection = new THREE.Vector3()
-    .fromArray(ENVIRONMENT_PRESETS.outdoor.accent.position)
-    .normalize();
-
   let currentPresetId = 'default';
   let disposed = false;
-  let prepared = false;
   let preparationAttempted = false;
   let preparePromise = null;
-  let outdoorEnvironmentTarget = null;
-  let outdoorEnvironmentTexture = null;
-  let outdoorIblAvailable = false;
-  let preparationError = null;
-  let pmremGenerationCount = 0;
+  const iblResources = new Map(
+    Object.keys(IBL_PROFILES).map(id => [id, {
+      target: null,
+      texture: null,
+      attempted: false,
+      available: false,
+      error: null,
+      generationCount: 0,
+    }]),
+  );
 
   function drawBackground(preset) {
     if (!preset.background) {
@@ -243,23 +407,9 @@ export function createEnvironmentController({
     applyAccent(preset.accent);
   }
 
-  function applyOutdoorLights() {
-    applyLights(outdoorIblAvailable
-      ? OUTDOOR_IBL_LIGHTING : ENVIRONMENT_PRESETS.outdoor);
-  }
-
   function restoreEnvironment() {
     scene.environment = originalEnvironment;
     scene.environmentIntensity = originalEnvironmentIntensity;
-  }
-
-  function applyOutdoorEnvironment() {
-    if (!outdoorEnvironmentTexture) {
-      restoreEnvironment();
-      return;
-    }
-    scene.environment = outdoorEnvironmentTexture;
-    scene.environmentIntensity = OUTDOOR_ENVIRONMENT_INTENSITY;
   }
 
   function applyDefault() {
@@ -270,91 +420,99 @@ export function createEnvironmentController({
     applyAccent(null);
   }
 
+  function applyPreset(id) {
+    const preset = ENVIRONMENT_PRESETS[id];
+    if (id === 'default') {
+      applyDefault();
+      return;
+    }
+
+    drawBackground(preset);
+    const profile = IBL_PROFILES[id];
+    const resource = iblResources.get(id);
+    if (profile && resource?.available && resource.texture) {
+      applyLights(profile.lighting);
+      scene.environment = resource.texture;
+      scene.environmentIntensity = profile.environmentIntensity;
+      return;
+    }
+
+    applyLights(preset);
+    restoreEnvironment();
+  }
+
   function setPreset(id) {
     if (disposed) return false;
     const preset = ENVIRONMENT_PRESETS[id];
     if (!preset) return false;
-
-    if (id === 'default') {
-      applyDefault();
-    } else if (id === 'outdoor') {
-      drawBackground(preset);
-      applyOutdoorLights();
-      applyOutdoorEnvironment();
-    } else {
-      drawBackground(preset);
-      applyLights(preset);
-      restoreEnvironment();
-    }
     currentPresetId = preset.id;
+    applyPreset(id);
     return true;
   }
 
-  function configureOutdoorSky(sky) {
-    sky.scale.setScalar(10000);
-    sky.turbidity.value = OUTDOOR_SKY.turbidity;
-    sky.rayleigh.value = OUTDOOR_SKY.rayleigh;
-    sky.mieCoefficient.value = OUTDOOR_SKY.mieCoefficient;
-    sky.mieDirectionalG.value = OUTDOOR_SKY.mieDirectionalG;
-    sky.cloudCoverage.value = OUTDOOR_SKY.cloudCoverage;
-    sky.cloudDensity.value = OUTDOOR_SKY.cloudDensity;
-    sky.cloudElevation.value = OUTDOOR_SKY.cloudElevation;
-    sky.sunPosition.value.copy(sunDirection);
-    sky.showSunDisc.value = false;
+  function generateIblResource(id, pmremGenerator) {
+    const profile = IBL_PROFILES[id];
+    const resource = iblResources.get(id);
+    resource.attempted = true;
+    resource.error = null;
+    let captureScene = null;
+    let generatedTarget = null;
+    try {
+      captureScene = profile.createCaptureScene();
+      const {sigma, near, far, size} = profile.pmrem;
+      generatedTarget = pmremGenerator.fromScene(
+        captureScene, sigma, near, far, {size});
+      if (!generatedTarget?.texture) {
+        throw new Error(`${id} PMREM generation returned no texture.`);
+      }
+      resource.target = generatedTarget;
+      resource.texture = generatedTarget.texture;
+      resource.available = true;
+      resource.generationCount += 1;
+      generatedTarget = null;
+      return true;
+    } catch (error) {
+      resource.available = false;
+      resource.error = error?.message || String(error);
+      console.debug(
+        `${id} environment preparation failed; using baseline lighting.`,
+        error,
+      );
+      return false;
+    } finally {
+      generatedTarget?.dispose?.();
+      disposeCaptureScene(captureScene);
+    }
   }
 
   async function prepare() {
     if (disposed) return false;
     if (preparePromise) return preparePromise;
-    if (prepared || preparationAttempted) return outdoorIblAvailable;
+    if (preparationAttempted) {
+      return [...iblResources.values()].every(resource => resource.available);
+    }
     preparationAttempted = true;
 
     preparePromise = (async () => {
-      let captureScene = null;
-      let captureSky = null;
       let pmremGenerator = null;
       try {
-        // Let rendererReady publish the usable viewer before GPU-heavy PMREM
-        // preparation begins. This also gives concurrent callers one promise
-        // to join while the optional warm-up is in progress.
-        await new Promise(resolve => setTimeout(resolve, 0));
-        if (disposed) return false;
-        captureScene = new THREE.Scene();
-        captureSky = new SkyMesh();
-        configureOutdoorSky(captureSky);
-        captureScene.add(captureSky);
-
-        pmremGenerator = new THREE.PMREMGenerator(renderer);
-        const target = pmremGenerator.fromScene(
-          captureScene, 0, 0.1, 100, {size: OUTDOOR_PMREM_SIZE});
-        if (!target?.texture) {
-          throw new Error('Outdoor PMREM generation returned no texture.');
+        let allAvailable = true;
+        for (const id of Object.keys(IBL_PROFILES)) {
+          // Yield before each GPU-heavy capture so renderer startup and the
+          // intervals between resources remain available to browser work.
+          await new Promise(resolve => setTimeout(resolve, 0));
+          if (disposed) return false;
+          pmremGenerator ||= new THREE.PMREMGenerator(renderer);
+          const generated = generateIblResource(id, pmremGenerator);
+          allAvailable = generated && allAvailable;
+          if (generated && !disposed && currentPresetId === id) {
+            applyPreset(id);
+            onVisualChange?.();
+          }
         }
-        outdoorEnvironmentTarget = target;
-        outdoorEnvironmentTexture = target.texture;
-        outdoorIblAvailable = true;
-        pmremGenerationCount += 1;
-        return true;
-      } catch (error) {
-        outdoorIblAvailable = false;
-        preparationError = error?.message || String(error);
-        console.debug(
-          'Outdoor environment preparation failed; using baseline lighting.',
-          error,
-        );
-        return false;
+        return allAvailable;
       } finally {
-        if (captureSky) {
-          captureScene.remove(captureSky);
-          captureSky.geometry?.dispose?.();
-          captureSky.material?.dispose?.();
-        }
         pmremGenerator?.dispose?.();
-        prepared = outdoorIblAvailable;
-        if (!disposed && currentPresetId === 'outdoor') {
-          applyOutdoorLights();
-          applyOutdoorEnvironment();
-        }
         preparePromise = null;
       }
     })();
@@ -362,18 +520,27 @@ export function createEnvironmentController({
   }
 
   function getDebugState() {
-    const environmentIsOutdoor = scene.environment === outdoorEnvironmentTexture
-      && outdoorEnvironmentTexture !== null;
+    const activeIblPreset = [...iblResources.entries()]
+      .find(([, resource]) => resource.texture
+        && scene.environment === resource.texture)?.[0] || null;
+    const resources = Object.fromEntries(
+      [...iblResources.entries()].map(([id, resource]) => [id, {
+        attempted: resource.attempted,
+        available: resource.available,
+        generationCount: resource.generationCount,
+        error: resource.error,
+      }]),
+    );
     return {
       preset: currentPresetId,
-      prepared,
-      outdoorIblAvailable,
-      environmentActive: environmentIsOutdoor,
+      activeIblPreset,
+      environmentActive: activeIblPreset !== null,
       environmentIntensity: scene.environmentIntensity,
-      pmremGenerationCount,
-      environmentIsOutdoor,
-      sunDirection: sunDirection.toArray(),
-      preparationError,
+      preparationInFlight: preparePromise !== null,
+      resources,
+      totalPmremGenerationCount: [...iblResources.values()]
+        .reduce((total, resource) => total + resource.generationCount, 0),
+      sunDirection: OUTDOOR_SUN_DIRECTION.toArray(),
     };
   }
 
@@ -383,13 +550,16 @@ export function createEnvironmentController({
 
   function dispose() {
     if (disposed) return;
+    disposed = true;
     applyDefault();
-    outdoorEnvironmentTarget?.dispose?.();
-    outdoorEnvironmentTarget = null;
-    outdoorEnvironmentTexture = null;
+    for (const resource of iblResources.values()) {
+      resource.target?.dispose?.();
+      resource.target = null;
+      resource.texture = null;
+      resource.available = false;
+    }
     background.texture.dispose();
     lightTarget.remove(accentLight);
-    disposed = true;
   }
 
   return {

--- a/src/web/js/scene/environment.js
+++ b/src/web/js/scene/environment.js
@@ -1,11 +1,23 @@
 // Viewer-only environment moods. This module deliberately knows nothing
 // about mods, meshes, INIs, or the Python bridge.
 
-import * as THREE from 'three';
+import * as THREE from 'three/webgpu';
+import { SkyMesh } from 'three/addons/objects/SkyMesh.js';
 
 const BACKGROUND_WIDTH = 512;
 const BACKGROUND_HEIGHT = 256;
 const freeze = Object.freeze;
+const OUTDOOR_PMREM_SIZE = 256;
+const OUTDOOR_ENVIRONMENT_INTENSITY = 0.7;
+const OUTDOOR_SKY = freeze({
+  turbidity: 2.5,
+  rayleigh: 0.8,
+  mieCoefficient: 0.003,
+  mieDirectionalG: 0.75,
+  cloudCoverage: 0.2,
+  cloudDensity: 0.35,
+  cloudElevation: 0.5,
+});
 
 const makeStops = (entries) => freeze(
   entries.map(([offset, color]) => freeze({ offset, color })));
@@ -82,8 +94,8 @@ export const ENVIRONMENT_PRESETS = freeze({
     verticalBackground([
       [0, '#285b8a'], [0.42, '#75a8ce'], [0.68, '#879eae'], [1, '#46515a'],
     ]),
-    makeAmbient(0xdbeaff, 0.26),
-    makeHemisphere(0x78b5ed, 0x667068, 0.45),
+    makeAmbient(0xdbeaff, 0.12),
+    makeHemisphere(0x78b5ed, 0x667068, 0.2),
     makeAccent(0xffe6bd, 0.7, [-6, 10, 6]),
   ),
 });
@@ -144,23 +156,26 @@ function restoreLightState(light, state) {
 }
 
 /**
- * Create the synchronous, asset-free environment controller.
+ * Create the synchronously constructible environment controller.
  *
  * Environment presets define baseline scene lighting. The movable key light
  * in scene.js remains an independent user-controlled inspection light layered
  * on top of these presets.
  */
 export function createEnvironmentController({
+  renderer,
   scene,
   ambientLight,
   hemisphereLight,
   lightTarget,
 }) {
-  if (!scene || !ambientLight || !hemisphereLight || !lightTarget) {
-    throw new Error('EnvironmentController needs a scene, viewer lights and target.');
+  if (!renderer || !scene || !ambientLight || !hemisphereLight || !lightTarget) {
+    throw new Error('EnvironmentController needs a renderer, scene, viewer lights and target.');
   }
 
   const originalBackground = scene.background;
+  const originalEnvironment = scene.environment;
+  const originalEnvironmentIntensity = scene.environmentIntensity;
   const originalAmbient = captureLightState(ambientLight);
   const originalHemisphere = captureLightState(hemisphereLight, true);
   const background = createBackgroundTexture();
@@ -171,8 +186,20 @@ export function createEnvironmentController({
   // movable key light updates this target whenever the model is reframed.
   lightTarget.add(accentLight);
 
+  const sunDirection = new THREE.Vector3()
+    .fromArray(ENVIRONMENT_PRESETS.outdoor.accent.position)
+    .normalize();
+
   let currentPresetId = 'default';
   let disposed = false;
+  let prepared = false;
+  let preparationAttempted = false;
+  let preparePromise = null;
+  let outdoorEnvironmentTarget = null;
+  let outdoorEnvironmentTexture = null;
+  let outdoorIblAvailable = false;
+  let preparationError = null;
+  let pmremGenerationCount = 0;
 
   function drawBackground(preset) {
     if (!preset.background) {
@@ -211,8 +238,23 @@ export function createEnvironmentController({
     applyAccent(preset.accent);
   }
 
+  function restoreEnvironment() {
+    scene.environment = originalEnvironment;
+    scene.environmentIntensity = originalEnvironmentIntensity;
+  }
+
+  function applyOutdoorEnvironment() {
+    if (!outdoorEnvironmentTexture) {
+      restoreEnvironment();
+      return;
+    }
+    scene.environment = outdoorEnvironmentTexture;
+    scene.environmentIntensity = OUTDOOR_ENVIRONMENT_INTENSITY;
+  }
+
   function applyDefault() {
     scene.background = originalBackground;
+    restoreEnvironment();
     restoreLightState(ambientLight, originalAmbient);
     restoreLightState(hemisphereLight, originalHemisphere);
     applyAccent(null);
@@ -228,9 +270,91 @@ export function createEnvironmentController({
     } else {
       drawBackground(preset);
       applyLights(preset);
+      if (id === 'outdoor') applyOutdoorEnvironment();
+      else restoreEnvironment();
     }
     currentPresetId = preset.id;
     return true;
+  }
+
+  function configureOutdoorSky(sky) {
+    sky.scale.setScalar(10000);
+    sky.turbidity.value = OUTDOOR_SKY.turbidity;
+    sky.rayleigh.value = OUTDOOR_SKY.rayleigh;
+    sky.mieCoefficient.value = OUTDOOR_SKY.mieCoefficient;
+    sky.mieDirectionalG.value = OUTDOOR_SKY.mieDirectionalG;
+    sky.cloudCoverage.value = OUTDOOR_SKY.cloudCoverage;
+    sky.cloudDensity.value = OUTDOOR_SKY.cloudDensity;
+    sky.cloudElevation.value = OUTDOOR_SKY.cloudElevation;
+    sky.sunPosition.value.copy(sunDirection);
+    sky.showSunDisc.value = false;
+  }
+
+  async function prepare() {
+    if (disposed) return false;
+    if (prepared || preparationAttempted) return outdoorIblAvailable;
+    if (preparePromise) return preparePromise;
+    preparationAttempted = true;
+
+    preparePromise = (async () => {
+      let captureScene = null;
+      let captureSky = null;
+      let pmremGenerator = null;
+      try {
+        captureScene = new THREE.Scene();
+        captureSky = new SkyMesh();
+        configureOutdoorSky(captureSky);
+        captureScene.add(captureSky);
+
+        pmremGenerator = new THREE.PMREMGenerator(renderer);
+        const target = pmremGenerator.fromScene(
+          captureScene, 0, 0.1, 100, {size: OUTDOOR_PMREM_SIZE});
+        if (!target?.texture) {
+          throw new Error('Outdoor PMREM generation returned no texture.');
+        }
+        outdoorEnvironmentTarget = target;
+        outdoorEnvironmentTexture = target.texture;
+        outdoorIblAvailable = true;
+        pmremGenerationCount += 1;
+        return true;
+      } catch (error) {
+        outdoorIblAvailable = false;
+        preparationError = error?.message || String(error);
+        console.debug(
+          'Outdoor environment preparation failed; using baseline lighting.',
+          error,
+        );
+        return false;
+      } finally {
+        if (captureSky) {
+          captureScene.remove(captureSky);
+          captureSky.geometry?.dispose?.();
+          captureSky.material?.dispose?.();
+        }
+        pmremGenerator?.dispose?.();
+        prepared = outdoorIblAvailable;
+        if (!disposed && currentPresetId === 'outdoor') {
+          applyOutdoorEnvironment();
+        }
+      }
+    })();
+    return preparePromise;
+  }
+
+  function getDebugState() {
+    const environmentIsOutdoor = scene.environment === outdoorEnvironmentTexture
+      && outdoorEnvironmentTexture !== null;
+    return {
+      preset: currentPresetId,
+      prepared,
+      outdoorIblAvailable,
+      environmentActive: environmentIsOutdoor,
+      environmentIntensity: scene.environmentIntensity,
+      pmremGenerationCount,
+      environmentIsOutdoor,
+      sunDirection: sunDirection.toArray(),
+      preparationError,
+    };
   }
 
   function getPreset() {
@@ -240,14 +364,19 @@ export function createEnvironmentController({
   function dispose() {
     if (disposed) return;
     applyDefault();
+    outdoorEnvironmentTarget?.dispose?.();
+    outdoorEnvironmentTarget = null;
+    outdoorEnvironmentTexture = null;
     background.texture.dispose();
     lightTarget.remove(accentLight);
     disposed = true;
   }
 
   return {
+    prepare,
     setPreset,
     getPreset,
+    getDebugState,
     dispose,
   };
 }

--- a/src/web/js/scene/environment.js
+++ b/src/web/js/scene/environment.js
@@ -653,6 +653,7 @@ export function createEnvironmentController({
   function dispose() {
     if (disposed) return;
     disposed = true;
+    currentPresetId = 'default';
     applyDefault();
     for (const resource of iblResources.values()) {
       resource.target?.dispose?.();

--- a/src/web/js/scene/environment.js
+++ b/src/web/js/scene/environment.js
@@ -55,6 +55,52 @@ const INDOOR_CAPTURE = freeze({
     distanceFromOrigin: 2.5,
   }),
 });
+const STUDIO_CAPTURE = freeze({
+  room: freeze({
+    color: 0x25282d,
+    size: freeze([18, 12, 18]),
+    position: freeze([0, 1, 0]),
+  }),
+  floor: freeze({
+    color: 0x17191c,
+    size: freeze([18, 18]),
+    position: freeze([0, -4.95, 0]),
+  }),
+  mainCard: freeze({
+    color: 0xffffff,
+    intensity: 3.0,
+    distance: 6,
+    size: freeze([5.0, 3.8]),
+  }),
+  fillCard: freeze({
+    color: 0xe8eef5,
+    intensity: 1.0,
+    position: freeze([-4.5, 1.5, -4]),
+    size: freeze([4.0, 3.0]),
+    target: freeze([0, 0, 0]),
+  }),
+  overheadCard: freeze({
+    color: 0xffffff,
+    intensity: 1.5,
+    position: freeze([0, 4.8, 0]),
+    size: freeze([6.5, 2.0]),
+    target: freeze([0, 0, 0]),
+  }),
+  backCard: freeze({
+    color: 0xdde3ea,
+    intensity: 0.45,
+    position: freeze([0, 2.0, -5.5]),
+    size: freeze([3.0, 3.5]),
+    target: freeze([0, 1, 0]),
+  }),
+  roomLight: freeze({
+    color: 0xffffff,
+    intensity: 20,
+    distance: 12,
+    decay: 2,
+    distanceFromOrigin: 2.0,
+  }),
+});
 
 const makeStops = (entries) => freeze(
   entries.map(([offset, color]) => freeze({ offset, color })));
@@ -184,30 +230,35 @@ function createLightCard({color, intensity, position, size, target}) {
   return card;
 }
 
-function createIndoorCaptureScene() {
-  const captureScene = new THREE.Scene();
-  captureScene.userData.iblPresetId = 'indoor';
+function createCaptureRoom({room: roomConfig, floor: floorConfig}) {
   const room = new THREE.Mesh(
-    new THREE.BoxGeometry(...INDOOR_CAPTURE.room.size),
+    new THREE.BoxGeometry(...roomConfig.size),
     new THREE.MeshStandardMaterial({
-      color: INDOOR_CAPTURE.room.color,
+      color: roomConfig.color,
       roughness: 1,
       metalness: 0,
       side: THREE.BackSide,
     }),
   );
-  room.position.fromArray(INDOOR_CAPTURE.room.position);
+  room.position.fromArray(roomConfig.position);
 
   const floor = new THREE.Mesh(
-    new THREE.PlaneGeometry(...INDOOR_CAPTURE.floor.size),
+    new THREE.PlaneGeometry(...floorConfig.size),
     new THREE.MeshStandardMaterial({
-      color: INDOOR_CAPTURE.floor.color,
+      color: floorConfig.color,
       roughness: 1,
       metalness: 0,
     }),
   );
   floor.rotation.x = -Math.PI / 2;
-  floor.position.fromArray(INDOOR_CAPTURE.floor.position);
+  floor.position.fromArray(floorConfig.position);
+  return {room, floor};
+}
+
+function createIndoorCaptureScene() {
+  const captureScene = new THREE.Scene();
+  captureScene.userData.iblPresetId = 'indoor';
+  const {room, floor} = createCaptureRoom(INDOOR_CAPTURE);
 
   const mainPosition = new THREE.Vector3()
     .fromArray(IBL_PROFILES.indoor.dominantDirection)
@@ -233,6 +284,36 @@ function createIndoorCaptureScene() {
   return captureScene;
 }
 
+function createStudioCaptureScene() {
+  const captureScene = new THREE.Scene();
+  captureScene.userData.iblPresetId = 'studio';
+  const {room, floor} = createCaptureRoom(STUDIO_CAPTURE);
+  const mainPosition = new THREE.Vector3()
+    .fromArray(IBL_PROFILES.studio.dominantDirection)
+    .multiplyScalar(STUDIO_CAPTURE.mainCard.distance)
+    .toArray();
+  const mainCard = createLightCard({
+    ...STUDIO_CAPTURE.mainCard,
+    position: mainPosition,
+    target: [0, 0, 0],
+  });
+  const fillCard = createLightCard(STUDIO_CAPTURE.fillCard);
+  const overheadCard = createLightCard(STUDIO_CAPTURE.overheadCard);
+  const backCard = createLightCard(STUDIO_CAPTURE.backCard);
+  const roomLight = new THREE.PointLight(
+    STUDIO_CAPTURE.roomLight.color,
+    STUDIO_CAPTURE.roomLight.intensity,
+    STUDIO_CAPTURE.roomLight.distance,
+    STUDIO_CAPTURE.roomLight.decay,
+  );
+  roomLight.position.fromArray(IBL_PROFILES.studio.dominantDirection)
+    .multiplyScalar(STUDIO_CAPTURE.roomLight.distanceFromOrigin);
+  captureScene.add(
+    room, floor, mainCard, fillCard, overheadCard, backCard, roomLight,
+  );
+  return captureScene;
+}
+
 const IBL_PROFILES = freeze({
   outdoor: freeze({
     environmentIntensity: 0.1,
@@ -255,6 +336,17 @@ const IBL_PROFILES = freeze({
     dominantDirection: directionFromPresetAccent('indoor'),
     pmrem: DEFAULT_PMREM,
     createCaptureScene: createIndoorCaptureScene,
+  }),
+  studio: freeze({
+    environmentIntensity: 0.15,
+    lightIntensity: freeze({
+      ambient: 0.03,
+      hemisphere: 0.06,
+      accent: 0.2,
+    }),
+    dominantDirection: directionFromPresetAccent('studio'),
+    pmrem: DEFAULT_PMREM,
+    createCaptureScene: createStudioCaptureScene,
   }),
 });
 

--- a/src/web/js/scene/environment.js
+++ b/src/web/js/scene/environment.js
@@ -8,14 +8,14 @@ const BACKGROUND_WIDTH = 512;
 const BACKGROUND_HEIGHT = 256;
 const freeze = Object.freeze;
 const OUTDOOR_PMREM_SIZE = 256;
-const OUTDOOR_ENVIRONMENT_INTENSITY = 0.7;
+const OUTDOOR_ENVIRONMENT_INTENSITY = 0.1;
 const OUTDOOR_SKY = freeze({
   turbidity: 2.5,
   rayleigh: 0.8,
   mieCoefficient: 0.003,
   mieDirectionalG: 0.75,
-  cloudCoverage: 0.2,
-  cloudDensity: 0.35,
+  cloudCoverage: 0,
+  cloudDensity: 0,
   cloudElevation: 0.5,
 });
 
@@ -46,6 +46,11 @@ const makeHemisphere = (color, groundColor, intensity) => freeze({
 });
 const makeAccent = (color, intensity, position) => freeze({
   color, intensity, position: freeze(position),
+});
+const OUTDOOR_IBL_LIGHTING = freeze({
+  ambient: makeAmbient(0xdbeaff, 0.04),
+  hemisphere: makeHemisphere(0x78b5ed, 0x667068, 0.08),
+  accent: makeAccent(0xffe6bd, 0.4, [-6, 10, 6]),
 });
 const makePreset = (id, label, background, ambient, hemisphere, accent) => freeze({
   id,
@@ -94,8 +99,8 @@ export const ENVIRONMENT_PRESETS = freeze({
     verticalBackground([
       [0, '#285b8a'], [0.42, '#75a8ce'], [0.68, '#879eae'], [1, '#46515a'],
     ]),
-    makeAmbient(0xdbeaff, 0.12),
-    makeHemisphere(0x78b5ed, 0x667068, 0.2),
+    makeAmbient(0xdbeaff, 0.26),
+    makeHemisphere(0x78b5ed, 0x667068, 0.45),
     makeAccent(0xffe6bd, 0.7, [-6, 10, 6]),
   ),
 });
@@ -238,6 +243,11 @@ export function createEnvironmentController({
     applyAccent(preset.accent);
   }
 
+  function applyOutdoorLights() {
+    applyLights(outdoorIblAvailable
+      ? OUTDOOR_IBL_LIGHTING : ENVIRONMENT_PRESETS.outdoor);
+  }
+
   function restoreEnvironment() {
     scene.environment = originalEnvironment;
     scene.environmentIntensity = originalEnvironmentIntensity;
@@ -267,11 +277,14 @@ export function createEnvironmentController({
 
     if (id === 'default') {
       applyDefault();
+    } else if (id === 'outdoor') {
+      drawBackground(preset);
+      applyOutdoorLights();
+      applyOutdoorEnvironment();
     } else {
       drawBackground(preset);
       applyLights(preset);
-      if (id === 'outdoor') applyOutdoorEnvironment();
-      else restoreEnvironment();
+      restoreEnvironment();
     }
     currentPresetId = preset.id;
     return true;
@@ -292,8 +305,8 @@ export function createEnvironmentController({
 
   async function prepare() {
     if (disposed) return false;
-    if (prepared || preparationAttempted) return outdoorIblAvailable;
     if (preparePromise) return preparePromise;
+    if (prepared || preparationAttempted) return outdoorIblAvailable;
     preparationAttempted = true;
 
     preparePromise = (async () => {
@@ -301,6 +314,10 @@ export function createEnvironmentController({
       let captureSky = null;
       let pmremGenerator = null;
       try {
+        // Let rendererReady publish the usable viewer before GPU-heavy PMREM
+        // preparation begins. This also gives concurrent callers one promise
+        // to join while the optional warm-up is in progress.
+        await new Promise(resolve => setTimeout(resolve, 0));
         captureScene = new THREE.Scene();
         captureSky = new SkyMesh();
         configureOutdoorSky(captureSky);
@@ -334,8 +351,10 @@ export function createEnvironmentController({
         pmremGenerator?.dispose?.();
         prepared = outdoorIblAvailable;
         if (!disposed && currentPresetId === 'outdoor') {
+          applyOutdoorLights();
           applyOutdoorEnvironment();
         }
+        preparePromise = null;
       }
     })();
     return preparePromise;

--- a/src/web/js/scene/environment.js
+++ b/src/web/js/scene/environment.js
@@ -137,12 +137,13 @@ export const ENVIRONMENT_PRESETS = freeze({
   ),
 });
 
-const OUTDOOR_SUN_DIRECTION = new THREE.Vector3()
-  .fromArray(ENVIRONMENT_PRESETS.outdoor.accent.position)
-  .normalize();
-const INDOOR_KEY_DIRECTION = new THREE.Vector3()
-  .fromArray(ENVIRONMENT_PRESETS.indoor.accent.position)
-  .normalize();
+function directionFromPresetAccent(id) {
+  return freeze(new THREE.Vector3()
+    .fromArray(ENVIRONMENT_PRESETS[id].accent.position)
+    .normalize()
+    .toArray());
+}
+
 const DEFAULT_PMREM = freeze({size: 256, sigma: 0, near: 0.1, far: 100});
 
 function configureOutdoorSky(sky) {
@@ -154,7 +155,7 @@ function configureOutdoorSky(sky) {
   sky.cloudCoverage.value = OUTDOOR_SKY.cloudCoverage;
   sky.cloudDensity.value = OUTDOOR_SKY.cloudDensity;
   sky.cloudElevation.value = OUTDOOR_SKY.cloudElevation;
-  sky.sunPosition.value.copy(OUTDOOR_SUN_DIRECTION);
+  sky.sunPosition.value.fromArray(IBL_PROFILES.outdoor.dominantDirection);
   sky.showSunDisc.value = false;
 }
 
@@ -208,7 +209,8 @@ function createIndoorCaptureScene() {
   floor.rotation.x = -Math.PI / 2;
   floor.position.fromArray(INDOOR_CAPTURE.floor.position);
 
-  const mainPosition = INDOOR_KEY_DIRECTION.clone()
+  const mainPosition = new THREE.Vector3()
+    .fromArray(IBL_PROFILES.indoor.dominantDirection)
     .multiplyScalar(INDOOR_CAPTURE.mainCard.distance)
     .toArray();
   const mainCard = createLightCard({
@@ -225,7 +227,7 @@ function createIndoorCaptureScene() {
     INDOOR_CAPTURE.roomLight.distance,
     INDOOR_CAPTURE.roomLight.decay,
   );
-  roomLight.position.copy(INDOOR_KEY_DIRECTION)
+  roomLight.position.fromArray(IBL_PROFILES.indoor.dominantDirection)
     .multiplyScalar(INDOOR_CAPTURE.roomLight.distanceFromOrigin);
   captureScene.add(room, floor, mainCard, ceilingCard, fillCard, roomLight);
   return captureScene;
@@ -234,21 +236,23 @@ function createIndoorCaptureScene() {
 const IBL_PROFILES = freeze({
   outdoor: freeze({
     environmentIntensity: 0.1,
-    lighting: freeze({
-      ambient: makeAmbient(0xdbeaff, 0.04),
-      hemisphere: makeHemisphere(0x78b5ed, 0x667068, 0.08),
-      accent: makeAccent(0xffe6bd, 0.4, [-6, 10, 6]),
+    lightIntensity: freeze({
+      ambient: 0.04,
+      hemisphere: 0.08,
+      accent: 0.4,
     }),
+    dominantDirection: directionFromPresetAccent('outdoor'),
     pmrem: DEFAULT_PMREM,
     createCaptureScene: createOutdoorCaptureScene,
   }),
   indoor: freeze({
     environmentIntensity: 0.15,
-    lighting: freeze({
-      ambient: makeAmbient(0xffd4af, 0.05),
-      hemisphere: makeHemisphere(0xffd3a6, 0x2b3440, 0.1),
-      accent: makeAccent(0xffb36b, 0.3, [4, 8, 5]),
+    lightIntensity: freeze({
+      ambient: 0.05,
+      hemisphere: 0.1,
+      accent: 0.3,
     }),
+    dominantDirection: directionFromPresetAccent('indoor'),
     pmrem: DEFAULT_PMREM,
     createCaptureScene: createIndoorCaptureScene,
   }),
@@ -385,7 +389,7 @@ export function createEnvironmentController({
     scene.background = background.texture;
   }
 
-  function applyAccent(config) {
+  function applyAccent(config, intensity = null) {
     if (!config) {
       accentLight.visible = false;
       accentLight.intensity = 0;
@@ -394,17 +398,18 @@ export function createEnvironmentController({
     accentLight.color.set(config.color);
     // This is local to lightTarget, so the accent follows offset models.
     accentLight.position.fromArray(config.position);
-    accentLight.intensity = config.intensity;
+    accentLight.intensity = intensity ?? config.intensity;
     accentLight.visible = true;
   }
 
-  function applyLights(preset) {
+  function applyLights(preset, intensities = null) {
     ambientLight.color.set(preset.ambient.color);
-    ambientLight.intensity = preset.ambient.intensity;
+    ambientLight.intensity = intensities?.ambient ?? preset.ambient.intensity;
     hemisphereLight.color.set(preset.hemisphere.color);
     hemisphereLight.groundColor.set(preset.hemisphere.groundColor);
-    hemisphereLight.intensity = preset.hemisphere.intensity;
-    applyAccent(preset.accent);
+    hemisphereLight.intensity = intensities?.hemisphere
+      ?? preset.hemisphere.intensity;
+    applyAccent(preset.accent, intensities?.accent);
   }
 
   function restoreEnvironment() {
@@ -431,7 +436,7 @@ export function createEnvironmentController({
     const profile = IBL_PROFILES[id];
     const resource = iblResources.get(id);
     if (profile && resource?.available && resource.texture) {
-      applyLights(profile.lighting);
+      applyLights(preset, profile.lightIntensity);
       scene.environment = resource.texture;
       scene.environmentIntensity = profile.environmentIntensity;
       return;
@@ -540,8 +545,13 @@ export function createEnvironmentController({
       resources,
       totalPmremGenerationCount: [...iblResources.values()]
         .reduce((total, resource) => total + resource.generationCount, 0),
-      sunDirection: OUTDOOR_SUN_DIRECTION.toArray(),
+      activeDominantDirection: getDominantLightDirection(),
     };
+  }
+
+  function getDominantLightDirection() {
+    const direction = IBL_PROFILES[currentPresetId]?.dominantDirection;
+    return direction ? [...direction] : null;
   }
 
   function getPreset() {
@@ -566,6 +576,7 @@ export function createEnvironmentController({
     prepare,
     setPreset,
     getPreset,
+    getDominantLightDirection,
     getDebugState,
     dispose,
   };

--- a/src/web/js/scene/environment.js
+++ b/src/web/js/scene/environment.js
@@ -646,11 +646,6 @@ export function createEnvironmentController({
     return direction ? [...direction] : null;
   }
 
-  function getDominantLight() {
-    return accentLight.visible && accentLight.intensity > 0
-      ? accentLight : null;
-  }
-
   function getPreset() {
     return ENVIRONMENT_PRESETS[currentPresetId];
   }
@@ -673,7 +668,6 @@ export function createEnvironmentController({
     prepare,
     setPreset,
     getPreset,
-    getDominantLight,
     getDominantLightDirection,
     getDebugState,
     dispose,

--- a/src/web/js/scene/environment.js
+++ b/src/web/js/scene/environment.js
@@ -338,11 +338,11 @@ const IBL_PROFILES = freeze({
     createCaptureScene: createIndoorCaptureScene,
   }),
   studio: freeze({
-    environmentIntensity: 0.15,
+    environmentIntensity: 0.18,
     lightIntensity: freeze({
-      ambient: 0.03,
-      hemisphere: 0.06,
-      accent: 0.2,
+      ambient: 0.04,
+      hemisphere: 0.08,
+      accent: 0.24,
     }),
     dominantDirection: directionFromPresetAccent('studio'),
     pmrem: DEFAULT_PMREM,

--- a/src/web/js/scene/environment.js
+++ b/src/web/js/scene/environment.js
@@ -318,6 +318,7 @@ export function createEnvironmentController({
         // preparation begins. This also gives concurrent callers one promise
         // to join while the optional warm-up is in progress.
         await new Promise(resolve => setTimeout(resolve, 0));
+        if (disposed) return false;
         captureScene = new THREE.Scene();
         captureSky = new SkyMesh();
         configureOutdoorSky(captureSky);

--- a/src/web/js/scene/environment.js
+++ b/src/web/js/scene/environment.js
@@ -646,6 +646,11 @@ export function createEnvironmentController({
     return direction ? [...direction] : null;
   }
 
+  function getDominantLight() {
+    return accentLight.visible && accentLight.intensity > 0
+      ? accentLight : null;
+  }
+
   function getPreset() {
     return ENVIRONMENT_PRESETS[currentPresetId];
   }
@@ -668,6 +673,7 @@ export function createEnvironmentController({
     prepare,
     setPreset,
     getPreset,
+    getDominantLight,
     getDominantLightDirection,
     getDebugState,
     dispose,

--- a/src/web/js/scene/key-light-controller.js
+++ b/src/web/js/scene/key-light-controller.js
@@ -10,37 +10,29 @@ function createLightHandle() {
   canvas.width = canvas.height = 128;
   const context = canvas.getContext('2d');
   const center = 64;
-  const corona = context.createRadialGradient(center, center, 8, center, center, 54);
-  corona.addColorStop(0, 'rgba(255,218,112,.22)');
-  corona.addColorStop(0.45, 'rgba(255,196,76,.08)');
-  corona.addColorStop(1, 'rgba(255,184,70,0)');
-  context.fillStyle = corona;
+  const halo = context.createRadialGradient(center, center, 10, center, center, 52);
+  halo.addColorStop(0, 'rgba(255,240,170,.25)');
+  halo.addColorStop(0.4, 'rgba(255,214,115,.14)');
+  halo.addColorStop(0.72, 'rgba(255,198,86,.04)');
+  halo.addColorStop(1, 'rgba(255,190,70,0)');
+  context.fillStyle = halo;
   context.fillRect(0, 0, 128, 128);
 
-  context.save();
-  context.translate(center, center);
-  for (let index = 0; index < 12; index += 1) {
-    context.rotate(Math.PI / 6);
-    const ray = context.createLinearGradient(0, 23, 0, 42);
-    ray.addColorStop(0, 'rgba(255,243,165,.26)');
-    ray.addColorStop(1, 'rgba(246,201,93,0)');
-    context.strokeStyle = ray;
-    context.lineWidth = 2;
-    context.beginPath();
-    context.moveTo(0, 22);
-    context.lineTo(0, 41);
-    context.stroke();
-  }
-  context.restore();
+  const innerGlow = context.createRadialGradient(center, center, 3, center, center, 31);
+  innerGlow.addColorStop(0, 'rgba(255,253,240,.92)');
+  innerGlow.addColorStop(0.32, 'rgba(255,245,190,.72)');
+  innerGlow.addColorStop(0.7, 'rgba(255,218,111,.3)');
+  innerGlow.addColorStop(1, 'rgba(255,198,86,0)');
+  context.fillStyle = innerGlow;
+  context.fillRect(0, 0, 128, 128);
 
-  const disk = context.createRadialGradient(58, 57, 2, center, center, 20);
-  disk.addColorStop(0, '#fffde5');
-  disk.addColorStop(0.5, '#fff3a5');
-  disk.addColorStop(1, '#f6c95d');
-  context.fillStyle = disk;
-  context.beginPath();
-  context.arc(center, center, 19, 0, Math.PI * 2);
-  context.fill();
+  const core = context.createRadialGradient(60, 59, 1, center, center, 16);
+  core.addColorStop(0, '#fffdf0');
+  core.addColorStop(0.45, 'rgba(255,248,205,.98)');
+  core.addColorStop(0.8, 'rgba(255,224,126,.7)');
+  core.addColorStop(1, 'rgba(246,201,93,0)');
+  context.fillStyle = core;
+  context.fillRect(0, 0, 128, 128);
   const handle = new THREE.Sprite(new THREE.SpriteMaterial({
     map: new THREE.CanvasTexture(canvas), transparent: true,
     // Model depth must occlude the marker instead of showing through meshes.

--- a/src/web/js/scene/key-light-controller.js
+++ b/src/web/js/scene/key-light-controller.js
@@ -2,17 +2,45 @@
 
 import * as THREE from 'three';
 
+export const KEY_LIGHT_MAX_INTENSITY = 1.5;
+export const DEFAULT_KEY_LIGHT_INTENSITY = 1.0;
+
 function createLightHandle() {
   const canvas = document.createElement('canvas');
-  canvas.width = canvas.height = 64;
+  canvas.width = canvas.height = 128;
   const context = canvas.getContext('2d');
-  const glow = context.createRadialGradient(32, 32, 4, 32, 32, 30);
-  glow.addColorStop(0, 'rgba(255,248,190,1)');
-  glow.addColorStop(0.35, 'rgba(255,216,102,.95)');
-  glow.addColorStop(0.7, 'rgba(255,184,70,.4)');
-  glow.addColorStop(1, 'rgba(255,184,70,0)');
-  context.fillStyle = glow;
-  context.fillRect(0, 0, 64, 64);
+  const center = 64;
+  const corona = context.createRadialGradient(center, center, 8, center, center, 54);
+  corona.addColorStop(0, 'rgba(255,218,112,.22)');
+  corona.addColorStop(0.45, 'rgba(255,196,76,.08)');
+  corona.addColorStop(1, 'rgba(255,184,70,0)');
+  context.fillStyle = corona;
+  context.fillRect(0, 0, 128, 128);
+
+  context.save();
+  context.translate(center, center);
+  for (let index = 0; index < 12; index += 1) {
+    context.rotate(Math.PI / 6);
+    const ray = context.createLinearGradient(0, 23, 0, 42);
+    ray.addColorStop(0, 'rgba(255,243,165,.26)');
+    ray.addColorStop(1, 'rgba(246,201,93,0)');
+    context.strokeStyle = ray;
+    context.lineWidth = 2;
+    context.beginPath();
+    context.moveTo(0, 22);
+    context.lineTo(0, 41);
+    context.stroke();
+  }
+  context.restore();
+
+  const disk = context.createRadialGradient(58, 57, 2, center, center, 20);
+  disk.addColorStop(0, '#fffde5');
+  disk.addColorStop(0.5, '#fff3a5');
+  disk.addColorStop(1, '#f6c95d');
+  context.fillStyle = disk;
+  context.beginPath();
+  context.arc(center, center, 19, 0, Math.PI * 2);
+  context.fill();
   const handle = new THREE.Sprite(new THREE.SpriteMaterial({
     map: new THREE.CanvasTexture(canvas), transparent: true,
     // Model depth must occlude the marker instead of showing through meshes.
@@ -31,8 +59,11 @@ export function createKeyLightController({
 
   let drag = null;
   let pointerInside = false;
-  const modes = ['double', 'current', 'off'];
-  let modeIndex = 0;
+  let intensity = Number.isFinite(light.intensity)
+    ? Math.min(KEY_LIGHT_MAX_INTENSITY, Math.max(0, light.intensity))
+    : DEFAULT_KEY_LIGHT_INTENSITY;
+  light.intensity = intensity;
+  handle.visible = intensity > 0;
   const raycaster = new THREE.Raycaster();
   const pointer = new THREE.Vector2();
   const dragPlane = new THREE.Plane();
@@ -133,32 +164,17 @@ export function createKeyLightController({
   renderer.domElement.addEventListener('pointerup', finishDrag);
   renderer.domElement.addEventListener('pointercancel', finishDrag);
 
-  function setMode(nextMode) {
-    const nextIndex = modes.indexOf(nextMode);
-    if (nextIndex < 0) return false;
-    modeIndex = nextIndex;
-    const mode = modes[modeIndex];
-    handle.visible = mode !== 'off';
-    light.intensity = mode === 'double' ? 1 : (mode === 'current' ? 0.5 : 0);
-    const button = document.getElementById('light-btn');
-    button.classList.toggle('double', mode === 'double');
-    button.classList.toggle('current', mode === 'current');
-    button.classList.toggle('off', mode === 'off');
-    const labels = {
-      double: 'Key light: double brightness and handle size',
-      current: 'Key light: normal (drag; Shift-drag for depth)',
-      off: 'Key light: off',
-    };
-    button.title = labels[mode];
-    button.setAttribute('aria-label', labels[mode]);
-    button.setAttribute('aria-pressed', String(mode !== 'off'));
+  function setIntensity(value) {
+    const number = Number(value);
+    const next = Number.isNaN(number)
+      ? 0 : Math.min(KEY_LIGHT_MAX_INTENSITY, Math.max(0, number));
+    if (next === intensity) return false;
+    intensity = next;
+    light.intensity = intensity;
+    handle.visible = intensity > 0;
     updateCursor();
     onChange?.();
     return true;
-  }
-
-  function toggleMode() {
-    return setMode(modes[(modeIndex + 1) % modes.length]);
   }
 
   function rebase(modelSize) {
@@ -172,12 +188,14 @@ export function createKeyLightController({
   function update() {
     light.target.position.copy(controls.target);
     handle.position.copy(light.position);
-    const multiplier = modes[modeIndex] === 'double' ? 2 : 1;
+    const normalized = THREE.MathUtils.clamp(
+      intensity / KEY_LIGHT_MAX_INTENSITY, 0, 1);
+    const sizeMultiplier = 0.75 + normalized * 1.25;
     const size = Math.max(
-      camera.position.distanceTo(controls.target) * 0.035 * multiplier,
+      camera.position.distanceTo(controls.target) * 0.035 * sizeMultiplier,
       0.0001);
     handle.scale.set(size, size, 1);
   }
 
-  return { toggleMode, setMode, getMode: () => modes[modeIndex], rebase, update };
+  return { setIntensity, getIntensity: () => intensity, rebase, update };
 }

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -152,6 +152,7 @@ const environmentController = createEnvironmentController({
   ambientLight,
   hemisphereLight,
   lightTarget: keyLight.target,
+  onVisualChange: requestRender,
 });
 const keyLightController = createKeyLightController({
   scene, camera, renderer, controls, light: keyLight, onChange: requestRender,
@@ -208,16 +209,10 @@ export const rendererReady = initializeRenderer()
     requestRender();
     openButton.disabled = !isRendererAvailable();
     void environmentController.prepare()
-      .then(prepared => {
-        if (prepared && environmentController.getPreset().id === 'outdoor') {
-          requestRender();
-        }
-      })
       .catch(error => {
-        // Outdoor IBL is optional; renderer startup must remain usable when
-        // the GPU cannot generate the cached environment.
+        // Optional IBL must not make renderer startup unusable.
         console.debug(
-          'Outdoor environment preparation failed; using baseline lighting.',
+          'Environment preparation failed; using baseline lighting.',
           error,
         );
       });

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -201,22 +201,24 @@ setRenderCallback(renderFrame);
 controls.addEventListener('change', requestRender);
 
 export const rendererReady = initializeRenderer()
-  .then(async () => {
+  .then(() => {
     if (!isRendererAvailable()) {
       throw new Error('The renderer is not using the required WebGPU core backend.');
     }
-    try {
-      await environmentController.prepare();
-    } catch (error) {
-      // Outdoor IBL is optional; renderer startup must remain usable when the
-      // GPU cannot generate the cached environment.
-      console.debug(
-        'Outdoor environment preparation failed; using baseline lighting.',
-        error,
-      );
-    }
     requestRender();
     openButton.disabled = !isRendererAvailable();
+    void environmentController.prepare()
+      .then(prepared => {
+        if (prepared) requestRender();
+      })
+      .catch(error => {
+        // Outdoor IBL is optional; renderer startup must remain usable when
+        // the GPU cannot generate the cached environment.
+        console.debug(
+          'Outdoor environment preparation failed; using baseline lighting.',
+          error,
+        );
+      });
     return true;
   })
   .catch(error => {

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -160,6 +160,12 @@ const keyLightController = createKeyLightController({
 const characterShadowController = createCharacterShadowController({
   renderer, scene, light: keyLight,
 });
+
+function syncCharacterShadowLight() {
+  characterShadowController.setLight(
+    environmentController.getDominantLight() || keyLight,
+  );
+}
 const viewportRenderPipeline = createViewportRenderPipeline({
   renderer, scene, camera,
 });
@@ -225,8 +231,10 @@ export const rendererReady = initializeRenderer()
 
 export function setEnvironmentPreset(id) {
   const changed = environmentController.setPreset(id);
-  if (changed) requestRender();
-  return changed;
+  if (!changed) return false;
+  syncCharacterShadowLight();
+  requestRender();
+  return true;
 }
 
 export function getEnvironmentPreset() {

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -106,20 +106,6 @@ renderer.onError = info => {
   failRenderer(`WebGPU reported an unrecoverable error: ${info?.message || 'unknown error'}.`);
 };
 
-export const rendererReady = initializeRenderer()
-  .then(() => {
-    if (!isRendererAvailable()) {
-      throw new Error('The renderer is not using the required WebGPU core backend.');
-    }
-    requestRender();
-    openButton.disabled = !isRendererAvailable();
-    return true;
-  })
-  .catch(error => {
-    showRendererError(rendererFailureMessage(error));
-    return false;
-  });
-
 export const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x0d1117);
 const ambientLight = new THREE.AmbientLight(0xffffff, 0.55);
@@ -161,6 +147,7 @@ export function setPhysicsInteractionEnabled(enabled) {
 }
 
 const environmentController = createEnvironmentController({
+  renderer,
   scene,
   ambientLight,
   hemisphereLight,
@@ -213,6 +200,30 @@ function renderFrame() {
 setRenderCallback(renderFrame);
 controls.addEventListener('change', requestRender);
 
+export const rendererReady = initializeRenderer()
+  .then(async () => {
+    if (!isRendererAvailable()) {
+      throw new Error('The renderer is not using the required WebGPU core backend.');
+    }
+    try {
+      await environmentController.prepare();
+    } catch (error) {
+      // Outdoor IBL is optional; renderer startup must remain usable when the
+      // GPU cannot generate the cached environment.
+      console.debug(
+        'Outdoor environment preparation failed; using baseline lighting.',
+        error,
+      );
+    }
+    requestRender();
+    openButton.disabled = !isRendererAvailable();
+    return true;
+  })
+  .catch(error => {
+    showRendererError(rendererFailureMessage(error));
+    return false;
+  });
+
 export function setEnvironmentPreset(id) {
   const changed = environmentController.setPreset(id);
   if (changed) requestRender();
@@ -221,6 +232,10 @@ export function setEnvironmentPreset(id) {
 
 export function getEnvironmentPreset() {
   return environmentController.getPreset();
+}
+
+export function getEnvironmentDebugState() {
+  return environmentController.getDebugState();
 }
 
 export function toggleGrid() {

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -160,12 +160,6 @@ const keyLightController = createKeyLightController({
 const characterShadowController = createCharacterShadowController({
   renderer, scene, light: keyLight,
 });
-
-function syncCharacterShadowLight() {
-  characterShadowController.setLight(
-    environmentController.getDominantLight() || keyLight,
-  );
-}
 const viewportRenderPipeline = createViewportRenderPipeline({
   renderer, scene, camera,
 });
@@ -231,10 +225,8 @@ export const rendererReady = initializeRenderer()
 
 export function setEnvironmentPreset(id) {
   const changed = environmentController.setPreset(id);
-  if (!changed) return false;
-  syncCharacterShadowLight();
-  requestRender();
-  return true;
+  if (changed) requestRender();
+  return changed;
 }
 
 export function getEnvironmentPreset() {
@@ -258,19 +250,14 @@ export function toggleTrackballGizmo() {
   viewGizmoController.toggle();
 }
 
-export function toggleLightHandle() {
-  keyLightController.toggleMode();
-  requestRender();
-}
-
-export function setLightMode(mode) {
-  const changed = keyLightController.setMode(mode);
+export function setKeyLightIntensity(value) {
+  const changed = keyLightController.setIntensity(value);
   if (changed) requestRender();
   return changed;
 }
 
-export function getLightMode() {
-  return keyLightController.getMode();
+export function getKeyLightIntensity() {
+  return keyLightController.getIntensity();
 }
 
 export function frameView(meshes = [], direction = null, targetYOffset = 0) {

--- a/src/web/js/scene/scene.js
+++ b/src/web/js/scene/scene.js
@@ -209,7 +209,9 @@ export const rendererReady = initializeRenderer()
     openButton.disabled = !isRendererAvailable();
     void environmentController.prepare()
       .then(prepared => {
-        if (prepared) requestRender();
+        if (prepared && environmentController.getPreset().id === 'outdoor') {
+          requestRender();
+        }
       })
       .catch(error => {
         // Outdoor IBL is optional; renderer startup must remain usable when

--- a/src/web/js/ui/toolbar.js
+++ b/src/web/js/ui/toolbar.js
@@ -3,9 +3,10 @@
 import { activeMeshes } from '../mesh/visibility.js';
 import { ENVIRONMENT_PRESETS } from '../scene/environment.js';
 import {
-  getAmbientOcclusionStrength, getEnvironmentPreset, getLightMode,
-  setAmbientOcclusionStrength, setEnvironmentPreset, setLightMode,
+  getAmbientOcclusionStrength, getEnvironmentPreset, getKeyLightIntensity,
+  setAmbientOcclusionStrength, setEnvironmentPreset, setKeyLightIntensity,
 } from '../scene/scene.js';
+import { KEY_LIGHT_MAX_INTENSITY } from '../scene/key-light-controller.js';
 import { setTextureDisplayMode } from '../scene/render-modes.js';
 
 const $ = (id) => document.getElementById(id);
@@ -20,6 +21,17 @@ function normalizeAmbientOcclusionLevel(value) {
 function strengthToAmbientOcclusionLevel(value) {
   return normalizeAmbientOcclusionLevel(
     Number(value) / AO_MAX_STRENGTH * 100);
+}
+
+function normalizeKeyLightLevel(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return 0;
+  return Math.min(100, Math.max(0, Math.round(number)));
+}
+
+function intensityToKeyLightLevel(value) {
+  return normalizeKeyLightLevel(
+    Number(value) / KEY_LIGHT_MAX_INTENSITY * 100);
 }
 
 export function initEnvironmentControl() {
@@ -98,6 +110,8 @@ export function initToolPopovers() {
   const aoPopover = $('ao-popover');
   const aoSlider = $('ao-slider');
   const aoValue = $('ao-value');
+  const lightSlider = $('light-slider');
+  const lightValue = $('light-value');
   const close = popover => {
     if (!popover) return;
     popover.hidden = true;
@@ -177,29 +191,39 @@ export function initToolPopovers() {
     positionPopover(texturePopover, textureButton);
   }
 
+  const updateKeyLightControl = value => {
+    const level = normalizeKeyLightLevel(value);
+    if (lightSlider) lightSlider.value = String(level);
+    if (lightValue) {
+      lightValue.value = level + '%';
+      lightValue.textContent = level + '%';
+    }
+    lightButton?.classList.toggle('active', level > 0);
+    lightButton?.classList.toggle('off', level === 0);
+    const label = 'Key light: ' + (level === 0 ? 'Off' : level + '%');
+    lightButton?.setAttribute('aria-label', label);
+    if (lightButton) lightButton.title = label;
+    return level;
+  };
+
+  const applyKeyLightLevel = value => {
+    const level = normalizeKeyLightLevel(value);
+    setKeyLightIntensity(level / 100 * KEY_LIGHT_MAX_INTENSITY);
+    return updateKeyLightControl(
+      intensityToKeyLightLevel(getKeyLightIntensity()));
+  };
+
   function toggleLightPopover() {
     if (!lightPopover) return;
     const wasOpen = !lightPopover.hidden;
     closeAll();
     if (wasOpen) return;
-    lightPopover.replaceChildren();
-    [['double', 'Bright'], ['current', 'Normal'], ['off', 'Off']].forEach(([mode, label]) => {
-      const option = document.createElement('button');
-      option.type = 'button';
-      option.className = 'ui-popover-option';
-      option.setAttribute('role', 'menuitemradio');
-      option.setAttribute('aria-checked', String(getLightMode() === mode));
-      option.textContent = label;
-      option.addEventListener('click', () => {
-        setLightMode(mode);
-        closeAll();
-      });
-      lightPopover.appendChild(option);
-    });
+    updateKeyLightControl(intensityToKeyLightLevel(getKeyLightIntensity()));
     lightPopover.hidden = false;
     lightButton?.setAttribute('aria-expanded', 'true');
     activeToolPopover = { popover: lightPopover, button: lightButton };
     positionPopover(lightPopover, lightButton);
+    lightSlider?.focus();
   }
 
   function toggleAmbientOcclusionPopover() {
@@ -217,16 +241,18 @@ export function initToolPopovers() {
   }
 
   textureButton?.setAttribute('aria-haspopup', 'menu');
-  lightButton?.setAttribute('aria-haspopup', 'menu');
+  lightButton?.setAttribute('aria-haspopup', 'dialog');
   aoButton?.setAttribute('aria-haspopup', 'dialog');
   textureButton?.setAttribute('aria-expanded', 'false');
   lightButton?.setAttribute('aria-expanded', 'false');
   aoButton?.setAttribute('aria-expanded', 'false');
   updateAmbientOcclusionControl(
     strengthToAmbientOcclusionLevel(getAmbientOcclusionStrength()));
+  updateKeyLightControl(intensityToKeyLightLevel(getKeyLightIntensity()));
   textureButton?.addEventListener('click', toggleTexturePopover);
   lightButton?.addEventListener('click', toggleLightPopover);
   aoButton?.addEventListener('click', toggleAmbientOcclusionPopover);
+  lightSlider?.addEventListener('input', () => applyKeyLightLevel(lightSlider.value));
   aoSlider?.addEventListener('input', () => applyAmbientOcclusionLevel(aoSlider.value));
   document.addEventListener('click', event => {
     if (event.target.closest(

--- a/src/web/js/ui/toolbar.js
+++ b/src/web/js/ui/toolbar.js
@@ -198,7 +198,8 @@ export function initToolPopovers() {
       lightValue.value = level + '%';
       lightValue.textContent = level + '%';
     }
-    lightButton?.classList.toggle('active', level > 0);
+    lightButton?.classList.toggle('active', level === 100);
+    lightButton?.classList.toggle('partial', level > 0 && level < 100);
     lightButton?.classList.toggle('off', level === 0);
     const label = 'Key light: ' + (level === 0 ? 'Off' : level + '%');
     lightButton?.setAttribute('aria-label', label);


### PR DESCRIPTION
## Summary

- Vendor the pinned Three.js r185 SkyMesh addon for offline builds.
- Generate and cache procedural PMREMs for Outdoor Sky, warm-room Indoor, and neutral Studio profiles through a shared per-profile lifecycle after WebGPU initialization.
- Preserve the existing preset backgrounds and legacy lighting fallbacks while isolating preparation failures and disposal per profile.
- Keep the movable key light as the sole character-shadow source across all environment presets; environment accent lighting remains non-shadowing.
- Replace the key-light Bright, Normal, and Off modes with a continuous 0–100% intensity slider mapped to 0.0–1.5, including a solar-style marker whose size tracks intensity.
- Keep capture scenes offscreen and request renders only for active visual upgrades or on-demand shadow work.

## Validation

- `python -m pytest -q src/tests/web`
- `python -m pytest -q`