### PR TITLE
Add startup mod launch contract

### DIFF
--- a/src/app/bridge/access.py
+++ b/src/app/bridge/access.py
@@ -1,11 +1,13 @@
-"""Authorization state for native-selected Mod and Asset folders."""
+"""Authorization state for Mod and Asset folders."""
+
+import os
 
 from app.assets import folders as asset_folders
 from app.settings import mod_folders
 
 
 class FolderAccess:
-    """Keep the bridge's native-picker and registered-root trust boundaries."""
+    """Keep native-picker, launch, and registered-root trust boundaries distinct."""
 
     def __init__(self):
         self._authorized_folders = set()
@@ -55,6 +57,22 @@ class FolderAccess:
         folder = mod_folders.normalize_path(folder_path)
         self._authorized_folders.add(folder)
         self._picker_authorized_folders.add(folder)
+        return folder
+
+    def remember_mod_launch_selection(self, folder_path):
+        """Authorize one existing absolute folder for this process only."""
+        try:
+            raw_path = os.fspath(folder_path)
+        except TypeError as error:
+            raise ValueError("Startup mod path must be absolute.") from error
+        if not isinstance(raw_path, str) or not raw_path.strip() \
+                or not os.path.isabs(raw_path):
+            raise ValueError("Startup mod path must be absolute.")
+
+        folder = mod_folders.normalize_path(raw_path)
+        if not os.path.isdir(folder):
+            raise ValueError(f"Startup mod folder does not exist: {folder}")
+        self._authorized_folders.add(folder)
         return folder
 
     def remember_asset_picker_selection(self, folder_path):

--- a/src/app/bridge/api.py
+++ b/src/app/bridge/api.py
@@ -19,19 +19,35 @@ from app.bridge import toggle as toggle_api
 
 
 class ModViewerAPI:
-    def __init__(self):
+    def __init__(self, startup_mod=None, startup_disabled_ini=False):
         # Underscore-private on purpose: pywebview reflects over the js_api
         # object's public attributes to expose them to JavaScript, and the
         # native window is a deeply self-referential COM object. Exposing it
         # sends that reflection into infinite recursion.
         self._window = None
         self._access = FolderAccess()
+        self._startup_request = None
+        if startup_mod is not None:
+            try:
+                path = self._access.remember_mod_launch_selection(startup_mod)
+            except (OSError, TypeError, ValueError) as error:
+                self._startup_request = {"error": str(error)}
+            else:
+                self._startup_request = {
+                    "path": path,
+                    "disabled_ini": bool(startup_disabled_ini),
+                }
         self._mod_preview = ModPreview(self._access)
         self._asset_preview = AssetPreview(self._access)
         self._mod_registry = ModFolderRegistry(self._access)
         self._asset_registry = AssetFolderRegistry(
             self._access,
             on_changed=self._asset_preview.invalidate_plan_cache)
+
+    def consume_startup_request(self):
+        request = self._startup_request
+        self._startup_request = None
+        return request
 
     # -- native folder pickers ---------------------------------------------
 

