### PR TITLE
Add read-only texture coverage analysis

### DIFF
--- a/src/app/assets/textures.py
+++ b/src/app/assets/textures.py
@@ -3,7 +3,7 @@
 import hashlib
 import os
 
-from core.textures import texture_key
+from core.textures import split_texture_key, texture_key
 
 from . import folders as asset_folders
 
@@ -22,4 +22,13 @@ def asset_texture_key(root, filename, role="diffuse"):
     return texture_key(asset_logical_key(root, filename), role)
 
 
-__all__ = ["asset_logical_key", "asset_root_id", "asset_texture_key"]
+def is_asset_texture_key(key):
+    """Return whether a role-aware texture key names the reserved Asset space."""
+    _role, relative_path = split_texture_key(key)
+    return bool(relative_path and relative_path.startswith("asset/"))
+
+
+__all__ = [
+    "asset_logical_key", "asset_root_id", "asset_texture_key",
+    "is_asset_texture_key",
+]

--- a/src/app/bridge/api.py
+++ b/src/app/bridge/api.py
@@ -157,6 +157,11 @@ class ModViewerAPI:
     def get_mesh_semantics(self, folder_path):
         return self._mod_preview.get_mesh_semantics(folder_path)
 
+    def analyze_mesh_texture_bake(
+            self, folder_path, semantic_key, tex_key, texture_usage):
+        return self._mod_preview.analyze_mesh_texture_bake(
+            folder_path, semantic_key, tex_key, texture_usage)
+
     def get_model_skinning_preview(self, folder_path):
         return self._mod_preview.get_model_skinning_preview(folder_path)
 

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -8,7 +8,6 @@ import webview
 from core.geometry.buffers import BufferStore
 from core.geometry.conventions import geometry_convention_for
 from core.geometry.mesh_builder import GeometryBlob
-from core.geometry.semantics import deduplicate_draws
 from core.geometry.skinning import (
     SkinningPreviewError, build_skinning_preview, skinning_source_descriptor,
 )
@@ -16,7 +15,8 @@ from core.resource_paths import safe_resource_path
 from core.textures import encode_texture_file
 from core.mod_discovery import discover_ini_paths
 from core.ini.health import analyze_mod
-from app.mods.analysis import analyze_mod_inis
+from app.mods.analysis import resolved_draws
+from app.mods.texture_bake import analyze_texture_bake
 from core.textures.profiles import texture_profile_for
 
 from app.assets import folders as asset_folders
@@ -151,16 +151,22 @@ class ModPreview:
         except Exception:
             return self._semantic_read_error()
 
+    def analyze_mesh_texture_bake(
+            self, folder_path, semantic_key, tex_key, texture_usage):
+        """Analyze selected-mesh DDS coverage without modifying the mod."""
+        try:
+            folder_path, overrides, _pending, context = \
+                self.authoritative_context(folder_path)
+            return analyze_texture_bake(
+                context, overrides, self._active_mesh_keys.get(folder_path),
+                semantic_key, tex_key, texture_usage)
+        except Exception:
+            return self._semantic_read_error()
+
     @staticmethod
     def _skinning_draws(context, overrides):
         """Resolve every rendered draw once for the model preview."""
-        parsed = analyze_mod_inis(
-            context.ini_paths, context.mod_dir, overrides, context.docs)
-        draws = {}
-        for group in parsed.groups:
-            for draw in deduplicate_draws(group):
-                draws.setdefault(draw.label, (draw, group))
-        return parsed, draws
+        return resolved_draws(context, overrides)
 
     @staticmethod
     def _decode_skinning_draw(draw, group, mod_dir, buffers,

--- a/src/app/mods/analysis.py
+++ b/src/app/mods/analysis.py
@@ -3,6 +3,7 @@
 import os
 from dataclasses import dataclass
 
+from core.geometry.semantics import deduplicate_draws
 from core.editing.present import SECTION_NAME as PRESENT_SECTION
 from core.ini.analysis import analyze_ini
 from core.ini.menu import attach_menu_images
@@ -231,3 +232,14 @@ def analyze_mod_inis(ini_paths, folder_path, overrides=None, documents=None):
         game=resolve_game_detection(
             game_evidence, runtime_evidence, texture_api_evidence),
     )
+
+
+def resolved_draws(context, overrides=None):
+    """Resolve the current staged draw map once for analysis consumers."""
+    parsed = analyze_mod_inis(
+        context.ini_paths, context.mod_dir, overrides, context.docs)
+    draws = {}
+    for group in parsed.groups:
+        for draw in deduplicate_draws(group):
+            draws.setdefault(draw.label, (draw, group))
+    return parsed, draws

