### PR TITLE
feat: add per-mesh color adjustments

### DIFF
--- a/src/app/bridge/api.py
+++ b/src/app/bridge/api.py
@@ -169,6 +169,10 @@ class ModViewerAPI:
     def save_mesh_textures(self, folder_path, textures):
         return self._mod_preview.save_mesh_textures(folder_path, textures)
 
+    def save_mesh_color_adjustment(self, folder_path, mesh_key, adjustment):
+        return self._mod_preview.save_mesh_color_adjustment(
+            folder_path, mesh_key, adjustment)
+
     def save_weight_selection(self, folder_path, bones):
         return self._mod_preview.save_weight_selection(folder_path, bones)
 

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -96,6 +96,8 @@ class ModPreview:
             saved_metadata = context.metadata
             result.setdefault("metadata", {})["mesh_names"] = \
                 metadata.hydrate_mesh_names(result, saved_metadata)
+            result["metadata"]["mesh_color_adjustments"] = \
+                metadata.hydrate_mesh_color_adjustments(result, saved_metadata)
             game_metadata = result.get("metadata", {}).get("game", {})
             publication.set_game_profile(game_metadata.get("id"))
             metadata.hydrate_textures(
@@ -320,6 +322,11 @@ class ModPreview:
         result = metadata.save_textures(folder_path, textures)
         edit_session.invalidate_diagnostics(folder_path)
         return result
+
+    def save_mesh_color_adjustment(self, folder_path, mesh_key, adjustment):
+        folder_path = self._access.mod_folder(folder_path)
+        return metadata.save_mesh_color_adjustment(
+            folder_path, mesh_key, adjustment)
 
     def save_weight_selection(self, folder_path, bones):
         folder_path = self._access.mod_folder(folder_path)

--- a/src/app/mods/loader.py
+++ b/src/app/mods/loader.py
@@ -109,7 +109,11 @@ def _structured_payload(meshes=None, textures=None, toggles=None, menu=None,
             "defaults": state_defaults or {},
         },
         "geometry": None,
-        "metadata": {"mesh_names": {}, "material_profiles": profile_table},
+        "metadata": {
+            "mesh_names": {},
+            "mesh_color_adjustments": {},
+            "material_profiles": profile_table,
+        },
         "health": health,
         "asset_resolution": asset_resolution,
     }

--- a/src/app/mods/metadata.py
+++ b/src/app/mods/metadata.py
@@ -1,7 +1,9 @@
 """Viewer-only mesh labels and texture choices stored beside a mod."""
 from collections import Counter
 import json
+import math
 import os
+import re
 import threading
 from copy import deepcopy
 
@@ -16,6 +18,30 @@ from core.textures.profiles import texture_profile_for
 METADATA_NAME = ".mod_viewer.json"
 PRESENT_NAMES_KEY = "__all__"
 _LOCK = threading.RLock()
+
+MESH_COLOR_ADJUSTMENTS_KEY = "mesh_color_adjustments"
+_COLOR_DEFAULTS = {
+    "hue": 0,
+    "saturation": 1.0,
+    "brightness": 1.0,
+    "contrast": 1.0,
+    "red": 1.0,
+    "green": 1.0,
+    "blue": 1.0,
+    "tint": "#ffffff",
+    "tint_strength": 0.0,
+}
+_COLOR_RANGES = {
+    "hue": (-180.0, 180.0),
+    "saturation": (0.0, 2.0),
+    "brightness": (0.0, 2.0),
+    "contrast": (0.0, 2.0),
+    "red": (0.0, 2.0),
+    "green": (0.0, 2.0),
+    "blue": (0.0, 2.0),
+    "tint_strength": (0.0, 1.0),
+}
+_TINT_PATTERN = re.compile(r"^#[0-9a-f]{6}$", re.IGNORECASE)
 
 
 def _legacy_mesh_key(name, entry):
@@ -83,6 +109,110 @@ def _save(folder_path, data):
         fh.write("\n")
     os.replace(temp_path, path)
     return {"saved": True, "path": path}
+
+
+def _normalize_mesh_color_adjustment(value, *, reject_invalid=False):
+    """Normalize one sparse viewer color state, or reject malformed input."""
+    if not isinstance(value, dict):
+        return None
+    result = {}
+    for field, default in _COLOR_DEFAULTS.items():
+        raw = value.get(field, default)
+        if field == "tint":
+            if not isinstance(raw, str) or not _TINT_PATTERN.fullmatch(raw):
+                if reject_invalid:
+                    return None
+                raw = default
+            result[field] = raw.lower()
+            continue
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            if reject_invalid:
+                return None
+            raw = default
+        elif not math.isfinite(raw):
+            if reject_invalid:
+                return None
+            raw = default
+        minimum, maximum = _COLOR_RANGES[field]
+        result[field] = min(maximum, max(minimum, float(raw)))
+    result["hue"] = int(result["hue"]) if result["hue"].is_integer() else result["hue"]
+    return result
+
+
+def _is_neutral_mesh_color_adjustment(value):
+    return value == _COLOR_DEFAULTS
+
+
+def mesh_color_adjustments(folder_path=None, data=None):
+    """Return validated non-neutral per-mesh color states."""
+    data = (load(folder_path) if data is None and folder_path is not None
+            else ({} if data is None else data))
+    saved = data.get(MESH_COLOR_ADJUSTMENTS_KEY) \
+        if isinstance(data, dict) else None
+    if not isinstance(saved, dict):
+        return {}
+    result = {}
+    for mesh_key, value in saved.items():
+        if not isinstance(mesh_key, str) or not mesh_key:
+            continue
+        normalized = _normalize_mesh_color_adjustment(value)
+        if normalized is not None and not _is_neutral_mesh_color_adjustment(
+                normalized):
+            result[mesh_key] = normalized
+    return result
+
+
+def save_mesh_color_adjustment(folder_path, mesh_key, adjustment):
+    """Persist one viewer-only color state without touching source assets."""
+    if not isinstance(mesh_key, str) or not mesh_key:
+        return {"saved": False, "error": "Invalid mesh metadata key."}
+    normalized = _normalize_mesh_color_adjustment(
+        adjustment, reject_invalid=True)
+    if normalized is None:
+        return {"saved": False, "error": "Invalid mesh color adjustment."}
+    with _LOCK:
+        data = load(folder_path)
+        raw_adjustments = data.get(MESH_COLOR_ADJUSTMENTS_KEY)
+        raw_has_entry = (isinstance(raw_adjustments, dict)
+                         and mesh_key in raw_adjustments)
+        adjustments = mesh_color_adjustments(data=data)
+        if _is_neutral_mesh_color_adjustment(normalized):
+            existed = mesh_key in adjustments or raw_has_entry
+            adjustments.pop(mesh_key, None)
+        else:
+            existed = adjustments.get(mesh_key) == normalized
+            adjustments[mesh_key] = normalized
+        if adjustments:
+            data[MESH_COLOR_ADJUSTMENTS_KEY] = adjustments
+        else:
+            data.pop(MESH_COLOR_ADJUSTMENTS_KEY, None)
+        if not adjustments and not data and not existed:
+            return {"saved": False}
+        if existed and not _is_neutral_mesh_color_adjustment(normalized):
+            return {"saved": False}
+        if not existed and _is_neutral_mesh_color_adjustment(normalized):
+            return {"saved": False}
+        return _save(folder_path, data)
+
+
+def hydrate_mesh_color_adjustments(payload, data=None):
+    """Project saved color state through canonical/legacy mesh identities."""
+    saved = mesh_color_adjustments(data=data)
+    meshes = payload.get("meshes", {}) if isinstance(payload, dict) else {}
+    if not isinstance(meshes, dict):
+        return {}
+    legacy_key_counts = _legacy_mesh_key_counts(meshes)
+    hydrated = {}
+    for name, entry in meshes.items():
+        if not isinstance(entry, dict) or entry.get("error"):
+            continue
+        keys = _mesh_metadata_keys(name, entry, legacy_key_counts)
+        if not keys:
+            continue
+        value = next((saved[key] for key in keys if key in saved), None)
+        if value is not None:
+            hydrated[_canonical_mesh_key(name, entry)] = value.copy()
+    return hydrated
 
 
 def save_mesh_names(folder_path, names):

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -49,6 +49,7 @@ EXPECTED_API_METHODS = {
     "record_toggle",
     "remove_missing_asset_parts",
     "save_component_material_kind",
+    "save_mesh_color_adjustment",
     "save_mesh_names",
     "save_mesh_textures",
     "save_weight_selection",

--- a/src/tests/app/mods/test_metadata.py
+++ b/src/tests/app/mods/test_metadata.py
@@ -75,3 +75,91 @@ def test_save_weight_selected_bones_rejects_non_list(tmp_path):
     assert metadata.save_weight_selected_bones(
         str(tmp_path), "45") == {"saved": False, "selected_bones": []}
     assert not (tmp_path / metadata.METADATA_NAME).exists()
+
+
+def test_mesh_color_adjustments_normalize_and_preserve_unrelated_metadata(
+        tmp_path):
+    path = tmp_path / metadata.METADATA_NAME
+    original = {"mesh_names": {"mesh": "Body"}, "weight": {"future": True}}
+    path.write_text(json.dumps(original), encoding="utf-8")
+
+    result = metadata.save_mesh_color_adjustment(str(tmp_path), "mesh-key", {
+        "hue": 240,
+        "saturation": 1.15,
+        "brightness": 1.0,
+        "contrast": 0.5,
+        "red": 0.25,
+        "green": 1.0,
+        "blue": 2.5,
+        "tint": "#AABBCC",
+        "tint_strength": 0.4,
+    })
+
+    assert result["saved"] is True
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        **original,
+        "mesh_color_adjustments": {
+            "mesh-key": {
+                "hue": 180,
+                "saturation": 1.15,
+                "brightness": 1.0,
+                "contrast": 0.5,
+                "red": 0.25,
+                "green": 1.0,
+                "blue": 2.0,
+                "tint": "#aabbcc",
+                "tint_strength": 0.4,
+            },
+        },
+    }
+
+    assert metadata.save_mesh_color_adjustment(
+        str(tmp_path), "mesh-key", {
+            "hue": 0, "saturation": 1, "brightness": 1, "contrast": 1,
+            "red": 1, "green": 1, "blue": 1,
+            "tint": "#ffffff", "tint_strength": 0,
+        })["saved"] is True
+    assert json.loads(path.read_text(encoding="utf-8")) == original
+
+
+@pytest.mark.parametrize("invalid", [
+    None,
+    {"hue": True},
+    {"brightness": float("nan")},
+    {"contrast": float("inf")},
+    {"tint": "white"},
+    [],
+])
+def test_save_mesh_color_adjustment_rejects_malformed_values(tmp_path, invalid):
+    assert metadata.save_mesh_color_adjustment(
+        str(tmp_path), "mesh-key", invalid)["saved"] is False
+    assert not (tmp_path / metadata.METADATA_NAME).exists()
+
+
+def test_hydrate_mesh_color_adjustments_uses_canonical_and_safe_legacy_keys():
+    canonical = "mesh:[5,\"A.ini\",\"Body\",null,null,[3,0,0],[]]"
+    payload = {"meshes": {
+        "Body-0": {
+            "component": "Body", "drawindexed": [3, 0, 0],
+            "identity": {"key": canonical},
+        },
+        "Body-1": {
+            "component": "Body", "drawindexed": [6, 0, 0],
+        },
+    }}
+    adjustment = {
+        "hue": 35, "saturation": 1, "brightness": 1, "contrast": 1,
+        "red": 1, "green": 1, "blue": 1,
+        "tint": "#ffffff", "tint_strength": 0.25,
+    }
+    hydrated = metadata.hydrate_mesh_color_adjustments(payload, {
+        "mesh_color_adjustments": {
+            canonical: adjustment,
+            "Body::6,0,0": adjustment,
+        },
+    })
+
+    assert hydrated == {
+        canonical: adjustment,
+        "Body::6,0,0": adjustment,
+    }

--- a/src/tests/web/support.py
+++ b/src/tests/web/support.py
@@ -335,7 +335,8 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                    "consumeStartupRequest": [],
                    "panelOpacity": [], "presentState": [],
                    "controlState": [], "meshSemantics": [],