--- a/src/tests/app/bridge/test_access.py
+++ b/src/tests/app/bridge/test_access.py
@@ -70,3 +70,37 @@ def test_malformed_optional_config_does_not_block_access_construction(
     access = FolderAccess()
 
     assert isinstance(access, FolderAccess)
+
+
+def test_launch_selection_is_exact_and_not_picker_authorized(
+        tmp_path, monkeypatch):
+    config = _config(tmp_path)
+    launch_folder = tmp_path / "mods" / "launch"
+    sibling = tmp_path / "mods" / "sibling"
+    launch_folder.mkdir(parents=True)
+    sibling.mkdir()
+    monkeypatch.setattr(paths, "config_path", lambda: str(config))
+
+    access = FolderAccess()
+    selected = access.remember_mod_launch_selection(str(launch_folder))
+
+    assert selected == mod_folders.normalize_path(str(launch_folder))
+    assert access.mod_folder(str(launch_folder)) == selected
+    assert access.was_picker_selected(str(launch_folder)) is False
+    with pytest.raises(PermissionError):
+        access.mod_folder(str(sibling))
+    with pytest.raises(PermissionError):
+        access.mod_folder(str(launch_folder.parent))
+    assert access._authorized_roots == set()
+    assert json.loads(config.read_text(encoding="utf-8"))["modFolders"] == []
+
+
+def test_launch_selection_rejects_relative_and_missing_paths(
+        tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "config_path", lambda: str(_config(tmp_path)))
+    access = FolderAccess()
+
+    with pytest.raises(ValueError, match="Startup mod path must be absolute"):
+        access.remember_mod_launch_selection("relative-mod")
+    with pytest.raises(ValueError, match="Startup mod folder does not exist"):
+        access.remember_mod_launch_selection(str(tmp_path / "missing"))

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 from app.bridge.api import ModViewerAPI
 from app.session import edit as edit_session
+from app.settings import mod_folders
 from app.settings import paths
 
 
@@ -11,6 +12,7 @@ EXPECTED_API_METHODS = {
     "add_present",
     "add_toggle",
     "capture_present",
+    "consume_startup_request",
     "delete_asset_folder",
     "delete_mod_folder",
     "delete_present",
@@ -68,6 +70,46 @@ def test_mod_viewer_api_surface_is_explicit_and_private_state_stays_private():
 
     assert public == EXPECTED_API_METHODS
     assert all(name.startswith("_") for name in vars(api))
+
+
+def test_startup_request_is_consumed_once_and_authorizes_valid_folder(
+        tmp_path, monkeypatch):
+    root = tmp_path / "unregistered-mod"
+    root.mkdir()
+    monkeypatch.setattr(paths, "config_path", lambda: str(tmp_path / "config.json"))
+
+    api = ModViewerAPI(startup_mod=str(root))
+    normalized = mod_folders.normalize_path(str(root))
+
+    assert api.consume_startup_request() == {
+        "path": normalized,
+        "disabled_ini": False,
+    }
+    assert api.consume_startup_request() is None
+    assert api._access.was_picker_selected(str(root)) is False
+    assert api._access.mod_folder(str(root)) == normalized
+
+
+def test_startup_request_preserves_disabled_ini_flag(tmp_path, monkeypatch):
+    root = tmp_path / "mod"
+    root.mkdir()
+    monkeypatch.setattr(paths, "config_path", lambda: str(tmp_path / "config.json"))
+
+    api = ModViewerAPI(startup_mod=str(root), startup_disabled_ini=True)
+
+    assert api.consume_startup_request()["disabled_ini"] is True
+
+
+def test_invalid_startup_request_is_reported_without_failing_api(
+        tmp_path, monkeypatch):
+    missing = tmp_path / "missing-mod"
+    monkeypatch.setattr(paths, "config_path", lambda: str(tmp_path / "config.json"))
+
+    api = ModViewerAPI(startup_mod=str(missing))
+
+    request = api.consume_startup_request()
+    assert request["error"].startswith("Startup mod folder does not exist:")
+    assert api.consume_startup_request() is None
 
 
 def test_facade_composes_picker_registry_preview_and_editing(tmp_path, monkeypatch):

--- a/src/tests/test_viewer_app.py
+++ b/src/tests/test_viewer_app.py
@@ -1,0 +1,15 @@
+from viewer_app import parse_args
+
+
+def test_parse_args_without_startup_mod():
+    args = parse_args([])
+
+    assert args.mod_folder is None
+    assert args.disabled_ini is False
+
+
+def test_parse_args_accepts_path_with_spaces_and_disabled_ini():
+    args = parse_args([r"D:\My Mods\Casual Outfit", "--disabled-ini"])
+
+    assert args.mod_folder == r"D:\My Mods\Casual Outfit"
+    assert args.disabled_ini is True

--- a/src/tests/web/support.py
+++ b/src/tests/web/support.py
@@ -305,7 +305,8 @@ def edge_browser():
 
 def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
           mod_folders=None, subfolders=None, diagnostics=None, panel_opacity=58,
-          panel_opacity_api=True, asset_folders=None, asset_subfolders=None):
+          panel_opacity_api=True, asset_folders=None, asset_subfolders=None,
+          startup_request=None, startup_api_ready=True):
     # Playwright's wait_for_function uses eval internally. Bypass the app's
     # production CSP only in this isolated test context so behavioral waits
     # do not require weakening the served application's policy.