--- a/src/app/mods/texture_bake.py
+++ b/src/app/mods/texture_bake.py
@@ -312,7 +312,8 @@ def analyze_texture_bake(
                 "unit_height": unit,
                 "total_units": total_units,
                 "selected_units": selected_units,
-                "unique_units": selected_units - shared_units,
+                "unique_units": (
+                    None if unresolved else selected_units - shared_units),
                 "shared_units": shared_units,
                 "selected_percent": 100 * selected_units / total_units,
                 "shared_percent_of_selected": (

--- a/src/app/mods/texture_bake.py
+++ b/src/app/mods/texture_bake.py
@@ -1,0 +1,339 @@
+"""Read-only DDS coverage analysis for the future texture baker."""
+
+import os
+import struct
+
+from core.geometry.buffers import BufferStore
+from core.geometry.conventions import geometry_convention_for
+from core.geometry.packing import pack_draw_geometry
+from core.resource_paths import _canonical, safe_resource_path
+from core.textures import split_texture_key
+from core.textures.dds import inspect_dds
+from core.textures.uv_coverage import UVCoverageError, rasterize_uv_coverage
+
+from app.assets.textures import is_asset_texture_key
+from app.mods.analysis import resolved_draws
+
+
+_SUPPORTED_COLOR_FORMATS = frozenset({
+    "bc1_unorm", "bc1_srgb", "bc2_unorm", "bc2_srgb",
+    "bc3_unorm", "bc3_srgb", "bc7_unorm", "bc7_srgb",
+    "rgba8", "bgra8",
+})
+_UNSUPPORTED_COLOR_FORMATS = frozenset({
+    "bc4_unorm", "bc4_snorm", "bc5_unorm", "bc5_snorm",
+    "bc6h_ufloat", "bc6h_float",
+})
+
+
+class TextureBakeAnalysisError(ValueError):
+    """An expected, stable failure from a coverage analysis request."""
+
+    def __init__(self, code, message, status="error"):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status = status
+
+
+def _error(code, message, status="error", **details):
+    result = {"status": status, "code": code, "error": message}
+    result.update(details)
+    return result
+
+
+def _canonical_mod_path(mod_dir, relative_path):
+    """Resolve a file strictly inside the mod root, not its escape ceiling."""
+    path = safe_resource_path(mod_dir, relative_path)
+    if not path or not os.path.isfile(path):
+        return None
+    root = _canonical(mod_dir)
+    canonical = _canonical(path)
+    try:
+        if os.path.commonpath((canonical, root)) != root:
+            return None
+    except ValueError:
+        return None
+    return path
+
+
+def _physical_identity(path):
+    return os.path.normcase(os.path.realpath(os.path.abspath(path))).casefold()
+
+
+def _texture_path(mod_dir, key, *, selected=False):
+    if not key:
+        if selected:
+            raise TextureBakeAnalysisError(
+                "no_diffuse", "The selected mesh has no diffuse texture.")
+        return None
+    role, relative_path = split_texture_key(key)
+    if selected and role != "diffuse":
+        raise TextureBakeAnalysisError(
+            "not_diffuse_texture", "Texture coverage requires a diffuse texture.")
+    if role != "diffuse" or not relative_path:
+        return None
+    if is_asset_texture_key(key):
+        if selected:
+            raise TextureBakeAnalysisError(
+                "asset_texture_read_only",
+                "Asset textures cannot be modified.", "unsupported")
+        return None
+    if selected and not relative_path.lower().endswith(".dds"):
+        raise TextureBakeAnalysisError(
+            "unsupported_texture_type",
+            "Texture baking currently requires a DDS source.", "unsupported")
+    path = _canonical_mod_path(mod_dir, relative_path)
+    if path is None:
+        if selected:
+            raise TextureBakeAnalysisError(
+                "texture_not_found", "The selected diffuse texture was not found.")
+        return None
+    return path
+
+
+def _texture_details(path, info):
+    return {
+        "file": os.path.basename(path),
+        "width": info.width,
+        "height": info.height,
+        "format": info.format,
+        "compressed": info.compressed,
+        "mip_count": info.mip_count,
+    }
+
+
+def _inspect_color_texture(path):
+    if not path.lower().endswith(".dds"):
+        raise TextureBakeAnalysisError(
+            "unsupported_texture_type",
+            "Texture baking currently requires a DDS source.", "unsupported")
+    info = inspect_dds(path)
+    if info is None:
+        raise TextureBakeAnalysisError(
+            "invalid_dds", "The selected texture is not a valid supported DDS.")
+    if info.format in _UNSUPPORTED_COLOR_FORMATS:
+        raise TextureBakeAnalysisError(
+            "unsupported_color_bake_format",
+            f"DDS format {info.format} is not a color-bake target.",
+            "unsupported")
+    if info.format not in _SUPPORTED_COLOR_FORMATS:
+        raise TextureBakeAnalysisError(
+            "unsupported_color_bake_format",
+            f"DDS format {info.format} is not a color-bake target.",
+            "unsupported")
+    return info
+
+
+def _draw_geometry(draw, group, mod_dir, buffers, sparse_shape_cache, convention):
+    paths = [
+        safe_resource_path(mod_dir, group.get("position_file")),
+        safe_resource_path(mod_dir, group.get("texcoord_file")),
+        safe_resource_path(mod_dir, group.get("ib_file")),
+    ]
+    if not all(path and os.path.isfile(path) for path in paths):
+        raise TextureBakeAnalysisError(
+            "geometry_not_available",
+            "The rendered draw geometry could not be prepared.")
+    default_streams = buffers.vertex_streams(
+        paths[0], group.get("position_stride"), paths[1],
+        group.get("texcoord_stride"))
+    buffers.raw(paths[2])
+    return pack_draw_geometry(
+        draw, group,
+        mod_dir=mod_dir,
+        default_streams=default_streams,
+        default_index_size=group.get("index_size", 4),
+        buffers=buffers,
+        geometry_convention=convention,
+        sparse_shape_cache=sparse_shape_cache,
+    )
+
+
+def _unpack_indices(raw):
+    if raw is None or len(raw) % 4:
+        raise TextureBakeAnalysisError(
+            "geometry_not_available", "Packed mesh indices could not be read.")
+    return struct.unpack(f"<{len(raw) // 4}I", raw)
+
+
+def _unpack_source_uvs(raw):
+    if raw is None or len(raw) % 8:
+        raise TextureBakeAnalysisError(
+            "mesh_has_no_uv", "The mesh has no UV coordinates.")
+    values = struct.unpack(f"<{len(raw) // 4}f", raw)
+    # pack_draw_geometry stores viewer-space V = 1 - source V for Three.js.
+    return [(u, 1.0 - v) for u, v in zip(values[::2], values[1::2])]
+
+
+def _coverage(draw, group, mod_dir, info, buffers, sparse_shape_cache, convention):
+    try:
+        packed = _draw_geometry(
+            draw, group, mod_dir, buffers, sparse_shape_cache, convention)
+        if packed is None:
+            raise TextureBakeAnalysisError(
+                "geometry_not_available",
+                "The rendered draw geometry could not be prepared.")
+        unit = 4 if info.compressed else 1
+        return rasterize_uv_coverage(
+            _unpack_indices(packed.indices),
+            _unpack_source_uvs(packed.texcoords) if packed.texcoords is not None
+            else None,
+            info.width, info.height,
+            unit_width=unit, unit_height=unit)
+    except UVCoverageError as error:
+        raise TextureBakeAnalysisError(error.code, error.message) from error
+    except TextureBakeAnalysisError:
+        raise
+    except Exception as error:
+        raise TextureBakeAnalysisError(
+            "geometry_not_available",
+            "The rendered draw geometry could not be prepared.") from error
+
+
+def _validate_usage(active_mesh_keys, selected_semantic_key, selected_texture_key,
+                    texture_usage):
+    if not isinstance(texture_usage, list):
+        raise TextureBakeAnalysisError(
+            "stale_mesh_state",
+            "The model changed before texture coverage could be analyzed.")
+    entries = []
+    keys = []
+    for item in texture_usage:
+        if not isinstance(item, dict):
+            raise TextureBakeAnalysisError(
+                "stale_mesh_state",
+                "The model changed before texture coverage could be analyzed.")
+        key = item.get("semantic_key")
+        if not isinstance(key, str) or not key or key in keys:
+            raise TextureBakeAnalysisError(
+                "stale_mesh_state",
+                "The model changed before texture coverage could be analyzed.")
+        keys.append(key)
+        entries.append({"semantic_key": key, "tex_key": item.get("tex_key")})
+    expected = set(active_mesh_keys or ())
+    if set(keys) != expected or len(keys) != len(expected):
+        raise TextureBakeAnalysisError(
+            "stale_mesh_state",
+            "The model changed before texture coverage could be analyzed.")
+    selected = next((item for item in entries
+                     if item["semantic_key"] == selected_semantic_key), None)
+    if selected is None or selected["tex_key"] != selected_texture_key:
+        raise TextureBakeAnalysisError(
+            "stale_mesh_state",
+            "The model changed before texture coverage could be analyzed.")
+    return entries
+
+
+def analyze_texture_bake(
+        context, overrides, active_mesh_keys, selected_semantic_key,
+        selected_texture_key, texture_usage):
+    """Analyze selected and same-source draws without opening texture data."""
+    try:
+        entries = _validate_usage(
+            active_mesh_keys, selected_semantic_key, selected_texture_key,
+            texture_usage)
+        selected_path = _texture_path(
+            context.mod_dir, selected_texture_key, selected=True)
+        info = _inspect_color_texture(selected_path)
+        parsed, draws = resolved_draws(context, overrides)
+        selected_draw = draws.get(selected_semantic_key)
+        if selected_draw is None:
+            raise TextureBakeAnalysisError(
+                "mesh_not_found", "The selected mesh is no longer available.")
+
+        selected_identity = _physical_identity(selected_path)
+        consumers = []
+        for entry in entries:
+            if entry["semantic_key"] == selected_semantic_key:
+                continue
+            path = _texture_path(context.mod_dir, entry["tex_key"])
+            if path and _physical_identity(path) == selected_identity:
+                consumers.append((entry["semantic_key"], draws.get(entry["semantic_key"])))
+
+        buffers = BufferStore()
+        sparse_shape_cache = {}
+        convention = geometry_convention_for(parsed.game.game)
+        try:
+            selected_coverage = _coverage(
+                selected_draw[0], selected_draw[1], context.mod_dir, info,
+                buffers, sparse_shape_cache, convention)
+        except TextureBakeAnalysisError as error:
+            return _error(error.code, error.message, error.status)
+
+        union = bytearray(len(selected_coverage.mask))
+        shared_with = []
+        unresolved = []
+        unresolved_details = []
+        for semantic_key, consumer in consumers:
+            try:
+                if consumer is None:
+                    raise TextureBakeAnalysisError(
+                        "geometry_not_available",
+                        "The rendered draw geometry could not be prepared.")
+                other = _coverage(
+                    consumer[0], consumer[1], context.mod_dir, info,
+                    buffers, sparse_shape_cache, convention)
+            except TextureBakeAnalysisError as error:
+                unresolved.append(semantic_key)
+                unresolved_details.append({
+                    "semantic_key": semantic_key,
+                    "code": error.code,
+                    "error": error.message,
+                })
+                continue
+            overlap = sum(
+                left and right
+                for left, right in zip(selected_coverage.mask, other.mask))
+            if overlap:
+                shared_with.append({
+                    "semantic_key": semantic_key,
+                    "shared_units": overlap,
+                })
+            for index, value in enumerate(other.mask):
+                union[index] = union[index] or value
+
+        shared_units = sum(
+            left and right
+            for left, right in zip(selected_coverage.mask, union))
+        selected_units = selected_coverage.count
+        total_units = len(selected_coverage.mask)
+        unit = 4 if info.compressed else 1
+        return {
+            "status": "ok",
+            "safety": "unknown" if unresolved else (
+                "shared" if shared_units else "safe"),
+            "semantic_key": selected_semantic_key,
+            "tex_key": selected_texture_key,
+            "texture": _texture_details(selected_path, info),
+            "coverage": {
+                "unit": "block" if info.compressed else "pixel",
+                "unit_width": unit,
+                "unit_height": unit,
+                "total_units": total_units,
+                "selected_units": selected_units,
+                "unique_units": selected_units - shared_units,
+                "shared_units": shared_units,
+                "selected_percent": 100 * selected_units / total_units,
+                "shared_percent_of_selected": (
+                    100 * shared_units / selected_units
+                    if selected_units else 0),
+            },
+            "shared_with": shared_with,
+            "unresolved_consumers": unresolved,
+            "diagnostics": {
+                "triangles": selected_coverage.triangle_count,
+                "degenerate_uv_triangles": (
+                    selected_coverage.degenerate_triangle_count),
+            },
+            "unresolved_consumer_details": unresolved_details,
+        }
+    except TextureBakeAnalysisError as error:
+        return _error(error.code, error.message, error.status)
+    except Exception:
+        return _error(
+            "coverage_incomplete",
+            "Texture coverage could not be analyzed safely.")
+
+
+__all__ = ["TextureBakeAnalysisError", "analyze_texture_bake"]

--- a/src/core/textures/__init__.py
+++ b/src/core/textures/__init__.py
@@ -17,6 +17,7 @@ from .pipeline import (
     texture_key,
     texture_key_for_role,
 )
+from .uv_coverage import UVCoverage, UVCoverageError, rasterize_uv_coverage
 
 __all__ = [
     "TEXTURE_ROLES",
@@ -34,4 +35,7 @@ __all__ = [
     "split_texture_key",
     "texture_key",
     "texture_key_for_role",
+    "UVCoverage",
+    "UVCoverageError",
+    "rasterize_uv_coverage",
 ]

--- a/src/core/textures/uv_coverage.py
+++ b/src/core/textures/uv_coverage.py
@@ -101,9 +101,13 @@ def _mark_point(mask, grid_width, grid_height, x, y):
     y_cell = _cell_index(y, grid_height)
     x_cells = {x_cell}
     y_cells = {y_cell}
-    if abs(x - round(x)) <= _UV_EPSILON and x > 0:
+    if (abs(x - round(x)) <= _UV_EPSILON
+            and x > 0
+            and x < grid_width - _UV_EPSILON):
         x_cells.add(max(0, x_cell - 1))
-    if abs(y - round(y)) <= _UV_EPSILON and y > 0:
+    if (abs(y - round(y)) <= _UV_EPSILON
+            and y > 0
+            and y < grid_height - _UV_EPSILON):
         y_cells.add(max(0, y_cell - 1))
     for cell_y in y_cells:
         for cell_x in x_cells:
@@ -132,7 +136,25 @@ def _supercover_segment(mask, grid_width, grid_height, start, end):
 
     cell_x = initial(x0, dx, grid_width)
     cell_y = initial(y0, dy, grid_height)
-    _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+    horizontal_boundary = (
+        abs(dy) <= _AREA_EPSILON
+        and abs(y0 - round(y0)) <= _UV_EPSILON
+        and y0 > _UV_EPSILON
+        and y0 < grid_height - _UV_EPSILON)
+    vertical_boundary = (
+        abs(dx) <= _AREA_EPSILON
+        and abs(x0 - round(x0)) <= _UV_EPSILON
+        and x0 > _UV_EPSILON
+        and x0 < grid_width - _UV_EPSILON)
+
+    def mark_traversed(cell_x, cell_y):
+        _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+        if horizontal_boundary:
+            _mark_cell(mask, grid_width, grid_height, cell_x, cell_y - 1)
+        if vertical_boundary:
+            _mark_cell(mask, grid_width, grid_height, cell_x - 1, cell_y)
+
+    mark_traversed(cell_x, cell_y)
     _mark_point(mask, grid_width, grid_height, x0, y0)
     _mark_point(mask, grid_width, grid_height, x1, y1)
 
@@ -144,20 +166,24 @@ def _supercover_segment(mask, grid_width, grid_height, start, end):
               else (cell_x - x0) / dx if dx < 0 else math.inf)
     next_y = ((cell_y + 1 - y0) / dy if dy > 0
               else (cell_y - y0) / dy if dy < 0 else math.inf)
-    while True:
+    while min(next_x, next_y) <= 1.0 + _UV_EPSILON:
         if next_x < next_y - _UV_EPSILON:
             cell_x += step_x
-            _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+            mark_traversed(cell_x, cell_y)
             next_x += delta_x
         elif next_y < next_x - _UV_EPSILON:
             cell_y += step_y
-            _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+            mark_traversed(cell_x, cell_y)
             next_y += delta_y
         else:
+            crossing_x = x0 + dx * next_x
+            crossing_y = y0 + dy * next_y
+            _mark_point(mask, grid_width, grid_height,
+                        crossing_x, crossing_y)
             cell_x += step_x
-            _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+            mark_traversed(cell_x, cell_y)
             cell_y += step_y
-            _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+            mark_traversed(cell_x, cell_y)
             next_x += delta_x
             next_y += delta_y
         if not (0 <= cell_x < grid_width and 0 <= cell_y < grid_height):

--- a/src/core/textures/uv_coverage.py
+++ b/src/core/textures/uv_coverage.py
@@ -1,0 +1,264 @@
+"""Conservative source-texture coverage for packed mesh UV triangles."""
+
+from dataclasses import dataclass
+import math
+import struct
+
+
+_UV_EPSILON = 1e-6
+_AREA_EPSILON = 1e-12
+
+
+class UVCoverageError(ValueError):
+    """A stable analysis failure raised by the pure UV coverage layer."""
+
+    def __init__(self, code, message):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass
+class UVCoverage:
+    """Compact edit-unit mask and diagnostics for one UV set."""
+
+    grid_width: int
+    grid_height: int
+    mask: bytearray
+    count: int
+    bounds: tuple | None
+    triangle_count: int
+    degenerate_triangle_count: int
+
+
+def _indices(values):
+    if isinstance(values, (bytes, bytearray, memoryview)):
+        raw = bytes(values)
+        if len(raw) % 4:
+            raise UVCoverageError(
+                "invalid_geometry", "Packed indices are not complete u32 values.")
+        return list(struct.unpack(f"<{len(raw) // 4}I", raw))
+    try:
+        return [int(value) for value in values]
+    except (TypeError, ValueError):
+        raise UVCoverageError(
+            "invalid_geometry", "Mesh indices could not be read.") from None
+
+
+def _texcoords(values):
+    if values is None:
+        raise UVCoverageError("mesh_has_no_uv", "The mesh has no UV coordinates.")
+    if isinstance(values, (bytes, bytearray, memoryview)):
+        raw = bytes(values)
+        if len(raw) % 8:
+            raise UVCoverageError(
+                "invalid_geometry", "Packed UVs are not complete Float32 pairs.")
+        flat = struct.unpack(f"<{len(raw) // 4}f", raw)
+        return list(zip(flat[::2], flat[1::2]))
+    try:
+        values = list(values)
+    except TypeError:
+        raise UVCoverageError(
+            "mesh_has_no_uv", "The mesh has no UV coordinates.") from None
+    if not values:
+        return []
+    if isinstance(values[0], (list, tuple)):
+        try:
+            return [(float(item[0]), float(item[1])) for item in values]
+        except (IndexError, TypeError, ValueError):
+            raise UVCoverageError(
+                "invalid_geometry", "Mesh UV coordinates could not be read.") from None
+    if len(values) % 2:
+        raise UVCoverageError(
+            "invalid_geometry", "Mesh UV coordinates are not complete pairs.")
+    try:
+        return [(float(u), float(v)) for u, v in zip(values[::2], values[1::2])]
+    except (TypeError, ValueError):
+        raise UVCoverageError(
+            "invalid_geometry", "Mesh UV coordinates could not be read.") from None
+
+
+def _clamp_uv(value):
+    value = float(value)
+    if not math.isfinite(value):
+        raise UVCoverageError("invalid_geometry", "Mesh UVs contain non-finite values.")
+    if value < -_UV_EPSILON or value > 1.0 + _UV_EPSILON:
+        raise UVCoverageError(
+            "tiled_uv_unsupported",
+            "The mesh uses UVs outside the 0-1 texture range.")
+    return min(1.0, max(0.0, value))
+
+
+def _cell_index(value, size):
+    return min(size - 1, max(0, math.floor(value)))
+
+
+def _mark_point(mask, grid_width, grid_height, x, y):
+    """Mark the cells touched by a point, including grid-line neighbors."""
+    x = min(float(grid_width), max(0.0, x))
+    y = min(float(grid_height), max(0.0, y))
+    x_cell = _cell_index(x, grid_width)
+    y_cell = _cell_index(y, grid_height)
+    x_cells = {x_cell}
+    y_cells = {y_cell}
+    if abs(x - round(x)) <= _UV_EPSILON and x > 0:
+        x_cells.add(max(0, x_cell - 1))
+    if abs(y - round(y)) <= _UV_EPSILON and y > 0:
+        y_cells.add(max(0, y_cell - 1))
+    for cell_y in y_cells:
+        for cell_x in x_cells:
+            mask[cell_y * grid_width + cell_x] = 1
+
+
+def _mark_cell(mask, grid_width, grid_height, cell_x, cell_y):
+    if 0 <= cell_x < grid_width and 0 <= cell_y < grid_height:
+        mask[cell_y * grid_width + cell_x] = 1
+
+
+def _supercover_segment(mask, grid_width, grid_height, start, end):
+    """Mark every grid cell crossed by a segment using a DDA supercover."""
+    x0, y0 = start
+    x1, y1 = end
+    dx, dy = x1 - x0, y1 - y0
+    if abs(dx) <= _AREA_EPSILON and abs(dy) <= _AREA_EPSILON:
+        _mark_point(mask, grid_width, grid_height, x0, y0)
+        return
+
+    def initial(value, delta, size):
+        cell = math.floor(value)
+        if delta < 0 and abs(value - round(value)) <= _UV_EPSILON:
+            cell -= 1
+        return min(size - 1, max(0, cell))
+
+    cell_x = initial(x0, dx, grid_width)
+    cell_y = initial(y0, dy, grid_height)
+    _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+    _mark_point(mask, grid_width, grid_height, x0, y0)
+    _mark_point(mask, grid_width, grid_height, x1, y1)
+
+    step_x = 1 if dx > 0 else -1
+    step_y = 1 if dy > 0 else -1
+    delta_x = abs(1.0 / dx) if dx else math.inf
+    delta_y = abs(1.0 / dy) if dy else math.inf
+    next_x = ((cell_x + 1 - x0) / dx if dx > 0
+              else (cell_x - x0) / dx if dx < 0 else math.inf)
+    next_y = ((cell_y + 1 - y0) / dy if dy > 0
+              else (cell_y - y0) / dy if dy < 0 else math.inf)
+    while True:
+        if next_x < next_y - _UV_EPSILON:
+            cell_x += step_x
+            _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+            next_x += delta_x
+        elif next_y < next_x - _UV_EPSILON:
+            cell_y += step_y
+            _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+            next_y += delta_y
+        else:
+            cell_x += step_x
+            _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+            cell_y += step_y
+            _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+            next_x += delta_x
+            next_y += delta_y
+        if not (0 <= cell_x < grid_width and 0 <= cell_y < grid_height):
+            break
+
+
+def _inside(px, py, triangle):
+    (ax, ay), (bx, by), (cx, cy) = triangle
+    ab = (bx - ax) * (py - ay) - (by - ay) * (px - ax)
+    bc = (cx - bx) * (py - by) - (cy - by) * (px - bx)
+    ca = (ax - cx) * (py - cy) - (ay - cy) * (px - cx)
+    return (ab >= -_AREA_EPSILON and bc >= -_AREA_EPSILON
+            and ca >= -_AREA_EPSILON) or (
+                ab <= _AREA_EPSILON and bc <= _AREA_EPSILON
+                and ca <= _AREA_EPSILON)
+
+
+def _rasterize_triangle(mask, grid_width, grid_height, triangle):
+    for point in triangle:
+        _mark_point(mask, grid_width, grid_height, *point)
+    for start, end in zip(triangle, triangle[1:] + triangle[:1]):
+        _supercover_segment(mask, grid_width, grid_height, start, end)
+
+    min_x = max(0, math.floor(min(point[0] for point in triangle)))
+    max_x = min(grid_width - 1,
+                math.ceil(max(point[0] for point in triangle)) - 1)
+    min_y = max(0, math.floor(min(point[1] for point in triangle)))
+    max_y = min(grid_height - 1,
+                math.ceil(max(point[1] for point in triangle)) - 1)
+    for cell_y in range(min_y, max_y + 1):
+        for cell_x in range(min_x, max_x + 1):
+            if _inside(cell_x + 0.5, cell_y + 0.5, triangle):
+                _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
+
+
+def rasterize_uv_coverage(
+        indices, texcoords, texture_width, texture_height, *,
+        unit_width=1, unit_height=1):
+    """Rasterize source-space UVs into a compact edit-unit mask.
+
+    ``texcoords`` are expected in source-texture orientation. Callers that
+    receive viewer-packed UVs must invert V before calling this function.
+    """
+    try:
+        texture_width = int(texture_width)
+        texture_height = int(texture_height)
+        unit_width = int(unit_width)
+        unit_height = int(unit_height)
+    except (TypeError, ValueError):
+        raise UVCoverageError(
+            "invalid_texture", "Texture dimensions are invalid.") from None
+    if min(texture_width, texture_height, unit_width, unit_height) <= 0:
+        raise UVCoverageError(
+            "invalid_texture", "Texture dimensions are invalid.")
+
+    indices = _indices(indices)
+    texcoords = _texcoords(texcoords)
+    if not texcoords:
+        raise UVCoverageError("mesh_has_no_uv", "The mesh has no UV coordinates.")
+    if len(indices) % 3:
+        raise UVCoverageError(
+            "invalid_geometry", "Mesh indices do not form complete triangles.")
+    if any(index < 0 or index >= len(texcoords) for index in indices):
+        raise UVCoverageError(
+            "invalid_geometry", "Mesh indices reference missing UV coordinates.")
+
+    grid_width = math.ceil(texture_width / unit_width)
+    grid_height = math.ceil(texture_height / unit_height)
+    mask = bytearray(grid_width * grid_height)
+    triangle_count = len(indices) // 3
+    degenerate = 0
+    for offset in range(0, len(indices), 3):
+        points = []
+        for index in indices[offset:offset + 3]:
+            u = _clamp_uv(texcoords[index][0])
+            v = _clamp_uv(texcoords[index][1])
+            points.append((u * texture_width / unit_width,
+                           v * texture_height / unit_height))
+        area = ((points[1][0] - points[0][0])
+                * (points[2][1] - points[0][1])
+                - (points[1][1] - points[0][1])
+                * (points[2][0] - points[0][0]))
+        if abs(area) <= _AREA_EPSILON:
+            degenerate += 1
+            continue
+        _rasterize_triangle(mask, grid_width, grid_height, points)
+
+    count = sum(mask)
+    if not count:
+        raise UVCoverageError(
+            "no_uv_coverage", "The mesh has no non-degenerate UV coverage.")
+    used = [index for index, value in enumerate(mask) if value]
+    bounds = (
+        min(index % grid_width for index in used),
+        min(index // grid_width for index in used),
+        max(index % grid_width for index in used),
+        max(index // grid_width for index in used),
+    )
+    return UVCoverage(
+        grid_width, grid_height, mask, count, bounds,
+        triangle_count, degenerate)
+
+
+__all__ = ["UVCoverage", "UVCoverageError", "rasterize_uv_coverage"]

--- a/src/tests/app/assets/test_textures.py
+++ b/src/tests/app/assets/test_textures.py
@@ -1,0 +1,21 @@
+"""Asset texture identity regressions."""
+
+from app.assets.textures import (
+    asset_texture_key, is_asset_texture_key,
+)
+from core.textures import texture_key
+
+
+def test_asset_texture_key_detection_uses_role_aware_relative_identity(tmp_path):
+    root = tmp_path / "assets"
+    root.mkdir()
+    texture = root / "body.dds"
+    texture.write_bytes(b"dds")
+
+    key = asset_texture_key(root, texture)
+
+    assert key.startswith("diffuse::asset/")
+    assert is_asset_texture_key(key)
+    assert is_asset_texture_key(texture_key(key.split("::", 1)[1], "normal_map"))
+    assert not is_asset_texture_key("diffuse::textures/body.dds")
+    assert not is_asset_texture_key("body.dds")

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -29,6 +29,7 @@ EXPECTED_API_METHODS = {
     "get_diagnostics",
     "get_ini_text",
     "get_mesh_semantics",
+    "analyze_mesh_texture_bake",
     "get_mod_folders",
     "get_panel_opacity",
     "get_present_state",
@@ -164,3 +165,19 @@ def test_load_mod_forwards_disabled_ini_flag(monkeypatch):
 
     assert api.load_mod("mod", True) == {"ok": True}
     assert calls == [("mod", True)]
+
+
+def test_texture_bake_analysis_forwards_semantic_snapshot(monkeypatch):
+    api = ModViewerAPI()
+    calls = []
+    monkeypatch.setattr(
+        api._mod_preview, "analyze_mesh_texture_bake",
+        lambda *args: calls.append(args) or {"status": "ok"},
+    )
+
+    usage = [{"semantic_key": "Body-1", "tex_key": "diffuse::body.dds"}]
+    result = api.analyze_mesh_texture_bake(
+        "mod", "Body-1", "diffuse::body.dds", usage)
+
+    assert result == {"status": "ok"}
+    assert calls == [("mod", "Body-1", "diffuse::body.dds", usage)]

--- a/src/tests/app/mods/test_texture_bake.py
+++ b/src/tests/app/mods/test_texture_bake.py
@@ -1,0 +1,223 @@
+"""Read-only texture coverage analysis regressions."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.mods import texture_bake
+from core.geometry.buffers import BufferStore
+from core.geometry.conventions import geometry_convention_for
+from core.geometry.draw_call import DrawCall
+from core.textures.uv_coverage import UVCoverage
+from core.textures.uv_coverage import rasterize_uv_coverage
+
+
+def _info(format_name="bc7_unorm", compressed=True):
+    return SimpleNamespace(
+        width=8, height=8, mip_count=1, format=format_name,
+        compressed=compressed, requires_bc=compressed)
+
+
+def _context(mod_dir):
+    return SimpleNamespace(
+        mod_dir=str(mod_dir), ini_paths=[], docs={},
+        game=SimpleNamespace(game="unknown"))
+
+
+def _draw(label):
+    return SimpleNamespace(label=label)
+
+
+def _coverage(mask):
+    return UVCoverage(
+        grid_width=2, grid_height=2, mask=bytearray(mask),
+        count=sum(mask), bounds=(0, 0, 1, 1),
+        triangle_count=1, degenerate_triangle_count=0)
+
+
+def _patch_analysis(monkeypatch, draws, coverage_by_label):
+    parsed = SimpleNamespace(game=SimpleNamespace(game="unknown"))
+    groups = {label: ({"draws": []}) for label in draws}
+    monkeypatch.setattr(
+        texture_bake, "resolved_draws",
+        lambda *_args: (parsed, {
+            label: (draw, groups[label]) for label, draw in draws.items()
+        }),
+    )
+    monkeypatch.setattr(
+        texture_bake, "_inspect_color_texture", lambda _path: _info())
+    monkeypatch.setattr(
+        texture_bake, "_coverage",
+        lambda draw, *_args: _coverage(coverage_by_label[draw.label]),
+    )
+
+
+def test_coverage_uses_packed_geometry_and_restores_source_v(tmp_path):
+    import struct
+
+    source_uvs = [(0.1, 0.2), (0.9, 0.2), (0.1, 0.8)]
+    (tmp_path / "position.buf").write_bytes(struct.pack(
+        "<9f", 0., 0., 0., 1., 0., 0., 0., 1., 0.))
+    (tmp_path / "texcoord.buf").write_bytes(struct.pack(
+        "<6f", *(component for uv in source_uvs for component in uv)))
+    (tmp_path / "body.ib").write_bytes(struct.pack("<3I", 0, 1, 2))
+    draw = DrawCall(
+        label="Body-1", count=3, ib_file="body.ib", index_size=4,
+        position_file="position.buf", position_stride=12,
+        texcoord_file="texcoord.buf", texcoord_stride=8)
+    group = {
+        "position_file": "position.buf", "position_stride": 12,
+        "texcoord_file": "texcoord.buf", "texcoord_stride": 8,
+        "ib_file": "body.ib", "index_size": 4, "draws": [draw],
+    }
+
+    result = texture_bake._coverage(
+        draw, group, str(tmp_path), _info("rgba8", False), BufferStore(), {},
+        geometry_convention_for("unknown"))
+    expected = rasterize_uv_coverage(
+        [0, 1, 2], source_uvs, 8, 8)
+
+    assert result.mask == expected.mask
+    assert result.count == expected.count
+
+
+def test_shared_physical_texture_reports_overlap_and_hidden_consumer(
+        tmp_path, monkeypatch):
+    texture = tmp_path / "body.dds"
+    original = b"unchanged DDS fixture"
+    texture.write_bytes(original)
+    before = texture.stat().st_mtime_ns
+    draws = {"Body-1": _draw("Body-1"), "Body-2": _draw("Body-2")}
+    _patch_analysis(monkeypatch, draws, {
+        "Body-1": [1, 1, 0, 0], "Body-2": [0, 1, 1, 0],
+    })
+    usage = [
+        {"semantic_key": "Body-1", "tex_key": "diffuse::body.dds"},
+        # This consumer is hidden in the viewport in the real UI, but remains
+        # part of the model-wide texture usage snapshot.
+        {"semantic_key": "Body-2", "tex_key": "diffuse::body.dds"},
+    ]
+
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, set(draws), "Body-1",
+        "diffuse::body.dds", usage)
+
+    assert result["status"] == "ok"
+    assert result["safety"] == "shared"
+    assert result["coverage"]["shared_units"] == 1
+    assert result["shared_with"] == [{
+        "semantic_key": "Body-2", "shared_units": 1,
+    }]
+    assert texture.read_bytes() == original
+    assert texture.stat().st_mtime_ns == before
+
+
+def test_unanalyzable_same_texture_consumer_is_unknown(
+        tmp_path, monkeypatch):
+    texture = tmp_path / "body.dds"
+    texture.write_bytes(b"fixture")
+    draws = {"Body-1": _draw("Body-1"), "Body-2": _draw("Body-2")}
+    _patch_analysis(monkeypatch, draws, {"Body-1": [1, 0, 0, 0]})
+
+    def coverage(draw, *_args):
+        if draw.label == "Body-2":
+            raise texture_bake.TextureBakeAnalysisError(
+                "geometry_not_available", "missing geometry")
+        return _coverage([1, 0, 0, 0])
+
+    monkeypatch.setattr(texture_bake, "_coverage", coverage)
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, set(draws), "Body-1",
+        "diffuse::body.dds", [
+            {"semantic_key": "Body-1", "tex_key": "diffuse::body.dds"},
+            {"semantic_key": "Body-2", "tex_key": "diffuse::body.dds"},
+        ])
+
+    assert result["status"] == "ok"
+    assert result["safety"] == "unknown"
+    assert result["unresolved_consumers"] == ["Body-2"]
+    assert result["unresolved_consumer_details"][0]["code"] == \
+        "geometry_not_available"
+
+
+@pytest.mark.parametrize(("key", "code", "status"), [
+    (None, "no_diffuse", "error"),
+    ("normal_map::body.dds", "not_diffuse_texture", "error"),
+    ("diffuse::asset/root/body.dds", "asset_texture_read_only", "unsupported"),
+    ("diffuse::body.png", "unsupported_texture_type", "unsupported"),
+    ("diffuse::missing.dds", "texture_not_found", "error"),
+    ("diffuse::../outside.dds", "texture_not_found", "error"),
+])
+def test_selected_texture_eligibility_is_safe_and_stable(
+        tmp_path, monkeypatch, key, code, status):
+    monkeypatch.setattr(
+        texture_bake, "resolved_draws",
+        lambda *_args: (SimpleNamespace(game=SimpleNamespace(game="unknown")), {}),
+    )
+    usage = [{"semantic_key": "Body-1", "tex_key": key}]
+
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, {"Body-1"}, "Body-1", key, usage)
+
+    assert result["code"] == code
+    assert result["status"] == status
+
+
+@pytest.mark.parametrize("format_name", [
+    "bc1_unorm", "bc2_srgb", "bc3_unorm", "bc7_srgb", "rgba8", "bgra8",
+])
+def test_supported_color_formats_are_analyzable(tmp_path, monkeypatch, format_name):
+    texture = tmp_path / "body.dds"
+    texture.write_bytes(b"fixture")
+    draws = {"Body-1": _draw("Body-1")}
+    _patch_analysis(monkeypatch, draws, {"Body-1": [1, 0, 0, 0]})
+    monkeypatch.setattr(
+        texture_bake, "_inspect_color_texture",
+        lambda _path: _info(format_name, format_name in texture_bake._UNSUPPORTED_COLOR_FORMATS
+                            or format_name.startswith("bc")),
+    )
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, set(draws), "Body-1",
+        "diffuse::body.dds", [{
+            "semantic_key": "Body-1", "tex_key": "diffuse::body.dds",
+        }])
+
+    assert result["status"] == "ok"
+
+
+@pytest.mark.parametrize("format_name", [
+    "bc4_unorm", "bc5_snorm", "bc6h_ufloat", "unknown",
+])
+def test_non_color_bake_formats_are_rejected(tmp_path, monkeypatch, format_name):
+    texture = tmp_path / "body.dds"
+    texture.write_bytes(b"fixture")
+    monkeypatch.setattr(
+        texture_bake, "inspect_dds", lambda _path: _info(format_name))
+
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, {"Body-1"}, "Body-1",
+        "diffuse::body.dds", [{
+            "semantic_key": "Body-1", "tex_key": "diffuse::body.dds",
+        }])
+
+    assert result["status"] == "unsupported"
+    assert result["code"] == "unsupported_color_bake_format"
+
+
+def test_invalid_dds_is_rejected_without_falling_back_to_texture_decode(
+        tmp_path, monkeypatch):
+    texture = tmp_path / "body.dds"
+    texture.write_bytes(b"not a DDS")
+    monkeypatch.setattr(texture_bake, "inspect_dds", lambda _path: None)
+
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, {"Body-1"}, "Body-1",
+        "diffuse::body.dds", [{
+            "semantic_key": "Body-1", "tex_key": "diffuse::body.dds",
+        }])
+
+    assert result == {
+        "status": "error",
+        "code": "invalid_dds",
+        "error": "The selected texture is not a valid supported DDS.",
+    }

--- a/src/tests/app/mods/test_texture_bake.py
+++ b/src/tests/app/mods/test_texture_bake.py
@@ -55,7 +55,7 @@ def _patch_analysis(monkeypatch, draws, coverage_by_label):
 def test_coverage_uses_packed_geometry_and_restores_source_v(tmp_path):
     import struct
 
-    source_uvs = [(0.1, 0.2), (0.9, 0.2), (0.1, 0.8)]
+    source_uvs = [(0.125, 0.25), (0.875, 0.25), (0.125, 0.75)]
     (tmp_path / "position.buf").write_bytes(struct.pack(
         "<9f", 0., 0., 0., 1., 0., 0., 0., 1., 0.))
     (tmp_path / "texcoord.buf").write_bytes(struct.pack(
@@ -136,6 +136,7 @@ def test_unanalyzable_same_texture_consumer_is_unknown(
     assert result["status"] == "ok"
     assert result["safety"] == "unknown"
     assert result["unresolved_consumers"] == ["Body-2"]
+    assert result["coverage"]["unique_units"] is None
     assert result["unresolved_consumer_details"][0]["code"] == \
         "geometry_not_available"
 

--- a/src/tests/core/textures/test_uv_coverage.py
+++ b/src/tests/core/textures/test_uv_coverage.py
@@ -2,7 +2,9 @@
 
 import pytest
 
-from core.textures.uv_coverage import UVCoverageError, rasterize_uv_coverage
+from core.textures.uv_coverage import (
+    UVCoverageError, _supercover_segment, rasterize_uv_coverage,
+)
 
 
 def test_full_uv_quad_covers_every_non_multiple_block():
@@ -52,6 +54,64 @@ def test_thin_triangle_crossing_a_unit_is_not_lost_to_center_sampling():
 
     assert result.count == 8
     assert result.bounds == (0, 0, 7, 0)
+
+
+@pytest.mark.parametrize("start,end", [
+    ((4, 4), (8, 4)), ((8, 4), (4, 4)),
+    ((4, 4), (4, 8)), ((4, 8), (4, 4)),
+])
+def test_short_axis_aligned_edges_stop_at_the_endpoint(start, end):
+    mask = bytearray(16 * 16)
+
+    _supercover_segment(mask, 16, 16, start, end)
+
+    assert [index for index, value in enumerate(mask) if value] == (
+        [51, 52, 53, 54, 55, 56, 67, 68, 69, 70, 71, 72]
+        if start[1] == end[1]
+        else [51, 52, 67, 68, 83, 84, 99, 100, 115, 116, 131, 132])
+
+
+@pytest.mark.parametrize("start,end", [
+    ((4, 4), (8, 8)), ((8, 8), (4, 4)),
+])
+def test_short_diagonal_edges_are_symmetric_and_stop_at_endpoint(start, end):
+    mask = bytearray(16 * 16)
+
+    _supercover_segment(mask, 16, 16, start, end)
+
+    assert [index for index, value in enumerate(mask) if value] == [
+        51, 52, 67, 68, 69, 84, 85, 86,
+        101, 102, 103, 118, 119, 120, 135, 136,
+    ]
+
+
+def test_interior_triangle_has_an_exact_local_mask():
+    result = rasterize_uv_coverage(
+        [0, 1, 2], [(0.25, 0.25), (0.50, 0.25), (0.25, 0.50)], 16, 16)
+
+    assert [index for index, value in enumerate(result.mask) if value] == [
+        51, 52, 53, 54, 55, 56, 67, 68, 69, 70, 71, 72,
+        83, 84, 85, 86, 87, 99, 100, 101, 102,
+        115, 116, 117, 131, 132,
+    ]
+
+
+@pytest.mark.parametrize("uvs,edge", [
+    ([(0.999, 0.25), (1.0, 0.25), (0.999, 0.26)], "right"),
+    ([(0.25, 0.999), (0.26, 0.999), (0.25, 1.0)], "bottom"),
+])
+def test_outer_texture_boundaries_do_not_mark_a_penultimate_unit(uvs, edge):
+    result = rasterize_uv_coverage([0, 1, 2], uvs, 16, 16)
+    occupied = [index for index, value in enumerate(result.mask) if value]
+    columns = {index % 16 for index in occupied}
+    rows = {index // 16 for index in occupied}
+
+    if edge == "right":
+        assert columns == {15}
+        assert rows <= {3, 4}
+    else:
+        assert rows == {15}
+        assert columns <= {3, 4}
 
 
 def test_source_uv_boundaries_are_inclusive():

--- a/src/tests/core/textures/test_uv_coverage.py
+++ b/src/tests/core/textures/test_uv_coverage.py
@@ -1,0 +1,83 @@
+"""Conservative texture edit-unit coverage regressions."""
+
+import pytest
+
+from core.textures.uv_coverage import UVCoverageError, rasterize_uv_coverage
+
+
+def test_full_uv_quad_covers_every_non_multiple_block():
+    result = rasterize_uv_coverage(
+        [0, 1, 2, 0, 2, 3],
+        [(0, 0), (1, 0), (1, 1), (0, 1)],
+        10, 9, unit_width=4, unit_height=4)
+
+    assert (result.grid_width, result.grid_height) == (3, 3)
+    assert result.count == 9
+    assert result.bounds == (0, 0, 2, 2)
+
+
+def test_shared_edge_and_repeated_triangles_do_not_double_count():
+    result = rasterize_uv_coverage(
+        [0, 1, 2, 0, 2, 3, 0, 1, 2],
+        [(0, 0), (1, 0), (1, 1), (0, 1)],
+        8, 8, unit_width=4, unit_height=4)
+
+    assert result.count == 4
+    assert sum(result.mask) == result.count
+    assert result.triangle_count == 3
+
+
+def test_degenerate_triangles_are_skipped_and_reported():
+    result = rasterize_uv_coverage(
+        [0, 1, 2, 0, 1, 3],
+        [(0, 0), (0.5, 0), (1, 0), (0, 1)],
+        8, 8)
+
+    assert result.triangle_count == 2
+    assert result.degenerate_triangle_count == 1
+    assert result.count > 0
+
+
+def test_all_degenerate_triangles_report_no_coverage():
+    with pytest.raises(UVCoverageError) as raised:
+        rasterize_uv_coverage(
+            [0, 1, 2], [(0, 0), (0.5, 0), (1, 0)], 8, 8)
+
+    assert raised.value.code == "no_uv_coverage"
+
+
+def test_thin_triangle_crossing_a_unit_is_not_lost_to_center_sampling():
+    result = rasterize_uv_coverage(
+        [0, 1, 2], [(0, 0), (1, 0), (0, 0.01)], 8, 8)
+
+    assert result.count == 8
+    assert result.bounds == (0, 0, 7, 0)
+
+
+def test_source_uv_boundaries_are_inclusive():
+    result = rasterize_uv_coverage(
+        [0, 1, 2], [(0, 0), (1, 0), (0, 1)], 4, 4)
+
+    assert result.count > 0
+    assert result.bounds == (0, 0, 3, 3)
+
+
+@pytest.mark.parametrize("uvs", [
+    [(0, 0), (1.001, 0), (0, 1)],
+    [(0, 0), (1, 0), (-0.001, 1)],
+])
+def test_substantial_out_of_range_uvs_are_rejected(uvs):
+    with pytest.raises(UVCoverageError) as raised:
+        rasterize_uv_coverage([0, 1, 2], uvs, 4, 4)
+
+    assert raised.value.code == "tiled_uv_unsupported"
+
+
+def test_missing_uvs_and_invalid_indices_have_stable_codes():
+    with pytest.raises(UVCoverageError) as missing:
+        rasterize_uv_coverage([0, 1, 2], None, 4, 4)
+    assert missing.value.code == "mesh_has_no_uv"
+
+    with pytest.raises(UVCoverageError) as invalid:
+        rasterize_uv_coverage([0, 1, 3], [(0, 0), (1, 0), (0, 1)], 4, 4)
+    assert invalid.value.code == "invalid_geometry"

--- a/src/tests/web/support.py
+++ b/src/tests/web/support.py
@@ -336,7 +336,7 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                    "panelOpacity": [], "presentState": [],
                    "controlState": [], "meshSemantics": [],
                    "deleteToggle": [], "exportChanges": [],
-                   "saveMeshColorAdjustment": []},
+                   "saveMeshColorAdjustment": [], "analyzeTextureBake": []},
     }
     encoded_state = json.dumps(json.dumps(state))
     context.add_init_script(
@@ -437,6 +437,23 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                   || payload.metadata?.material_profiles || {},
                 asset_resolution: payload.meshSemanticsAssetResolution
                   ?? payload.asset_resolution ?? null,
+              });
+            },
+            analyze_mesh_texture_bake: async (path, semanticKey, texKey, usage) => {
+              state.calls.analyzeTextureBake.push([path, semanticKey, texKey, usage]);
+              return copy(state.responses[path]?.textureBakeResponse || {
+                status: 'ok',
+                safety: 'safe',
+                semantic_key: semanticKey,
+                tex_key: texKey,
+                texture: {file: 'body.dds', width: 8, height: 8, format: 'bc7_unorm'},
+                coverage: {
+                  unit: 'block', unit_width: 4, unit_height: 4,
+                  total_units: 4, selected_units: 1, unique_units: 1,
+                  shared_units: 0, selected_percent: 25,
+                  shared_percent_of_selected: 0,
+                },
+                shared_with: [], unresolved_consumers: [],
               });
             },
             get_model_skinning_preview: async path => {

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -953,6 +953,113 @@ def test_inspector_color_controls_gate_asset_textures_and_persist_on_change(
         context.close()
 
 
+def test_texture_coverage_action_is_read_only_and_includes_hidden_meshes(
+        edge_browser, frontend_url):
+    payload = _payload("Bake")
+    first = payload["meshes"]["Body-Bake-0"]
+    old_key = first["tex_key"]
+    dds_key = "diffuse::Bake-one.dds"
+    first["tex_key"] = dds_key
+    payload["texture_pools"]["p0"][0]["tex_key"] = dds_key
+    payload["textures"][dds_key] = payload["textures"].pop(old_key)
+    second = copy.deepcopy(first)
+    second["component"] = "Face Bake"
+    payload["meshes"]["Face-Bake-0"] = second
+    response = {
+        "status": "ok", "safety": "shared",
+        "texture": {"file": "Bake-one.dds", "width": 8, "height": 8,
+                     "format": "bc7_unorm"},
+        "coverage": {"unit": "block", "selected_units": 2,
+                     "total_units": 4, "unique_units": 1, "shared_units": 1,
+                     "selected_percent": 50, "shared_percent_of_selected": 50},
+        "shared_with": [{"semantic_key": "Face-Bake-0", "shared_units": 1}],
+        "unresolved_consumers": [],
+    }
+    context, page = _page(edge_browser, frontend_url, {"Bake": {
+        **payload, "textureBakeResponse": response,
+    }})
+    try:
+        _open(page, "Bake")
+        page.locator(".draw-item").first.wait_for()
+        page.evaluate("""() => {
+          window.modViewer.activeMeshes[1].visible = false;
+        }""")
+        page.evaluate("""async () => {
+          const {setMeshTextureState} = await import('./js/mesh/mesh-factory.js');
+          setMeshTextureState(window.modViewer.activeMeshes[1], {
+            diffuse: 'diffuse::Bake-two.dds',
+          });
+        }""")
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        button = page.locator(".inspector-texture-bake")
+        assert button.count() == 1
+        button.click()
+        page.locator("#texture-bake-modal-backdrop.show").wait_for()
+        assert page.locator("#texture-bake-body").inner_text().find(
+            "Texture Coverage Results") >= 0
+        assert page.locator("#texture-bake-close").count() == 1
+        assert page.locator("#texture-bake-close-x").count() == 1
+        assert page.locator("#texture-bake-body").inner_text().find(
+            "Coverage overlaps") >= 0
+        usage = page.evaluate("window.__fakeApi.calls.analyzeTextureBake[0][3]")
+        assert len(usage) == 2
+        assert {item["semantic_key"] for item in usage} == {
+            "Body-Bake-0", "Face-Bake-0"}
+        assert usage[1]["tex_key"] == "diffuse::Bake-two.dds"
+        assert page.evaluate("window.__fakeApi.calls.saveMeshColorAdjustment.length") == 0
+        page.locator("#texture-bake-close").click()
+        assert page.locator("#texture-bake-modal-backdrop.show").count() == 0
+    finally:
+        context.close()
+
+
+def test_texture_coverage_action_explains_non_dds_without_backend_call(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url, {"NonDDS": _payload("NonDDS")})
+    try:
+        _open(page, "NonDDS")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        color = page.locator(".inspector-color-section")
+        assert color.locator(".inspector-texture-bake").count() == 0
+        assert "requires a DDS source" in color.inner_text()
+        assert page.evaluate("window.__fakeApi.calls.analyzeTextureBake.length") == 0
+    finally:
+        context.close()
+
+
+def test_texture_coverage_stale_response_is_discarded(
+        edge_browser, frontend_url):
+    payload = _payload("Stale")
+    key = "diffuse::Stale-one.dds"
+    old_key = payload["meshes"]["Body-Stale-0"]["tex_key"]
+    payload["meshes"]["Body-Stale-0"]["tex_key"] = key
+    payload["texture_pools"]["p0"][0]["tex_key"] = key
+    payload["textures"][key] = payload["textures"].pop(old_key)
+    context, page = _page(edge_browser, frontend_url, {"Stale": payload})
+    try:
+        _open(page, "Stale")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.evaluate("""() => {
+          window.pywebview.api.analyze_mesh_texture_bake = async () =>
+            new Promise(resolve => { window.__releaseBake = resolve; });
+        }""")
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-modal-backdrop.show").wait_for()
+        page.wait_for_function("window.__releaseBake !== undefined")
+        page.evaluate("import('./js/scene/selection.js').then(({clearSelection}) => clearSelection())")
+        page.evaluate("window.__releaseBake({status: 'ok', safety: 'safe', coverage: {}})")
+        page.wait_for_function(
+            "document.querySelector('#texture-bake-modal-backdrop').classList.contains('show') === false")
+        assert page.locator("#texture-bake-state").count() == 0
+    finally:
+        context.close()
+
+
 def test_viewport_toolbar_popovers_and_responsive_overflow(
         edge_browser, frontend_url):
     context, page = _page(edge_browser, frontend_url, {"A": _payload("A")})

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -964,6 +964,7 @@ def test_texture_coverage_action_is_read_only_and_includes_hidden_meshes(
     payload["textures"][dds_key] = payload["textures"].pop(old_key)
     second = copy.deepcopy(first)
     second["component"] = "Face Bake"
+    second["display_name"] = "Friendly Face"
     payload["meshes"]["Face-Bake-0"] = second
     response = {
         "status": "ok", "safety": "shared",
@@ -1002,6 +1003,7 @@ def test_texture_coverage_action_is_read_only_and_includes_hidden_meshes(
         assert page.locator("#texture-bake-close-x").count() == 1
         assert page.locator("#texture-bake-body").inner_text().find(
             "Coverage overlaps") >= 0
+        assert "Friendly Face" in page.locator("#texture-bake-body").inner_text()
         usage = page.evaluate("window.__fakeApi.calls.analyzeTextureBake[0][3]")
         assert len(usage) == 2
         assert {item["semantic_key"] for item in usage} == {
@@ -1010,6 +1012,67 @@ def test_texture_coverage_action_is_read_only_and_includes_hidden_meshes(
         assert page.evaluate("window.__fakeApi.calls.saveMeshColorAdjustment.length") == 0
         page.locator("#texture-bake-close").click()
         assert page.locator("#texture-bake-modal-backdrop.show").count() == 0
+    finally:
+        context.close()
+
+
+def test_texture_coverage_unknown_state_does_not_claim_unique_units(
+        edge_browser, frontend_url):
+    payload = _payload("Unknown")
+    old_key = payload["meshes"]["Body-Unknown-0"]["tex_key"]
+    dds_key = "diffuse::Unknown-one.dds"
+    payload["meshes"]["Body-Unknown-0"]["tex_key"] = dds_key
+    payload["texture_pools"]["p0"][0]["tex_key"] = dds_key
+    payload["textures"][dds_key] = payload["textures"].pop(old_key)
+    payload["textureBakeResponse"] = {
+        "status": "ok", "safety": "unknown",
+        "texture": {"file": "Unknown-one.dds", "width": 8, "height": 8,
+                     "format": "bc7_unorm"},
+        "coverage": {"unit": "block", "selected_units": 4,
+                     "total_units": 4, "unique_units": None,
+                     "shared_units": 1, "selected_percent": 100,
+                     "shared_percent_of_selected": 25},
+        "shared_with": [], "unresolved_consumers": ["Other-0"],
+    }
+    context, page = _page(edge_browser, frontend_url, {"Unknown": payload})
+    try:
+        _open(page, "Unknown")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-modal-backdrop.show").wait_for()
+        details = page.locator("#texture-bake-body").inner_text()
+        assert "Safety is unknown" in details
+        assert "Unknown" in details
+    finally:
+        context.close()
+
+
+def test_texture_coverage_error_clears_loading_message(
+        edge_browser, frontend_url):
+    payload = _payload("Error")
+    old_key = payload["meshes"]["Body-Error-0"]["tex_key"]
+    dds_key = "diffuse::Error-one.dds"
+    payload["meshes"]["Body-Error-0"]["tex_key"] = dds_key
+    payload["texture_pools"]["p0"][0]["tex_key"] = dds_key
+    payload["textures"][dds_key] = payload["textures"].pop(old_key)
+    payload["textureBakeResponse"] = {
+        "status": "error", "code": "coverage_incomplete",
+        "error": "Texture coverage could not be analyzed safely.",
+    }
+    context, page = _page(edge_browser, frontend_url, {"Error": payload})
+    try:
+        _open(page, "Error")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-error").wait_for()
+        assert page.locator("#texture-bake-error").inner_text() == (
+            "Texture coverage could not be analyzed safely.")
+        assert "Analyzing texture coverage" not in page.locator(
+            "#texture-bake-body").inner_text()
     finally:
         context.close()
 

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -711,6 +711,27 @@ body.right-dock-mounted #view-gizmo { top: 52px; right: 338px; }
   border-radius: 6px; padding: 6px 14px; font-size: 12px; cursor: pointer; border: 1px solid var(--border);
 }
 #asset-folder-modal-backdrop .modal { width: 360px; }
+.texture-bake-modal { width: min(520px, calc(100vw - 40px)); }
+.texture-bake-title-row {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
+}
+.texture-bake-title-row h4 { margin-bottom: 0; }
+.texture-bake-body { min-height: 58px; color: var(--text-muted); font-size: 11px; line-height: 1.45; }
+.texture-bake-loading { padding: 12px 0; }
+.texture-bake-state { color: var(--success); font-size: 12px; font-weight: 600; }
+.texture-bake-state-unknown { color: var(--warning); }
+.texture-bake-summary { margin: 7px 0 10px; }
+.texture-bake-details {
+  display: grid; grid-template-columns: minmax(120px, 1fr) minmax(0, 2fr);
+  gap: 5px 12px; margin: 0;
+}
+.texture-bake-details dt { color: var(--text-muted); }
+.texture-bake-details dd { margin: 0; color: var(--text); text-align: right; overflow-wrap: anywhere; }
+.texture-bake-warning { margin: 12px 0 0; padding: 7px 8px; border-radius: 5px; }
+.texture-bake-warning-shared { color: var(--warning); background: rgba(210,153,34,.1); }
+.texture-bake-warning-unknown { color: var(--warning); background: rgba(210,153,34,.1); }
+.inspector-texture-bake { width: 100%; margin-top: 2px; }
+.inspector-texture-bake-hint { color: var(--text-muted); font-size: 10px; line-height: 1.35; }
 #mfm-cancel { background: var(--bg-control); color: var(--text); }
 #mfm-cancel:hover { background: var(--border); }
 #mfm-save { background: var(--success); color: #fff; border-color: rgba(240,246,252,.15); }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -488,6 +488,22 @@
   </div>
 </div>
 
+<div id="texture-bake-modal-backdrop" class="modal-backdrop">
+  <div class="modal texture-bake-modal" role="dialog" aria-modal="true"
+       aria-labelledby="texture-bake-title">
+    <div class="texture-bake-title-row">
+      <h4 id="texture-bake-title">Texture Coverage</h4>
+      <button type="button" id="texture-bake-close-x" class="icon-btn"
+              aria-label="Close texture coverage">×</button>
+    </div>
+    <div id="texture-bake-error" class="modal-error"></div>
+    <div id="texture-bake-body" class="texture-bake-body"></div>
+    <div class="modal-actions">
+      <button type="button" id="texture-bake-close">Close</button>
+    </div>
+  </div>
+</div>
+
 <div id="dialog-backdrop" class="dialog-backdrop">
   <div class="dialog-box" role="alertdialog" aria-modal="true" aria-describedby="dialog-message">
     <div id="dialog-message" class="dialog-message"></div>

--- a/src/web/js/mesh/texture-bake-analysis.js
+++ b/src/web/js/mesh/texture-bake-analysis.js
@@ -112,12 +112,15 @@ export function formatBakeAnalysis(result, displayName = key => key) {
     };
   }
   const coverage = result.coverage || {};
+  const uniqueUnits = coverage.unique_units == null
+    ? 'Unknown'
+    : `${coverage.unique_units} ${coverage.unit || 'units'}`;
   const rows = [
     ['Texture', result.texture?.file || 'Unknown'],
     ['Format', result.texture?.format || 'Unknown'],
     ['Texture size', `${result.texture?.width || 0} × ${result.texture?.height || 0}`],
     ['Selected coverage', `${coverage.selected_percent?.toFixed?.(1) ?? 0}% (${coverage.selected_units || 0} ${coverage.unit || 'units'})`],
-    ['Unique coverage', `${coverage.unique_units || 0} ${coverage.unit || 'units'}`],
+    ['Unique coverage', uniqueUnits],
     ['Shared coverage', `${coverage.shared_percent_of_selected?.toFixed?.(1) ?? 0}% (${coverage.shared_units || 0} ${coverage.unit || 'units'})`],
   ];
   const shared = (result.shared_with || []).map(item =>

--- a/src/web/js/mesh/texture-bake-analysis.js
+++ b/src/web/js/mesh/texture-bake-analysis.js
@@ -1,0 +1,147 @@
+// Read-only selected-mesh texture coverage requests.
+
+import { viewerState, samePath } from '../app/state.js';
+import { activeMeshes } from './mesh-state.js';
+import { isAssetTextureKey, splitTextureKey } from '../textures/texture-key.js';
+
+let requestToken = 0;
+
+const REASON_TEXT = Object.freeze({
+  'asset-texture': 'Asset textures are read-only.',
+  'no-diffuse': 'Select a diffuse texture before analyzing coverage.',
+  'not-diffuse': 'Texture coverage requires a diffuse texture.',
+  'different-mod': 'The selected mesh belongs to a different mod.',
+  'unsupported-texture-type': 'Texture coverage currently requires a DDS source.',
+});
+
+function reasonText(reason) {
+  return REASON_TEXT[reason] || 'Texture coverage is unavailable for this mesh.';
+}
+
+/** Return the current normal-mesh texture identities used by the backend. */
+export function buildTextureUsageSnapshot() {
+  return activeMeshes
+    .filter(mesh => mesh?.userData?.assetFill !== true)
+    .map(mesh => ({
+      semantic_key: mesh.userData?.semanticKey || '',
+      tex_key: mesh.userData?.texKey || null,
+    }));
+}
+
+/** Check the selected mesh without touching the backend or material state. */
+export function canAnalyzeTextureBake(mesh) {
+  const data = mesh?.userData;
+  const key = data?.texKey;
+  const parsed = splitTextureKey(key);
+  if (data?.assetFill === true || isAssetTextureKey(key)) {
+    return { editable: false, reason: 'asset-texture', message: reasonText('asset-texture') };
+  }
+  if (!parsed) {
+    return { editable: false, reason: 'no-diffuse', message: reasonText('no-diffuse') };
+  }
+  if (parsed.role !== 'diffuse') {
+    return { editable: false, reason: 'not-diffuse', message: reasonText('not-diffuse') };
+  }
+  if (!viewerState.currentModPath || !samePath(data.modPath, viewerState.currentModPath)) {
+    return { editable: false, reason: 'different-mod', message: reasonText('different-mod') };
+  }
+  if (!parsed.path.toLowerCase().endsWith('.dds')) {
+    return {
+      editable: false,
+      reason: 'unsupported-texture-type',
+      message: reasonText('unsupported-texture-type'),
+    };
+  }
+  return { editable: true, reason: null, message: '' };
+}
+
+function currentSelectionStillMatches(mesh, semanticKey, texKey, modPath, isCurrent) {
+  if (typeof isCurrent === 'function' && !isCurrent()) return false;
+  return activeMeshes.includes(mesh)
+    && mesh.userData?.semanticKey === semanticKey
+    && (mesh.userData?.texKey || null) === (texKey || null)
+    && samePath(mesh.userData?.modPath, modPath)
+    && samePath(viewerState.currentModPath, modPath);
+}
+
+/**
+ * Request selected-mesh coverage using only semantic texture identities.
+ * A stale response is discarded and returned as null.
+ */
+export async function analyzeMeshTextureBake(mesh, { isCurrent } = {}) {
+  const token = ++requestToken;
+  const eligibility = canAnalyzeTextureBake(mesh);
+  if (!eligibility.editable) {
+    return {
+      status: 'unsupported',
+      code: eligibility.reason,
+      error: eligibility.message,
+    };
+  }
+
+  const semanticKey = mesh.userData.semanticKey;
+  const texKey = mesh.userData.texKey || null;
+  const modPath = viewerState.currentModPath;
+  const api = window.pywebview?.api?.analyze_mesh_texture_bake;
+  if (typeof api !== 'function') {
+    return {
+      status: 'error',
+      code: 'analysis_unavailable',
+      error: 'Texture coverage analysis is unavailable.',
+    };
+  }
+  const textureUsage = buildTextureUsageSnapshot();
+  const result = await api(modPath, semanticKey, texKey, textureUsage);
+  if (token !== requestToken || !currentSelectionStillMatches(
+      mesh, semanticKey, texKey, modPath, isCurrent)) {
+    return null;
+  }
+  return result;
+}
+
+/** Convert the stable backend schema into modal-friendly text. */
+export function formatBakeAnalysis(result, displayName = key => key) {
+  if (!result) return null;
+  if (result.status !== 'ok') {
+    return {
+      kind: result.status === 'unsupported' ? 'unsupported' : 'error',
+      title: result.status === 'unsupported' ? 'Texture Coverage Unavailable' : 'Texture Coverage Failed',
+      summary: result.error || 'Texture coverage could not be analyzed safely.',
+      warning: '',
+      rows: [],
+    };
+  }
+  const coverage = result.coverage || {};
+  const rows = [
+    ['Texture', result.texture?.file || 'Unknown'],
+    ['Format', result.texture?.format || 'Unknown'],
+    ['Texture size', `${result.texture?.width || 0} × ${result.texture?.height || 0}`],
+    ['Selected coverage', `${coverage.selected_percent?.toFixed?.(1) ?? 0}% (${coverage.selected_units || 0} ${coverage.unit || 'units'})`],
+    ['Unique coverage', `${coverage.unique_units || 0} ${coverage.unit || 'units'}`],
+    ['Shared coverage', `${coverage.shared_percent_of_selected?.toFixed?.(1) ?? 0}% (${coverage.shared_units || 0} ${coverage.unit || 'units'})`],
+  ];
+  const shared = (result.shared_with || []).map(item =>
+    `${displayName(item.semantic_key)} (${item.shared_units} ${coverage.unit || 'units'})`);
+  const unresolved = (result.unresolved_consumers || []).map(displayName);
+  let warning = '';
+  if (result.safety === 'unknown') {
+    warning = unresolved.length
+      ? `Safety is unknown because coverage could not be analyzed for: ${unresolved.join(', ')}.`
+      : 'Safety is unknown because one or more consumers could not be analyzed.';
+  } else if (result.safety === 'shared') {
+    warning = shared.length
+      ? `Coverage overlaps: ${shared.join(', ')}.`
+      : 'Coverage overlaps another active draw using this texture.';
+  }
+  return {
+    kind: result.safety === 'unknown' ? 'unknown' : 'ok',
+    title: result.safety === 'safe' ? 'Texture Coverage Is Unique' : 'Texture Coverage Results',
+    summary: `${coverage.selected_percent?.toFixed?.(1) ?? 0}% of the texture is touched by this mesh.`,
+    warning,
+    rows,
+  };
+}
+
+export function cancelTextureBakeAnalysis() {
+  requestToken += 1;
+}

--- a/src/web/js/panels/inspector-panel.js
+++ b/src/web/js/panels/inspector-panel.js
@@ -7,6 +7,8 @@ import {
   canEditMeshColor, getMeshColorAdjustment, resetMeshColorAdjustment,
   setMeshColorAdjustment,
 } from '../mesh/mesh-color-state.js';
+import { canAnalyzeTextureBake } from '../mesh/texture-bake-analysis.js';
+import { openTextureBakeModal } from '../ui/texture-bake-modal.js';
 
 const meshRecords = new WeakMap();
 let current = null;
@@ -272,6 +274,29 @@ function updateColorAdjustment(mesh, field, controlValue, persist = false) {
   setMeshColorAdjustment(mesh, next, { persist, render: true });
 }
 
+function buildTextureBakeAction(section, mesh) {
+  const eligibility = canAnalyzeTextureBake(mesh);
+  if (eligibility.editable) {
+    const analyze = document.createElement('button');
+    analyze.type = 'button';
+    analyze.className = 'ui-button inspector-texture-bake';
+    analyze.textContent = 'Analyze Texture Coverage';
+    analyze.addEventListener('click', async () => {
+      analyze.disabled = true;
+      try {
+        await openTextureBakeModal(mesh, {
+          isCurrent: () => current?.type === 'mesh' && current.mesh === mesh,
+        });
+      } finally {
+        analyze.disabled = false;
+      }
+    });
+    section.appendChild(analyze);
+  } else if (eligibility.reason === 'unsupported-texture-type') {
+    addText(section, 'inspector-texture-bake-hint', eligibility.message);
+  }
+}
+
 function buildColorSection(content, mesh) {
   const section = document.createElement('section');
   section.className = 'inspector-section inspector-color-section';
@@ -354,6 +379,7 @@ function buildColorSection(content, mesh) {
     updateColorControlState(content, mesh);
   });
   section.appendChild(reset);
+  buildTextureBakeAction(section, mesh);
   content.appendChild(section);
   return section;
 }

--- a/src/web/js/ui/texture-bake-modal.js
+++ b/src/web/js/ui/texture-bake-modal.js
@@ -4,11 +4,18 @@ import { bindModalDismiss, setModalError } from './modal-shell.js';
 import {
   analyzeMeshTextureBake, cancelTextureBakeAnalysis, formatBakeAnalysis,
 } from '../mesh/texture-bake-analysis.js';
+import { activeMeshes } from '../mesh/mesh-state.js';
 
 const $ = id => document.getElementById(id);
 const backdrop = $('texture-bake-modal-backdrop');
 const body = $('texture-bake-body');
 const error = $('texture-bake-error');
+
+function displayNameForSemanticKey(semanticKey) {
+  const mesh = activeMeshes.find(item =>
+    item.userData?.semanticKey === semanticKey);
+  return mesh?.userData?.displayName || semanticKey;
+}
 
 function closeTextureBakeModal() {
   cancelTextureBakeAnalysis();
@@ -26,15 +33,15 @@ function setLoading(loading) {
   }
 }
 
-function renderResult(result, displayName) {
+function renderResult(result, displayName = displayNameForSemanticKey) {
   setModalError(error, '');
+  body.replaceChildren();
   const formatted = formatBakeAnalysis(result, displayName);
   if (!formatted) return false;
   if (formatted.kind === 'error') {
     setModalError(error, formatted.summary);
     return true;
   }
-  body.replaceChildren();
   const state = document.createElement('div');
   state.className = `texture-bake-state texture-bake-state-${formatted.kind}`;
   state.textContent = formatted.title;

--- a/src/web/js/ui/texture-bake-modal.js
+++ b/src/web/js/ui/texture-bake-modal.js
@@ -1,0 +1,99 @@
+// Read-only texture coverage result modal.
+
+import { bindModalDismiss, setModalError } from './modal-shell.js';
+import {
+  analyzeMeshTextureBake, cancelTextureBakeAnalysis, formatBakeAnalysis,
+} from '../mesh/texture-bake-analysis.js';
+
+const $ = id => document.getElementById(id);
+const backdrop = $('texture-bake-modal-backdrop');
+const body = $('texture-bake-body');
+const error = $('texture-bake-error');
+
+function closeTextureBakeModal() {
+  cancelTextureBakeAnalysis();
+  backdrop?.classList.remove('show');
+}
+
+function setLoading(loading) {
+  if (!body) return;
+  body.replaceChildren();
+  if (loading) {
+    const message = document.createElement('div');
+    message.className = 'texture-bake-loading';
+    message.textContent = 'Analyzing texture coverage…';
+    body.appendChild(message);
+  }
+}
+
+function renderResult(result, displayName) {
+  setModalError(error, '');
+  const formatted = formatBakeAnalysis(result, displayName);
+  if (!formatted) return false;
+  if (formatted.kind === 'error') {
+    setModalError(error, formatted.summary);
+    return true;
+  }
+  body.replaceChildren();
+  const state = document.createElement('div');
+  state.className = `texture-bake-state texture-bake-state-${formatted.kind}`;
+  state.textContent = formatted.title;
+  body.appendChild(state);
+  const summary = document.createElement('p');
+  summary.className = 'texture-bake-summary';
+  summary.textContent = formatted.summary;
+  body.appendChild(summary);
+
+  const rows = document.createElement('dl');
+  rows.className = 'texture-bake-details';
+  formatted.rows.forEach(([label, value]) => {
+    const term = document.createElement('dt');
+    term.textContent = label;
+    const description = document.createElement('dd');
+    description.textContent = value;
+    rows.append(term, description);
+  });
+  body.appendChild(rows);
+  if (formatted.warning) {
+    const warning = document.createElement('p');
+    warning.className = `texture-bake-warning texture-bake-warning-${formatted.kind}`;
+    warning.textContent = formatted.warning;
+    body.appendChild(warning);
+  }
+  return true;
+}
+
+/** Open the read-only analysis modal and resolve after the request settles. */
+export async function openTextureBakeModal(mesh, { isCurrent } = {}) {
+  if (!backdrop || !body) return null;
+  setModalError(error, '');
+  setLoading(true);
+  backdrop.classList.add('show');
+  let result;
+  try {
+    result = await analyzeMeshTextureBake(mesh, { isCurrent });
+  } catch (requestError) {
+    result = {
+      status: 'error',
+      error: 'Texture coverage could not be analyzed safely.',
+    };
+  }
+  if (result === null) {
+    closeTextureBakeModal();
+    return null;
+  }
+  renderResult(result);
+  return result;
+}
+
+bindModalDismiss({
+  backdrop,
+  close: closeTextureBakeModal,
+  buttons: [$('texture-bake-close'), $('texture-bake-close-x')].filter(Boolean),
+});
+
+window.addEventListener('mod-viewer-mesh-selected', () => {
+  if (backdrop?.classList.contains('show')) closeTextureBakeModal();
+});
+
+export { closeTextureBakeModal };


### PR DESCRIPTION
## Summary

- Add conservative, pure UV coverage rasterization for pixel and DDS block edit units.
- Add read-only backend analysis using authoritative staged INI draws, packed geometry, safe mod paths, DDS format eligibility, and shared-texture safety reporting.
- Add the bridge API, Inspector action, stale-request handling, and read-only results modal.
- Add regressions for UV boundaries, malformed geometry, Asset/path/format safety, shared consumers, V conversion, no-write behavior, and frontend state.

## Validation

- `pytest -q --ignore=src/tests/web`