-                   "deleteToggle": [], "exportChanges": []},
+                   "deleteToggle": [], "exportChanges": [],
+                   "saveMeshColorAdjustment": []},
     }
     encoded_state = json.dumps(json.dumps(state))
     context.add_init_script(
@@ -566,6 +567,10 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
             get_ini_text: async () => ({ini: 'A.ini', text: '[Test]\\nkey = 1\\n', dirty: false}),
             update_ini_text: async () => ({pending: true}),
             save_mesh_textures: async () => ({}),
+            save_mesh_color_adjustment: async (path, key, adjustment) => {
+              state.calls.saveMeshColorAdjustment.push([path, key, adjustment]);
+              return {};
+            },
             save_mesh_names: async () => ({}),
             save_weight_selection: async (_path, bones) => ({
               saved: true, selected_bones: [...bones],

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -3854,6 +3854,16 @@ def test_texture_stays_fallback_until_png_load_completes(
         pending_pixel = _sample_mesh_pixel(page)
         assert min(pending_pixel) > 20
         assert max(pending_pixel) - min(pending_pixel) < 30
+        page.evaluate("""async () => {
+          const {setMeshColorAdjustment} = await import(
+            './js/mesh/mesh-color-state.js');
+          setMeshColorAdjustment(window.modViewer.activeMeshes[0], {
+            hue: 0, saturation: 1, brightness: 0, contrast: 1,
+            red: 1, green: 1, blue: 1, tint: '#ffffff', tintStrength: 0,
+          });
+        }""")
+        page.wait_for_timeout(250)
+        assert _sample_mesh_pixel(page) == pytest.approx(pending_pixel, abs=2)
 
         idle_count = page.evaluate("window.modViewer.getRenderCount()")
         page.wait_for_timeout(200)
@@ -3880,8 +3890,63 @@ def test_texture_stays_fallback_until_png_load_completes(
         page.wait_for_function(
             "count => window.modViewer.getRenderCount() > count", arg=changed_count)
         loaded_pixel = _sample_mesh_pixel(page)
-        assert loaded_pixel[0] > loaded_pixel[1] * 1.5, loaded_pixel
-        assert loaded_pixel != pending_pixel, (pending_pixel, loaded_pixel)
+        assert any(abs(left - right) > 5
+                   for left, right in zip(loaded_pixel, pending_pixel)), (
+                       pending_pixel, loaded_pixel)
+    finally:
+        context.close()
+
+def test_mesh_color_adjustment_does_not_recolor_flat_texture_fallback(
+        edge_browser, frontend_url):
+    payload = _payload("FallbackColor")
+    entry = payload["meshes"]["Body-FallbackColor-0"]
+    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    entry["pos"] = _f32(-1, -1, 0, 1, -1, 0, -1, 1, 0)
+    entry["idx"] = _u32(0, 1, 2)
+    entry["drawindexed"] = [3, 0, 0]
+    payload["textures"] = {
+        entry["tex_key"]: _flat_png_uri((220, 40, 40, 255)),
+    }
+    context, page = _page(edge_browser, frontend_url, {"FallbackColor": payload})
+    try:
+        _open(page, "FallbackColor")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 1")
+        page.wait_for_function("""() => window.modViewer.activeMeshes[0]
+          ?.material?.userData?.gameMaterial?.bindings?.diffuse
+          ?.enabledNode?.value === true""")
+        page.wait_for_timeout(250)
+        page.evaluate("""async () => {
+          const {setTextureDisplayMode} = await import(
+            './js/scene/render-modes.js');
+          setTextureDisplayMode('none', window.modViewer.activeMeshes);
+        }""")
+        page.wait_for_timeout(250)
+        fallback_pixel = _sample_mesh_pixel_at(page, -0.25, -0.25)
+        page.evaluate("""async () => {
+          const {setMeshColorAdjustment} = await import(
+            './js/mesh/mesh-color-state.js');
+          setMeshColorAdjustment(window.modViewer.activeMeshes[0], {
+            hue: 0, saturation: 1, brightness: 0, contrast: 1,
+            red: 1, green: 1, blue: 1, tint: '#4080c0', tintStrength: 1,
+          });
+        }""")
+        page.wait_for_timeout(250)
+        assert _sample_mesh_pixel_at(page, -0.25, -0.25) == pytest.approx(
+            fallback_pixel, abs=2)
+
+        page.evaluate("""async () => {
+          const {setTextureDisplayMode} = await import(
+            './js/scene/render-modes.js');
+          setTextureDisplayMode('all', window.modViewer.activeMeshes);
+        }""")
+        page.wait_for_function("""() => window.modViewer.activeMeshes[0]
+          ?.material?.userData?.gameMaterial?.bindings?.diffuse
+          ?.enabledNode?.value === true""")
+        page.wait_for_timeout(250)
+        textured_pixel = _sample_mesh_pixel_at(page, -0.25, -0.25)
+        assert any(abs(left - right) > 5
+                   for left, right in zip(textured_pixel, fallback_pixel)), (
+                       fallback_pixel, textured_pixel)
     finally:
         context.close()
 
@@ -4417,12 +4482,24 @@ def test_mesh_color_adjustment_updates_stable_uniforms_and_gates_assets(
           const sameTextureDuringLive = mesh.material.userData.gameMaterial
             .bindings.diffuse.textureNode.value === oldTexture;
           setMeshTextureState(mesh, {diffuse: assetKey});
+          window.__fakeApi.calls.saveMeshColorAdjustment = [];
+          setMeshColorAdjustment(mesh, {
+            ...before.adjustment, hue: 55,
+          }, {persist: true});
+          const assetPersistenceCalls =
+            window.__fakeApi.calls.saveMeshColorAdjustment.length;
           const asset = {
             adjustment: getMeshColorAdjustment(mesh),
             editable: canEditMeshColor(mesh),
             enabled: mesh.material.userData.gameMaterial
               .colorAdjustmentEnabledNode.value,
           };
+          setMeshTextureState(mesh, {diffuse: null});
+          setMeshColorAdjustment(mesh, {
+            ...before.adjustment, hue: 55,
+          }, {persist: true});
+          const noDiffusePersistenceCalls =
+            window.__fakeApi.calls.saveMeshColorAdjustment.length;
           setMeshTextureState(mesh, {diffuse: mesh.userData.defaultTexKey});
           const restored = {
             editable: canEditMeshColor(mesh),
@@ -4435,6 +4512,7 @@ def test_mesh_color_adjustment_updates_stable_uniforms_and_gates_assets(
           });
           return {
             before, live, asset, restored,
+            assetPersistenceCalls, noDiffusePersistenceCalls,
             sameMaterialDuringLive, sameTextureDuringLive,
             materialReplaced: mesh.material !== oldMaterial,
             sameTexture: mesh.material.userData.gameMaterial
@@ -4456,6 +4534,8 @@ def test_mesh_color_adjustment_updates_stable_uniforms_and_gates_assets(
         assert state["asset"]["editable"] == {
             "editable": False, "reason": "asset-texture"}
         assert state["asset"]["enabled"] is False
+        assert state["assetPersistenceCalls"] == 0
+        assert state["noDiffusePersistenceCalls"] == 0
         assert state["restored"] == {
             "editable": {"editable": True, "reason": None},
             "enabled": True, "hue": 55,
@@ -4498,6 +4578,37 @@ def test_mesh_color_adjustment_changes_diffuse_rgb_without_changing_alpha(
         assert after[1] > after[2], (before, after)
         assert page.evaluate(
             "window.modViewer.activeMeshes[0].material.opacity") == opacity
+
+        tints = page.evaluate("""async () => {
+          const {setGameMaterialColorAdjustment,
+            getGameMaterialColorAdjustment} = await import(
+            './js/mesh/material-profile.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          const cases = [
+            ['#808080', 1], ['#4080c0', 1], ['#4080c0', .5],
+          ];
+          return cases.map(([tint, tintStrength]) => {
+            setGameMaterialColorAdjustment(mesh.material, {
+              hue: 0, saturation: 1, brightness: 1, contrast: 1,
+              red: 1, green: 1, blue: 1, tint, tintStrength,
+            }, {enabled: true});
+            return {
+              state: getGameMaterialColorAdjustment(mesh.material),
+              raw: mesh.material.userData.gameMaterial.colorTintNode.value
+                .toArray(),
+            };
+          });
+        }""")
+        assert [item["state"]["tint"] for item in tints] == [
+            "#808080", "#4080c0", "#4080c0"]
+        expected_raw_tints = [
+            [128 / 255, 128 / 255, 128 / 255],
+            [64 / 255, 128 / 255, 192 / 255],
+            [64 / 255, 128 / 255, 192 / 255],
+        ]
+        for actual, expected in zip(
+                [item["raw"] for item in tints], expected_raw_tints):
+            assert actual == pytest.approx(expected)
     finally:
         context.close()
 
@@ -4565,7 +4676,8 @@ def test_material_kind_refresh_hot_swaps_profile_without_reloading_model(
             manualTexOverride: mesh.userData.manualTexOverride,
             normalDataBound: game.bindings.normal_data.enabledNode.value,
             debugMode: window.modViewer.getMaterialState(0).debugMode,
-            selected: game.selectionEnabledNode.value,
+            selected: mesh.userData.viewerOutline.userData.selectionSelected,
+            selectionOutline: window.modViewer.getOutlineState(0),
           };
         }""")
         page.evaluate("""data => {
@@ -4611,7 +4723,8 @@ def test_material_kind_refresh_hot_swaps_profile_without_reloading_model(
             normalDataBound: game.bindings.normal_data.enabledNode.value,
             normalSource: game.normalSource,
             debugMode: window.modViewer.getMaterialState(0).debugMode,
-            selected: game.selectionEnabledNode.value,
+            selected: mesh.userData.viewerOutline.userData.selectionSelected,
+            selectionOutline: window.modViewer.getOutlineState(0),
             wireframe: mesh.material.wireframe,
             flatShading: mesh.material.flatShading,
             roughness: mesh.material.roughness,
@@ -4637,6 +4750,9 @@ def test_material_kind_refresh_hot_swaps_profile_without_reloading_model(
         assert switched["normalSource"] == "normal_data"
         assert switched["debugMode"] == "normal-data-b"
         assert switched["selected"]
+        assert switched["selectionOutline"]["selected"] is True
+        assert switched["selectionOutline"]["visible"] is True
+        assert switched["selectionOutline"]["material"] == "selection"
         assert switched["wireframe"]
         assert switched["flatShading"]
         assert switched["roughness"] == pytest.approx(0.2)
@@ -4660,7 +4776,7 @@ def test_material_kind_refresh_hot_swaps_profile_without_reloading_model(
             materialKindOverride: mesh.userData.materialKindOverride,
             manualTexOverride: mesh.userData.manualTexOverride,
             debugMode: window.modViewer.getMaterialState(0).debugMode,
-            selected: game.selectionEnabledNode.value,
+            selected: mesh.userData.viewerOutline.userData.selectionSelected,
             normalDataBound: game.bindings.normal_data.enabledNode.value,
             wireframe: mesh.material.wireframe,
             flatShading: mesh.material.flatShading,
@@ -6188,6 +6304,7 @@ def test_outline_child_shares_geometry_and_render_modes_suppress_it(
         assert structure["state"]["referenceProjectionSpan"] > 0
         base_outline_state = {
             "attached": True, "visible": False, "globalEnabled": False,
+            "selected": False, "material": "normal",
             "referenceWidthPixels": 0.75,
             "minWidthPixels": 0.5,
             "maxWidthPixels": 1.5,
@@ -6234,6 +6351,68 @@ def test_outline_child_shares_geometry_and_render_modes_suppress_it(
     finally:
         context.close()
 
+
+def test_mesh_selection_uses_outline_without_surface_tint(
+        edge_browser, frontend_url):
+    payload = _payload("SelectionOutline")
+    entry = payload["meshes"]["Body-SelectionOutline-0"]
+    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    entry["pos"] = _f32(-1, -1, 0, 1, -1, 0, -1, 1, 0)
+    entry["idx"] = _u32(0, 1, 2)
+    entry["drawindexed"] = [3, 0, 0]
+    payload["textures"] = {
+        entry["tex_key"]: _flat_png_uri((160, 80, 40, 255)),
+    }
+    context, page = _page(
+        edge_browser, frontend_url, {"SelectionOutline": payload})
+    try:
+        _open(page, "SelectionOutline")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 1")
+        page.wait_for_function("""() => window.modViewer.activeMeshes[0]
+          ?.material?.userData?.gameMaterial?.bindings?.diffuse
+          ?.enabledNode?.value === true""")
+        page.wait_for_timeout(250)
+        before = _sample_mesh_pixel_at(page, -0.25, -0.25)
+        render_count = page.evaluate("window.modViewer.getRenderCount()")
+        page.evaluate("""async () => {
+          const {selectMesh} = await import('./js/scene/selection.js');
+          selectMesh(window.modViewer.activeMeshes[0]);
+        }""")
+        page.wait_for_function(
+            "count => window.modViewer.getRenderCount() > count",
+            arg=render_count)
+        after = _sample_mesh_pixel_at(page, -0.25, -0.25)
+        assert after == pytest.approx(before, abs=3), (before, after)
+
+        selected = page.evaluate("""async () => {
+          const mesh = window.modViewer.activeMeshes[0];
+          const outline = mesh.userData.viewerOutline;
+          return {
+            state: window.modViewer.getOutlineState(0),
+            outlineRaycastDisabled: outline.raycast !== mesh.raycast,
+          };
+        }""")
+        assert selected["state"]["selected"] is True
+        assert selected["state"]["visible"] is True
+        assert selected["state"]["material"] == "selection"
+        assert selected["outlineRaycastDisabled"] is True
+
+        page.evaluate("import('./js/scene/selection.js').then(({clearSelection}) => clearSelection())")
+        deselected = page.evaluate("window.modViewer.getOutlineState(0)")
+        assert deselected["selected"] is False
+        assert deselected["visible"] is False
+        assert deselected["material"] == "normal"
+        page.evaluate("window.modViewer.setOutlineEnabled(true)")
+        normal = page.evaluate("window.modViewer.getOutlineState(0)")
+        assert normal["visible"] is True
+        assert normal["selected"] is False
+        assert normal["material"] == "normal"
+        page.evaluate("window.modViewer.setOutlineEnabled(false)")
+        hidden = page.evaluate("window.modViewer.getOutlineState(0)")
+        assert hidden["visible"] is False
+        assert hidden["material"] == "normal"
+    finally:
+        context.close()
 
 def test_outline_width_is_perspective_correct_and_material_stable(
         edge_browser, frontend_url):

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -4347,6 +4347,161 @@ def test_packed_material_profile_uses_tsl_nodes_and_stable_bindings(
     finally:
         context.close()
 
+
+def test_asset_texture_identity_is_reserved_to_the_canonical_namespace(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {})
+    try:
+        result = page.evaluate("""async () => {
+          const {isAssetTextureKey} = await import('./js/textures/texture-key.js');
+          return [
+            isAssetTextureKey('diffuse::BodyDiffuse.dds'),
+            isAssetTextureKey('diffuse::Textures/Body.dds'),
+            isAssetTextureKey('diffuse::asset/abc123/BodyDiffuse.dds'),
+            isAssetTextureKey('normal_map::asset/abc123/BodyNormal.dds'),
+            isAssetTextureKey('diffuse::textures/my_asset_copy.dds'),
+            isAssetTextureKey('invalid'),
+          ];
+        }""")
+        assert result == [False, False, True, True, False, False]
+    finally:
+        context.close()
+
+
+def test_mesh_color_adjustment_updates_stable_uniforms_and_gates_assets(
+        edge_browser, frontend_url):
+    payload = _payload("Color")
+    entry = payload["meshes"]["Body-Color-0"]
+    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    asset_key = "diffuse::asset/root/Body.dds"
+    payload["textures"][entry["tex_key"]] = _flat_png_uri((255, 0, 0, 255))
+    payload["textures"][asset_key] = _flat_png_uri((0, 255, 0, 255))
+    payload["metadata"]["mesh_color_adjustments"] = {
+        "Body Color::3,0,0": {
+            "hue": 40, "saturation": 1, "brightness": 1, "contrast": 1,
+            "red": 1, "green": 1, "blue": 1,
+            "tint": "#ffffff", "tint_strength": 0,
+        },
+    }
+    context, page = _page(edge_browser, frontend_url, {"Color": payload})
+    try:
+        _open(page, "Color")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 1")
+        page.wait_for_function("""() => {
+          const game = window.modViewer.activeMeshes[0]?.material
+            ?.userData?.gameMaterial;
+          return game?.bindings?.diffuse?.enabledNode?.value === true;
+        }""")
+        state = page.evaluate("""async assetKey => {
+          const {getMeshColorAdjustment, canEditMeshColor,
+            setMeshColorAdjustment} = await import('./js/mesh/mesh-color-state.js');
+          const {getGameMaterialColorAdjustment} =
+            await import('./js/mesh/material-profile.js');
+          const {setMeshTextureState} = await import('./js/mesh/mesh-factory.js');
+          const {replaceMeshMaterial} = await import('./js/mesh/mesh-material-state.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          const oldMaterial = mesh.material;
+          const oldTexture = oldMaterial.userData.gameMaterial
+            .bindings.diffuse.textureNode.value;
+          const before = {
+            adjustment: getMeshColorAdjustment(mesh),
+            editable: canEditMeshColor(mesh),
+            enabled: oldMaterial.userData.gameMaterial
+              .colorAdjustmentEnabledNode.value,
+          };
+          setMeshColorAdjustment(mesh, {
+            ...before.adjustment, hue: 55,
+          }, {persist: false});
+          const live = getGameMaterialColorAdjustment(mesh.material);
+          const sameMaterialDuringLive = mesh.material === oldMaterial;
+          const sameTextureDuringLive = mesh.material.userData.gameMaterial
+            .bindings.diffuse.textureNode.value === oldTexture;
+          setMeshTextureState(mesh, {diffuse: assetKey});
+          const asset = {
+            adjustment: getMeshColorAdjustment(mesh),
+            editable: canEditMeshColor(mesh),
+            enabled: mesh.material.userData.gameMaterial
+              .colorAdjustmentEnabledNode.value,
+          };
+          setMeshTextureState(mesh, {diffuse: mesh.userData.defaultTexKey});
+          const restored = {
+            editable: canEditMeshColor(mesh),
+            enabled: mesh.material.userData.gameMaterial
+              .colorAdjustmentEnabledNode.value,
+            hue: getGameMaterialColorAdjustment(mesh.material).hue,
+          };
+          replaceMeshMaterial(mesh, mesh.userData.materialProfile, {}, {
+            render: false,
+          });
+          return {
+            before, live, asset, restored,
+            sameMaterialDuringLive, sameTextureDuringLive,
+            materialReplaced: mesh.material !== oldMaterial,
+            sameTexture: mesh.material.userData.gameMaterial
+              .bindings.diffuse.textureNode.value === oldTexture,
+            afterReplacement: {
+              hue: getGameMaterialColorAdjustment(mesh.material).hue,
+              enabled: mesh.material.userData.gameMaterial
+                .colorAdjustmentEnabledNode.value,
+            },
+          };
+        }""", asset_key)
+        assert state["before"]["adjustment"]["hue"] == 40
+        assert state["before"]["editable"] == {"editable": True, "reason": None}
+        assert state["before"]["enabled"] is True
+        assert state["live"]["hue"] == 55
+        assert state["sameMaterialDuringLive"] is True
+        assert state["sameTextureDuringLive"] is True
+        assert state["asset"]["adjustment"]["hue"] == 55
+        assert state["asset"]["editable"] == {
+            "editable": False, "reason": "asset-texture"}
+        assert state["asset"]["enabled"] is False
+        assert state["restored"] == {
+            "editable": {"editable": True, "reason": None},
+            "enabled": True, "hue": 55,
+        }
+        assert state["materialReplaced"] is True
+        assert state["afterReplacement"] == {"hue": 55, "enabled": True}
+    finally:
+        context.close()
+
+def test_mesh_color_adjustment_changes_diffuse_rgb_without_changing_alpha(
+        edge_browser, frontend_url):
+    payload = _payload("ColorRender")
+    entry = payload["meshes"]["Body-ColorRender-0"]
+    entry["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    entry["pos"] = _f32(-1, -1, 0, 1, -1, 0, -1, 1, 0)
+    entry["idx"] = _u32(0, 1, 2)
+    entry["drawindexed"] = [3, 0, 0]
+    payload["textures"] = {
+        entry["tex_key"]: _flat_png_uri((255, 0, 0, 255)),
+    }
+    context, page = _page(edge_browser, frontend_url, {"ColorRender": payload})
+    try:
+        _open(page, "ColorRender")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 1")
+        page.wait_for_timeout(250)
+        opacity = page.evaluate("window.modViewer.activeMeshes[0].material.opacity")
+        before = _sample_mesh_pixel_at(page, -0.5, -0.5)
+        page.evaluate("""async () => {
+          const {setMeshColorAdjustment} = await import(
+            './js/mesh/mesh-color-state.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          setMeshColorAdjustment(mesh, {
+            hue: 120, saturation: 1, brightness: 1, contrast: 1,
+            red: 1, green: 1, blue: 1, tint: '#ffffff', tintStrength: 0,
+          });
+        }""")
+        page.wait_for_timeout(250)
+        after = _sample_mesh_pixel_at(page, -0.5, -0.5)
+        assert after[1] > after[0], (before, after)
+        assert after[1] > after[2], (before, after)
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].material.opacity") == opacity
+    finally:
+        context.close()
+
+
 def test_material_kind_refresh_hot_swaps_profile_without_reloading_model(
         edge_browser, frontend_url):
     payload = _packed_material_payload("wuwa:rabbitfx")

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -4555,6 +4555,7 @@ def test_mesh_color_adjustment_changes_diffuse_rgb_without_changing_alpha(
     entry["drawindexed"] = [3, 0, 0]
     payload["textures"] = {
         entry["tex_key"]: _flat_png_uri((255, 0, 0, 255)),
+        "diffuse::ColorRender-white.png": _flat_png_uri((255, 255, 255, 255)),
     }
     context, page = _page(edge_browser, frontend_url, {"ColorRender": payload})
     try:
@@ -4609,6 +4610,56 @@ def test_mesh_color_adjustment_changes_diffuse_rgb_without_changing_alpha(
         for actual, expected in zip(
                 [item["raw"] for item in tints], expected_raw_tints):
             assert actual == pytest.approx(expected)
+
+        white_key = "diffuse::ColorRender-white.png"
+        page.evaluate("""async ({whiteKey}) => {
+          const {setMeshTextureState} = await import(
+            './js/mesh/mesh-factory.js');
+          const {setMeshColorAdjustment} = await import(
+            './js/mesh/mesh-color-state.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          setMeshTextureState(mesh, {diffuse: whiteKey});
+          setMeshColorAdjustment(mesh, {
+            hue: 0, saturation: 1, brightness: 1, contrast: 1,
+            red: 1, green: 1, blue: 1, tint: '#ffffff', tintStrength: 0,
+          });
+        }""", {"whiteKey": white_key})
+        page.wait_for_function("""() =>
+          window.modViewer.activeMeshes[0]?.material?.userData?.gameMaterial
+            ?.bindings?.diffuse?.textureNode?.value?.image?.width === 4""")
+        page.wait_for_timeout(250)
+        neutral_rendered = _sample_mesh_pixel_at(page, -0.25, -0.25)
+
+        page.evaluate("""async () => {
+          const {setMeshColorAdjustment} = await import(
+            './js/mesh/mesh-color-state.js');
+          setMeshColorAdjustment(window.modViewer.activeMeshes[0], {
+            hue: 0, saturation: 1, brightness: 1, contrast: 1,
+            red: 1, green: 1, blue: 1, tint: '#4080c0', tintStrength: 1,
+          });
+        }""")
+        page.wait_for_timeout(250)
+        full_rendered = _sample_mesh_pixel_at(page, -0.25, -0.25)
+
+        page.evaluate("""async () => {
+          const {setMeshColorAdjustment} = await import(
+            './js/mesh/mesh-color-state.js');
+          setMeshColorAdjustment(window.modViewer.activeMeshes[0], {
+            hue: 0, saturation: 1, brightness: 1, contrast: 1,
+            red: 1, green: 1, blue: 1, tint: '#4080c0', tintStrength: .5,
+          });
+        }""")
+        page.wait_for_timeout(250)
+        half_rendered = _sample_mesh_pixel_at(page, -0.25, -0.25)
+
+        assert full_rendered[2] > full_rendered[1] > full_rendered[0], (
+            neutral_rendered, full_rendered)
+        assert any(abs(neutral - full) > 5
+                   for neutral, full in zip(neutral_rendered, full_rendered))
+        for neutral, full, half in zip(
+                neutral_rendered, full_rendered, half_rendered):
+            assert min(neutral, full) - 3 <= half <= max(neutral, full) + 3, (
+                neutral_rendered, full_rendered, half_rendered)
     finally:
         context.close()
 
@@ -4751,7 +4802,8 @@ def test_material_kind_refresh_hot_swaps_profile_without_reloading_model(
         assert switched["debugMode"] == "normal-data-b"
         assert switched["selected"]
         assert switched["selectionOutline"]["selected"] is True
-        assert switched["selectionOutline"]["visible"] is True
+        assert switched["selectionOutline"]["visible"] is False
+        assert switched["selectionOutline"]["suppressedByDebug"] is True
         assert switched["selectionOutline"]["material"] == "selection"
         assert switched["wireframe"]
         assert switched["flatShading"]
@@ -6396,6 +6448,28 @@ def test_mesh_selection_uses_outline_without_surface_tint(
         assert selected["state"]["visible"] is True
         assert selected["state"]["material"] == "selection"
         assert selected["outlineRaycastDisabled"] is True
+
+        page.locator("#wire-btn").click()
+        wireframe_selected = page.evaluate("window.modViewer.getOutlineState(0)")
+        assert wireframe_selected["selected"] is True
+        assert wireframe_selected["visible"] is False
+        assert wireframe_selected["suppressedByWireframe"] is True
+        page.locator("#wire-btn").click()
+        wireframe_disabled = page.evaluate("window.modViewer.getOutlineState(0)")
+        assert wireframe_disabled["selected"] is True
+        assert wireframe_disabled["visible"] is True
+        assert wireframe_disabled["suppressedByWireframe"] is False
+
+        page.evaluate("window.modViewer.setMaterialDebugMode('shadow-mask')")
+        debug_selected = page.evaluate("window.modViewer.getOutlineState(0)")
+        assert debug_selected["selected"] is True
+        assert debug_selected["visible"] is False
+        assert debug_selected["suppressedByDebug"] is True
+        page.evaluate("window.modViewer.setMaterialDebugMode('off')")
+        debug_disabled = page.evaluate("window.modViewer.getOutlineState(0)")
+        assert debug_disabled["selected"] is True
+        assert debug_disabled["visible"] is True
+        assert debug_disabled["suppressedByDebug"] is False
 
         page.evaluate("import('./js/scene/selection.js').then(({clearSelection}) => clearSelection())")
         deselected = page.evaluate("window.modViewer.getOutlineState(0)")

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -101,12 +101,16 @@ def test_mesh_row_selection_invalidates_on_demand_renderer(
           return window.modViewer.activeMeshes.map(mesh => ({
             emissive: mesh.material.emissive.getHex(),
             intensity: mesh.material.emissiveIntensity,
-            selected: mesh.material.userData.gameMaterial.selectionEnabledNode.value,
+            selected: mesh.userData.viewerOutline.userData.selectionSelected,
+            outlineVisible: mesh.userData.viewerOutline.visible,
+            outlineMaterial: mesh.userData.viewerOutline.material.color.getHex(),
           }));
         }""")
         assert first_state == [
-            {"emissive": 0x000000, "intensity": 1, "selected": True},
-            {"emissive": 0x000000, "intensity": 1, "selected": False},
+            {"emissive": 0x000000, "intensity": 1, "selected": True,
+             "outlineVisible": True, "outlineMaterial": 0xffd60a},
+            {"emissive": 0x000000, "intensity": 1, "selected": False,
+             "outlineVisible": False, "outlineMaterial": 0x111318},
         ]
 
         selected_count = page.evaluate("window.modViewer.getRenderCount()")
@@ -120,12 +124,16 @@ def test_mesh_row_selection_invalidates_on_demand_renderer(
           return window.modViewer.activeMeshes.map(mesh => ({
             emissive: mesh.material.emissive.getHex(),
             intensity: mesh.material.emissiveIntensity,
-            selected: mesh.material.userData.gameMaterial.selectionEnabledNode.value,
+            selected: mesh.userData.viewerOutline.userData.selectionSelected,
+            outlineVisible: mesh.userData.viewerOutline.visible,
+            outlineMaterial: mesh.userData.viewerOutline.material.color.getHex(),
           }));
         }""")
         assert second_state == [
-            {"emissive": 0x000000, "intensity": 1, "selected": False},
-            {"emissive": 0x000000, "intensity": 1, "selected": True},
+            {"emissive": 0x000000, "intensity": 1, "selected": False,
+             "outlineVisible": False, "outlineMaterial": 0x111318},
+            {"emissive": 0x000000, "intensity": 1, "selected": True,
+             "outlineVisible": True, "outlineMaterial": 0xffd60a},
         ]
 
         final_count = page.evaluate("window.modViewer.getRenderCount()")

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -803,7 +803,7 @@ def test_inspector_follows_component_and_mesh_selection(
         assert inspector.locator(".inspector-header h3").inner_text()
         assert inspector.locator(".inspector-context").inner_text() == "Body A"
         assert inspector.locator(".inspector-section-title").all_inner_texts() == [
-            "MATERIAL", "TEXTURE"]
+            "MATERIAL", "TEXTURE", "COLOR"]
         assert "State" not in inspector.inner_text()
         assert "Material kind" not in inspector.inner_text()
         assert "Texture provenance" not in inspector.inner_text()
@@ -863,6 +863,87 @@ def test_inspector_follows_component_and_mesh_selection(
         assert not page.locator("#inspector-panel").is_hidden()
     finally:
         context.close()
+
+def test_inspector_color_controls_gate_asset_textures_and_persist_on_change(
+        edge_browser, frontend_url):
+    payload = _payload("ColorUI")
+    payload["metadata"]["mesh_color_adjustments"] = {
+        "Body ColorUI::3,0,0": {
+            "hue": 30, "saturation": 1.15, "brightness": 1,
+            "contrast": 1, "red": 1, "green": 1, "blue": 1,
+            "tint": "#ffffff", "tint_strength": 0,
+        },
+    }
+    context, page = _page(edge_browser, frontend_url, {"ColorUI": payload})
+    try:
+        _open(page, "ColorUI")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        color = page.locator(".inspector-color-section")
+        assert color.locator(".inspector-color-slider").count() == 8
+        hue = color.locator("[data-color-field='hue'] .inspector-color-slider")
+        assert hue.input_value() == "30"
+        assert color.locator("[data-color-field='saturation'] .inspector-color-value").inner_text() == "115%"
+
+        before_loads = page.evaluate("window.__fakeApi.calls.loadMod.length")
+        page.evaluate("""() => {
+          const slider = document.querySelector(
+            '[data-color-field="hue"] .inspector-color-slider');
+          slider.value = '55';
+          slider.dispatchEvent(new Event('input', {bubbles: true}));
+        }""")
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue") == 55
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].material.userData.gameMaterial.colorAdjustmentEnabledNode.value")
+        assert page.evaluate("window.__fakeApi.calls.loadMod.length") == before_loads
+        page.evaluate("""() => document.querySelector(
+          '[data-color-field="hue"] .inspector-color-slider')
+          .dispatchEvent(new Event('change', {bubbles: true}))""")
+        page.wait_for_function(
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length === 1")
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment[0][2].hue") == 55
+
+        page.evaluate("""async () => {
+          const {setMeshTextureState} = await import('./js/mesh/mesh-factory.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          setMeshTextureState(mesh, {diffuse: 'diffuse::asset/root/Body.dds'});
+          window.dispatchEvent(new CustomEvent('mod-viewer-mesh-state-changed', {
+            detail: {meshes: [mesh]},
+          }));
+        }""")
+        page.locator(".inspector-color-readonly-title").wait_for()
+        assert color.locator(".inspector-color-slider").count() == 0
+        assert "Color editing is unavailable for Asset textures." in color.inner_text()
+
+        page.evaluate("""async () => {
+          const {setMeshTextureState} = await import('./js/mesh/mesh-factory.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          setMeshTextureState(mesh, {diffuse: mesh.userData.defaultTexKey});
+          window.dispatchEvent(new CustomEvent('mod-viewer-mesh-state-changed', {
+            detail: {meshes: [mesh]},
+          }));
+        }""")
+        page.locator(".inspector-color-slider").first.wait_for()
+        assert page.locator(
+            "[data-color-field='hue'] .inspector-color-slider").input_value() == "55"
+
+        page.evaluate("""async () => {
+          const {setMeshTextureState} = await import('./js/mesh/mesh-factory.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          setMeshTextureState(mesh, {diffuse: null});
+          window.dispatchEvent(new CustomEvent('mod-viewer-mesh-state-changed', {
+            detail: {meshes: [mesh]},
+          }));
+        }""")
+        page.locator(".inspector-color-readonly-title").wait_for()
+        assert page.locator(".inspector-color-readonly-title").inner_text() == (
+            "No diffuse texture")
+    finally:
+        context.close()
+
 
 def test_viewport_toolbar_popovers_and_responsive_overflow(
         edge_browser, frontend_url):

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -1150,6 +1150,31 @@ button:focus-visible, input:focus-visible, select:focus-visible,
 .inspector-texture-option:hover, .inspector-texture-option.selected {
   color: var(--accent-soft); border-color: var(--accent-soft); background: var(--surface-active);
 }
+.inspector-color-section { gap: 8px; }
+.inspector-color-control {
+  display: grid; grid-template-columns: 76px minmax(0, 1fr) 44px;
+  align-items: center; gap: 7px; font-size: 11px; cursor: default;
+}
+.inspector-color-control-heading { color: var(--text-muted); }
+.inspector-color-slider { width: 100%; accent-color: var(--accent-soft); cursor: pointer; }
+.inspector-color-value {
+  color: var(--accent-soft); text-align: right; font-variant-numeric: tabular-nums;
+}
+.inspector-color-subtitle {
+  padding-top: 4px; color: var(--text-muted); font-size: 9px; font-weight: 700;
+  letter-spacing: .1em; text-transform: uppercase;
+}
+.inspector-color-tint {
+  display: grid; grid-template-columns: 76px minmax(0, 1fr) 65px;
+  align-items: center; gap: 7px; font-size: 11px;
+}
+.inspector-color-tint-input {
+  width: 100%; height: 24px; padding: 1px; border: 1px solid var(--border);
+  border-radius: var(--radius-sm); background: var(--surface-raised); cursor: pointer;
+}
+.inspector-color-reset { width: 100%; margin-top: 2px; }
+.inspector-color-readonly-title { color: var(--text); font-size: 11px; font-weight: 600; }
+.inspector-color-readonly { color: var(--text-muted); font-size: 11px; line-height: 1.4; }
 #mod-folder-empty[hidden] { display: none; }
 #mod-folder-empty .ui-button { margin-top: 5px; }
 .mod-folder-row { min-height: 32px; padding: 3px 0; }

--- a/src/web/js/app/model-flow.js
+++ b/src/web/js/app/model-flow.js
@@ -196,6 +196,7 @@ export async function displayMeshPayload(payload, {
     meshes, modelPath, payload.metadata?.mesh_names || {},
     payload.metadata?.material_profiles || {},
     {
+      colorAdjustments: payload.metadata?.mesh_color_adjustments || {},
       onMaterialKindChanged: assetMode ? null : onMaterialKindChanged,
       texturePools: payload.texture_pools || {},
       assetResolution: payload.asset_resolution || null,

--- a/src/web/js/mesh/color-adjustment.js
+++ b/src/web/js/mesh/color-adjustment.js
@@ -1,0 +1,107 @@
+// Pure, shared schema helpers for viewer-owned mesh color adjustments.
+
+export const DEFAULT_COLOR_ADJUSTMENT = Object.freeze({
+  hue: 0,
+  saturation: 1,
+  brightness: 1,
+  contrast: 1,
+  red: 1,
+  green: 1,
+  blue: 1,
+  tint: '#ffffff',
+  tintStrength: 0,
+});
+
+const COLOR_RANGES = Object.freeze({
+  hue: [-180, 180],
+  saturation: [0, 2],
+  brightness: [0, 2],
+  contrast: [0, 2],
+  red: [0, 2],
+  green: [0, 2],
+  blue: [0, 2],
+  tintStrength: [0, 1],
+});
+
+const TINT_PATTERN = /^#[0-9a-f]{6}$/i;
+
+function finiteNumber(value, fallback) {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value : fallback;
+}
+
+function clamp(value, [minimum, maximum]) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function tintValue(value) {
+  return typeof value === 'string' && TINT_PATTERN.test(value)
+    ? value.toLowerCase() : DEFAULT_COLOR_ADJUSTMENT.tint;
+}
+
+/** Normalize frontend or backend-shaped state to the canonical JS shape. */
+export function normalizeColorAdjustment(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const read = (name, legacyName = name) =>
+    source[name] ?? source[legacyName];
+  return {
+    hue: clamp(finiteNumber(read('hue'), DEFAULT_COLOR_ADJUSTMENT.hue),
+      COLOR_RANGES.hue),
+    saturation: clamp(
+      finiteNumber(read('saturation'), DEFAULT_COLOR_ADJUSTMENT.saturation),
+      COLOR_RANGES.saturation),
+    brightness: clamp(
+      finiteNumber(read('brightness'), DEFAULT_COLOR_ADJUSTMENT.brightness),
+      COLOR_RANGES.brightness),
+    contrast: clamp(
+      finiteNumber(read('contrast'), DEFAULT_COLOR_ADJUSTMENT.contrast),
+      COLOR_RANGES.contrast),
+    red: clamp(finiteNumber(read('red'), DEFAULT_COLOR_ADJUSTMENT.red),
+      COLOR_RANGES.red),
+    green: clamp(
+      finiteNumber(read('green'), DEFAULT_COLOR_ADJUSTMENT.green),
+      COLOR_RANGES.green),
+    blue: clamp(
+      finiteNumber(read('blue'), DEFAULT_COLOR_ADJUSTMENT.blue),
+      COLOR_RANGES.blue),
+    tint: tintValue(read('tint')),
+    tintStrength: clamp(
+      finiteNumber(read('tintStrength', 'tint_strength'),
+        DEFAULT_COLOR_ADJUSTMENT.tintStrength), COLOR_RANGES.tintStrength),
+  };
+}
+
+export function isNeutralColorAdjustment(value) {
+  const adjustment = normalizeColorAdjustment(value);
+  return adjustment.hue === 0
+    && adjustment.saturation === 1
+    && adjustment.brightness === 1
+    && adjustment.contrast === 1
+    && adjustment.red === 1
+    && adjustment.green === 1
+    && adjustment.blue === 1
+    && adjustment.tint === '#ffffff'
+    && adjustment.tintStrength === 0;
+}
+
+/** Parse picker sRGB bytes without Three.js color-management conversion. */
+export function tintRgbFromHex(value) {
+  const tint = tintValue(value);
+  return [
+    parseInt(tint.slice(1, 3), 16) / 255,
+    parseInt(tint.slice(3, 5), 16) / 255,
+    parseInt(tint.slice(5, 7), 16) / 255,
+  ];
+}
+
+/** Format a raw sRGB vector back to the color-picker representation. */
+export function tintHexFromRgb(value) {
+  if (!value) return DEFAULT_COLOR_ADJUSTMENT.tint;
+  const channels = [value.x, value.y, value.z].map(channel =>
+    Number.isFinite(channel) ? Math.min(1, Math.max(0, channel)) : null);
+  if (channels.some(channel => channel === null)) {
+    return DEFAULT_COLOR_ADJUSTMENT.tint;
+  }
+  return `#${channels.map(channel => Math.round(channel * 255)
+    .toString(16).padStart(2, '0')).join('')}`;
+}

--- a/src/web/js/mesh/material-profile.js
+++ b/src/web/js/mesh/material-profile.js
@@ -3,7 +3,6 @@
 // through stable TSL nodes and their bindings are changed in place.
 
 import {
-  Color,
   DataTexture,
   DoubleSide,
   MeshPhysicalNodeMaterial,
@@ -16,7 +15,14 @@ import {
   TSL,
   UnsignedByteType,
   Vector2,
+  Vector3,
 } from 'three/webgpu';
+import {
+  DEFAULT_COLOR_ADJUSTMENT,
+  normalizeColorAdjustment,
+  tintHexFromRgb,
+  tintRgbFromHex,
+} from './color-adjustment.js';
 import {
   abs,
   clamp,
@@ -378,18 +384,19 @@ function setStableMaterialNodes(material, state, fallbackColor) {
   const fallbackNormal = orientedGeometryNormal;
   let baseColor;
   if (hasUv) {
-    // The conditional keeps the texture binding live without changing the
-    // material graph when a diffuse texture is loaded or removed.
+    // Apply adjustments only to an active diffuse sample. A loading, failed,
+    // disabled or no-texture state must retain the viewer's flat fallback.
+    const adjustedDiffuse = createColorAdjustmentNode(
+      state, bindings.diffuse.textureNode.rgb);
     baseColor = bindings.diffuse.enabledNode.select(
-      bindings.diffuse.textureNode.rgb, color(fallbackColor));
+      adjustedDiffuse, color(fallbackColor));
     material.normalNode = createProfileNormalNode(
       profile, bindings, state.normalScaleNode, fallbackNormal);
   } else {
     baseColor = color(fallbackColor);
     material.normalNode = fallbackNormal;
   }
-  material.colorNode = createDebugOutputNode(
-    state, createColorAdjustmentNode(state, baseColor));
+  material.colorNode = createDebugOutputNode(state, baseColor);
   material.emissiveNode = state.emissionNode;
 
   if (!state.packedResponse) return;
@@ -427,18 +434,8 @@ function applyViewerRim(state, result) {
   return vec4(result.rgb.add(tint.mul(amount)), result.a);
 }
 
-function applyViewerSelection(state, result) {
-  if (!state?.selectionEnabledNode || !state?.selectionStrengthNode) {
-    return result;
-  }
-  const highlighted = mix(result.rgb, color(0xffd60a), state.selectionStrengthNode);
-  return vec4(
-    mix(result.rgb, highlighted, state.selectionEnabledNode), result.a);
-}
-
 function applyViewerOutput(state, result) {
-  return applyDebugOverride(
-    state, applyViewerSelection(state, applyViewerRim(state, result)));
+  return applyDebugOverride(state, applyViewerRim(state, result));
 }
 
 function createEmissionNode(profile, bindings, hasUv) {
@@ -899,8 +896,6 @@ export function configureGameMaterial(material, profile, options = {}) {
     rimEnabledNode: uniform(true),
     rimStrengthNode: uniform(0.075),
     rimPowerNode: uniform(4.0),
-    selectionEnabledNode: uniform(false),
-    selectionStrengthNode: uniform(0.22),
     colorAdjustmentEnabledNode: uniform(false),
     colorHueNode: uniform(0),
     colorSaturationNode: uniform(1),
@@ -909,7 +904,9 @@ export function configureGameMaterial(material, profile, options = {}) {
     colorRedNode: uniform(1),
     colorGreenNode: uniform(1),
     colorBlueNode: uniform(1),
-    colorTintNode: uniform(new Color(0xffffff)),
+    // Picker values are raw editor-sRGB components. Do not use THREE.Color,
+    // whose hex/CSS setters convert into the linear working color space.
+    colorTintNode: uniform(new Vector3(1, 1, 1)),
     colorTintStrengthNode: uniform(0),
     hasMaterialId,
     hasSpecularArea,
@@ -1052,49 +1049,11 @@ export function getMaterialDebugMode(material) {
     || 'off';
 }
 
-const COLOR_ADJUSTMENT_DEFAULTS = Object.freeze({
-  hue: 0,
-  saturation: 1,
-  brightness: 1,
-  contrast: 1,
-  red: 1,
-  green: 1,
-  blue: 1,
-  tint: '#ffffff',
-  tintStrength: 0,
-});
-
-function colorAdjustmentNumber(value, fallback, minimum, maximum) {
-  const number = typeof value === 'number' && Number.isFinite(value)
-    ? value : fallback;
-  return Math.min(maximum, Math.max(minimum, number));
-}
-
-function colorAdjustmentTint(value) {
-  return typeof value === 'string' && /^#[0-9a-f]{6}$/i.test(value)
-    ? value.toLowerCase() : COLOR_ADJUSTMENT_DEFAULTS.tint;
-}
-
-function normalizedMaterialColorAdjustment(value = {}) {
-  return {
-    hue: colorAdjustmentNumber(value.hue, 0, -180, 180),
-    saturation: colorAdjustmentNumber(value.saturation, 1, 0, 2),
-    brightness: colorAdjustmentNumber(value.brightness, 1, 0, 2),
-    contrast: colorAdjustmentNumber(value.contrast, 1, 0, 2),
-    red: colorAdjustmentNumber(value.red, 1, 0, 2),
-    green: colorAdjustmentNumber(value.green, 1, 0, 2),
-    blue: colorAdjustmentNumber(value.blue, 1, 0, 2),
-    tint: colorAdjustmentTint(value.tint),
-    tintStrength: colorAdjustmentNumber(
-      value.tintStrength ?? value.tint_strength, 0, 0, 1),
-  };
-}
-
 export function getGameMaterialColorAdjustment(material) {
   const state = material?.userData?.gameMaterial;
-  if (!state) return {...COLOR_ADJUSTMENT_DEFAULTS};
+  if (!state) return {...DEFAULT_COLOR_ADJUSTMENT};
   const tint = state.colorTintNode?.value;
-  return normalizedMaterialColorAdjustment({
+  return normalizeColorAdjustment({
     hue: state.colorHueNode?.value,
     saturation: state.colorSaturationNode?.value,
     brightness: state.colorBrightnessNode?.value,
@@ -1102,7 +1061,7 @@ export function getGameMaterialColorAdjustment(material) {
     red: state.colorRedNode?.value,
     green: state.colorGreenNode?.value,
     blue: state.colorBlueNode?.value,
-    tint: tint?.getHexString ? `#${tint.getHexString()}` : '#ffffff',
+    tint: tintHexFromRgb(tint),
     tintStrength: state.colorTintStrengthNode?.value,
   });
 }
@@ -1111,7 +1070,7 @@ export function setGameMaterialColorAdjustment(
     material, adjustment = {}, {enabled = false} = {}) {
   const state = material?.userData?.gameMaterial;
   if (!state?.colorAdjustmentEnabledNode) return false;
-  const value = normalizedMaterialColorAdjustment(adjustment);
+  const value = normalizeColorAdjustment(adjustment);
   let changed = false;
   const scalarNodes = [
     ['colorHueNode', value.hue],
@@ -1129,11 +1088,11 @@ export function setGameMaterialColorAdjustment(
     node.value = next;
   });
   const tintNode = state.colorTintNode;
-  const currentTint = tintNode.value?.getHexString
-    ? `#${tintNode.value.getHexString()}` : '#ffffff';
+  const currentTint = tintHexFromRgb(tintNode.value);
+  const tintRgb = tintRgbFromHex(value.tint);
   changed = currentTint !== value.tint || changed;
-  if (tintNode.value?.set) tintNode.value.set(value.tint);
-  else tintNode.value = new Color(value.tint);
+  if (tintNode.value?.set) tintNode.value.set(...tintRgb);
+  else tintNode.value = new Vector3(...tintRgb);
   const nextEnabled = enabled === true;
   changed = !Object.is(state.colorAdjustmentEnabledNode.value, nextEnabled)
     || changed;
@@ -1146,7 +1105,6 @@ export function captureGameMaterialViewerState(material) {
   const state = material?.userData?.gameMaterial;
   return {
     debugMode: getMaterialDebugMode(material),
-    selectionEnabled: state?.selectionEnabledNode?.value === true,
     colorAdjustment: getGameMaterialColorAdjustment(material),
     colorAdjustmentEnabled: state?.colorAdjustmentEnabledNode?.value === true,
   };
@@ -1155,10 +1113,8 @@ export function captureGameMaterialViewerState(material) {
 /** Restore per-material viewer state onto a newly-created material graph. */
 export function restoreGameMaterialViewerState(material, viewerState = {}) {
   setMaterialDebugMode([material], viewerState.debugMode || 'off');
-  setGameMaterialSelectionEnabled(
-    material, viewerState.selectionEnabled === true);
   setGameMaterialColorAdjustment(
-    material, viewerState.colorAdjustment || COLOR_ADJUSTMENT_DEFAULTS,
+    material, viewerState.colorAdjustment || DEFAULT_COLOR_ADJUSTMENT,
     {enabled: viewerState.colorAdjustmentEnabled === true});
 }
 
@@ -1173,14 +1129,6 @@ export function setGameMaterialRimEnabled(material, enabled) {
 /** Toggle profile-driven toon direct diffuse without rebuilding the material. */
 export function setGameMaterialToonEnabled(material, enabled) {
   const node = material?.userData?.gameMaterial?.toonEnabledNode;
-  if (!node) return false;
-  node.value = enabled === true;
-  return true;
-}
-
-/** Keep selection out of material emissive so MRT bloom sees authored light only. */
-export function setGameMaterialSelectionEnabled(material, enabled) {
-  const node = material?.userData?.gameMaterial?.selectionEnabledNode;
   if (!node) return false;
   node.value = enabled === true;
   return true;

--- a/src/web/js/mesh/material-profile.js
+++ b/src/web/js/mesh/material-profile.js
@@ -3,6 +3,7 @@
 // through stable TSL nodes and their bindings are changed in place.
 
 import {
+  Color,
   DataTexture,
   DoubleSide,
   MeshPhysicalNodeMaterial,
@@ -21,6 +22,7 @@ import {
   clamp,
   color,
   diffuseColor,
+  floor,
   float,
   Fn,
   ior,
@@ -260,6 +262,81 @@ function createRawChannelNode(ref, bindings) {
     : float(0);
 }
 
+function colorMap(rgb, transform) {
+  return vec3(transform(rgb.r), transform(rgb.g), transform(rgb.b));
+}
+
+function linearToEditorSrgbChannel(value) {
+  const clamped = value.clamp(0, 1);
+  return clamped.lessThanEqual(0.0031308)
+    .select(clamped.mul(12.92), clamped.pow(1 / 2.4).mul(1.055).sub(0.055));
+}
+
+function editorSrgbToLinearChannel(value) {
+  const clamped = value.clamp(0, 1);
+  return clamped.lessThanEqual(0.04045)
+    .select(clamped.div(12.92), clamped.add(0.055).div(1.055).pow(2.4));
+}
+
+function rgbToHsv(rgb) {
+  const maximum = rgb.r.max(rgb.g).max(rgb.b);
+  const minimum = rgb.r.min(rgb.g).min(rgb.b);
+  const delta = maximum.sub(minimum);
+  const safeDelta = delta.max(0.000001);
+  const redHue = rgb.g.sub(rgb.b).div(safeDelta);
+  const greenHue = rgb.b.sub(rgb.r).div(safeDelta).add(2);
+  const blueHue = rgb.r.sub(rgb.g).div(safeDelta).add(4);
+  const hue = maximum.equal(rgb.r).select(
+    redHue.lessThan(0).select(redHue.add(6), redHue),
+    maximum.equal(rgb.g).select(greenHue, blueHue),
+  ).div(6);
+  const saturation = maximum.equal(0).select(0, delta.div(maximum));
+  return vec3(hue, saturation, maximum);
+}
+
+function hsvToRgb(hsv) {
+  const hue = hsv.x;
+  const saturation = hsv.y;
+  const value = hsv.z;
+  const sectorValue = hue.mul(6);
+  const sector = floor(sectorValue);
+  const fraction = sectorValue.sub(sector);
+  const p = value.mul(float(1).sub(saturation));
+  const q = value.mul(float(1).sub(saturation.mul(fraction)));
+  const t = value.mul(float(1).sub(
+    saturation.mul(float(1).sub(fraction))));
+  return sector.equal(0).select(vec3(value, t, p),
+    sector.equal(1).select(vec3(q, value, p),
+      sector.equal(2).select(vec3(p, value, t),
+        sector.equal(3).select(vec3(p, q, value),
+          sector.equal(4).select(vec3(t, p, value),
+            vec3(value, p, q))))));
+}
+
+function createColorAdjustmentNode(state, baseColor) {
+  const editorColor = colorMap(baseColor, linearToEditorSrgbChannel);
+  const hsv = rgbToHsv(editorColor);
+  let hue = hsv.x.add(state.colorHueNode.div(360));
+  hue = hue.lessThan(0).select(hue.add(1), hue);
+  hue = hue.greaterThanEqual(1).select(hue.sub(1), hue);
+  const adjustedHsv = vec3(
+    hue,
+    hsv.y.mul(state.colorSaturationNode).clamp(0, 1),
+    hsv.z.mul(state.colorBrightnessNode).clamp(0, 1),
+  );
+  let result = hsvToRgb(adjustedHsv);
+  result = result.sub(0.5).mul(state.colorContrastNode).add(0.5);
+  result = vec3(
+    result.r.mul(state.colorRedNode),
+    result.g.mul(state.colorGreenNode),
+    result.b.mul(state.colorBlueNode),
+  ).clamp(0, 1);
+  result = mix(result, state.colorTintNode, state.colorTintStrengthNode);
+  result = result.clamp(0, 1);
+  result = colorMap(result, editorSrgbToLinearChannel);
+  return state.colorAdjustmentEnabledNode.select(result, baseColor);
+}
+
 function createDebugOutputNode(state, baseColor) {
   // Build the mode table once while the material graph is created.  An
   // unsupported mode has no active branch, so the final output remains the
@@ -311,7 +388,8 @@ function setStableMaterialNodes(material, state, fallbackColor) {
     baseColor = color(fallbackColor);
     material.normalNode = fallbackNormal;
   }
-  material.colorNode = createDebugOutputNode(state, baseColor);
+  material.colorNode = createDebugOutputNode(
+    state, createColorAdjustmentNode(state, baseColor));
   material.emissiveNode = state.emissionNode;
 
   if (!state.packedResponse) return;
@@ -823,6 +901,16 @@ export function configureGameMaterial(material, profile, options = {}) {
     rimPowerNode: uniform(4.0),
     selectionEnabledNode: uniform(false),
     selectionStrengthNode: uniform(0.22),
+    colorAdjustmentEnabledNode: uniform(false),
+    colorHueNode: uniform(0),
+    colorSaturationNode: uniform(1),
+    colorBrightnessNode: uniform(1),
+    colorContrastNode: uniform(1),
+    colorRedNode: uniform(1),
+    colorGreenNode: uniform(1),
+    colorBlueNode: uniform(1),
+    colorTintNode: uniform(new Color(0xffffff)),
+    colorTintStrengthNode: uniform(0),
     hasMaterialId,
     hasSpecularArea,
     hasShadowMask,
@@ -964,12 +1052,103 @@ export function getMaterialDebugMode(material) {
     || 'off';
 }
 
+const COLOR_ADJUSTMENT_DEFAULTS = Object.freeze({
+  hue: 0,
+  saturation: 1,
+  brightness: 1,
+  contrast: 1,
+  red: 1,
+  green: 1,
+  blue: 1,
+  tint: '#ffffff',
+  tintStrength: 0,
+});
+
+function colorAdjustmentNumber(value, fallback, minimum, maximum) {
+  const number = typeof value === 'number' && Number.isFinite(value)
+    ? value : fallback;
+  return Math.min(maximum, Math.max(minimum, number));
+}
+
+function colorAdjustmentTint(value) {
+  return typeof value === 'string' && /^#[0-9a-f]{6}$/i.test(value)
+    ? value.toLowerCase() : COLOR_ADJUSTMENT_DEFAULTS.tint;
+}
+
+function normalizedMaterialColorAdjustment(value = {}) {
+  return {
+    hue: colorAdjustmentNumber(value.hue, 0, -180, 180),
+    saturation: colorAdjustmentNumber(value.saturation, 1, 0, 2),
+    brightness: colorAdjustmentNumber(value.brightness, 1, 0, 2),
+    contrast: colorAdjustmentNumber(value.contrast, 1, 0, 2),
+    red: colorAdjustmentNumber(value.red, 1, 0, 2),
+    green: colorAdjustmentNumber(value.green, 1, 0, 2),
+    blue: colorAdjustmentNumber(value.blue, 1, 0, 2),
+    tint: colorAdjustmentTint(value.tint),
+    tintStrength: colorAdjustmentNumber(
+      value.tintStrength ?? value.tint_strength, 0, 0, 1),
+  };
+}
+
+export function getGameMaterialColorAdjustment(material) {
+  const state = material?.userData?.gameMaterial;
+  if (!state) return {...COLOR_ADJUSTMENT_DEFAULTS};
+  const tint = state.colorTintNode?.value;
+  return normalizedMaterialColorAdjustment({
+    hue: state.colorHueNode?.value,
+    saturation: state.colorSaturationNode?.value,
+    brightness: state.colorBrightnessNode?.value,
+    contrast: state.colorContrastNode?.value,
+    red: state.colorRedNode?.value,
+    green: state.colorGreenNode?.value,
+    blue: state.colorBlueNode?.value,
+    tint: tint?.getHexString ? `#${tint.getHexString()}` : '#ffffff',
+    tintStrength: state.colorTintStrengthNode?.value,
+  });
+}
+
+export function setGameMaterialColorAdjustment(
+    material, adjustment = {}, {enabled = false} = {}) {
+  const state = material?.userData?.gameMaterial;
+  if (!state?.colorAdjustmentEnabledNode) return false;
+  const value = normalizedMaterialColorAdjustment(adjustment);
+  let changed = false;
+  const scalarNodes = [
+    ['colorHueNode', value.hue],
+    ['colorSaturationNode', value.saturation],
+    ['colorBrightnessNode', value.brightness],
+    ['colorContrastNode', value.contrast],
+    ['colorRedNode', value.red],
+    ['colorGreenNode', value.green],
+    ['colorBlueNode', value.blue],
+    ['colorTintStrengthNode', value.tintStrength],
+  ];
+  scalarNodes.forEach(([name, next]) => {
+    const node = state[name];
+    changed = !Object.is(node.value, next) || changed;
+    node.value = next;
+  });
+  const tintNode = state.colorTintNode;
+  const currentTint = tintNode.value?.getHexString
+    ? `#${tintNode.value.getHexString()}` : '#ffffff';
+  changed = currentTint !== value.tint || changed;
+  if (tintNode.value?.set) tintNode.value.set(value.tint);
+  else tintNode.value = new Color(value.tint);
+  const nextEnabled = enabled === true;
+  changed = !Object.is(state.colorAdjustmentEnabledNode.value, nextEnabled)
+    || changed;
+  state.colorAdjustmentEnabledNode.value = nextEnabled;
+  return changed;
+}
+
 /** Capture viewer state that is owned by an individual material instance. */
 export function captureGameMaterialViewerState(material) {
   const state = material?.userData?.gameMaterial;
   return {
     debugMode: getMaterialDebugMode(material),
     selectionEnabled: state?.selectionEnabledNode?.value === true,
+    colorAdjustment: getGameMaterialColorAdjustment(material),
+    colorAdjustmentEnabled: state?.colorAdjustmentEnabledNode?.value === true,
   };
 }
 
@@ -978,6 +1157,9 @@ export function restoreGameMaterialViewerState(material, viewerState = {}) {
   setMaterialDebugMode([material], viewerState.debugMode || 'off');
   setGameMaterialSelectionEnabled(
     material, viewerState.selectionEnabled === true);
+  setGameMaterialColorAdjustment(
+    material, viewerState.colorAdjustment || COLOR_ADJUSTMENT_DEFAULTS,
+    {enabled: viewerState.colorAdjustmentEnabled === true});
 }
 
 /** Toggle viewer rim lighting without rebuilding the material node graph. */

--- a/src/web/js/mesh/mesh-color-state.js
+++ b/src/web/js/mesh/mesh-color-state.js
@@ -1,0 +1,156 @@
+// Viewer-owned per-mesh diffuse color adjustment state.
+
+import { isAssetTextureKey, splitTextureKey } from '../textures/texture-key.js';
+import { setGameMaterialColorAdjustment } from './material-profile.js';
+import { requestRender } from '../scene/render-scheduler.js';
+
+export const DEFAULT_COLOR_ADJUSTMENT = Object.freeze({
+  hue: 0,
+  saturation: 1,
+  brightness: 1,
+  contrast: 1,
+  red: 1,
+  green: 1,
+  blue: 1,
+  tint: '#ffffff',
+  tintStrength: 0,
+});
+
+const COLOR_RANGES = Object.freeze({
+  hue: [-180, 180],
+  saturation: [0, 2],
+  brightness: [0, 2],
+  contrast: [0, 2],
+  red: [0, 2],
+  green: [0, 2],
+  blue: [0, 2],
+  tintStrength: [0, 1],
+});
+
+const TINT_PATTERN = /^#[0-9a-f]{6}$/i;
+
+function finiteNumber(value, fallback) {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value : fallback;
+}
+
+function clamp(value, [minimum, maximum]) {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+function tintValue(value) {
+  return typeof value === 'string' && TINT_PATTERN.test(value)
+    ? value.toLowerCase() : DEFAULT_COLOR_ADJUSTMENT.tint;
+}
+
+/** Normalize frontend or backend-shaped state to the canonical JS shape. */
+export function normalizeColorAdjustment(value) {
+  const source = value && typeof value === 'object' ? value : {};
+  const read = (name, legacyName = name) =>
+    source[name] ?? source[legacyName];
+  return {
+    hue: clamp(finiteNumber(read('hue'), DEFAULT_COLOR_ADJUSTMENT.hue),
+      COLOR_RANGES.hue),
+    saturation: clamp(
+      finiteNumber(read('saturation'), DEFAULT_COLOR_ADJUSTMENT.saturation),
+      COLOR_RANGES.saturation),
+    brightness: clamp(
+      finiteNumber(read('brightness'), DEFAULT_COLOR_ADJUSTMENT.brightness),
+      COLOR_RANGES.brightness),
+    contrast: clamp(
+      finiteNumber(read('contrast'), DEFAULT_COLOR_ADJUSTMENT.contrast),
+      COLOR_RANGES.contrast),
+    red: clamp(finiteNumber(read('red'), DEFAULT_COLOR_ADJUSTMENT.red),
+      COLOR_RANGES.red),
+    green: clamp(
+      finiteNumber(read('green'), DEFAULT_COLOR_ADJUSTMENT.green),
+      COLOR_RANGES.green),
+    blue: clamp(finiteNumber(read('blue'), DEFAULT_COLOR_ADJUSTMENT.blue),
+      COLOR_RANGES.blue),
+    tint: tintValue(read('tint')),
+    tintStrength: clamp(
+      finiteNumber(read('tintStrength', 'tint_strength'),
+        DEFAULT_COLOR_ADJUSTMENT.tintStrength), COLOR_RANGES.tintStrength),
+  };
+}
+
+export function isNeutralColorAdjustment(value) {
+  const adjustment = normalizeColorAdjustment(value);
+  return adjustment.hue === 0
+    && adjustment.saturation === 1
+    && adjustment.brightness === 1
+    && adjustment.contrast === 1
+    && adjustment.red === 1
+    && adjustment.green === 1
+    && adjustment.blue === 1
+    && adjustment.tint === '#ffffff'
+    && adjustment.tintStrength === 0;
+}
+
+export function getMeshColorAdjustment(mesh) {
+  return normalizeColorAdjustment(mesh?.userData?.colorAdjustment);
+}
+
+function persistenceValue(adjustment) {
+  return {
+    hue: adjustment.hue,
+    saturation: adjustment.saturation,
+    brightness: adjustment.brightness,
+    contrast: adjustment.contrast,
+    red: adjustment.red,
+    green: adjustment.green,
+    blue: adjustment.blue,
+    tint: adjustment.tint,
+    tint_strength: adjustment.tintStrength,
+  };
+}
+
+function persistMeshColorAdjustment(mesh) {
+  const path = mesh?.userData?.modPath;
+  const key = mesh?.userData?.metadataKey;
+  const save = window.pywebview?.api?.save_mesh_color_adjustment;
+  if (!path || !key || typeof save !== 'function') return null;
+  const adjustment = getMeshColorAdjustment(mesh);
+  const request = save(path, key, persistenceValue(adjustment));
+  if (request && typeof request.catch === 'function') request.catch(() => {});
+  return request;
+}
+
+/** Return the active diffuse editability and the reason when it is blocked. */
+export function canEditMeshColor(mesh) {
+  const key = mesh?.userData?.texKey;
+  const parsed = splitTextureKey(key);
+  if (!parsed || parsed.role !== 'diffuse') {
+    return { editable: false, reason: 'no-diffuse' };
+  }
+  if (isAssetTextureKey(key)) {
+    return { editable: false, reason: 'asset-texture' };
+  }
+  return { editable: true, reason: null };
+}
+
+export function syncMeshColorAdjustment(mesh, { render = true } = {}) {
+  if (!mesh?.material) return false;
+  const adjustment = getMeshColorAdjustment(mesh);
+  const eligibility = canEditMeshColor(mesh);
+  const changed = setGameMaterialColorAdjustment(mesh.material, adjustment, {
+    enabled: eligibility.editable && !isNeutralColorAdjustment(adjustment),
+  });
+  if (render && (changed || mesh.visible)) requestRender();
+  return changed;
+}
+
+export function setMeshColorAdjustment(mesh, adjustment, {
+  render = true, persist = false, sync = true,
+} = {}) {
+  if (!mesh) return DEFAULT_COLOR_ADJUSTMENT;
+  const normalized = normalizeColorAdjustment(adjustment);
+  mesh.userData.colorAdjustment = normalized;
+  if (sync) syncMeshColorAdjustment(mesh, { render });
+  if (persist && canEditMeshColor(mesh)) persistMeshColorAdjustment(mesh);
+  return normalized;
+}
+
+export function resetMeshColorAdjustment(mesh, options = {}) {
+  return setMeshColorAdjustment(mesh, DEFAULT_COLOR_ADJUSTMENT, options);
+}

--- a/src/web/js/mesh/mesh-color-state.js
+++ b/src/web/js/mesh/mesh-color-state.js
@@ -2,90 +2,11 @@
 
 import { isAssetTextureKey, splitTextureKey } from '../textures/texture-key.js';
 import { setGameMaterialColorAdjustment } from './material-profile.js';
+import {
+  DEFAULT_COLOR_ADJUSTMENT, isNeutralColorAdjustment,
+  normalizeColorAdjustment,
+} from './color-adjustment.js';
 import { requestRender } from '../scene/render-scheduler.js';
-
-export const DEFAULT_COLOR_ADJUSTMENT = Object.freeze({
-  hue: 0,
-  saturation: 1,
-  brightness: 1,
-  contrast: 1,
-  red: 1,
-  green: 1,
-  blue: 1,
-  tint: '#ffffff',
-  tintStrength: 0,
-});
-
-const COLOR_RANGES = Object.freeze({
-  hue: [-180, 180],
-  saturation: [0, 2],
-  brightness: [0, 2],
-  contrast: [0, 2],
-  red: [0, 2],
-  green: [0, 2],
-  blue: [0, 2],
-  tintStrength: [0, 1],
-});
-
-const TINT_PATTERN = /^#[0-9a-f]{6}$/i;
-
-function finiteNumber(value, fallback) {
-  return typeof value === 'number' && Number.isFinite(value)
-    ? value : fallback;
-}
-
-function clamp(value, [minimum, maximum]) {
-  return Math.min(maximum, Math.max(minimum, value));
-}
-
-function tintValue(value) {
-  return typeof value === 'string' && TINT_PATTERN.test(value)
-    ? value.toLowerCase() : DEFAULT_COLOR_ADJUSTMENT.tint;
-}
-
-/** Normalize frontend or backend-shaped state to the canonical JS shape. */
-export function normalizeColorAdjustment(value) {
-  const source = value && typeof value === 'object' ? value : {};
-  const read = (name, legacyName = name) =>
-    source[name] ?? source[legacyName];
-  return {
-    hue: clamp(finiteNumber(read('hue'), DEFAULT_COLOR_ADJUSTMENT.hue),
-      COLOR_RANGES.hue),
-    saturation: clamp(
-      finiteNumber(read('saturation'), DEFAULT_COLOR_ADJUSTMENT.saturation),
-      COLOR_RANGES.saturation),
-    brightness: clamp(
-      finiteNumber(read('brightness'), DEFAULT_COLOR_ADJUSTMENT.brightness),
-      COLOR_RANGES.brightness),
-    contrast: clamp(
-      finiteNumber(read('contrast'), DEFAULT_COLOR_ADJUSTMENT.contrast),
-      COLOR_RANGES.contrast),
-    red: clamp(finiteNumber(read('red'), DEFAULT_COLOR_ADJUSTMENT.red),
-      COLOR_RANGES.red),
-    green: clamp(
-      finiteNumber(read('green'), DEFAULT_COLOR_ADJUSTMENT.green),
-      COLOR_RANGES.green),
-    blue: clamp(finiteNumber(read('blue'), DEFAULT_COLOR_ADJUSTMENT.blue),
-      COLOR_RANGES.blue),
-    tint: tintValue(read('tint')),
-    tintStrength: clamp(
-      finiteNumber(read('tintStrength', 'tint_strength'),
-        DEFAULT_COLOR_ADJUSTMENT.tintStrength), COLOR_RANGES.tintStrength),
-  };
-}
-
-export function isNeutralColorAdjustment(value) {
-  const adjustment = normalizeColorAdjustment(value);
-  return adjustment.hue === 0
-    && adjustment.saturation === 1
-    && adjustment.brightness === 1
-    && adjustment.contrast === 1
-    && adjustment.red === 1
-    && adjustment.green === 1
-    && adjustment.blue === 1
-    && adjustment.tint === '#ffffff'
-    && adjustment.tintStrength === 0;
-}
 
 export function getMeshColorAdjustment(mesh) {
   return normalizeColorAdjustment(mesh?.userData?.colorAdjustment);
@@ -147,7 +68,8 @@ export function setMeshColorAdjustment(mesh, adjustment, {
   const normalized = normalizeColorAdjustment(adjustment);
   mesh.userData.colorAdjustment = normalized;
   if (sync) syncMeshColorAdjustment(mesh, { render });
-  if (persist && canEditMeshColor(mesh)) persistMeshColorAdjustment(mesh);
+  const eligibility = canEditMeshColor(mesh);
+  if (persist && eligibility.editable) persistMeshColorAdjustment(mesh);
   return normalized;
 }
 

--- a/src/web/js/mesh/mesh-factory.js
+++ b/src/web/js/mesh/mesh-factory.js
@@ -6,6 +6,7 @@ import {
   createGameMaterial, getGameMaterialSources, updateGameMaterialTextures,
   usesPackedNormal,
 } from './material-profile.js';
+import { syncMeshColorAdjustment } from './mesh-color-state.js';
 import { getMeshView } from './mesh-view-bindings.js';
 import { loadDDSTexture } from '../textures/dds-loader.js';
 import { requestRender } from '../scene/render-scheduler.js';
@@ -274,7 +275,12 @@ export function setMeshTextureState(mesh, state, { render = true } = {}) {
   mesh.userData.lightMapKey = state.light_map || null;
   mesh.userData.materialMapKey = state.material_map || null;
   mesh.userData.emissionMapKey = state.emission_map || null;
-  return refreshMeshTexture(mesh, { render });
+  const textureChanged = refreshMeshTexture(mesh, { render: false });
+  const colorChanged = syncMeshColorAdjustment(mesh, { render: false });
+  if (render && (textureChanged || colorChanged) && mesh.visible) {
+    requestRender();
+  }
+  return textureChanged || colorChanged;
 }
 
 /** Colour for meshes with no texture, guessed from the component name. */

--- a/src/web/js/panels/inspector-panel.js
+++ b/src/web/js/panels/inspector-panel.js
@@ -3,6 +3,10 @@
 
 import { getRightDockTab, isRightDockOpen, setRightDockTab } from './right-dock.js';
 import { clearSelection } from '../scene/selection.js';
+import {
+  canEditMeshColor, getMeshColorAdjustment, resetMeshColorAdjustment,
+  setMeshColorAdjustment,
+} from '../mesh/mesh-color-state.js';
 
 const meshRecords = new WeakMap();
 let current = null;
@@ -213,6 +217,174 @@ function updateTextureControlState(content, mesh, component) {
   });
 }
 
+function formatHue(value) {
+  const rounded = Math.round(value);
+  return `${rounded > 0 ? '+' : ''}${rounded}°`;
+}
+
+function formatPercent(value) {
+  return `${Math.round(value)}%`;
+}
+
+function colorControlValue(field, adjustment) {
+  return field === 'hue' ? adjustment.hue : adjustment[field] * 100;
+}
+
+function colorAdjustmentValue(field, controlValue) {
+  return field === 'hue' ? controlValue : controlValue / 100;
+}
+
+/** Build one range control shared by the Inspector's color sliders. */
+function buildRangeControl({
+  field, label, min, max, step, value, formatValue, onInput, onChange,
+}) {
+  const row = document.createElement('label');
+  row.className = 'inspector-color-control';
+  row.dataset.colorField = field;
+  const heading = document.createElement('span');
+  heading.className = 'inspector-color-control-heading';
+  heading.textContent = label;
+  const valueNode = document.createElement('span');
+  valueNode.className = 'inspector-color-value';
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.className = 'inspector-color-slider';
+  slider.min = String(min);
+  slider.max = String(max);
+  slider.step = String(step);
+  slider.value = String(value);
+  const syncValue = () => {
+    valueNode.textContent = formatValue(Number(slider.value));
+  };
+  slider.addEventListener('input', () => {
+    syncValue();
+    onInput(Number(slider.value));
+  });
+  slider.addEventListener('change', () => onChange(Number(slider.value)));
+  syncValue();
+  row.append(heading, slider, valueNode);
+  return row;
+}
+
+function updateColorAdjustment(mesh, field, controlValue, persist = false) {
+  const next = getMeshColorAdjustment(mesh);
+  next[field] = colorAdjustmentValue(field, controlValue);
+  setMeshColorAdjustment(mesh, next, { persist, render: true });
+}
+
+function buildColorSection(content, mesh) {
+  const section = document.createElement('section');
+  section.className = 'inspector-section inspector-color-section';
+  const title = document.createElement('div');
+  title.className = 'inspector-section-title';
+  title.textContent = 'Color';
+  section.appendChild(title);
+
+  const eligibility = canEditMeshColor(mesh);
+  section.dataset.colorEditable = String(eligibility.editable);
+  section.dataset.colorReason = eligibility.reason || '';
+  if (!eligibility.editable) {
+    if (eligibility.reason === 'asset-texture') {
+      addText(section, 'inspector-color-readonly-title', 'Asset texture');
+      addText(section, 'inspector-color-readonly',
+        'Color editing is unavailable for Asset textures.');
+    } else {
+      addText(section, 'inspector-color-readonly-title', 'No diffuse texture');
+      addText(section, 'inspector-color-readonly',
+        'Select a diffuse texture to adjust its color.');
+    }
+    content.appendChild(section);
+    return section;
+  }
+
+  const adjustment = getMeshColorAdjustment(mesh);
+  const addSlider = (field, label, min, max, step, formatValue) => {
+    section.appendChild(buildRangeControl({
+      field, label, min, max, step,
+      value: colorControlValue(field, adjustment), formatValue,
+      onInput: value => updateColorAdjustment(mesh, field, value),
+      onChange: value => updateColorAdjustment(mesh, field, value, true),
+    }));
+  };
+  addSlider('hue', 'Hue', -180, 180, 1, formatHue);
+  addSlider('saturation', 'Saturation', 0, 200, 1, formatPercent);
+  addSlider('brightness', 'Brightness', 0, 200, 1, formatPercent);
+  addSlider('contrast', 'Contrast', 0, 200, 1, formatPercent);
+
+  const rgbTitle = document.createElement('div');
+  rgbTitle.className = 'inspector-color-subtitle';
+  rgbTitle.textContent = 'RGB';
+  section.appendChild(rgbTitle);
+  addSlider('red', 'R', 0, 200, 1, formatPercent);
+  addSlider('green', 'G', 0, 200, 1, formatPercent);
+  addSlider('blue', 'B', 0, 200, 1, formatPercent);
+
+  const tint = document.createElement('label');
+  tint.className = 'inspector-color-tint';
+  const tintLabel = document.createElement('span');
+  tintLabel.className = 'inspector-color-control-heading';
+  tintLabel.textContent = 'Tint';
+  const tintInput = document.createElement('input');
+  tintInput.type = 'color';
+  tintInput.className = 'inspector-color-tint-input';
+  tintInput.value = adjustment.tint;
+  const tintValue = document.createElement('span');
+  tintValue.className = 'inspector-color-value';
+  tintValue.dataset.colorTintValue = 'true';
+  tintValue.textContent = adjustment.tint.toUpperCase();
+  const applyTint = persist => {
+    tintValue.textContent = tintInput.value.toUpperCase();
+    const next = getMeshColorAdjustment(mesh);
+    next.tint = tintInput.value;
+    setMeshColorAdjustment(mesh, next, { persist, render: true });
+  };
+  tintInput.addEventListener('input', () => applyTint(false));
+  tintInput.addEventListener('change', () => applyTint(true));
+  tint.append(tintLabel, tintInput, tintValue);
+  section.appendChild(tint);
+
+  addSlider('tintStrength', 'Strength', 0, 100, 1, formatPercent);
+
+  const reset = document.createElement('button');
+  reset.type = 'button';
+  reset.className = 'ui-button inspector-color-reset';
+  reset.textContent = 'Reset Color';
+  reset.addEventListener('click', () => {
+    resetMeshColorAdjustment(mesh, { persist: true, render: true });
+    updateColorControlState(content, mesh);
+  });
+  section.appendChild(reset);
+  content.appendChild(section);
+  return section;
+}
+
+function updateColorControlState(content, mesh) {
+  const section = content.querySelector('.inspector-color-section');
+  if (!section) return true;
+  const eligibility = canEditMeshColor(mesh);
+  if (section.dataset.colorEditable !== String(eligibility.editable)
+      || section.dataset.colorReason !== (eligibility.reason || '')) {
+    return false;
+  }
+  if (!eligibility.editable) return true;
+  const adjustment = getMeshColorAdjustment(mesh);
+  section.querySelectorAll('[data-color-field]').forEach(row => {
+    const field = row.dataset.colorField;
+    const slider = row.querySelector('.inspector-color-slider');
+    const value = row.querySelector('.inspector-color-value');
+    if (!slider || !value || !Object.hasOwn(adjustment, field)) return;
+    const controlValue = colorControlValue(field, adjustment);
+    slider.value = String(controlValue);
+    value.textContent = field === 'hue'
+      ? formatHue(controlValue) : formatPercent(controlValue);
+  });
+  const tintInput = section.querySelector('.inspector-color-tint-input');
+  const tintValue = section.querySelector('[data-color-tint-value]');
+  if (tintInput) tintInput.value = adjustment.tint;
+  if (tintValue) tintValue.textContent = adjustment.tint.toUpperCase();
+  return true;
+}
+
 function buildComponent(record) {
   const content = showContent();
   content.replaceChildren();
@@ -232,6 +404,7 @@ function buildMesh(mesh, record) {
     record.entry?.source?.[0]?.ini || '');
   buildMaterialSection(content, component || {});
   buildTextureControls(content, record, mesh);
+  buildColorSection(content, mesh);
 }
 
 function updateInspectorState() {
@@ -245,6 +418,9 @@ function updateInspectorState() {
   }
   if (current.type === 'mesh') {
     updateTextureControlState(content, current.mesh, current.record.component);
+    if (!updateColorControlState(content, current.mesh)) {
+      buildMesh(current.mesh, current.record);
+    }
   } else {
     const context = content.querySelector('[data-inspector-context="true"]');
     if (context) context.textContent = componentContext(current.record);

--- a/src/web/js/panels/mesh-panel.js
+++ b/src/web/js/panels/mesh-panel.js
@@ -22,9 +22,8 @@ import { notifyMeshStateChanged } from '../mesh/mesh-state-events.js';
 import {
   assetSecondaryLabel, assetSummaryLabel, summarizeAssetBindings,
 } from './asset-diagnostics.js';
-import {
-  normalizeColorAdjustment, syncMeshColorAdjustment,
-} from '../mesh/mesh-color-state.js';
+import { normalizeColorAdjustment } from '../mesh/color-adjustment.js';
+import { syncMeshColorAdjustment } from '../mesh/mesh-color-state.js';
 
 let groupsUI = [];
 let meshSectionId = 0;

--- a/src/web/js/panels/mesh-panel.js
+++ b/src/web/js/panels/mesh-panel.js
@@ -22,6 +22,9 @@ import { notifyMeshStateChanged } from '../mesh/mesh-state-events.js';
 import {
   assetSecondaryLabel, assetSummaryLabel, summarizeAssetBindings,
 } from './asset-diagnostics.js';
+import {
+  normalizeColorAdjustment, syncMeshColorAdjustment,
+} from '../mesh/mesh-color-state.js';
 
 let groupsUI = [];
 let meshSectionId = 0;
@@ -301,6 +304,7 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
   }
   registerViewSync('mesh-panel', syncMeshPanel);
   const texturePools = options.texturePools || {};
+  const colorAdjustments = options.colorAdjustments || {};
   const readOnlySource = options.readOnlySource === true;
   const texturePicker = options.texturePicker || null;
 
@@ -426,6 +430,8 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
         mesh.userData.identity = entry.identity || null;
         mesh.userData.metadataKey = entry.identity?.key
           || legacyMeshMetadataKey(name, entry);
+        mesh.userData.colorAdjustment = normalizeColorAdjustment(
+          colorAdjustments[mesh.userData.metadataKey]);
         mesh.userData.texturePool = texturePool;
         mesh.userData.displayName = meshNames[mesh.userData.metadataKey]
           || entry.display_name || null;
@@ -444,6 +450,7 @@ export function appendMeshPanel(meshes, modPath, meshNames = {},
             material_map: meshes[name].material_map_variants,
             emission_map: meshes[name].emission_map_variants,
           });
+        syncMeshColorAdjustment(mesh, { render: false });
         // addMesh establishes the automatic defaults; restore persisted
         // viewer choices only after that initialization has completed.
         if (Object.hasOwn(meshes[name], 'saved_texture_override')) {

--- a/src/web/js/scene/outline-renderer.js
+++ b/src/web/js/scene/outline-renderer.js
@@ -14,19 +14,27 @@ const REFERENCE_OUTLINE_WIDTH_PIXELS = 0.75;
 const MIN_OUTLINE_WIDTH_PIXELS = 0.5;
 const MAX_OUTLINE_WIDTH_PIXELS = 1.5;
 const outlineScalePerDepthNode = uniform(0);
-const outlineMaterial = new THREE.MeshBasicNodeMaterial({
-  color: 0x111318,
-  side: THREE.BackSide,
-  depthTest: true,
-  depthWrite: false,
-});
-outlineMaterial.toneMapped = false;
 const outlineViewDepth = positionView.z.negate().max(0.000001);
 const outlineWidthView = outlineViewDepth.mul(outlineScalePerDepthNode);
 const displacedOutlinePositionView = positionView.add(
   normalViewGeometry.mul(outlineWidthView));
-outlineMaterial.vertexNode = cameraProjectionMatrix.mul(
+const outlineVertexNode = cameraProjectionMatrix.mul(
   vec4(displacedOutlinePositionView, 1));
+
+function createOutlineMaterial(color) {
+  const material = new THREE.MeshBasicNodeMaterial({
+    color,
+    side: THREE.BackSide,
+    depthTest: true,
+    depthWrite: false,
+  });
+  material.toneMapped = false;
+  material.vertexNode = outlineVertexNode;
+  return material;
+}
+
+const outlineMaterial = createOutlineMaterial(0x111318);
+const selectionOutlineMaterial = createOutlineMaterial(0xffd60a);
 
 const attachedOutlines = new Set();
 let outlinesEnabled = false;
@@ -44,8 +52,13 @@ function outlinesVisible() {
 }
 
 function syncOutlineVisibility() {
-  const visible = outlinesVisible();
-  attachedOutlines.forEach(outline => { outline.visible = visible; });
+  attachedOutlines.forEach(syncOutline);
+}
+
+function syncOutline(outline) {
+  const selected = outline.userData.selectionSelected === true;
+  outline.material = selected ? selectionOutlineMaterial : outlineMaterial;
+  outline.visible = selected || outlinesVisible();
 }
 
 /** Attach one outline child while retaining the base mesh's exact geometry. */
@@ -61,12 +74,22 @@ export function attachOutline(mesh) {
   outline.name = `${mesh.name || 'mesh'}-viewer-outline`;
   outline.renderOrder = 1;
   outline.userData.isViewerOutline = true;
+  outline.userData.selectionSelected = false;
   outline.raycast = () => {};
   mesh.add(outline);
   mesh.userData.viewerOutline = outline;
   attachedOutlines.add(outline);
-  outline.visible = outlinesVisible();
+  syncOutline(outline);
   return outline;
+}
+
+/** Show selection on the existing inverted hull without changing the surface. */
+export function setMeshSelectionOutline(mesh, selected) {
+  const outline = mesh?.userData?.viewerOutline;
+  if (!outline) return false;
+  outline.userData.selectionSelected = selected === true;
+  syncOutline(outline);
+  return true;
 }
 
 /** Remove the child reference without disposing shared geometry or material. */
@@ -169,6 +192,9 @@ export function getOutlineState(mesh) {
   return {
     attached: !!outline,
     visible: !!outline?.visible,
+    selected: outline?.userData?.selectionSelected === true,
+    material: outline?.material === selectionOutlineMaterial
+      ? 'selection' : 'normal',
     globalEnabled: outlinesEnabled,
     referenceWidthPixels: REFERENCE_OUTLINE_WIDTH_PIXELS,
     minWidthPixels: MIN_OUTLINE_WIDTH_PIXELS,

--- a/src/web/js/scene/outline-renderer.js
+++ b/src/web/js/scene/outline-renderer.js
@@ -47,10 +47,6 @@ let outlineProjectionSpan = 0;
 let outlineReferenceProjectionSpan = 0;
 let outlineProjectionRatio = 1;
 
-function outlinesVisible() {
-  return outlinesEnabled && !suppressedByWireframe && !suppressedByDebug;
-}
-
 function syncOutlineVisibility() {
   attachedOutlines.forEach(syncOutline);
 }
@@ -58,7 +54,8 @@ function syncOutlineVisibility() {
 function syncOutline(outline) {
   const selected = outline.userData.selectionSelected === true;
   outline.material = selected ? selectionOutlineMaterial : outlineMaterial;
-  outline.visible = selected || outlinesVisible();
+  const allowed = !suppressedByWireframe && !suppressedByDebug;
+  outline.visible = allowed && (selected || outlinesEnabled);
 }
 
 /** Attach one outline child while retaining the base mesh's exact geometry. */

--- a/src/web/js/scene/selection.js
+++ b/src/web/js/scene/selection.js
@@ -6,14 +6,14 @@
 import { camera, renderer } from './scene.js';
 import { activeMeshes } from '../mesh/visibility.js';
 import { getMeshView } from '../mesh/mesh-view-bindings.js';
-import { setGameMaterialSelectionEnabled } from '../mesh/material-profile.js';
+import { setMeshSelectionOutline } from './outline-renderer.js';
 import { raycastModelAtClientPoint } from './model-picking.js';
 import { requestRender } from './render-scheduler.js';
 
 let selected = null; // currently selected mesh, or null
 
 function setHighlight(mesh, on) {
-  setGameMaterialSelectionEnabled(mesh.material, on);
+  setMeshSelectionOutline(mesh, on);
 }
 
 function setRowSelected(mesh, on) {

--- a/src/web/js/textures/texture-key.js
+++ b/src/web/js/textures/texture-key.js
@@ -26,3 +26,9 @@ export function textureRole(key) {
 export function textureFile(key) {
   return splitTextureKey(key)?.path || '';
 }
+
+/** Return whether a canonical role-aware key names an Asset texture. */
+export function isAssetTextureKey(key) {
+  const parsed = splitTextureKey(key);
+  return !!parsed?.path.startsWith('asset/');
+}


### PR DESCRIPTION
## Summary

- Add per-mesh color adjustment controls with live preview and reset behavior.
- Protect Asset textures and keep material/shader state stable while editing.
- Persist sparse mesh adjustments through the backend bridge in .mod_viewer.json.