@@ -322,6 +323,8 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
             "summary": {"issues": 0, "errors": 0}, "files": {}, "issues": []},
         "panelOpacity": panel_opacity,
         "panelOpacityApi": panel_opacity_api,
+        "startupRequest": startup_request,
+        "startupApiReady": startup_api_ready,
         "calls": {"loadMod": [], "loadModArgs": [], "loadAsset": [], "listSubfolders": [],
                    "listAssetSubfolders": [],
                    "selectAssetFolder": [],
@@ -329,6 +332,7 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                    "loadMissingAssetParts": [],
                    "removeMissingAssetParts": [],
                    "discardChanges": [], "switches": [], "diagnostics": [],
+                   "consumeStartupRequest": [],
                    "panelOpacity": [], "presentState": [],
                    "controlState": [], "meshSemantics": [],
                    "deleteToggle": [], "exportChanges": []},
@@ -356,6 +360,12 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
               state.nextPath = null;
               state.calls.selectAssetFolder.push(path);
               return path;
+            },
+            consume_startup_request: async () => {
+              state.calls.consumeStartupRequest.push(true);
+              const request = state.startupRequest;
+              state.startupRequest = null;
+              return copy(request);
             },
             load_mod: async (path, disabledIni = false) => {
               state.calls.loadMod.push(path);
@@ -567,6 +577,9 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
           if (!state.panelOpacityApi) {
             delete window.pywebview.api.get_panel_opacity;
             delete window.pywebview.api.set_panel_opacity;
+          }
+          if (!state.startupApiReady) {
+            delete window.pywebview.api.consume_startup_request;
           }
         }
         """.replace("__STATE__", encoded_state),

--- a/src/tests/web/test_app_flow.py
+++ b/src/tests/web/test_app_flow.py
@@ -1,5 +1,64 @@
 from .support import *
 
+def test_startup_mod_uses_switch_flow_and_disabled_ini_setting(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"Startup": _payload("Startup")},
+        startup_request={"path": "Startup", "disabled_ini": True})
+    try:
+        page.wait_for_function("window.__fakeApi.calls.loadMod.length === 1")
+        page.locator(".draw-item").wait_for()
+
+        assert page.evaluate("window.__fakeApi.calls.consumeStartupRequest") == [True]
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["Startup"]
+        assert page.evaluate("window.__fakeApi.calls.loadModArgs") == [["Startup", True]]
+        assert page.locator("#open-disabled-mod").is_checked()
+        assert page.evaluate("window.modViewer.getCurrentSource().path") == "Startup"
+    finally:
+        context.close()
+
+
+def test_startup_mod_waits_for_pywebview_ready(edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"Startup": _payload("Startup")},
+        startup_request={"path": "Startup"}, startup_api_ready=False)
+    try:
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == []
+        page.evaluate("""() => {
+          const state = window.__fakeApi;
+          window.pywebview.api.consume_startup_request = async () => {
+            state.calls.consumeStartupRequest.push(true);
+            const request = state.startupRequest;
+            state.startupRequest = null;
+            return structuredClone(request);
+          };
+          window.dispatchEvent(new Event('pywebviewready'));
+        }""")
+        page.wait_for_function("window.__fakeApi.calls.loadMod.length === 1")
+
+        assert page.evaluate("window.__fakeApi.calls.consumeStartupRequest") == [True]
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == ["Startup"]
+    finally:
+        context.close()
+
+
+def test_invalid_startup_request_shows_dialog_and_keeps_viewer_usable(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"Unused": _payload("Unused")},
+        startup_request={"error": "Startup mod folder does not exist: missing"})
+    try:
+        page.locator("#dialog-backdrop.show").wait_for()
+        assert page.locator("#dialog-message").inner_text() == (
+            "Could not open startup mod:\n\n"
+            "Startup mod folder does not exist: missing")
+        assert page.evaluate("window.__fakeApi.calls.loadMod") == []
+        page.locator("#dialog-ok").click()
+        assert page.locator("#open-btn").is_enabled()
+    finally:
+        context.close()
+
+
 def test_frontend_public_surface_and_lifecycle_events(edge_browser, frontend_url):
     context, page = _page(
         edge_browser, frontend_url,

--- a/src/viewer_app.py
+++ b/src/viewer_app.py
@@ -11,6 +11,7 @@ This module is only the entry point. The application lives in the `app`
 package and the user interface in `web/`.
 """
 
+import argparse
 import sys
 
 try:
@@ -22,15 +23,34 @@ except ImportError:
 from app.bridge.api import ModViewerAPI
 from app.runtime import server, webview2
 
-__all__ = ["ModViewerAPI", "main"]
+__all__ = ["ModViewerAPI", "main", "parse_args"]
 
 
-def main():
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="3DMigoto Mod Viewer")
+    parser.add_argument(
+        "mod_folder",
+        nargs="?",
+        help="Mod folder to open on startup",
+    )
+    parser.add_argument(
+        "--disabled-ini",
+        action="store_true",
+        help="Open the startup mod using DISABLED INIs",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
     if not webview2.is_installed():
         webview2.report_missing()
         return 1
 
-    api = ModViewerAPI()
+    api = ModViewerAPI(
+        startup_mod=args.mod_folder,
+        startup_disabled_ini=args.disabled_ini,
+    )
     window = webview.create_window(
         "3DMigoto Mod Viewer",
         url=server.start(),

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -29,6 +29,7 @@ import { initInspectorPanel } from './panels/inspector-panel.js';
 import { initRightDock } from './panels/right-dock.js';
 import { initWeightPanel } from './panels/weight-panel.js';
 import { initPanelOpacityControl } from './ui/appearance.js';
+import { alertDialog } from './ui/dialogs.js';
 import {
   getOutlineState as getMeshOutlineState,
   setOutlineSuppressedByDebug, setOutlinesEnabled,
@@ -108,6 +109,32 @@ function openMod() {
 
 function switchMod(path) {
   return switchModFlow(path, modelHandlers());
+}
+
+async function openStartupMod() {
+  const consume = window.pywebview?.api?.consume_startup_request;
+  if (typeof consume !== 'function') return false;
+
+  let request;
+  try {
+    request = await consume.call(window.pywebview.api);
+  } catch (error) {
+    await alertDialog(
+      'Could not open startup mod:\n\n' + (error?.message || String(error)));
+    return true;
+  }
+  if (!request) return true;
+  if (request.error) {
+    await alertDialog(`Could not open startup mod:\n\n${request.error}`);
+    return true;
+  }
+
+  if (typeof request.disabled_ini === 'boolean') {
+    const checkbox = $('open-disabled-mod');
+    if (checkbox) checkbox.checked = request.disabled_ini;
+  }
+  await switchMod(request.path);
+  return true;
 }
 
 function switchAsset(path, entry = {}) {
@@ -329,4 +356,11 @@ rendererReady.then(ready => {
     getCurrentSource: () => viewerState.currentSource
       ? { ...viewerState.currentSource } : null,
   };
+
+  void openStartupMod().then(apiReady => {
+    if (!apiReady) {
+      window.addEventListener(
+        'pywebviewready', () => void openStartupMod(), { once: true });
+    }
+  });
 });


### PR DESCRIPTION
Adds a generic startup-mod launch contract: parses an optional folder and --disabled-ini, grants exact process-local access without picker or registry privileges, consumes the request once, and routes frontend startup through switchMod with pywebview readiness and error handling. Includes backend, CLI, and frontend regression coverage.