### PR TITLE
feat: add safe DDS color bake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build/
 /dist/
 /src/assets/
+/src/runtime_tools/texconv.exe
 /src/build/
 /src/dist/
 *.spec

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,3 +10,32 @@
 This application vendors the minified no-conflict Ace core, INI mode,
 Tomorrow Night theme, and search-box extension without modifying those
 upstream files.
+
+## DirectXTex / texconv
+
+- Version: May 2026 (`may2026`)
+- Source: https://github.com/microsoft/DirectXTex
+- License: MIT
+
+The build downloads a pinned, SHA-256-verified `texconv.exe` release asset at
+build time. The executable is not committed to this repository.
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/app/bridge/api.py
+++ b/src/app/bridge/api.py
@@ -162,6 +162,13 @@ class ModViewerAPI:
         return self._mod_preview.analyze_mesh_texture_bake(
             folder_path, semantic_key, tex_key, texture_usage)
 
+    def bake_mesh_texture_color(
+            self, folder_path, semantic_key, metadata_key, tex_key,
+            texture_usage, adjustment):
+        return self._mod_preview.bake_mesh_texture_color(
+            folder_path, semantic_key, metadata_key, tex_key,
+            texture_usage, adjustment)
+
     def get_model_skinning_preview(self, folder_path):
         return self._mod_preview.get_model_skinning_preview(folder_path)
 

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -16,7 +16,9 @@ from core.textures import encode_texture_file
 from core.mod_discovery import discover_ini_paths
 from core.ini.health import analyze_mod
 from app.mods.analysis import resolved_draws
-from app.mods.texture_bake import analyze_texture_bake
+from app.mods.texture_bake import (
+    analyze_texture_bake, bake_mesh_texture_color,
+)
 from core.textures.profiles import texture_profile_for
 
 from app.assets import folders as asset_folders
@@ -160,6 +162,30 @@ class ModPreview:
             return analyze_texture_bake(
                 context, overrides, self._active_mesh_keys.get(folder_path),
                 semantic_key, tex_key, texture_usage)
+        except Exception:
+            return self._semantic_read_error()
+
+    def bake_mesh_texture_color(
+            self, folder_path, semantic_key, metadata_key, tex_key,
+            texture_usage, adjustment):
+        """Bake selected-mesh color into safe units of its mod DDS."""
+        try:
+            folder_path, overrides, _pending, context = \
+                self.authoritative_context(folder_path)
+            result = bake_mesh_texture_color(
+                context, overrides, self._active_mesh_keys.get(folder_path),
+                semantic_key, tex_key, texture_usage, adjustment)
+            if result.get("status") != "ok":
+                return result
+            try:
+                from core.textures.color_adjustment import COLOR_DEFAULTS
+                reset = metadata.save_mesh_color_adjustment(
+                    folder_path, metadata_key, dict(COLOR_DEFAULTS))
+                if reset.get("error"):
+                    result["warning"] = "color_state_reset_failed"
+            except Exception:
+                result["warning"] = "color_state_reset_failed"
+            return result
         except Exception:
             return self._semantic_read_error()
 

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -174,7 +174,8 @@ class ModPreview:
                 self.authoritative_context(folder_path)
             result = bake_mesh_texture_color(
                 context, overrides, self._active_mesh_keys.get(folder_path),
-                semantic_key, tex_key, texture_usage, adjustment)
+                semantic_key, tex_key, texture_usage, adjustment,
+                metadata_key)
             if result.get("status") != "ok":
                 return result
             try:

--- a/src/app/mods/metadata.py
+++ b/src/app/mods/metadata.py
@@ -1,9 +1,7 @@
 """Viewer-only mesh labels and texture choices stored beside a mod."""
 from collections import Counter
 import json
-import math
 import os
-import re
 import threading
 from copy import deepcopy
 
@@ -14,34 +12,16 @@ from core.geometry.skinning import (
     normalize_skinning_source_file, skinning_source_key,
 )
 from core.textures.profiles import texture_profile_for
+from core.textures.color_adjustment import (
+    normalize_color_adjustment as _normalize_mesh_color_adjustment,
+    is_neutral_color_adjustment as _is_neutral_mesh_color_adjustment,
+)
 
 METADATA_NAME = ".mod_viewer.json"
 PRESENT_NAMES_KEY = "__all__"
 _LOCK = threading.RLock()
 
 MESH_COLOR_ADJUSTMENTS_KEY = "mesh_color_adjustments"
-_COLOR_DEFAULTS = {
-    "hue": 0,
-    "saturation": 1.0,
-    "brightness": 1.0,
-    "contrast": 1.0,
-    "red": 1.0,
-    "green": 1.0,
-    "blue": 1.0,
-    "tint": "#ffffff",
-    "tint_strength": 0.0,
-}
-_COLOR_RANGES = {
-    "hue": (-180.0, 180.0),
-    "saturation": (0.0, 2.0),
-    "brightness": (0.0, 2.0),
-    "contrast": (0.0, 2.0),
-    "red": (0.0, 2.0),
-    "green": (0.0, 2.0),
-    "blue": (0.0, 2.0),
-    "tint_strength": (0.0, 1.0),
-}
-_TINT_PATTERN = re.compile(r"^#[0-9a-f]{6}$", re.IGNORECASE)
 
 
 def _legacy_mesh_key(name, entry):
@@ -109,38 +89,6 @@ def _save(folder_path, data):
         fh.write("\n")
     os.replace(temp_path, path)
     return {"saved": True, "path": path}
-
-
-def _normalize_mesh_color_adjustment(value, *, reject_invalid=False):
-    """Normalize one sparse viewer color state, or reject malformed input."""
-    if not isinstance(value, dict):
-        return None
-    result = {}
-    for field, default in _COLOR_DEFAULTS.items():
-        raw = value.get(field, default)
-        if field == "tint":
-            if not isinstance(raw, str) or not _TINT_PATTERN.fullmatch(raw):
-                if reject_invalid:
-                    return None
-                raw = default
-            result[field] = raw.lower()
-            continue
-        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
-            if reject_invalid:
-                return None
-            raw = default
-        elif not math.isfinite(raw):
-            if reject_invalid:
-                return None
-            raw = default
-        minimum, maximum = _COLOR_RANGES[field]
-        result[field] = min(maximum, max(minimum, float(raw)))
-    result["hue"] = int(result["hue"]) if result["hue"].is_integer() else result["hue"]
-    return result
-
-
-def _is_neutral_mesh_color_adjustment(value):
-    return value == _COLOR_DEFAULTS
 
 
 def mesh_color_adjustments(folder_path=None, data=None):

--- a/src/app/mods/texture_bake.py
+++ b/src/app/mods/texture_bake.py
@@ -895,6 +895,8 @@ def bake_texture_color(
                     "The DDS encoder produced an invalid candidate.") from error
             candidate_layout = _validate_candidate(
                 prepared.layout, candidate_path, candidate)
+            _validate_alpha_preservation(
+                candidate, candidate_layout, prepared.safe_masks)
             final = _patch_dds_units(
                 original, candidate, prepared.layout,
                 prepared.safe_masks, candidate_layout)

--- a/src/app/mods/texture_bake.py
+++ b/src/app/mods/texture_bake.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import hashlib
+import io
 import os
 import struct
 import tempfile
@@ -703,22 +704,101 @@ def _validate_candidate(source_layout, candidate_path, candidate_bytes):
     return candidate_layout
 
 
-def _validate_alpha_preservation(info, image):
-    """Reject BC1/BC7 transparency that the block patch cannot preserve."""
-    if info.format not in _OPAQUE_ONLY_FORMATS:
-        return
+def _alpha_preservation_error():
+    return TextureBakeAnalysisError(
+        "alpha_preservation_unsupported",
+        "This texture contains transparency that cannot currently be "
+        "preserved exactly while recoloring its compressed blocks.",
+        "unsupported")
+
+
+def _bc1_block_is_opaque(block):
+    """Return whether a BC1 block decodes to opaque alpha in every texel."""
+    if len(block) != 8:
+        raise TextureBakeAnalysisError(
+            "texture_validation_failed", "DDS payload layout is invalid.")
+    color0, color1 = struct.unpack_from("<HH", block)
+    if color0 > color1:
+        return True
+    selectors = struct.unpack_from("<I", block, 4)[0]
+    return all(((selectors >> (2 * index)) & 0x3) != 3
+               for index in range(16))
+
+
+def _decode_dds_mip_rgba(source, layout, mip):
+    """Decode one source mip using the shared Pillow DDS decoder."""
+    if (layout.info.format not in {"bc7_unorm", "bc7_srgb"}
+            or len(source) < layout.data_offset
+            or len(source) < mip.offset + mip.length):
+        raise TextureBakeAnalysisError(
+            "texture_validation_failed", "DDS payload layout is invalid.")
+    header = bytearray(source[:layout.data_offset])
+    struct.pack_into("<II", header, 12, mip.height, mip.width)
+    struct.pack_into("<I", header, 28, 1)
+    if layout.info.format == "bc7_srgb":
+        # Pillow's BC7 decoder accepts the equivalent UNORM payload more
+        # consistently than the typed sRGB DXGI variant. The alpha plane is
+        # identical, so this header-only conversion is lossless for validation.
+        struct.pack_into("<I", header, 128, 98)
+    payload = source[mip.offset:mip.offset + mip.length]
     try:
-        alpha_min, _alpha_max = image.getchannel("A").getextrema()
+        from PIL import Image
+        image = Image.open(io.BytesIO(bytes(header) + payload))
+        image.load()
+        return image.convert("RGBA")
     except Exception as error:
+        raise _alpha_preservation_error() from error
+
+
+def _validate_bc7_safe_blocks(source, layout, safe_masks):
+    """Require decoded alpha 255 for every safe BC7 block at every mip."""
+    for mip, mask in zip(layout.mips, safe_masks):
+        if not any(mask):
+            continue
+        try:
+            image = _decode_dds_mip_rgba(source, layout, mip)
+            if image.size != (mip.width, mip.height):
+                raise ValueError("decoded mip dimensions differ from DDS")
+            alpha = image.getchannel("A").tobytes()
+        except TextureBakeAnalysisError:
+            raise
+        except Exception as error:
+            raise _alpha_preservation_error() from error
+        for index, selected in enumerate(mask):
+            if not selected:
+                continue
+            unit_x = (index % mip.units_x) * 4
+            unit_y = (index // mip.units_x) * 4
+            unit_width = min(4, mip.width - unit_x)
+            unit_height = min(4, mip.height - unit_y)
+            if any(alpha[row * mip.width + unit_x:
+                       row * mip.width + unit_x + unit_width].count(255)
+                   != unit_width
+                   for row in range(unit_y, unit_y + unit_height)):
+                raise _alpha_preservation_error()
+
+
+def _validate_alpha_preservation(source, layout, safe_masks):
+    """Prove alpha is unchanged for every compressed block being replaced."""
+    if layout.info.format not in _OPAQUE_ONLY_FORMATS:
+        return
+    if (len(source) < layout.payload_end
+            or len(safe_masks) != len(layout.mips)
+            or any(len(mask) != mip.units_x * mip.units_y
+                   for mip, mask in zip(layout.mips, safe_masks))):
         raise TextureBakeAnalysisError(
-            "texture_decode_failed",
-            "The source DDS alpha channel could not be inspected.") from error
-    if alpha_min != 255:
-        raise TextureBakeAnalysisError(
-            "alpha_preservation_unsupported",
-            "This texture contains transparency that cannot currently be "
-            "preserved exactly while recoloring its compressed blocks.",
-            "unsupported")
+            "texture_validation_failed", "DDS payload layout is invalid.")
+    if layout.info.format.startswith("bc1"):
+        for mip, mask in zip(layout.mips, safe_masks):
+            for index, selected in enumerate(mask):
+                if not selected:
+                    continue
+                start = mip.offset + index * mip.bytes_per_unit
+                if not _bc1_block_is_opaque(
+                        source[start:start + mip.bytes_per_unit]):
+                    raise _alpha_preservation_error()
+        return
+    _validate_bc7_safe_blocks(source, layout, safe_masks)
 
 
 def _affected_texture_keys(context, prepared):
@@ -785,7 +865,8 @@ def bake_texture_color(
             raise TextureBakeAnalysisError(
                 "texture_decode_failed", "The source DDS could not be decoded at full resolution.")
         rgba = image.convert("RGBA")
-        _validate_alpha_preservation(prepared.info, rgba)
+        _validate_alpha_preservation(
+            original, prepared.layout, prepared.safe_masks)
         masked_rgba = adjust_rgba_bytes(
             rgba.tobytes(), rgba.width, rgba.height, normalized,
             prepared.selected_pixels.mask)
@@ -799,7 +880,7 @@ def bake_texture_color(
             try:
                 candidate_path = encode_png_to_dds(
                     png_path, workdir, prepared.info.format,
-                    prepared.info.mip_count)
+                    prepared.info.mip_count, srgb=True)
             except TexconvUnavailableError as error:
                 raise TextureBakeAnalysisError(
                     "texconv_unavailable", str(error)) from error

--- a/src/app/mods/texture_bake.py
+++ b/src/app/mods/texture_bake.py
@@ -176,6 +176,31 @@ def _usage_texture_path(mod_dir, key, expected_role):
     return _canonical_mod_path(mod_dir, relative_path)
 
 
+def authored_diffuse_run_consumers(
+        group, mod_dir, selected_physical_identity, game_profile=None):
+    """Project possible diffuse consumers through one ordered draw group.
+
+    A conditional authored diffuse assignment can start a texture run whose
+    following draws inherit the selected texture.  The conservative projection
+    keeps every draw after the first possible selected assignment because a
+    later boundary is not necessarily active in every reachable state.
+    """
+    consumers = []
+    run_started = False
+    for draw in deduplicate_draws(group):
+        if not run_started:
+            owned = authored_texture_keys_for_draw(
+                draw, mod_dir, game_profile)
+            run_started = any(
+                path and _physical_identity(path) == selected_physical_identity
+                for texture_key in owned.get("diffuse", ())
+                for path in (_usage_texture_path(
+                    mod_dir, texture_key, "diffuse"),))
+        if run_started and draw.label not in consumers:
+            consumers.append(draw.label)
+    return tuple(consumers)
+
+
 def _texture_details(path, info):
     return {
         "file": os.path.basename(path),
@@ -411,20 +436,22 @@ def _resolve_request(context, overrides, active_mesh_keys, selected_semantic_key
             owned = authored_texture_keys_for_draw(
                 draw, context.mod_dir, parsed.game.game)
             for role in _TEXTURE_USAGE_ROLES:
+                if role == "diffuse":
+                    continue
                 for texture_key in owned.get(role, ()):
                     path = _usage_texture_path(
                         context.mod_dir, texture_key, role)
                     if not path or _physical_identity(path) != selected_identity:
                         continue
-                    if role == "diffuse":
-                        if draw.label != selected_semantic_key:
-                            authored_consumers.setdefault(
-                                draw.label, draws.get(draw.label))
-                    else:
-                        value = (draw.label, role)
-                        if value not in cross_role_seen:
-                            cross_role_seen.add(value)
-                            cross_role_usage.append(value)
+                    value = (draw.label, role)
+                    if value not in cross_role_seen:
+                        cross_role_seen.add(value)
+                        cross_role_usage.append(value)
+        for semantic_key in authored_diffuse_run_consumers(
+                group, context.mod_dir, selected_identity, parsed.game.game):
+            if semantic_key != selected_semantic_key:
+                authored_consumers.setdefault(
+                    semantic_key, draws.get(semantic_key))
     if cross_role_usage:
         uses = []
         for semantic_key, role in cross_role_usage:

--- a/src/app/mods/texture_bake.py
+++ b/src/app/mods/texture_bake.py
@@ -39,6 +39,9 @@ _UNSUPPORTED_COLOR_FORMATS = frozenset({
     "bc4_unorm", "bc4_snorm", "bc5_unorm", "bc5_snorm",
     "bc6h_ufloat", "bc6h_float",
 })
+_OPAQUE_ONLY_FORMATS = frozenset({
+    "bc1_unorm", "bc1_srgb", "bc7_unorm", "bc7_srgb",
+})
 
 
 class TextureBakeAnalysisError(ValueError):
@@ -644,7 +647,7 @@ def _write_temp(path, data):
 
 
 def _patch_dds_units(original, candidate, layout, safe_masks, candidate_layout=None):
-    """Copy only selected-and-unique edit units from candidate DDS bytes."""
+    """Copy safe color data while retaining source alpha when possible."""
     candidate_layout = candidate_layout or layout
     if (len(original) < layout.payload_end
             or len(candidate) < candidate_layout.payload_end
@@ -667,8 +670,20 @@ def _patch_dds_units(original, candidate, layout, safe_masks, candidate_layout=N
                 continue
             source_start = candidate_mip.offset + index * candidate_mip.bytes_per_unit
             target_start = mip.offset + index * mip.bytes_per_unit
-            result[target_start:target_start + mip.bytes_per_unit] = candidate[
+            candidate_unit = candidate[
                 source_start:source_start + candidate_mip.bytes_per_unit]
+            if layout.info.format in {"rgba8", "bgra8"}:
+                # The first three bytes are the format's RGB channels; byte 3
+                # is authored alpha and must remain byte-for-byte unchanged.
+                unit = candidate_unit[:3] + original[
+                    target_start + 3:target_start + 4]
+            elif layout.info.format.startswith(("bc2", "bc3")):
+                # BC2/BC3 store alpha in an independent eight-byte sub-block.
+                unit = original[target_start:target_start + 8] + candidate_unit[8:]
+            else:
+                # BC1/BC7 are admitted only after the source was proven opaque.
+                unit = candidate_unit
+            result[target_start:target_start + mip.bytes_per_unit] = unit
     return bytes(result)
 
 
@@ -688,10 +703,56 @@ def _validate_candidate(source_layout, candidate_path, candidate_bytes):
     return candidate_layout
 
 
+def _validate_alpha_preservation(info, image):
+    """Reject BC1/BC7 transparency that the block patch cannot preserve."""
+    if info.format not in _OPAQUE_ONLY_FORMATS:
+        return
+    try:
+        alpha_min, _alpha_max = image.getchannel("A").getextrema()
+    except Exception as error:
+        raise TextureBakeAnalysisError(
+            "texture_decode_failed",
+            "The source DDS alpha channel could not be inspected.") from error
+    if alpha_min != 255:
+        raise TextureBakeAnalysisError(
+            "alpha_preservation_unsupported",
+            "This texture contains transparency that cannot currently be "
+            "preserved exactly while recoloring its compressed blocks.",
+            "unsupported")
+
+
+def _affected_texture_keys(context, prepared):
+    """Resolve every active usage key for the physically changed source."""
+    selected_identity = _physical_identity(prepared.selected_path)
+    affected = []
+    seen_keys = set()
+    for entry in prepared.entries:
+        key = entry["tex_key"]
+        path = _texture_path(context.mod_dir, key) if key else None
+        if (not key or not path or key in seen_keys
+                or _physical_identity(path) != selected_identity):
+            continue
+        seen_keys.add(key)
+        affected.append(key)
+    return affected
+
+
+def _replacement_completed(source_path, temporary_path, final):
+    """Detect a replace call that completed before surfacing an OSError."""
+    try:
+        if os.path.exists(temporary_path):
+            return False
+        return _read_source(source_path) == final
+    except Exception:
+        return False
+
+
 def bake_texture_color(
         context, overrides, active_mesh_keys, selected_semantic_key,
         selected_texture_key, texture_usage, adjustment):
     """Safely bake a non-neutral adjustment into unique DDS units only."""
+    committed = False
+    success_result = None
     try:
         # Preparation includes the independent mod-root/Asset check and must be
         # repeated for the destructive request, even after a prior analysis.
@@ -724,9 +785,12 @@ def bake_texture_color(
             raise TextureBakeAnalysisError(
                 "texture_decode_failed", "The source DDS could not be decoded at full resolution.")
         rgba = image.convert("RGBA")
+        _validate_alpha_preservation(prepared.info, rgba)
         masked_rgba = adjust_rgba_bytes(
             rgba.tobytes(), rgba.width, rgba.height, normalized,
             prepared.selected_pixels.mask)
+        # Resolve all post-commit metadata before the destructive boundary.
+        affected = _affected_texture_keys(context, prepared)
 
         with tempfile.TemporaryDirectory(prefix="modviewer-bake-") as workdir:
             from PIL import Image
@@ -760,6 +824,21 @@ def bake_texture_color(
             backup_path = _write_backup(prepared.selected_path, original)
             _assert_source_unchanged(prepared.selected_path, original_hash)
             temporary = _write_temp(prepared.selected_path, final)
+            success_result = {
+                "status": "ok",
+                "tex_key": selected_texture_key,
+                "affected_tex_keys": affected,
+                "texture": _texture_details(
+                    prepared.selected_path, prepared.info),
+                "patched": {
+                    "mip0_units": mip0_safe,
+                    "total_units": sum(
+                        len(mask) for mask in prepared.safe_masks),
+                    "shared_units_preserved": sum(
+                        sum(mask) for mask in prepared.shared_masks),
+                },
+                "backup": {"file": os.path.basename(backup_path)},
+            }
             try:
                 final_layout = inspect_dds_layout(temporary)
                 if final_layout is None:
@@ -772,40 +851,29 @@ def bake_texture_color(
                 try:
                     os.replace(temporary, prepared.selected_path)
                 except OSError as error:
-                    raise TextureBakeAnalysisError(
-                        "texture_write_failed", "The DDS could not be replaced safely.") from error
-                temporary = None
+                    if not _replacement_completed(
+                            prepared.selected_path, temporary, final):
+                        raise TextureBakeAnalysisError(
+                            "texture_write_failed",
+                            "The DDS could not be replaced safely.") from error
+                    committed = True
+                    temporary = None
+                else:
+                    committed = True
+                    temporary = None
             finally:
                 if temporary and os.path.exists(temporary):
                     os.remove(temporary)
-
-        selected_identity = _physical_identity(prepared.selected_path)
-        affected = []
-        seen_keys = set()
-        for entry in prepared.entries:
-            key = entry["tex_key"]
-            path = _texture_path(context.mod_dir, key) if key else None
-            if (not key or not path or key in seen_keys
-                    or _physical_identity(path) != selected_identity):
-                continue
-            seen_keys.add(key)
-            affected.append(key)
-        return {
-            "status": "ok",
-            "tex_key": selected_texture_key,
-            "affected_tex_keys": affected,
-            "texture": _texture_details(prepared.selected_path, prepared.info),
-            "patched": {
-                "mip0_units": mip0_safe,
-                "total_units": sum(len(mask) for mask in prepared.safe_masks),
-                "shared_units_preserved": sum(
-                    sum(mask) for mask in prepared.shared_masks),
-            },
-            "backup": {"file": os.path.basename(backup_path)},
-        }
+        return success_result
     except TextureBakeAnalysisError as error:
+        if committed and success_result is not None:
+            success_result["warning"] = "post_bake_cleanup_failed"
+            return success_result
         return _error(error.code, error.message, error.status)
     except Exception:
+        if committed and success_result is not None:
+            success_result["warning"] = "post_bake_cleanup_failed"
+            return success_result
         return _error(
             "texture_write_failed", "The DDS could not be baked safely.")
 

--- a/src/app/mods/texture_bake.py
+++ b/src/app/mods/texture_bake.py
@@ -1,14 +1,29 @@
-"""Read-only DDS coverage analysis for the future texture baker."""
+"""Authoritative analysis and safe, unit-preserving DDS color baking."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
 import os
 import struct
+import tempfile
 
 from core.geometry.buffers import BufferStore
 from core.geometry.conventions import geometry_convention_for
 from core.geometry.packing import pack_draw_geometry
 from core.resource_paths import _canonical, safe_resource_path
 from core.textures import split_texture_key
-from core.textures.dds import inspect_dds
+from core.textures.color_adjustment import (
+    adjust_rgba_bytes, is_neutral_color_adjustment,
+    normalize_color_adjustment,
+)
+from core.textures.dds import (
+    dds_layout_for_info, inspect_dds, inspect_dds_layout,
+)
+from core.textures.pipeline import load_texture_image_full
+from core.textures.texconv import (
+    TexconvError, TexconvUnavailableError, encode_png_to_dds,
+)
 from core.textures.uv_coverage import UVCoverageError, rasterize_uv_coverage
 
 from app.assets.textures import is_asset_texture_key
@@ -27,13 +42,50 @@ _UNSUPPORTED_COLOR_FORMATS = frozenset({
 
 
 class TextureBakeAnalysisError(ValueError):
-    """An expected, stable failure from a coverage analysis request."""
+    """An expected, stable failure from a coverage or bake request."""
 
     def __init__(self, code, message, status="error"):
         super().__init__(message)
         self.code = code
         self.message = message
         self.status = status
+
+
+@dataclass(frozen=True)
+class _PreparedGeometry:
+    indices: tuple
+    source_uvs: tuple
+    triangle_count: int
+    degenerate_triangle_count: int
+
+
+@dataclass(frozen=True)
+class _PreparedConsumer:
+    semantic_key: str
+    geometry: _PreparedGeometry
+    coverages: tuple
+
+
+@dataclass(frozen=True)
+class _PreparedTextureBake:
+    entries: tuple
+    selected_path: str
+    info: object
+    layout: object
+    selected_pixels: object
+    selected_consumer: _PreparedConsumer
+    other_consumers: tuple
+    safe_masks: tuple
+    shared_masks: tuple
+    shared_with: tuple
+    unresolved: tuple
+    unresolved_details: tuple
+
+    @property
+    def safety(self):
+        if self.unresolved:
+            return "unknown"
+        return "shared" if any(sum(mask) for mask in self.shared_masks) else "safe"
 
 
 def _error(code, message, status="error", **details):
@@ -163,10 +215,13 @@ def _unpack_source_uvs(raw):
             "mesh_has_no_uv", "The mesh has no UV coordinates.")
     values = struct.unpack(f"<{len(raw) // 4}f", raw)
     # pack_draw_geometry stores viewer-space V = 1 - source V for Three.js.
-    return [(u, 1.0 - v) for u, v in zip(values[::2], values[1::2])]
+    return tuple((u, 1.0 - v)
+                 for u, v in zip(values[::2], values[1::2]))
 
 
-def _coverage(draw, group, mod_dir, info, buffers, sparse_shape_cache, convention):
+def _prepare_uv_geometry(draw, group, mod_dir, buffers, sparse_shape_cache,
+                         convention):
+    """Pack one draw once and retain source-orientation UV triangles."""
     try:
         packed = _draw_geometry(
             draw, group, mod_dir, buffers, sparse_shape_cache, convention)
@@ -174,21 +229,36 @@ def _coverage(draw, group, mod_dir, info, buffers, sparse_shape_cache, conventio
             raise TextureBakeAnalysisError(
                 "geometry_not_available",
                 "The rendered draw geometry could not be prepared.")
-        unit = 4 if info.compressed else 1
-        return rasterize_uv_coverage(
-            _unpack_indices(packed.indices),
-            _unpack_source_uvs(packed.texcoords) if packed.texcoords is not None
-            else None,
-            info.width, info.height,
-            unit_width=unit, unit_height=unit)
-    except UVCoverageError as error:
-        raise TextureBakeAnalysisError(error.code, error.message) from error
+        indices = _unpack_indices(packed.indices)
+        source_uvs = _unpack_source_uvs(packed.texcoords)
+        return _PreparedGeometry(
+            indices=indices, source_uvs=source_uvs,
+            triangle_count=len(indices) // 3,
+            degenerate_triangle_count=0)
     except TextureBakeAnalysisError:
         raise
     except Exception as error:
         raise TextureBakeAnalysisError(
             "geometry_not_available",
             "The rendered draw geometry could not be prepared.") from error
+
+
+def _rasterize_geometry(geometry, width, height, unit_width, unit_height):
+    try:
+        return rasterize_uv_coverage(
+            geometry.indices, geometry.source_uvs, width, height,
+            unit_width=unit_width, unit_height=unit_height)
+    except UVCoverageError as error:
+        raise TextureBakeAnalysisError(error.code, error.message) from error
+
+
+def _coverage(draw, group, mod_dir, info, buffers, sparse_shape_cache, convention):
+    """Compatibility helper for the original mip-0 analysis contract."""
+    geometry = _prepare_uv_geometry(
+        draw, group, mod_dir, buffers, sparse_shape_cache, convention)
+    unit = 4 if info.compressed else 1
+    return _rasterize_geometry(
+        geometry, info.width, info.height, unit, unit)
 
 
 def _validate_usage(active_mesh_keys, selected_semantic_key, selected_texture_key,
@@ -209,10 +279,20 @@ def _validate_usage(active_mesh_keys, selected_semantic_key, selected_texture_ke
             raise TextureBakeAnalysisError(
                 "stale_mesh_state",
                 "The model changed before texture coverage could be analyzed.")
+        texture_key = item.get("tex_key")
+        if texture_key is not None and not isinstance(texture_key, str):
+            raise TextureBakeAnalysisError(
+                "stale_mesh_state",
+                "The model changed before texture coverage could be analyzed.")
         keys.append(key)
-        entries.append({"semantic_key": key, "tex_key": item.get("tex_key")})
+        entries.append({"semantic_key": key, "tex_key": texture_key})
     expected = set(active_mesh_keys or ())
     if set(keys) != expected or len(keys) != len(expected):
+        raise TextureBakeAnalysisError(
+            "stale_mesh_state",
+            "The model changed before texture coverage could be analyzed.")
+    if selected_texture_key is not None and not isinstance(
+            selected_texture_key, str):
         raise TextureBakeAnalysisError(
             "stale_mesh_state",
             "The model changed before texture coverage could be analyzed.")
@@ -222,113 +302,273 @@ def _validate_usage(active_mesh_keys, selected_semantic_key, selected_texture_ke
         raise TextureBakeAnalysisError(
             "stale_mesh_state",
             "The model changed before texture coverage could be analyzed.")
-    return entries
+    return tuple(entries)
+
+
+def _resolve_request(context, overrides, active_mesh_keys, selected_semantic_key,
+                     selected_texture_key, texture_usage):
+    entries = _validate_usage(
+        active_mesh_keys, selected_semantic_key, selected_texture_key,
+        texture_usage)
+    selected_path = _texture_path(
+        context.mod_dir, selected_texture_key, selected=True)
+    info = _inspect_color_texture(selected_path)
+    parsed, draws = resolved_draws(context, overrides)
+    selected_draw = draws.get(selected_semantic_key)
+    if selected_draw is None:
+        raise TextureBakeAnalysisError(
+            "mesh_not_found", "The selected mesh is no longer available.")
+    selected_identity = _physical_identity(selected_path)
+    consumers = []
+    for entry in entries:
+        if entry["semantic_key"] == selected_semantic_key:
+            continue
+        path = _texture_path(context.mod_dir, entry["tex_key"])
+        if path and _physical_identity(path) == selected_identity:
+            consumers.append((entry["semantic_key"], draws.get(entry["semantic_key"])))
+        elif entry["tex_key"] == selected_texture_key:
+            # A consumer claiming the selected key but lacking a resolvable
+            # source cannot be safely excluded from the sharing analysis.
+            consumers.append((entry["semantic_key"], None))
+    return entries, selected_path, info, parsed, selected_draw, tuple(consumers)
+
+
+def _unit_size(info):
+    """Return the source-pixel span represented by one edit unit."""
+    return (4, 4) if info.compressed else (1, 1)
+
+
+def _prepare_texture_bake(context, overrides, active_mesh_keys,
+                          selected_semantic_key, selected_texture_key,
+                          texture_usage, *, require_file_layout=True):
+    """Resolve geometry and all per-mip masks for one authoritative request."""
+    (entries, selected_path, info, parsed, selected_draw,
+     consumers) = _resolve_request(
+         context, overrides, active_mesh_keys, selected_semantic_key,
+         selected_texture_key, texture_usage)
+    layout = inspect_dds_layout(selected_path)
+    if layout is None:
+        if require_file_layout:
+            raise TextureBakeAnalysisError(
+                "invalid_dds", "The selected texture is not a valid supported DDS.")
+        layout = dds_layout_for_info(info)
+
+    buffers = BufferStore()
+    sparse_shape_cache = {}
+    convention = geometry_convention_for(parsed.game.game)
+    selected_geometry = _prepare_uv_geometry(
+        selected_draw[0], selected_draw[1], context.mod_dir, buffers,
+        sparse_shape_cache, convention)
+    selected_pixels = _rasterize_geometry(
+        selected_geometry, layout.mips[0].width, layout.mips[0].height, 1, 1)
+    selected_coverages = tuple(
+        _rasterize_geometry(
+            selected_geometry, mip.width, mip.height, *_unit_size(info))
+        for mip in layout.mips)
+    selected_consumer = _PreparedConsumer(
+        selected_semantic_key, selected_geometry, selected_coverages)
+
+    other_consumers = []
+    unresolved = []
+    unresolved_details = []
+    for semantic_key, consumer in consumers:
+        try:
+            if consumer is None:
+                raise TextureBakeAnalysisError(
+                    "geometry_not_available",
+                    "The rendered draw geometry could not be prepared.")
+            geometry = _prepare_uv_geometry(
+                consumer[0], consumer[1], context.mod_dir, buffers,
+                sparse_shape_cache, convention)
+            coverages = tuple(
+                _rasterize_geometry(
+                    geometry, mip.width, mip.height, *_unit_size(info))
+                for mip in layout.mips)
+        except TextureBakeAnalysisError as error:
+            unresolved.append(semantic_key)
+            unresolved_details.append({
+                "semantic_key": semantic_key,
+                "code": error.code,
+                "error": error.message,
+            })
+            continue
+        other_consumers.append(_PreparedConsumer(
+            semantic_key, geometry, coverages))
+
+    safe_masks = []
+    shared_masks = []
+    shared_with = []
+    for level, selected in enumerate(selected_coverages):
+        union = bytearray(len(selected.mask))
+        for other in other_consumers:
+            other_mask = other.coverages[level].mask
+            overlap = sum(left and right
+                          for left, right in zip(selected.mask, other_mask))
+            if level == 0 and overlap:
+                shared_with.append({
+                    "semantic_key": other.semantic_key,
+                    "shared_units": overlap,
+                })
+            for index, value in enumerate(other_mask):
+                union[index] = union[index] or value
+        shared = bytearray(
+            left and right for left, right in zip(selected.mask, union))
+        safe = bytearray(
+            value and not shared[index]
+            for index, value in enumerate(selected.mask))
+        safe_masks.append(safe)
+        shared_masks.append(shared)
+    return _PreparedTextureBake(
+        entries=entries, selected_path=selected_path, info=info, layout=layout,
+        selected_pixels=selected_pixels, selected_consumer=selected_consumer,
+        other_consumers=tuple(other_consumers), safe_masks=tuple(safe_masks),
+        shared_masks=tuple(shared_masks), shared_with=tuple(shared_with),
+        unresolved=tuple(unresolved), unresolved_details=tuple(unresolved_details))
+
+
+def _analysis_result(prepared):
+    selected = prepared.selected_consumer.coverages[0]
+    shared = prepared.shared_masks[0]
+    selected_units = selected.count
+    shared_units = sum(shared)
+    total_units = len(selected.mask)
+    mip_shared_levels = [
+        level for level, mask in enumerate(prepared.shared_masks) if sum(mask)]
+    return {
+        "status": "ok",
+        "safety": prepared.safety,
+        "semantic_key": prepared.selected_consumer.semantic_key,
+        "tex_key": next(item["tex_key"] for item in prepared.entries
+                         if item["semantic_key"] == prepared.selected_consumer.semantic_key),
+        "texture": _texture_details(prepared.selected_path, prepared.info),
+        "coverage": {
+            "mip_level": 0,
+            "unit": "block" if prepared.info.compressed else "pixel",
+            "unit_width": 4 if prepared.info.compressed else 1,
+            "unit_height": 4 if prepared.info.compressed else 1,
+            "total_units": total_units,
+            "selected_units": selected_units,
+            "unique_units": (
+                None if prepared.unresolved else selected_units - shared_units),
+            "shared_units": shared_units,
+            "selected_percent": 100 * selected_units / total_units,
+            "shared_percent_of_selected": (
+                100 * shared_units / selected_units if selected_units else 0),
+        },
+        "mip_summary": {
+            "levels": len(prepared.layout.mips),
+            "shared_levels": mip_shared_levels,
+            "safe_units": sum(sum(mask) for mask in prepared.safe_masks),
+            "shared_units": sum(sum(mask) for mask in prepared.shared_masks),
+        },
+        "shared_with": list(prepared.shared_with),
+        "unresolved_consumers": list(prepared.unresolved),
+        "diagnostics": {
+            "triangles": prepared.selected_consumer.geometry.triangle_count,
+            "degenerate_uv_triangles": (
+                selected.degenerate_triangle_count),
+        },
+        "unresolved_consumer_details": list(prepared.unresolved_details),
+    }
+
+
+def _legacy_analysis(context, overrides, active_mesh_keys, selected_semantic_key,
+                     selected_texture_key, texture_usage):
+    """Keep direct mocked analysis fixtures compatible with the PR 72 API."""
+    (entries, selected_path, info, parsed, selected_draw,
+     consumers) = _resolve_request(
+         context, overrides, active_mesh_keys, selected_semantic_key,
+         selected_texture_key, texture_usage)
+    buffers = BufferStore()
+    sparse_shape_cache = {}
+    convention = geometry_convention_for(parsed.game.game)
+    selected_coverage = _coverage(
+        selected_draw[0], selected_draw[1], context.mod_dir, info,
+        buffers, sparse_shape_cache, convention)
+    union = bytearray(len(selected_coverage.mask))
+    shared_with = []
+    unresolved = []
+    unresolved_details = []
+    for semantic_key, consumer in consumers:
+        try:
+            if consumer is None:
+                raise TextureBakeAnalysisError(
+                    "geometry_not_available",
+                    "The rendered draw geometry could not be prepared.")
+            other = _coverage(
+                consumer[0], consumer[1], context.mod_dir, info,
+                buffers, sparse_shape_cache, convention)
+        except TextureBakeAnalysisError as error:
+            unresolved.append(semantic_key)
+            unresolved_details.append({
+                "semantic_key": semantic_key,
+                "code": error.code,
+                "error": error.message,
+            })
+            continue
+        overlap = sum(left and right
+                      for left, right in zip(selected_coverage.mask, other.mask))
+        if overlap:
+            shared_with.append({"semantic_key": semantic_key, "shared_units": overlap})
+        for index, value in enumerate(other.mask):
+            union[index] = union[index] or value
+    shared_mask = bytearray(
+        left and right for left, right in zip(selected_coverage.mask, union))
+    safe_mask = bytearray(
+        value and not shared_mask[index]
+        for index, value in enumerate(selected_coverage.mask))
+    return {
+        "status": "ok",
+        "safety": "unknown" if unresolved else ("shared" if sum(shared_mask) else "safe"),
+        "semantic_key": selected_semantic_key,
+        "tex_key": selected_texture_key,
+        "texture": _texture_details(selected_path, info),
+        "coverage": {
+            "mip_level": 0,
+            "unit": "block" if info.compressed else "pixel",
+            "unit_width": 4 if info.compressed else 1,
+            "unit_height": 4 if info.compressed else 1,
+            "total_units": len(selected_coverage.mask),
+            "selected_units": selected_coverage.count,
+            "unique_units": (None if unresolved
+                              else selected_coverage.count - sum(shared_mask)),
+            "shared_units": sum(shared_mask),
+            "selected_percent": 100 * selected_coverage.count / len(selected_coverage.mask),
+            "shared_percent_of_selected": (
+                100 * sum(shared_mask) / selected_coverage.count
+                if selected_coverage.count else 0),
+        },
+        "mip_summary": {
+            "levels": 1, "shared_levels": [0] if sum(shared_mask) else [],
+            "safe_units": sum(safe_mask), "shared_units": sum(shared_mask),
+        },
+        "shared_with": shared_with,
+        "unresolved_consumers": unresolved,
+        "diagnostics": {
+            "triangles": selected_coverage.triangle_count,
+            "degenerate_uv_triangles": selected_coverage.degenerate_triangle_count,
+        },
+        "unresolved_consumer_details": unresolved_details,
+    }
 
 
 def analyze_texture_bake(
         context, overrides, active_mesh_keys, selected_semantic_key,
         selected_texture_key, texture_usage):
-    """Analyze selected and same-source draws without opening texture data."""
+    """Analyze selected and same-source draws without modifying the texture."""
     try:
-        entries = _validate_usage(
-            active_mesh_keys, selected_semantic_key, selected_texture_key,
-            texture_usage)
-        selected_path = _texture_path(
-            context.mod_dir, selected_texture_key, selected=True)
-        info = _inspect_color_texture(selected_path)
-        parsed, draws = resolved_draws(context, overrides)
-        selected_draw = draws.get(selected_semantic_key)
-        if selected_draw is None:
-            raise TextureBakeAnalysisError(
-                "mesh_not_found", "The selected mesh is no longer available.")
-
-        selected_identity = _physical_identity(selected_path)
-        consumers = []
-        for entry in entries:
-            if entry["semantic_key"] == selected_semantic_key:
-                continue
-            path = _texture_path(context.mod_dir, entry["tex_key"])
-            if path and _physical_identity(path) == selected_identity:
-                consumers.append((entry["semantic_key"], draws.get(entry["semantic_key"])))
-
-        buffers = BufferStore()
-        sparse_shape_cache = {}
-        convention = geometry_convention_for(parsed.game.game)
-        try:
-            selected_coverage = _coverage(
-                selected_draw[0], selected_draw[1], context.mod_dir, info,
-                buffers, sparse_shape_cache, convention)
-        except TextureBakeAnalysisError as error:
-            return _error(error.code, error.message, error.status)
-
-        union = bytearray(len(selected_coverage.mask))
-        shared_with = []
-        unresolved = []
-        unresolved_details = []
-        for semantic_key, consumer in consumers:
-            try:
-                if consumer is None:
-                    raise TextureBakeAnalysisError(
-                        "geometry_not_available",
-                        "The rendered draw geometry could not be prepared.")
-                other = _coverage(
-                    consumer[0], consumer[1], context.mod_dir, info,
-                    buffers, sparse_shape_cache, convention)
-            except TextureBakeAnalysisError as error:
-                unresolved.append(semantic_key)
-                unresolved_details.append({
-                    "semantic_key": semantic_key,
-                    "code": error.code,
-                    "error": error.message,
-                })
-                continue
-            overlap = sum(
-                left and right
-                for left, right in zip(selected_coverage.mask, other.mask))
-            if overlap:
-                shared_with.append({
-                    "semantic_key": semantic_key,
-                    "shared_units": overlap,
-                })
-            for index, value in enumerate(other.mask):
-                union[index] = union[index] or value
-
-        shared_units = sum(
-            left and right
-            for left, right in zip(selected_coverage.mask, union))
-        selected_units = selected_coverage.count
-        total_units = len(selected_coverage.mask)
-        unit = 4 if info.compressed else 1
-        return {
-            "status": "ok",
-            "safety": "unknown" if unresolved else (
-                "shared" if shared_units else "safe"),
-            "semantic_key": selected_semantic_key,
-            "tex_key": selected_texture_key,
-            "texture": _texture_details(selected_path, info),
-            "coverage": {
-                "unit": "block" if info.compressed else "pixel",
-                "unit_width": unit,
-                "unit_height": unit,
-                "total_units": total_units,
-                "selected_units": selected_units,
-                "unique_units": (
-                    None if unresolved else selected_units - shared_units),
-                "shared_units": shared_units,
-                "selected_percent": 100 * selected_units / total_units,
-                "shared_percent_of_selected": (
-                    100 * shared_units / selected_units
-                    if selected_units else 0),
-            },
-            "shared_with": shared_with,
-            "unresolved_consumers": unresolved,
-            "diagnostics": {
-                "triangles": selected_coverage.triangle_count,
-                "degenerate_uv_triangles": (
-                    selected_coverage.degenerate_triangle_count),
-            },
-            "unresolved_consumer_details": unresolved_details,
-        }
+        _entries, selected_path, _info, _parsed, _draw, _consumers = \
+            _resolve_request(
+                context, overrides, active_mesh_keys, selected_semantic_key,
+                selected_texture_key, texture_usage)
+        if inspect_dds_layout(selected_path) is None:
+            return _legacy_analysis(
+                context, overrides, active_mesh_keys, selected_semantic_key,
+                selected_texture_key, texture_usage)
+        prepared = _prepare_texture_bake(
+            context, overrides, active_mesh_keys, selected_semantic_key,
+            selected_texture_key, texture_usage, require_file_layout=False)
+        return _analysis_result(prepared)
     except TextureBakeAnalysisError as error:
         return _error(error.code, error.message, error.status)
     except Exception:
@@ -337,4 +577,245 @@ def analyze_texture_bake(
             "Texture coverage could not be analyzed safely.")
 
 
-__all__ = ["TextureBakeAnalysisError", "analyze_texture_bake"]
+def _sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def _read_source(path):
+    try:
+        with open(path, "rb") as stream:
+            return stream.read()
+    except OSError as error:
+        raise TextureBakeAnalysisError(
+            "texture_read_failed", "The source DDS could not be read.") from error
+
+
+def _assert_source_unchanged(path, original_hash):
+    try:
+        current_hash = _sha256_bytes(_read_source(path))
+    except TextureBakeAnalysisError as error:
+        raise TextureBakeAnalysisError(
+            "texture_changed_during_bake",
+            "The DDS changed while it was being baked.") from error
+    if current_hash != original_hash:
+        raise TextureBakeAnalysisError(
+            "texture_changed_during_bake",
+            "The DDS changed while it was being baked.")
+
+
+def _write_backup(path, original):
+    directory = os.path.dirname(path)
+    stem = os.path.basename(path) + ".modviewer"
+    for index in range(1, 10000):
+        suffix = ".bak" if index == 1 else f".{index}.bak"
+        backup = os.path.join(directory, stem + suffix)
+        try:
+            with open(backup, "xb") as stream:
+                stream.write(original)
+                stream.flush()
+                os.fsync(stream.fileno())
+            return backup
+        except FileExistsError:
+            continue
+        except OSError as error:
+            raise TextureBakeAnalysisError(
+                "backup_failed", "The DDS backup could not be created.") from error
+    raise TextureBakeAnalysisError(
+        "backup_failed", "The DDS backup could not be created.")
+
+
+def _write_temp(path, data):
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+                mode="wb", dir=os.path.dirname(path),
+                prefix=f".{os.path.basename(path)}.", suffix=".tmp",
+                delete=False) as stream:
+            temporary = stream.name
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        return temporary
+    except OSError as error:
+        if temporary and os.path.exists(temporary):
+            os.remove(temporary)
+        raise TextureBakeAnalysisError(
+            "texture_write_failed", "The DDS temporary file could not be written.") from error
+
+
+def _patch_dds_units(original, candidate, layout, safe_masks, candidate_layout=None):
+    """Copy only selected-and-unique edit units from candidate DDS bytes."""
+    candidate_layout = candidate_layout or layout
+    if (len(original) < layout.payload_end
+            or len(candidate) < candidate_layout.payload_end
+            or len(safe_masks) != len(layout.mips)):
+        raise TextureBakeAnalysisError(
+            "texture_validation_failed", "DDS payload layout is invalid.")
+    result = bytearray(original)
+    for mip, candidate_mip, mask in zip(
+            layout.mips, candidate_layout.mips, safe_masks):
+        if (mip.width != candidate_mip.width
+                or mip.height != candidate_mip.height
+                or mip.units_x != candidate_mip.units_x
+                or mip.units_y != candidate_mip.units_y
+                or mip.bytes_per_unit != candidate_mip.bytes_per_unit
+                or len(mask) != mip.units_x * mip.units_y):
+            raise TextureBakeAnalysisError(
+                "texture_validation_failed", "DDS payload layout is invalid.")
+        for index, selected in enumerate(mask):
+            if not selected:
+                continue
+            source_start = candidate_mip.offset + index * candidate_mip.bytes_per_unit
+            target_start = mip.offset + index * mip.bytes_per_unit
+            result[target_start:target_start + mip.bytes_per_unit] = candidate[
+                source_start:source_start + candidate_mip.bytes_per_unit]
+    return bytes(result)
+
+
+def _validate_candidate(source_layout, candidate_path, candidate_bytes):
+    candidate_layout = inspect_dds_layout(candidate_path)
+    if candidate_layout is None:
+        raise TextureBakeAnalysisError(
+            "texconv_output_invalid", "The DDS encoder produced an invalid candidate.")
+    if (candidate_layout.info.width != source_layout.info.width
+            or candidate_layout.info.height != source_layout.info.height
+            or candidate_layout.info.format != source_layout.info.format
+            or candidate_layout.info.compressed != source_layout.info.compressed
+            or candidate_layout.info.mip_count != source_layout.info.mip_count
+            or len(candidate_bytes) < candidate_layout.payload_end):
+        raise TextureBakeAnalysisError(
+            "texconv_output_invalid", "The DDS encoder changed the source texture layout.")
+    return candidate_layout
+
+
+def bake_texture_color(
+        context, overrides, active_mesh_keys, selected_semantic_key,
+        selected_texture_key, texture_usage, adjustment):
+    """Safely bake a non-neutral adjustment into unique DDS units only."""
+    try:
+        # Preparation includes the independent mod-root/Asset check and must be
+        # repeated for the destructive request, even after a prior analysis.
+        prepared = _prepare_texture_bake(
+            context, overrides, active_mesh_keys, selected_semantic_key,
+            selected_texture_key, texture_usage, require_file_layout=True)
+        normalized = normalize_color_adjustment(
+            adjustment, reject_invalid=True)
+        if normalized is None:
+            raise TextureBakeAnalysisError(
+                "invalid_color_adjustment", "The color adjustment is invalid.")
+        if is_neutral_color_adjustment(normalized):
+            raise TextureBakeAnalysisError(
+                "no_color_adjustment", "Adjust the mesh color before baking.")
+        if prepared.unresolved:
+            raise TextureBakeAnalysisError(
+                "unknown_texture_coverage",
+                "Texture coverage could not be determined safely.")
+        mip0_safe = sum(prepared.safe_masks[0])
+        if not mip0_safe:
+            raise TextureBakeAnalysisError(
+                "no_unique_texture_coverage",
+                "The selected mesh has no unique texture coverage to bake.")
+
+        original = _read_source(prepared.selected_path)
+        original_hash = _sha256_bytes(original)
+        image = load_texture_image_full(prepared.selected_path, preserve_alpha=True)
+        if image is None or image.size != (
+                prepared.info.width, prepared.info.height):
+            raise TextureBakeAnalysisError(
+                "texture_decode_failed", "The source DDS could not be decoded at full resolution.")
+        rgba = image.convert("RGBA")
+        masked_rgba = adjust_rgba_bytes(
+            rgba.tobytes(), rgba.width, rgba.height, normalized,
+            prepared.selected_pixels.mask)
+
+        with tempfile.TemporaryDirectory(prefix="modviewer-bake-") as workdir:
+            from PIL import Image
+            png_path = os.path.join(workdir, "bake.png")
+            Image.frombytes("RGBA", rgba.size, masked_rgba).save(png_path, format="PNG")
+            try:
+                candidate_path = encode_png_to_dds(
+                    png_path, workdir, prepared.info.format,
+                    prepared.info.mip_count)
+            except TexconvUnavailableError as error:
+                raise TextureBakeAnalysisError(
+                    "texconv_unavailable", str(error)) from error
+            except TexconvError as error:
+                raise TextureBakeAnalysisError(
+                    "texconv_failed", str(error)) from error
+            try:
+                candidate = _read_source(candidate_path)
+            except TextureBakeAnalysisError as error:
+                raise TextureBakeAnalysisError(
+                    "texconv_output_invalid",
+                    "The DDS encoder produced an invalid candidate.") from error
+            candidate_layout = _validate_candidate(
+                prepared.layout, candidate_path, candidate)
+            final = _patch_dds_units(
+                original, candidate, prepared.layout,
+                prepared.safe_masks, candidate_layout)
+
+            # Check immediately before backup, and again after the backup has
+            # been created. A valid backup may remain if the source went stale.
+            _assert_source_unchanged(prepared.selected_path, original_hash)
+            backup_path = _write_backup(prepared.selected_path, original)
+            _assert_source_unchanged(prepared.selected_path, original_hash)
+            temporary = _write_temp(prepared.selected_path, final)
+            try:
+                final_layout = inspect_dds_layout(temporary)
+                if final_layout is None:
+                    raise TextureBakeAnalysisError(
+                        "texture_validation_failed",
+                        "The patched DDS failed validation.")
+                _validate_candidate(prepared.layout, temporary, final)
+                _assert_source_unchanged(
+                    prepared.selected_path, original_hash)
+                try:
+                    os.replace(temporary, prepared.selected_path)
+                except OSError as error:
+                    raise TextureBakeAnalysisError(
+                        "texture_write_failed", "The DDS could not be replaced safely.") from error
+                temporary = None
+            finally:
+                if temporary and os.path.exists(temporary):
+                    os.remove(temporary)
+
+        selected_identity = _physical_identity(prepared.selected_path)
+        affected = []
+        seen_keys = set()
+        for entry in prepared.entries:
+            key = entry["tex_key"]
+            path = _texture_path(context.mod_dir, key) if key else None
+            if (not key or not path or key in seen_keys
+                    or _physical_identity(path) != selected_identity):
+                continue
+            seen_keys.add(key)
+            affected.append(key)
+        return {
+            "status": "ok",
+            "tex_key": selected_texture_key,
+            "affected_tex_keys": affected,
+            "texture": _texture_details(prepared.selected_path, prepared.info),
+            "patched": {
+                "mip0_units": mip0_safe,
+                "total_units": sum(len(mask) for mask in prepared.safe_masks),
+                "shared_units_preserved": sum(
+                    sum(mask) for mask in prepared.shared_masks),
+            },
+            "backup": {"file": os.path.basename(backup_path)},
+        }
+    except TextureBakeAnalysisError as error:
+        return _error(error.code, error.message, error.status)
+    except Exception:
+        return _error(
+            "texture_write_failed", "The DDS could not be baked safely.")
+
+
+def bake_mesh_texture_color(*args, **kwargs):
+    """Compatibility name for callers that use the public bake operation name."""
+    return bake_texture_color(*args, **kwargs)
+
+
+__all__ = [
+    "TextureBakeAnalysisError", "analyze_texture_bake",
+    "bake_mesh_texture_color", "bake_texture_color", "_patch_dds_units",
+]

--- a/src/app/mods/texture_bake.py
+++ b/src/app/mods/texture_bake.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 import hashlib
 import io
 import os
@@ -12,6 +13,9 @@ import tempfile
 from core.geometry.buffers import BufferStore
 from core.geometry.conventions import geometry_convention_for
 from core.geometry.packing import pack_draw_geometry
+from core.geometry.semantics import (
+    authored_texture_keys_for_draw, deduplicate_draws,
+)
 from core.resource_paths import _canonical, safe_resource_path
 from core.textures import TEXTURE_ROLES, split_texture_key
 from core.textures.color_adjustment import (
@@ -25,7 +29,10 @@ from core.textures.pipeline import load_texture_image_full
 from core.textures.texconv import (
     TexconvError, TexconvUnavailableError, encode_png_to_dds,
 )
-from core.textures.uv_coverage import UVCoverageError, rasterize_uv_coverage
+from core.textures.uv_coverage import (
+    UVCoverage, UVCoverageError, collapse_pixel_mask_to_units,
+    dilate_pixel_mask, rasterize_uv_coverage,
+)
 
 from app.assets.textures import is_asset_texture_key
 from app.mods.analysis import resolved_draws
@@ -82,6 +89,7 @@ class _PreparedConsumer:
 class _PreparedTextureBake:
     entries: tuple
     selected_path: str
+    selected_metadata_key: str | None
     info: object
     layout: object
     selected_pixels: object
@@ -286,7 +294,7 @@ def _coverage(draw, group, mod_dir, info, buffers, sparse_shape_cache, conventio
 
 
 def _validate_usage(active_mesh_keys, selected_semantic_key, selected_texture_key,
-                    texture_usage):
+                    texture_usage, *, require_complete_roles=False):
     if not isinstance(texture_usage, list):
         raise TextureBakeAnalysisError(
             "stale_mesh_state",
@@ -304,6 +312,10 @@ def _validate_usage(active_mesh_keys, selected_semantic_key, selected_texture_ke
                 "stale_mesh_state",
                 "The model changed before texture coverage could be analyzed.")
         has_role_snapshot = "texture_keys" in item
+        if require_complete_roles and not has_role_snapshot:
+            raise TextureBakeAnalysisError(
+                "stale_mesh_state",
+                "The model changed before texture coverage could be analyzed.")
         role_keys = item.get("texture_keys")
         legacy_texture_key = item.get("tex_key")
         if not has_role_snapshot:
@@ -361,10 +373,11 @@ def _validate_usage(active_mesh_keys, selected_semantic_key, selected_texture_ke
 
 
 def _resolve_request(context, overrides, active_mesh_keys, selected_semantic_key,
-                     selected_texture_key, texture_usage):
+                     selected_texture_key, texture_usage,
+                     require_complete_roles=False):
     entries = _validate_usage(
         active_mesh_keys, selected_semantic_key, selected_texture_key,
-        texture_usage)
+        texture_usage, require_complete_roles=require_complete_roles)
     selected_path = _texture_path(
         context.mod_dir, selected_texture_key, selected=True)
     info = _inspect_color_texture(selected_path)
@@ -375,6 +388,7 @@ def _resolve_request(context, overrides, active_mesh_keys, selected_semantic_key
             "mesh_not_found", "The selected mesh is no longer available.")
     selected_identity = _physical_identity(selected_path)
     cross_role_usage = []
+    cross_role_seen = set()
     for entry in entries:
         for role in _TEXTURE_USAGE_ROLES:
             if role == "diffuse":
@@ -383,7 +397,34 @@ def _resolve_request(context, overrides, active_mesh_keys, selected_semantic_key
             path = _usage_texture_path(
                 context.mod_dir, texture_key, role)
             if path and _physical_identity(path) == selected_identity:
-                cross_role_usage.append((entry["semantic_key"], role))
+                value = (entry["semantic_key"], role)
+                if value not in cross_role_seen:
+                    cross_role_seen.add(value)
+                    cross_role_usage.append(value)
+
+    # The live viewer snapshot only describes active bindings.  Parse the
+    # authored defaults and every conditional variant as well, since an
+    # inactive branch can still own the same physical DDS.
+    authored_consumers = {}
+    for group in getattr(parsed, "groups", ()):
+        for draw in deduplicate_draws(group):
+            owned = authored_texture_keys_for_draw(
+                draw, context.mod_dir, parsed.game.game)
+            for role in _TEXTURE_USAGE_ROLES:
+                for texture_key in owned.get(role, ()):
+                    path = _usage_texture_path(
+                        context.mod_dir, texture_key, role)
+                    if not path or _physical_identity(path) != selected_identity:
+                        continue
+                    if role == "diffuse":
+                        if draw.label != selected_semantic_key:
+                            authored_consumers.setdefault(
+                                draw.label, draws.get(draw.label))
+                    else:
+                        value = (draw.label, role)
+                        if value not in cross_role_seen:
+                            cross_role_seen.add(value)
+                            cross_role_usage.append(value)
     if cross_role_usage:
         uses = []
         for semantic_key, role in cross_role_usage:
@@ -396,18 +437,24 @@ def _resolve_request(context, overrides, active_mesh_keys, selected_semantic_key
             message += f", and {uses[-1]}."
         raise TextureBakeAnalysisError(
             "cross_role_texture_usage", message, "unsupported")
-    consumers = []
+    consumer_map = {}
     for entry in entries:
         if entry["semantic_key"] == selected_semantic_key:
             continue
         path = _texture_path(context.mod_dir, entry["tex_key"])
         if path and _physical_identity(path) == selected_identity:
-            consumers.append((entry["semantic_key"], draws.get(entry["semantic_key"])))
+            consumer_map[entry["semantic_key"]] = draws.get(entry["semantic_key"])
         elif entry["tex_key"] == selected_texture_key:
             # A consumer claiming the selected key but lacking a resolvable
             # source cannot be safely excluded from the sharing analysis.
-            consumers.append((entry["semantic_key"], None))
-    return entries, selected_path, info, parsed, selected_draw, tuple(consumers)
+            consumer_map[entry["semantic_key"]] = None
+    for semantic_key, consumer in authored_consumers.items():
+        if semantic_key not in consumer_map:
+            consumer_map[semantic_key] = consumer
+        elif consumer_map[semantic_key] is None and consumer is not None:
+            consumer_map[semantic_key] = consumer
+    return entries, selected_path, info, parsed, selected_draw, tuple(
+        consumer_map.items())
 
 
 def _unit_size(info):
@@ -415,14 +462,55 @@ def _unit_size(info):
     return (4, 4) if info.compressed else (1, 1)
 
 
+def _protected_consumer_coverages(geometry, layout, info):
+    """Protect neighboring edit units for non-selected texture consumers."""
+    unit_width, unit_height = _unit_size(info)
+    coverages = []
+    for mip in layout.mips:
+        pixels = _rasterize_geometry(
+            geometry, mip.width, mip.height, 1, 1)
+        protected = dilate_pixel_mask(
+            pixels.mask, mip.width, mip.height, radius=1)
+        mask = collapse_pixel_mask_to_units(
+            protected, mip.width, mip.height, unit_width, unit_height)
+        grid_width = (mip.width + unit_width - 1) // unit_width
+        grid_height = (mip.height + unit_height - 1) // unit_height
+        used = [index for index, value in enumerate(mask) if value]
+        bounds = None
+        if used:
+            bounds = (
+                min(index % grid_width for index in used),
+                min(index // grid_width for index in used),
+                max(index % grid_width for index in used),
+                max(index // grid_width for index in used),
+            )
+        coverages.append(UVCoverage(
+            grid_width, grid_height, mask, sum(mask), bounds,
+            pixels.triangle_count, pixels.degenerate_triangle_count))
+    return tuple(coverages)
+
+
 def _prepare_texture_bake(context, overrides, active_mesh_keys,
                           selected_semantic_key, selected_texture_key,
-                          texture_usage, *, require_file_layout=True):
+                          texture_usage, *, require_file_layout=True,
+                          require_complete_roles=False, metadata_key=None):
     """Resolve geometry and all per-mip masks for one authoritative request."""
     (entries, selected_path, info, parsed, selected_draw,
      consumers) = _resolve_request(
          context, overrides, active_mesh_keys, selected_semantic_key,
-         selected_texture_key, texture_usage)
+         selected_texture_key, texture_usage, require_complete_roles)
+    from core.geometry.identity import mesh_identity_for_draw
+    try:
+        selected_metadata_key = mesh_identity_for_draw(
+            selected_draw[0], selected_draw[1]).key
+    except AttributeError:
+        # Keep low-level mocked analysis fixtures source-compatible; real
+        # resolved DrawCall records always contain the identity fields.
+        selected_metadata_key = None
+    if metadata_key is not None and metadata_key != selected_metadata_key:
+        raise TextureBakeAnalysisError(
+            "stale_mesh_state",
+            "The selected mesh identity changed before the bake started.")
     layout = inspect_dds_layout(selected_path)
     if layout is None:
         if require_file_layout:
@@ -457,10 +545,7 @@ def _prepare_texture_bake(context, overrides, active_mesh_keys,
             geometry = _prepare_uv_geometry(
                 consumer[0], consumer[1], context.mod_dir, buffers,
                 sparse_shape_cache, convention)
-            coverages = tuple(
-                _rasterize_geometry(
-                    geometry, mip.width, mip.height, *_unit_size(info))
-                for mip in layout.mips)
+            coverages = _protected_consumer_coverages(geometry, layout, info)
         except TextureBakeAnalysisError as error:
             unresolved.append(semantic_key)
             unresolved_details.append({
@@ -496,7 +581,8 @@ def _prepare_texture_bake(context, overrides, active_mesh_keys,
         safe_masks.append(safe)
         shared_masks.append(shared)
     return _PreparedTextureBake(
-        entries=entries, selected_path=selected_path, info=info, layout=layout,
+        entries=entries, selected_path=selected_path,
+        selected_metadata_key=selected_metadata_key, info=info, layout=layout,
         selected_pixels=selected_pixels, selected_consumer=selected_consumer,
         other_consumers=tuple(other_consumers), safe_masks=tuple(safe_masks),
         shared_masks=tuple(shared_masks), shared_with=tuple(shared_with),
@@ -682,10 +768,11 @@ def _assert_source_unchanged(path, original_hash):
 
 def _write_backup(path, original):
     directory = os.path.dirname(path)
-    stem = os.path.basename(path) + ".modviewer"
-    for index in range(1, 10000):
-        suffix = ".bak" if index == 1 else f".{index}.bak"
-        backup = os.path.join(directory, stem + suffix)
+    stem = os.path.splitext(os.path.basename(path))[0]
+    moment = datetime.now()
+    for _index in range(10000):
+        backup = os.path.join(
+            directory, f"{stem}-{moment.strftime('%Y%m%d%H%M%S')}.dds")
         try:
             with open(backup, "xb") as stream:
                 stream.write(original)
@@ -693,6 +780,7 @@ def _write_backup(path, original):
                 os.fsync(stream.fileno())
             return backup
         except FileExistsError:
+            moment += timedelta(seconds=1)
             continue
         except OSError as error:
             raise TextureBakeAnalysisError(
@@ -907,7 +995,7 @@ def _replacement_completed(source_path, temporary_path, final):
 
 def bake_texture_color(
         context, overrides, active_mesh_keys, selected_semantic_key,
-        selected_texture_key, texture_usage, adjustment):
+        selected_texture_key, texture_usage, adjustment, metadata_key=None):
     """Safely bake a non-neutral adjustment into unique DDS units only."""
     committed = False
     success_result = None
@@ -916,7 +1004,8 @@ def bake_texture_color(
         # repeated for the destructive request, even after a prior analysis.
         prepared = _prepare_texture_bake(
             context, overrides, active_mesh_keys, selected_semantic_key,
-            selected_texture_key, texture_usage, require_file_layout=True)
+            selected_texture_key, texture_usage, require_file_layout=True,
+            require_complete_roles=True, metadata_key=metadata_key)
         normalized = normalize_color_adjustment(
             adjustment, reject_invalid=True)
         if normalized is None:
@@ -979,27 +1068,7 @@ def bake_texture_color(
                 original, candidate, prepared.layout,
                 prepared.safe_masks, candidate_layout)
 
-            # Check immediately before backup, and again after the backup has
-            # been created. A valid backup may remain if the source went stale.
-            _assert_source_unchanged(prepared.selected_path, original_hash)
-            backup_path = _write_backup(prepared.selected_path, original)
-            _assert_source_unchanged(prepared.selected_path, original_hash)
             temporary = _write_temp(prepared.selected_path, final)
-            success_result = {
-                "status": "ok",
-                "tex_key": selected_texture_key,
-                "affected_tex_keys": affected,
-                "texture": _texture_details(
-                    prepared.selected_path, prepared.info),
-                "patched": {
-                    "mip0_units": mip0_safe,
-                    "total_units": sum(
-                        len(mask) for mask in prepared.safe_masks),
-                    "shared_units_preserved": sum(
-                        sum(mask) for mask in prepared.shared_masks),
-                },
-                "backup": {"file": os.path.basename(backup_path)},
-            }
             try:
                 final_layout = inspect_dds_layout(temporary)
                 if final_layout is None:
@@ -1007,8 +1076,30 @@ def bake_texture_color(
                         "texture_validation_failed",
                         "The patched DDS failed validation.")
                 _validate_candidate(prepared.layout, temporary, final)
+                _validate_alpha_preservation(
+                    final, final_layout, prepared.safe_masks)
+                # The backup is deliberately created only after the complete
+                # temporary candidate has passed validation. If a later source
+                # race or replace failure occurs, that backup remains useful.
                 _assert_source_unchanged(
                     prepared.selected_path, original_hash)
+                backup_path = _write_backup(prepared.selected_path, original)
+                _assert_source_unchanged(prepared.selected_path, original_hash)
+                success_result = {
+                    "status": "ok",
+                    "tex_key": selected_texture_key,
+                    "affected_tex_keys": affected,
+                    "texture": _texture_details(
+                        prepared.selected_path, prepared.info),
+                    "patched": {
+                        "mip0_units": mip0_safe,
+                        "total_units": sum(
+                            len(mask) for mask in prepared.safe_masks),
+                        "shared_units_preserved": sum(
+                            sum(mask) for mask in prepared.shared_masks),
+                    },
+                    "backup": {"file": os.path.basename(backup_path)},
+                }
                 try:
                     os.replace(temporary, prepared.selected_path)
                 except OSError as error:

--- a/src/app/mods/texture_bake.py
+++ b/src/app/mods/texture_bake.py
@@ -13,7 +13,7 @@ from core.geometry.buffers import BufferStore
 from core.geometry.conventions import geometry_convention_for
 from core.geometry.packing import pack_draw_geometry
 from core.resource_paths import _canonical, safe_resource_path
-from core.textures import split_texture_key
+from core.textures import TEXTURE_ROLES, split_texture_key
 from core.textures.color_adjustment import (
     adjust_rgba_bytes, is_neutral_color_adjustment,
     normalize_color_adjustment,
@@ -43,6 +43,14 @@ _UNSUPPORTED_COLOR_FORMATS = frozenset({
 _OPAQUE_ONLY_FORMATS = frozenset({
     "bc1_unorm", "bc1_srgb", "bc7_unorm", "bc7_srgb",
 })
+_TEXTURE_USAGE_ROLES = tuple(TEXTURE_ROLES)
+_TEXTURE_ROLE_LABELS = {
+    "normal_map": "Normal Map",
+    "normal_data": "Normal Data",
+    "light_map": "Light Map",
+    "material_map": "Material Map",
+    "emission_map": "Emission Map",
+}
 
 
 class TextureBakeAnalysisError(ValueError):
@@ -146,6 +154,18 @@ def _texture_path(mod_dir, key, *, selected=False):
                 "texture_not_found", "The selected diffuse texture was not found.")
         return None
     return path
+
+
+def _usage_texture_path(mod_dir, key, expected_role):
+    """Resolve one submitted role assignment with the shared mod sandbox."""
+    if not key:
+        return None
+    role, relative_path = split_texture_key(key, expected_role)
+    if role != expected_role or not relative_path:
+        return None
+    if is_asset_texture_key(key):
+        return None
+    return _canonical_mod_path(mod_dir, relative_path)
 
 
 def _texture_details(path, info):
@@ -283,13 +303,44 @@ def _validate_usage(active_mesh_keys, selected_semantic_key, selected_texture_ke
             raise TextureBakeAnalysisError(
                 "stale_mesh_state",
                 "The model changed before texture coverage could be analyzed.")
-        texture_key = item.get("tex_key")
-        if texture_key is not None and not isinstance(texture_key, str):
+        has_role_snapshot = "texture_keys" in item
+        role_keys = item.get("texture_keys")
+        legacy_texture_key = item.get("tex_key")
+        if not has_role_snapshot:
+            # Keep older direct callers safe while the browser rolls forward;
+            # a complete role snapshot is authoritative when it is present.
+            role_keys = {role: None for role in _TEXTURE_USAGE_ROLES}
+            role_keys["diffuse"] = legacy_texture_key
+        if (not isinstance(role_keys, dict)
+                or set(role_keys) != set(_TEXTURE_USAGE_ROLES)):
             raise TextureBakeAnalysisError(
                 "stale_mesh_state",
                 "The model changed before texture coverage could be analyzed.")
+        if (legacy_texture_key is not None
+                and legacy_texture_key != role_keys["diffuse"]):
+            raise TextureBakeAnalysisError(
+                "stale_mesh_state",
+                "The model changed before texture coverage could be analyzed.")
+        for role in _TEXTURE_USAGE_ROLES:
+            texture_key = role_keys[role]
+            if texture_key is not None and not isinstance(texture_key, str):
+                raise TextureBakeAnalysisError(
+                    "stale_mesh_state",
+                    "The model changed before texture coverage could be analyzed.")
+            if texture_key is not None and has_role_snapshot:
+                parsed_role, relative_path = split_texture_key(
+                    texture_key, role)
+                if parsed_role != role or not relative_path:
+                    raise TextureBakeAnalysisError(
+                        "stale_mesh_state",
+                        "The model changed before texture coverage could be analyzed.")
         keys.append(key)
-        entries.append({"semantic_key": key, "tex_key": texture_key})
+        entries.append({
+            "semantic_key": key,
+            # The alias is retained for the existing diffuse consumer result.
+            "tex_key": role_keys["diffuse"],
+            "texture_keys": dict(role_keys),
+        })
     expected = set(active_mesh_keys or ())
     if set(keys) != expected or len(keys) != len(expected):
         raise TextureBakeAnalysisError(
@@ -323,6 +374,28 @@ def _resolve_request(context, overrides, active_mesh_keys, selected_semantic_key
         raise TextureBakeAnalysisError(
             "mesh_not_found", "The selected mesh is no longer available.")
     selected_identity = _physical_identity(selected_path)
+    cross_role_usage = []
+    for entry in entries:
+        for role in _TEXTURE_USAGE_ROLES:
+            if role == "diffuse":
+                continue
+            texture_key = entry["texture_keys"][role]
+            path = _usage_texture_path(
+                context.mod_dir, texture_key, role)
+            if path and _physical_identity(path) == selected_identity:
+                cross_role_usage.append((entry["semantic_key"], role))
+    if cross_role_usage:
+        uses = []
+        for semantic_key, role in cross_role_usage:
+            uses.append(
+                f"as a {_TEXTURE_ROLE_LABELS[role]} by {semantic_key}")
+        if len(uses) == 1:
+            message = f"This DDS is also used {uses[0]}."
+        else:
+            message = "This DDS is also used " + ", ".join(uses[:-1])
+            message += f", and {uses[-1]}."
+        raise TextureBakeAnalysisError(
+            "cross_role_texture_usage", message, "unsupported")
     consumers = []
     for entry in entries:
         if entry["semantic_key"] == selected_semantic_key:
@@ -807,13 +880,18 @@ def _affected_texture_keys(context, prepared):
     affected = []
     seen_keys = set()
     for entry in prepared.entries:
-        key = entry["tex_key"]
-        path = _texture_path(context.mod_dir, key) if key else None
-        if (not key or not path or key in seen_keys
-                or _physical_identity(path) != selected_identity):
-            continue
-        seen_keys.add(key)
-        affected.append(key)
+        role_keys = entry.get("texture_keys")
+        if role_keys is None:
+            role_keys = {"diffuse": entry.get("tex_key")}
+        for role in _TEXTURE_USAGE_ROLES:
+            key = role_keys.get(role)
+            path = _usage_texture_path(
+                context.mod_dir, key, role) if key else None
+            if (not key or not path or key in seen_keys
+                    or _physical_identity(path) != selected_identity):
+                continue
+            seen_keys.add(key)
+            affected.append(key)
     return affected
 
 

--- a/src/app/settings/paths.py
+++ b/src/app/settings/paths.py
@@ -55,6 +55,16 @@ def vendor_dir():
     return os.path.join(app_root(), "assets")
 
 
+def runtime_tools_dir():
+    """Directory containing bundled non-browser runtime executables."""
+    return os.path.join(app_root(), "runtime_tools")
+
+
+def texconv_path():
+    """Return the bundled texconv path when it is present."""
+    return os.path.join(runtime_tools_dir(), "texconv.exe")
+
+
 def has_vendored_three():
     required = (
         "three.core.js",

--- a/src/build.py
+++ b/src/build.py
@@ -7,7 +7,7 @@ Three.js is vendored, no internet connection.
     py -3 build.py                # single-file portable .exe (default)
     py -3 build.py --onedir       # folder build (much faster startup)
     py -3 build.py --skip-deps    # don't touch pip
-    py -3 build.py --refresh-assets   # re-download Three.js
+    py -3 build.py --refresh-assets   # re-download pinned assets and tools
     py -3 build.py --rebuild-bootloader   # recompile PyInstaller's bootloader
 
 --rebuild-bootloader compiles PyInstaller's bootloader from source in an
@@ -100,6 +100,14 @@ ASSET_FILES = {
     "addons/tsl/display/BloomNode.js": {
         "url": f"https://cdn.jsdelivr.net/npm/three@{THREE_VERSION}/examples/jsm/tsl/display/BloomNode.js",
         "sha256": "f80f40d013f4d94aa089c68c673cae6a8ab45fb290970a696bc1dded312e3fc8",
+    },
+}
+
+RUNTIME_TOOLS = os.path.join(HERE, "runtime_tools")
+RUNTIME_TOOL_FILES = {
+    "texconv.exe": {
+        "url": "https://github.com/microsoft/DirectXTex/releases/download/may2026/texconv.exe",
+        "sha256": "dcfdec10244e02cf5037fba089c55fb7e1326b1c8181742d77d15fa5cb5eef06",
     },
 }
 
@@ -326,47 +334,78 @@ def prepare_bootloader_venv(force=False):
     return py
 
 
+def download_verified_file(dest, spec, *, refresh=False, label=None):
+    """Download one pinned artifact with atomic replacement and hash checks."""
+    label = label or os.path.basename(dest)
+    if os.path.isfile(dest) and not refresh:
+        actual = sha256_file(dest)
+        if actual != spec["sha256"]:
+            raise RuntimeError(
+                f"asset {label} SHA-256 mismatch: expected "
+                f"{spec['sha256']}, got {actual}; use --refresh-assets "
+                "if replacement is intentional")
+        log(f"asset verified: {label}")
+        return
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    log(f"downloading {label}")
+    with urllib.request.urlopen(spec["url"], timeout=60) as resp:
+        data = resp.read()
+    if len(data) < 1024:
+        raise RuntimeError(f"suspiciously small download for {label} ({len(data)} bytes)")
+    actual = sha256_bytes(data)
+    if actual != spec["sha256"]:
+        raise RuntimeError(
+            f"downloaded asset {label} SHA-256 mismatch: expected "
+            f"{spec['sha256']}, got {actual}; existing asset was not "
+            "replaced")
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+                mode="wb", dir=os.path.dirname(dest),
+                prefix=f".{os.path.basename(dest)}.",
+                suffix=".tmp", delete=False) as fh:
+            temporary = fh.name
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(temporary, dest)
+        temporary = None
+    finally:
+        if temporary and os.path.exists(temporary):
+            os.remove(temporary)
+    log(f"  {len(data):,} bytes")
+
+
 def fetch_assets(refresh=False):
     """Download Three.js so the built app runs fully offline."""
     for rel, spec in ASSET_FILES.items():
         dest = os.path.join(ASSETS, *rel.split("/"))
-        if os.path.isfile(dest) and not refresh:
-            actual = sha256_file(dest)
+        download_verified_file(dest, spec, refresh=refresh, label=rel)
+
+
+def fetch_runtime_tools(refresh=False):
+    """Download pinned runtime tools used by the packaged application."""
+    for rel, spec in RUNTIME_TOOL_FILES.items():
+        dest = os.path.join(RUNTIME_TOOLS, *rel.split("/"))
+        download_verified_file(dest, spec, refresh=refresh, label=rel)
+
+
+def verify_runtime_tools():
+    missing = []
+    mismatched = []
+    for rel, spec in RUNTIME_TOOL_FILES.items():
+        path = os.path.join(RUNTIME_TOOLS, *rel.split("/"))
+        if not os.path.isfile(path):
+            missing.append(rel)
+        else:
+            actual = sha256_file(path)
             if actual != spec["sha256"]:
-                raise RuntimeError(
-                    f"asset {rel} SHA-256 mismatch: expected "
-                    f"{spec['sha256']}, got {actual}; use --refresh-assets "
-                    "if replacement is intentional")
-            log(f"asset verified: {rel}")
-            continue
-        os.makedirs(os.path.dirname(dest), exist_ok=True)
-        log(f"downloading {rel}")
-        with urllib.request.urlopen(spec["url"], timeout=60) as resp:
-            data = resp.read()
-        if len(data) < 1024:
-            raise RuntimeError(f"suspiciously small download for {rel} ({len(data)} bytes)")
-        actual = sha256_bytes(data)
-        if actual != spec["sha256"]:
-            raise RuntimeError(
-                f"downloaded asset {rel} SHA-256 mismatch: expected "
-                f"{spec['sha256']}, got {actual}; existing asset was not "
-                "replaced")
-        temporary = None
-        try:
-            with tempfile.NamedTemporaryFile(
-                    mode="wb", dir=os.path.dirname(dest),
-                    prefix=f".{os.path.basename(dest)}.",
-                    suffix=".tmp", delete=False) as fh:
-                temporary = fh.name
-                fh.write(data)
-                fh.flush()
-                os.fsync(fh.fileno())
-            os.replace(temporary, dest)
-            temporary = None
-        finally:
-            if temporary and os.path.exists(temporary):
-                os.remove(temporary)
-        log(f"  {len(data):,} bytes")
+                mismatched.append(
+                    f"{rel} (expected {spec['sha256']}, got {actual})")
+    if missing:
+        raise RuntimeError(f"missing runtime tools: {missing}")
+    if mismatched:
+        raise RuntimeError(f"runtime tool SHA-256 mismatch: {mismatched}")
 
 
 def verify_assets():
@@ -544,6 +583,8 @@ def build(onedir=False, console=False, python=None):
             "--noupx",
             # Three.js, served to the webview from a localhost port at runtime.
             "--add-data", f"{ASSETS}{os.pathsep}assets",
+            # DirectXTex is a runtime encoder, never browser-served data.
+            "--add-binary", f"{os.path.join(RUNTIME_TOOLS, 'texconv.exe')}{os.pathsep}runtime_tools",
             # The HTML/CSS/JS UI, served from that same port.
             "--add-data", f"{WEB}{os.pathsep}web",
             # Pulled in dynamically by the WebView2 backend, so PyInstaller's static
@@ -586,7 +627,8 @@ def main():
     ap.add_argument("--console", action="store_true",
                     help="keep a console window open (useful for debugging)")
     ap.add_argument("--skip-deps", action="store_true", help="skip pip install")
-    ap.add_argument("--refresh-assets", action="store_true", help="re-download Three.js")
+    ap.add_argument("--refresh-assets", action="store_true",
+                    help="re-download pinned assets and runtime tools")
     ap.add_argument("--rebuild-bootloader", action="store_true",
                     help="recompile PyInstaller's bootloader in an isolated venv "
                          "(clears most antivirus false positives; needs a C compiler). "
@@ -605,6 +647,8 @@ def main():
         install_deps()
     fetch_assets(refresh=args.refresh_assets)
     verify_assets()
+    fetch_runtime_tools(refresh=args.refresh_assets)
+    verify_runtime_tools()
     verify_web()
     verify_features()
     clean()

--- a/src/build.py
+++ b/src/build.py
@@ -38,6 +38,7 @@ from app.settings.paths import APP_VERSION
 
 ASSETS = os.path.join(HERE, "assets")
 WEB = os.path.join(HERE, "web")
+THIRD_PARTY_NOTICES = os.path.join(HERE, "..", "THIRD_PARTY_NOTICES.md")
 FEATURES_FILE = os.path.join(HERE, "features.ini")
 # Generated at build time from FEATURES_FILE and deleted again right after --
 # see resolve_features()/write_baked_features()/clean_baked_features(). Never
@@ -585,6 +586,9 @@ def build(onedir=False, console=False, python=None):
             "--add-data", f"{ASSETS}{os.pathsep}assets",
             # DirectXTex is a runtime encoder, never browser-served data.
             "--add-binary", f"{os.path.join(RUNTIME_TOOLS, 'texconv.exe')}{os.pathsep}runtime_tools",
+            # Make the licenses for bundled runtime tools available beside the
+            # packaged application rather than only in the source checkout.
+            "--add-data", f"{THIRD_PARTY_NOTICES}{os.pathsep}.",
             # The HTML/CSS/JS UI, served from that same port.
             "--add-data", f"{WEB}{os.pathsep}web",
             # Pulled in dynamically by the WebView2 backend, so PyInstaller's static

--- a/src/core/geometry/identity.py
+++ b/src/core/geometry/identity.py
@@ -235,6 +235,17 @@ def make_mesh_identity(draw, source=None, component=None):
     )
 
 
+def mesh_identity_for_draw(draw, group):
+    """Build the canonical identity using a parsed draw group.
+
+    Mesh construction, semantic refresh, and destructive texture operations
+    must derive the metadata key from the same source/component projection.
+    """
+    source = group.get("identity_source") or group.get("source")
+    component = group.get("display_name") or group.get("name")
+    return make_mesh_identity(draw, source=source, component=component)
+
+
 def normalize_geometry_hash(value):
     """Return a canonical eight-digit geometry hash, or ``None``."""
     if not isinstance(value, str):

--- a/src/core/geometry/mesh_builder.py
+++ b/src/core/geometry/mesh_builder.py
@@ -18,7 +18,7 @@ from .texture_bindings import (
     TextureRegistry, apply_draw_texture_bindings, build_texture_options,
 )
 from .transport import GeometryBlob
-from .identity import make_mesh_identity
+from .identity import mesh_identity_for_draw
 from ..resource_paths import safe_resource_path
 
 
@@ -67,9 +67,8 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
         tc_stride = group["texcoord_stride"]
         pos_stride = group.get("position_stride", POSITION_STRIDE)
         index_size = group.get("index_size", INDEX_SIZE)
-        component = group.get("display_name") or group.get("name")
         source = group.get("source")
-        identity_source = group.get("identity_source") or source
+        component = group.get("display_name") or group.get("name")
 
         if not all(path and os.path.exists(path)
                    for path in (pos_path, tc_path, ib_path)):
@@ -137,8 +136,7 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
                 entry["source"] = source
             if component:
                 entry["component"] = component
-            entry["identity"] = make_mesh_identity(
-                draw, source=identity_source, component=component).to_dict()
+            entry["identity"] = mesh_identity_for_draw(draw, group).to_dict()
             binding = draw.asset_binding
             if binding is not None and hasattr(binding, "to_dict"):
                 entry["asset_binding"] = binding.to_dict()

--- a/src/core/geometry/semantics.py
+++ b/src/core/geometry/semantics.py
@@ -3,7 +3,7 @@
 import os
 
 from .draw_call import DrawCall
-from .identity import make_mesh_identity
+from .identity import mesh_identity_for_draw
 from ..resource_paths import safe_resource_path
 from ..textures.pipeline import normalize_texture_role, texture_key
 
@@ -89,6 +89,40 @@ def _semantic_texture_variants(draw, mod_dir, authored_role, transport_role=None
     return variants
 
 
+def authored_texture_keys_for_draw(draw, mod_dir, game_profile=None):
+    """Return every authored texture identity owned by a resolved draw.
+
+    This includes inactive conditional variants because they still identify
+    the same physical resource ownership for destructive texture edits.  The
+    profile's normal transport role is used so packed normal sources are
+    compared in the same namespace as the runtime texture registry.
+    """
+    from ..textures.profiles import TEXTURE_ROLES, texture_profile_for
+
+    normal_role = texture_profile_for(game_profile).normal_transport_role
+    result = {role: set() for role in TEXTURE_ROLES}
+    roles = (
+        ("diffuse", "diffuse"),
+        ("normal_map", normal_role),
+        ("light_map", "light_map"),
+        ("material_map", "material_map"),
+        ("emission_map", "emission_map"),
+    )
+    for authored_role, transport_role in roles:
+        default = (_semantic_asset_key(draw, authored_role, transport_role)
+                   or _semantic_texture_key(
+                       mod_dir, draw.texture_default(authored_role),
+                       transport_role))
+        if default:
+            result[transport_role].add(default)
+        for variant in draw.texture_rules(authored_role):
+            key = _semantic_texture_key(
+                mod_dir, variant.get("file"), transport_role)
+            if key:
+                result[transport_role].add(key)
+    return result
+
+
 def validate_draw_count(groups):
     draw_total = sum(len(group.get("draws", [])) for group in groups)
     if draw_total > _MAX_DRAWS:
@@ -131,14 +165,12 @@ def build_mesh_semantics(groups, mod_dir, max_draws=0, game_profile=None,
                         "emission_map")),
             }
             source = group.get("source")
-            identity_source = group.get("identity_source") or source
             component = group.get("display_name") or group.get("name")
             if source:
                 entry["source"] = source
             if component:
                 entry["component"] = component
-            entry["identity"] = make_mesh_identity(
-                draw, source=identity_source, component=component).to_dict()
+            entry["identity"] = mesh_identity_for_draw(draw, group).to_dict()
             normal_key = _semantic_texture_key(
                 mod_dir, draw.texture_default("normal_map"), normal_role)
             normal_key = (_semantic_asset_key(
@@ -173,5 +205,5 @@ def build_mesh_semantics(groups, mod_dir, max_draws=0, game_profile=None,
 
 __all__ = [
     "build_mesh_semantics", "deduplicate_draws", "validate_draw_count",
-    "_deduplicate_draws", "_rel_source",
+    "authored_texture_keys_for_draw", "_deduplicate_draws", "_rel_source",
 ]

--- a/src/core/textures/__init__.py
+++ b/src/core/textures/__init__.py
@@ -7,6 +7,7 @@ from .pipeline import (
     encode_texture_file,
     encode_texture_key,
     load_texture_image,
+    load_texture_image_full,
     normalize_texture_key,
     normalize_texture_role,
     normalize_texture_transform,
@@ -18,6 +19,11 @@ from .pipeline import (
     texture_key_for_role,
 )
 from .uv_coverage import UVCoverage, UVCoverageError, rasterize_uv_coverage
+from .color_adjustment import (
+    COLOR_DEFAULTS, COLOR_RANGES, adjust_rgba_bytes,
+    apply_color_adjustment, is_neutral_color_adjustment,
+    normalize_color_adjustment,
+)
 
 __all__ = [
     "TEXTURE_ROLES",
@@ -26,6 +32,7 @@ __all__ = [
     "encode_texture_file",
     "encode_texture_key",
     "load_texture_image",
+    "load_texture_image_full",
     "normalize_texture_key",
     "normalize_texture_role",
     "normalize_texture_transform",
@@ -38,4 +45,10 @@ __all__ = [
     "UVCoverage",
     "UVCoverageError",
     "rasterize_uv_coverage",
+    "COLOR_DEFAULTS",
+    "COLOR_RANGES",
+    "adjust_rgba_bytes",
+    "apply_color_adjustment",
+    "is_neutral_color_adjustment",
+    "normalize_color_adjustment",
 ]

--- a/src/core/textures/__init__.py
+++ b/src/core/textures/__init__.py
@@ -18,7 +18,10 @@ from .pipeline import (
     texture_key,
     texture_key_for_role,
 )
-from .uv_coverage import UVCoverage, UVCoverageError, rasterize_uv_coverage
+from .uv_coverage import (
+    UVCoverage, UVCoverageError, collapse_pixel_mask_to_units,
+    dilate_pixel_mask, rasterize_uv_coverage,
+)
 from .color_adjustment import (
     COLOR_DEFAULTS, COLOR_RANGES, adjust_rgba_bytes,
     apply_color_adjustment, is_neutral_color_adjustment,
@@ -44,6 +47,8 @@ __all__ = [
     "texture_key_for_role",
     "UVCoverage",
     "UVCoverageError",
+    "collapse_pixel_mask_to_units",
+    "dilate_pixel_mask",
     "rasterize_uv_coverage",
     "COLOR_DEFAULTS",
     "COLOR_RANGES",

--- a/src/core/textures/color_adjustment.py
+++ b/src/core/textures/color_adjustment.py
@@ -1,0 +1,207 @@
+"""Shared color-adjustment validation and the CPU equivalent of the viewer shader."""
+
+from __future__ import annotations
+
+import math
+import re
+
+
+COLOR_DEFAULTS = {
+    "hue": 0,
+    "saturation": 1.0,
+    "brightness": 1.0,
+    "contrast": 1.0,
+    "red": 1.0,
+    "green": 1.0,
+    "blue": 1.0,
+    "tint": "#ffffff",
+    "tint_strength": 0.0,
+}
+
+COLOR_RANGES = {
+    "hue": (-180.0, 180.0),
+    "saturation": (0.0, 2.0),
+    "brightness": (0.0, 2.0),
+    "contrast": (0.0, 2.0),
+    "red": (0.0, 2.0),
+    "green": (0.0, 2.0),
+    "blue": (0.0, 2.0),
+    "tint_strength": (0.0, 1.0),
+}
+
+_TINT_PATTERN = re.compile(r"^#[0-9a-f]{6}$", re.IGNORECASE)
+
+
+def _number(value, default, *, reject_invalid):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        if reject_invalid:
+            return None
+        return default
+    if not math.isfinite(value):
+        if reject_invalid:
+            return None
+        return default
+    return float(value)
+
+
+def normalize_color_adjustment(value, *, reject_invalid=False):
+    """Return the canonical color state, or ``None`` for malformed input.
+
+    Missing fields deliberately use the neutral defaults.  This keeps the
+    persistence format sparse while allowing the bake endpoint to validate a
+    complete state with the same ranges used by the metadata layer.
+    """
+    if not isinstance(value, dict):
+        return None
+    result = {}
+    for field, default in COLOR_DEFAULTS.items():
+        raw = value.get(field, value.get("tintStrength", default)
+                        if field == "tint_strength" else default)
+        if field == "tint":
+            if not isinstance(raw, str) or not _TINT_PATTERN.fullmatch(raw):
+                if reject_invalid:
+                    return None
+                raw = default
+            result[field] = raw.lower()
+            continue
+        number = _number(raw, default, reject_invalid=reject_invalid)
+        if number is None:
+            return None
+        minimum, maximum = COLOR_RANGES[field]
+        result[field] = min(maximum, max(minimum, number))
+    result["hue"] = (int(result["hue"])
+                      if result["hue"].is_integer() else result["hue"])
+    return result
+
+
+def is_neutral_color_adjustment(value):
+    """Return whether *value* is the normalized neutral adjustment."""
+    normalized = normalize_color_adjustment(value)
+    return normalized == COLOR_DEFAULTS
+
+
+def tint_rgb(value):
+    """Decode a canonical ``#rrggbb`` value into raw sRGB floats."""
+    normalized = value.lower() if isinstance(value, str) else COLOR_DEFAULTS["tint"]
+    if not _TINT_PATTERN.fullmatch(normalized):
+        normalized = COLOR_DEFAULTS["tint"]
+    return tuple(int(normalized[index:index + 2], 16) / 255.0
+                 for index in (1, 3, 5))
+
+
+def _rgb_to_hsv(red, green, blue):
+    maximum = max(red, green, blue)
+    minimum = min(red, green, blue)
+    delta = maximum - minimum
+    safe_delta = max(delta, 0.000001)
+    if maximum == red:
+        hue = (green - blue) / safe_delta
+        if hue < 0:
+            hue += 6.0
+    elif maximum == green:
+        hue = (blue - red) / safe_delta + 2.0
+    else:
+        hue = (red - green) / safe_delta + 4.0
+    return hue / 6.0, (0.0 if maximum == 0 else delta / maximum), maximum
+
+
+def _hsv_to_rgb(hue, saturation, value):
+    sector_value = hue * 6.0
+    sector = math.floor(sector_value)
+    fraction = sector_value - sector
+    p = value * (1.0 - saturation)
+    q = value * (1.0 - saturation * fraction)
+    t = value * (1.0 - saturation * (1.0 - fraction))
+    if sector == 0:
+        return value, t, p
+    if sector == 1:
+        return q, value, p
+    if sector == 2:
+        return p, value, t
+    if sector == 3:
+        return p, q, value
+    if sector == 4:
+        return t, p, value
+    return value, p, q
+
+
+def _apply_normalized(rgb, normalized):
+    """Apply the operation order to RGB floats and a validated state."""
+    try:
+        red, green, blue = (float(channel) for channel in rgb)
+    except (TypeError, ValueError):
+        raise ValueError("RGB must contain three numeric channels") from None
+    hue, saturation, value = _rgb_to_hsv(red, green, blue)
+    hue = (hue + normalized["hue"] / 360.0) % 1.0
+    saturation = min(1.0, max(0.0, saturation * normalized["saturation"]))
+    value = min(1.0, max(0.0, value * normalized["brightness"]))
+    red, green, blue = _hsv_to_rgb(hue, saturation, value)
+    red = (red - 0.5) * normalized["contrast"] + 0.5
+    green = (green - 0.5) * normalized["contrast"] + 0.5
+    blue = (blue - 0.5) * normalized["contrast"] + 0.5
+    red *= normalized["red"]
+    green *= normalized["green"]
+    blue *= normalized["blue"]
+    red = min(1.0, max(0.0, red))
+    green = min(1.0, max(0.0, green))
+    blue = min(1.0, max(0.0, blue))
+    tint_red, tint_green, tint_blue = tint_rgb(normalized["tint"])
+    strength = normalized["tint_strength"]
+    red = red * (1.0 - strength) + tint_red * strength
+    green = green * (1.0 - strength) + tint_green * strength
+    blue = blue * (1.0 - strength) + tint_blue * strength
+    return tuple(min(1.0, max(0.0, channel))
+                 for channel in (red, green, blue))
+
+
+def apply_color_adjustment(rgb, adjustment):
+    """Apply the viewer's operation order to raw sRGB RGB floats.
+
+    The input and output are editor-sRGB values.  No color-space conversion is
+    performed here: the GPU graph converts its sampled linear value into this
+    same editor space before applying these operations.
+    """
+    normalized = normalize_color_adjustment(adjustment, reject_invalid=True)
+    if normalized is None:
+        raise ValueError("invalid color adjustment")
+    return _apply_normalized(rgb, normalized)
+
+
+def adjust_rgba_bytes(data, width, height, adjustment, pixel_mask=None):
+    """Return adjusted RGBA bytes, preserving every source alpha byte.
+
+    When *pixel_mask* is supplied it must contain one truthy entry per pixel;
+    only selected pixels receive the RGB operation.  A full adjusted candidate
+    is still computed for each source pixel before the mask is composited, which
+    mirrors the bake pipeline's image-to-encoder boundary.
+    """
+    normalized = normalize_color_adjustment(adjustment, reject_invalid=True)
+    if normalized is None:
+        raise ValueError("invalid color adjustment")
+    try:
+        width, height = int(width), int(height)
+    except (TypeError, ValueError):
+        raise ValueError("image dimensions are invalid") from None
+    if width <= 0 or height <= 0 or len(data) != width * height * 4:
+        raise ValueError("RGBA data has the wrong size")
+    if pixel_mask is not None and len(pixel_mask) != width * height:
+        raise ValueError("pixel mask has the wrong size")
+    result = bytearray(len(data))
+    for index in range(0, len(data), 4):
+        red, green, blue = (data[index + channel] / 255.0
+                            for channel in range(3))
+        adjusted = _apply_normalized((red, green, blue), normalized)
+        pixel_index = index // 4
+        source = adjusted if pixel_mask is None or pixel_mask[pixel_index] else (
+            red, green, blue)
+        result[index:index + 3] = bytes(
+            min(255, max(0, round(channel * 255.0))) for channel in source)
+        result[index + 3] = data[index + 3]
+    return bytes(result)
+
+
+__all__ = [
+    "COLOR_DEFAULTS", "COLOR_RANGES", "adjust_rgba_bytes",
+    "apply_color_adjustment", "is_neutral_color_adjustment",
+    "normalize_color_adjustment", "tint_rgb",
+]

--- a/src/core/textures/color_adjustment.py
+++ b/src/core/textures/color_adjustment.py
@@ -171,9 +171,8 @@ def adjust_rgba_bytes(data, width, height, adjustment, pixel_mask=None):
     """Return adjusted RGBA bytes, preserving every source alpha byte.
 
     When *pixel_mask* is supplied it must contain one truthy entry per pixel;
-    only selected pixels receive the RGB operation.  A full adjusted candidate
-    is still computed for each source pixel before the mask is composited, which
-    mirrors the bake pipeline's image-to-encoder boundary.
+    only selected pixels receive the RGB operation. Unselected pixels are
+    copied without entering the color transform.
     """
     normalized = normalize_color_adjustment(adjustment, reject_invalid=True)
     if normalized is None:
@@ -188,14 +187,15 @@ def adjust_rgba_bytes(data, width, height, adjustment, pixel_mask=None):
         raise ValueError("pixel mask has the wrong size")
     result = bytearray(len(data))
     for index in range(0, len(data), 4):
+        pixel_index = index // 4
+        if pixel_mask is not None and not pixel_mask[pixel_index]:
+            result[index:index + 4] = data[index:index + 4]
+            continue
         red, green, blue = (data[index + channel] / 255.0
                             for channel in range(3))
         adjusted = _apply_normalized((red, green, blue), normalized)
-        pixel_index = index // 4
-        source = adjusted if pixel_mask is None or pixel_mask[pixel_index] else (
-            red, green, blue)
         result[index:index + 3] = bytes(
-            min(255, max(0, round(channel * 255.0))) for channel in source)
+            min(255, max(0, round(channel * 255.0))) for channel in adjusted)
         result[index + 3] = data[index + 3]
     return bytes(result)
 

--- a/src/core/textures/dds.py
+++ b/src/core/textures/dds.py
@@ -30,6 +30,37 @@ class DDSInfo:
     requires_bc: bool
 
 
+@dataclass(frozen=True)
+class DDSMipLayout:
+    """Byte layout and edit-unit grid for one DDS mip level."""
+
+    level: int
+    width: int
+    height: int
+    offset: int
+    length: int
+    units_x: int
+    units_y: int
+    bytes_per_unit: int
+
+
+@dataclass(frozen=True)
+class DDSLayout:
+    """Validated payload layout for every mip in a 2D DDS texture."""
+
+    info: DDSInfo
+    data_offset: int
+    mips: tuple[DDSMipLayout, ...]
+
+    @property
+    def payload_length(self):
+        return sum(mip.length for mip in self.mips)
+
+    @property
+    def payload_end(self):
+        return self.data_offset + self.payload_length
+
+
 _DXGI_FORMATS = {
     71: "bc1_unorm",
     72: "bc1_srgb",
@@ -72,6 +103,39 @@ def _info(width, height, mip_count, format_name):
     compressed = format_name in _COMPRESSED_FORMATS
     return DDSInfo(width, height, mip_count, format_name, compressed,
                    compressed)
+
+
+def _bytes_per_unit(format_name):
+    if not format_name.startswith("bc"):
+        return 4
+    return 8 if format_name.startswith(("bc1", "bc4")) else 16
+
+
+def _layout(info, data_offset):
+    """Build the one authoritative DDS payload layout from validated info."""
+    offset = int(data_offset)
+    width, height = info.width, info.height
+    bytes_per_unit = _bytes_per_unit(info.format)
+    mips = []
+    for level in range(info.mip_count):
+        units_x = ((width + 3) // 4) if info.compressed else width
+        units_y = ((height + 3) // 4) if info.compressed else height
+        length = units_x * units_y * bytes_per_unit
+        mips.append(DDSMipLayout(
+            level=level, width=width, height=height, offset=offset,
+            length=length, units_x=units_x, units_y=units_y,
+            bytes_per_unit=bytes_per_unit))
+        offset += length
+        width = max(1, width // 2)
+        height = max(1, height // 2)
+    return DDSLayout(info=info, data_offset=data_offset, mips=tuple(mips))
+
+
+def dds_layout_for_info(info, data_offset=None):
+    """Build a layout for validated metadata without rereading a file."""
+    if data_offset is None:
+        data_offset = 148 if info.format in _COMPRESSED_FORMATS else 128
+    return _layout(info, data_offset)
 
 
 def _inspect_header(header):
@@ -142,6 +206,12 @@ def _inspect_header(header):
 
 def inspect_dds(path):
     """Inspect only the DDS header and return ``None`` for unsafe inputs."""
+    layout = inspect_dds_layout(path)
+    return layout.info if layout is not None else None
+
+
+def inspect_dds_layout(path):
+    """Inspect a DDS and return the exact byte layout of its mip payload."""
     try:
         with open(path, "rb") as stream:
             header = stream.read(148)
@@ -152,19 +222,10 @@ def inspect_dds(path):
     if info is None:
         return None
     header_size = 148 if _fourcc(header, 84) == _DX10_FOURCC else 128
-    width, height = info.width, info.height
-    payload_size = 0
-    for _ in range(info.mip_count):
-        if info.compressed:
-            block_size = 8 if info.format.startswith(("bc1", "bc4")) else 16
-            payload_size += ((width + 3) // 4) * ((height + 3) // 4) * block_size
-        else:
-            payload_size += width * height * 4
-        width = max(1, width // 2)
-        height = max(1, height // 2)
-    if file_size < header_size + payload_size:
+    layout = _layout(info, header_size)
+    if file_size < layout.payload_end:
         return None
-    return info
+    return layout
 
 
 def native_dds_info(path, max_size=2048, transform="passthrough"):
@@ -187,3 +248,9 @@ def native_dds_info(path, max_size=2048, transform="passthrough"):
     if info is None or max(info.width, info.height) > max_size:
         return None
     return info
+
+
+__all__ = [
+    "DDSInfo", "DDSMipLayout", "DDSLayout", "dds_layout_for_info",
+    "inspect_dds", "inspect_dds_layout", "native_dds_info",
+]

--- a/src/core/textures/pipeline.py
+++ b/src/core/textures/pipeline.py
@@ -204,13 +204,14 @@ def _open_texture_image(path, image_module):
             return None
 
 
-def load_texture_image(path, max_size=2048, preserve_alpha=False):
-    """Decode a texture once and return its bounded Pillow image."""
+def _decode_texture_image(path, max_size=None, preserve_alpha=False):
+    """Decode a texture with the shared DDS and decompression safeguards."""
     try:
-        max_size = int(max_size)
+        if max_size is not None:
+            max_size = int(max_size)
+            if max_size <= 0:
+                return None
     except (TypeError, ValueError):
-        return None
-    if max_size <= 0:
         return None
     try:
         from PIL import Image
@@ -221,11 +222,21 @@ def load_texture_image(path, max_size=2048, preserve_alpha=False):
             if image is None:
                 return None
         image = image.convert("RGBA" if preserve_alpha else "RGB")
-        if max(image.size) > max_size:
+        if max_size is not None and max(image.size) > max_size:
             image.thumbnail((max_size, max_size), Image.LANCZOS)
         return image
     except Exception:
         return None
+
+
+def load_texture_image(path, max_size=2048, preserve_alpha=False):
+    """Decode a texture once and return its bounded Pillow image."""
+    return _decode_texture_image(path, max_size, preserve_alpha)
+
+
+def load_texture_image_full(path, preserve_alpha=True):
+    """Decode a texture at its authored dimensions without preview resizing."""
+    return _decode_texture_image(path, None, preserve_alpha)
 
 
 def render_texture_png(path, max_size=2048, preserve_alpha=False,

--- a/src/core/textures/texconv.py
+++ b/src/core/textures/texconv.py
@@ -1,0 +1,128 @@
+"""Small, deterministic adapter around the bundled DirectXTex encoder."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+
+FORMAT_TO_TEXCONV = {
+    "bc1_unorm": "BC1_UNORM",
+    "bc1_srgb": "BC1_UNORM_SRGB",
+    "bc2_unorm": "BC2_UNORM",
+    "bc2_srgb": "BC2_UNORM_SRGB",
+    "bc3_unorm": "BC3_UNORM",
+    "bc3_srgb": "BC3_UNORM_SRGB",
+    "bc7_unorm": "BC7_UNORM",
+    "bc7_srgb": "BC7_UNORM_SRGB",
+    "rgba8": "R8G8B8A8_UNORM",
+    "bgra8": "B8G8R8A8_UNORM",
+}
+
+DEFAULT_TIMEOUT = 120
+
+
+class TexconvError(RuntimeError):
+    """The encoder ran but did not produce a usable result."""
+
+
+class TexconvUnavailableError(TexconvError):
+    """No trusted or development texconv executable was available."""
+
+
+def texconv_path():
+    """Return the bundled encoder, or a development PATH fallback."""
+    try:
+        from app.settings.paths import is_frozen
+        from app.settings.paths import texconv_path as configured_path
+        bundled = configured_path()
+    except (ImportError, AttributeError):
+        is_frozen = lambda: False
+        bundled = None
+    if bundled and os.path.isfile(bundled):
+        return bundled
+    if is_frozen():
+        return None
+    return shutil.which("texconv.exe") or shutil.which("texconv")
+
+
+def build_texconv_command(executable, input_png, output_dir, format_name,
+                          mip_count):
+    """Build the no-shell command for an exact-format DDS conversion."""
+    dxgi_format = FORMAT_TO_TEXCONV.get(format_name)
+    if dxgi_format is None:
+        raise ValueError(f"Unsupported texconv format: {format_name}")
+    try:
+        mip_count = int(mip_count)
+    except (TypeError, ValueError):
+        raise ValueError("DDS mip count is invalid") from None
+    if mip_count <= 0:
+        raise ValueError("DDS mip count is invalid")
+    return [
+        os.fspath(executable), "-nologo", "-y", "-ft", "DDS",
+        "-f", dxgi_format, "-m", str(mip_count), "-if", "LINEAR",
+        "-sepalpha", "-nogpu", "-o", os.fspath(output_dir),
+        os.fspath(input_png),
+    ]
+
+
+def _hidden_startupinfo():
+    if os.name != "nt":
+        return None
+    startupinfo = subprocess.STARTUPINFO()
+    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    startupinfo.wShowWindow = subprocess.SW_HIDE
+    return startupinfo
+
+
+def encode_png_to_dds(input_png, output_dir, format_name, mip_count,
+                      *, executable=None, runner=None,
+                      timeout=DEFAULT_TIMEOUT):
+    """Encode a PNG and return its candidate DDS path.
+
+    The runner is injectable so command construction and failure handling can
+    be tested without requiring the Windows-only bundled executable.
+    """
+    executable = executable or texconv_path()
+    if not executable:
+        raise TexconvUnavailableError("texconv.exe is unavailable")
+    command = build_texconv_command(
+        executable, input_png, output_dir, format_name, mip_count)
+    runner = subprocess.run if runner is None else runner
+    kwargs = {
+        "shell": False,
+        "check": False,
+        "capture_output": True,
+        "text": True,
+        "timeout": timeout,
+    }
+    startupinfo = _hidden_startupinfo()
+    if startupinfo is not None:
+        kwargs["startupinfo"] = startupinfo
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    try:
+        completed = runner(command, **kwargs)
+    except FileNotFoundError as error:
+        raise TexconvUnavailableError("texconv.exe is unavailable") from error
+    except subprocess.TimeoutExpired as error:
+        raise TexconvError("texconv timed out") from error
+    except OSError as error:
+        raise TexconvError("texconv could not be started") from error
+    if completed.returncode != 0:
+        details = (completed.stderr or completed.stdout or "").strip()
+        raise TexconvError(
+            "texconv failed" + (f": {details}" if details else ""))
+    candidate = os.path.join(
+        os.fspath(output_dir),
+        os.path.splitext(os.path.basename(os.fspath(input_png)))[0] + ".dds")
+    if not os.path.isfile(candidate):
+        raise TexconvError("texconv did not produce a DDS candidate")
+    return candidate
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT", "FORMAT_TO_TEXCONV", "build_texconv_command",
+    "TexconvError", "TexconvUnavailableError", "encode_png_to_dds",
+    "texconv_path",
+]

--- a/src/core/textures/texconv.py
+++ b/src/core/textures/texconv.py
@@ -59,12 +59,18 @@ def build_texconv_command(executable, input_png, output_dir, format_name,
         raise ValueError("DDS mip count is invalid") from None
     if mip_count <= 0:
         raise ValueError("DDS mip count is invalid")
-    return [
+    command = [
         os.fspath(executable), "-nologo", "-y", "-ft", "DDS",
         "-f", dxgi_format, "-m", str(mip_count), "-if", "LINEAR",
         "-sepalpha", "-nogpu", "-o", os.fspath(output_dir),
         os.fspath(input_png),
     ]
+    if format_name.endswith("_srgb"):
+        # LINEAR selects the resize filter; it does not select the colorspace
+        # used while filtering. The bake PNG contains editor-sRGB bytes, so
+        # typed sRGB outputs must opt into linear-light mip generation.
+        command.insert(command.index("-sepalpha"), "-srgb")
+    return command
 
 
 def _hidden_startupinfo():

--- a/src/core/textures/texconv.py
+++ b/src/core/textures/texconv.py
@@ -48,7 +48,7 @@ def texconv_path():
 
 
 def build_texconv_command(executable, input_png, output_dir, format_name,
-                          mip_count):
+                          mip_count, *, srgb=False):
     """Build the no-shell command for an exact-format DDS conversion."""
     dxgi_format = FORMAT_TO_TEXCONV.get(format_name)
     if dxgi_format is None:
@@ -65,10 +65,11 @@ def build_texconv_command(executable, input_png, output_dir, format_name,
         "-sepalpha", "-nogpu", "-o", os.fspath(output_dir),
         os.fspath(input_png),
     ]
-    if format_name.endswith("_srgb"):
+    if srgb:
         # LINEAR selects the resize filter; it does not select the colorspace
-        # used while filtering. The bake PNG contains editor-sRGB bytes, so
-        # typed sRGB outputs must opt into linear-light mip generation.
+        # used while filtering. Diffuse bake PNGs contain editor-sRGB bytes,
+        # so they must opt into linear-light mip generation regardless of the
+        # source DDS's physical UNORM/sRGB format.
         command.insert(command.index("-sepalpha"), "-srgb")
     return command
 
@@ -84,7 +85,7 @@ def _hidden_startupinfo():
 
 def encode_png_to_dds(input_png, output_dir, format_name, mip_count,
                       *, executable=None, runner=None,
-                      timeout=DEFAULT_TIMEOUT):
+                      timeout=DEFAULT_TIMEOUT, srgb=False):
     """Encode a PNG and return its candidate DDS path.
 
     The runner is injectable so command construction and failure handling can
@@ -94,7 +95,7 @@ def encode_png_to_dds(input_png, output_dir, format_name, mip_count,
     if not executable:
         raise TexconvUnavailableError("texconv.exe is unavailable")
     command = build_texconv_command(
-        executable, input_png, output_dir, format_name, mip_count)
+        executable, input_png, output_dir, format_name, mip_count, srgb=srgb)
     runner = subprocess.run if runner is None else runner
     kwargs = {
         "shell": False,

--- a/src/core/textures/uv_coverage.py
+++ b/src/core/textures/uv_coverage.py
@@ -219,6 +219,65 @@ def _rasterize_triangle(mask, grid_width, grid_height, triangle):
                 _mark_cell(mask, grid_width, grid_height, cell_x, cell_y)
 
 
+def _rasterize_degenerate(mask, grid_width, grid_height, points):
+    """Conservatively retain point and segment coverage for zero-area UVs."""
+    for point in points:
+        _mark_point(mask, grid_width, grid_height, *point)
+    for start, end in zip(points, points[1:] + points[:1]):
+        _supercover_segment(mask, grid_width, grid_height, start, end)
+
+
+def dilate_pixel_mask(mask, width, height, radius=1):
+    """Dilate a pixel mask by a clamped square neighborhood."""
+    try:
+        width, height, radius = int(width), int(height), int(radius)
+    except (TypeError, ValueError):
+        raise UVCoverageError(
+            "invalid_geometry", "Pixel mask dimensions are invalid.") from None
+    if width <= 0 or height <= 0 or radius < 0:
+        raise UVCoverageError(
+            "invalid_geometry", "Pixel mask dimensions are invalid.")
+    if len(mask) != width * height:
+        raise UVCoverageError(
+            "invalid_geometry", "Pixel mask length does not match dimensions.")
+    result = bytearray(width * height)
+    for index, value in enumerate(mask):
+        if not value:
+            continue
+        x, y = index % width, index // width
+        for row in range(max(0, y - radius), min(height, y + radius + 1)):
+            start = max(0, x - radius)
+            end = min(width, x + radius + 1)
+            result[row * width + start:row * width + end] = \
+                b"\x01" * (end - start)
+    return result
+
+
+def collapse_pixel_mask_to_units(pixel_mask, width, height,
+                                 unit_width, unit_height):
+    """Collapse protected source pixels into conservative edit units."""
+    try:
+        width, height = int(width), int(height)
+        unit_width, unit_height = int(unit_width), int(unit_height)
+    except (TypeError, ValueError):
+        raise UVCoverageError(
+            "invalid_geometry", "Edit-unit dimensions are invalid.") from None
+    if min(width, height, unit_width, unit_height) <= 0:
+        raise UVCoverageError(
+            "invalid_geometry", "Edit-unit dimensions are invalid.")
+    if len(pixel_mask) != width * height:
+        raise UVCoverageError(
+            "invalid_geometry", "Pixel mask length does not match dimensions.")
+    grid_width = math.ceil(width / unit_width)
+    grid_height = math.ceil(height / unit_height)
+    result = bytearray(grid_width * grid_height)
+    for y in range(height):
+        for x in range(width):
+            if pixel_mask[y * width + x]:
+                result[(y // unit_height) * grid_width + x // unit_width] = 1
+    return result
+
+
 def rasterize_uv_coverage(
         indices, texcoords, texture_width, texture_height, *,
         unit_width=1, unit_height=1):
@@ -268,13 +327,14 @@ def rasterize_uv_coverage(
                 * (points[2][0] - points[0][0]))
         if abs(area) <= _AREA_EPSILON:
             degenerate += 1
-            continue
-        _rasterize_triangle(mask, grid_width, grid_height, points)
+            _rasterize_degenerate(mask, grid_width, grid_height, points)
+        else:
+            _rasterize_triangle(mask, grid_width, grid_height, points)
 
     count = sum(mask)
     if not count:
         raise UVCoverageError(
-            "no_uv_coverage", "The mesh has no non-degenerate UV coverage.")
+            "no_uv_coverage", "The mesh has no UV coverage.")
     used = [index for index, value in enumerate(mask) if value]
     bounds = (
         min(index % grid_width for index in used),
@@ -287,4 +347,7 @@ def rasterize_uv_coverage(
         triangle_count, degenerate)
 
 
-__all__ = ["UVCoverage", "UVCoverageError", "rasterize_uv_coverage"]
+__all__ = [
+    "UVCoverage", "UVCoverageError", "collapse_pixel_mask_to_units",
+    "dilate_pixel_mask", "rasterize_uv_coverage",
+]

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -30,6 +30,7 @@ EXPECTED_API_METHODS = {
     "get_ini_text",
     "get_mesh_semantics",
     "analyze_mesh_texture_bake",
+    "bake_mesh_texture_color",
     "get_mod_folders",
     "get_panel_opacity",
     "get_present_state",

--- a/src/tests/app/bridge/test_mod_preview.py
+++ b/src/tests/app/bridge/test_mod_preview.py
@@ -272,3 +272,50 @@ def test_semantic_control_read_reuses_active_mesh_keys(monkeypatch):
 
     assert result["controls"]["present"] == {}
     assert captured[0][1]["active_mesh_keys"] == {"Body-1"}
+
+
+def test_bake_resets_metadata_only_after_success(monkeypatch):
+    preview = ModPreview(_Access())
+    context = _context()
+    captured = []
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {"override": 1}, {}, context))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.bake_mesh_texture_color",
+        lambda *args: captured.append(args) or {
+            "status": "ok", "tex_key": "diffuse::body.dds",
+        })
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.save_mesh_color_adjustment",
+        lambda *args: captured.append(("reset", args)) or {"saved": True})
+
+    result = preview.bake_mesh_texture_color(
+        "mod", "Body-1", "Body::3,0,0", "diffuse::body.dds",
+        [{"semantic_key": "Body-1", "tex_key": "diffuse::body.dds"}],
+        {"hue": 30})
+
+    assert result["status"] == "ok"
+    assert captured[0][1:]
+    assert captured[1][0] == "reset"
+
+
+def test_bake_does_not_reset_metadata_on_write_failure(monkeypatch):
+    preview = ModPreview(_Access())
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {}, {}, _context()))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.bake_mesh_texture_color",
+        lambda *args: {"status": "error", "code": "texconv_failed"})
+    reset = []
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.save_mesh_color_adjustment",
+        lambda *args: reset.append(args) or {"saved": True})
+
+    result = preview.bake_mesh_texture_color(
+        "mod", "Body-1", "Body::3,0,0", "diffuse::body.dds", [],
+        {"hue": 30})
+
+    assert result["code"] == "texconv_failed"
+    assert reset == []

--- a/src/tests/app/mods/test_texture_bake.py
+++ b/src/tests/app/mods/test_texture_bake.py
@@ -35,6 +35,23 @@ def _coverage(mask):
         triangle_count=1, degenerate_triangle_count=0)
 
 
+def _role_usage(semantic_key, diffuse=None, **roles):
+    texture_keys = {
+        "diffuse": diffuse,
+        "normal_map": None,
+        "normal_data": None,
+        "light_map": None,
+        "material_map": None,
+        "emission_map": None,
+    }
+    texture_keys.update(roles)
+    return {
+        "semantic_key": semantic_key,
+        "tex_key": diffuse,
+        "texture_keys": texture_keys,
+    }
+
+
 def _patch_analysis(monkeypatch, draws, coverage_by_label):
     parsed = SimpleNamespace(game=SimpleNamespace(game="unknown"))
     groups = {label: ({"draws": []}) for label in draws}
@@ -110,6 +127,150 @@ def test_shared_physical_texture_reports_overlap_and_hidden_consumer(
     }]
     assert texture.read_bytes() == original
     assert texture.stat().st_mtime_ns == before
+
+
+@pytest.mark.parametrize(("role", "key", "semantic_key", "draws"), [
+    ("normal_map", "normal_map::body.dds", "Face-1",
+     ("selected", "consumer")),
+    ("normal_data", "normal_data::body.dds", "Face-1",
+     ("selected", "consumer")),
+    ("light_map", "light_map::body.dds", "Face-1",
+     ("selected", "consumer")),
+    ("material_map", "material_map::body.dds", "Body-1",
+     ("selected",)),
+    # Visibility is intentionally absent from this backend snapshot: active
+    # hidden meshes must remain part of the ownership proof.
+    ("emission_map", "emission_map::body.dds", "Hidden-1",
+     ("selected", "consumer")),
+    ("normal_map", "normal_map::nested/../body.dds", "Face-1",
+     ("selected", "consumer")),
+])
+def test_cross_role_texture_usage_blocks_safe_bake(
+        tmp_path, monkeypatch, role, key, semantic_key, draws):
+    source = tmp_path / "body.dds"
+    source.write_bytes(b"fixture")
+    draw_map = {
+        "Body-1": _draw("Body-1"),
+    }
+    if "consumer" in draws:
+        draw_map[semantic_key] = _draw(semantic_key)
+    _patch_analysis(monkeypatch, draw_map, {
+        label: [1, 0, 0, 0] for label in draw_map
+    })
+    selected_entry = _role_usage(
+        "Body-1", "diffuse::body.dds", **({role: key}
+                                             if semantic_key == "Body-1"
+                                             else {}))
+    usage = [selected_entry]
+    if semantic_key != "Body-1":
+        usage.append(_role_usage(semantic_key, **{role: key}))
+
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, set(draw_map), "Body-1",
+        "diffuse::body.dds", usage)
+
+    assert result["status"] == "unsupported"
+    assert result["code"] == "cross_role_texture_usage"
+    assert "This DDS is also used as a" in result["error"]
+    assert semantic_key in result["error"]
+    assert result["error"].endswith(".")
+
+
+def test_unrelated_non_diffuse_role_does_not_block_safe_bake(
+        tmp_path, monkeypatch):
+    (tmp_path / "body.dds").write_bytes(b"fixture")
+    (tmp_path / "other.dds").write_bytes(b"fixture")
+    draws = {"Body-1": _draw("Body-1"), "Face-1": _draw("Face-1")}
+    _patch_analysis(monkeypatch, draws, {
+        "Body-1": [1, 0, 0, 0], "Face-1": [0, 1, 0, 0],
+    })
+    usage = [
+        _role_usage("Body-1", "diffuse::body.dds"),
+        _role_usage("Face-1", "diffuse::other.dds",
+                    normal_map="normal_map::other.dds"),
+    ]
+
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, set(draws), "Body-1",
+        "diffuse::body.dds", usage)
+
+    assert result["status"] == "ok"
+    assert result["safety"] == "safe"
+
+
+def test_affected_texture_keys_include_role_assignments_and_dedupe_keys(
+        tmp_path):
+    source = tmp_path / "body.dds"
+    source.write_bytes(b"fixture")
+    prepared = SimpleNamespace(
+        selected_path=str(source),
+        entries=(
+            _role_usage("Body-1", "diffuse::body.dds",
+                        normal_map="normal_map::body.dds"),
+            _role_usage("Face-1", "diffuse::nested/../body.dds",
+                        normal_map="normal_map::body.dds",
+                        material_map="material_map::body.dds"),
+        ),
+    )
+
+    assert texture_bake._affected_texture_keys(
+        _context(tmp_path), prepared) == [
+            "diffuse::body.dds",
+            "normal_map::body.dds",
+            "diffuse::nested/../body.dds",
+            "material_map::body.dds",
+        ]
+
+
+def test_bake_rechecks_cross_role_texture_usage_before_writing(
+        tmp_path, monkeypatch):
+    source = tmp_path / "body.dds"
+    source.write_bytes(b"fixture")
+    draws = {"Body-1": _draw("Body-1"), "Face-1": _draw("Face-1")}
+    _patch_analysis(monkeypatch, draws, {
+        "Body-1": [1, 0, 0, 0], "Face-1": [0, 1, 0, 0],
+    })
+    usage = [
+        _role_usage("Body-1", "diffuse::body.dds"),
+        _role_usage("Face-1", normal_map="normal_map::body.dds"),
+    ]
+
+    result = texture_bake.bake_texture_color(
+        _context(tmp_path), {}, set(draws), "Body-1",
+        "diffuse::body.dds", usage, {"hue": 30})
+
+    assert result["status"] == "unsupported"
+    assert result["code"] == "cross_role_texture_usage"
+    assert source.read_bytes() == b"fixture"
+    assert not (tmp_path / "body.dds.modviewer.bak").exists()
+
+
+def test_texture_usage_rejects_arbitrary_role_names(tmp_path, monkeypatch):
+    source = tmp_path / "body.dds"
+    source.write_bytes(b"fixture")
+    monkeypatch.setattr(
+        texture_bake, "resolved_draws",
+        lambda *_args: (SimpleNamespace(game=SimpleNamespace(game="unknown")), {}),
+    )
+    texture_keys = {
+        "diffuse": "diffuse::body.dds",
+        "normal_map": None,
+        "normal_data": None,
+        "light_map": None,
+        "material_map": None,
+        "unexpected": "unexpected::body.dds",
+    }
+
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, {"Body-1"}, "Body-1",
+        "diffuse::body.dds", [{
+            "semantic_key": "Body-1",
+            "tex_key": "diffuse::body.dds",
+            "texture_keys": texture_keys,
+        }])
+
+    assert result["status"] == "error"
+    assert result["code"] == "stale_mesh_state"
 
 
 def test_unanalyzable_same_texture_consumer_is_unknown(

--- a/src/tests/app/mods/test_texture_bake.py
+++ b/src/tests/app/mods/test_texture_bake.py
@@ -198,6 +198,96 @@ def test_unrelated_non_diffuse_role_does_not_block_safe_bake(
     assert result["safety"] == "safe"
 
 
+def test_authored_inactive_diffuse_variant_is_a_texture_consumer(
+        tmp_path, monkeypatch):
+    source = tmp_path / "body.dds"
+    (tmp_path / "face.dds").write_bytes(b"fixture")
+    source.write_bytes(b"fixture")
+    selected = DrawCall(label="Body-1", count=3,
+                        texture_default_file="body.dds")
+    inactive = DrawCall(
+        label="Face-1", count=3, texture_default_file="face.dds",
+        texture_variants=[{
+            "conditions": [[{"var": "toggle", "value": "1"}]],
+            "file": "body.dds",
+        }])
+    selected_group = {"draws": [selected]}
+    inactive_group = {"draws": [inactive]}
+    parsed = SimpleNamespace(
+        game=SimpleNamespace(game="unknown"),
+        groups=[selected_group, inactive_group],
+    )
+    monkeypatch.setattr(
+        texture_bake, "resolved_draws",
+        lambda *_args: (parsed, {
+            "Body-1": (selected, selected_group),
+            "Face-1": (inactive, inactive_group),
+        }))
+    monkeypatch.setattr(texture_bake, "_inspect_color_texture", lambda _: _info())
+
+    resolved = texture_bake._resolve_request(
+        _context(tmp_path), {}, {"Body-1"}, "Body-1",
+        "diffuse::body.dds", [_role_usage("Body-1", "diffuse::body.dds")])
+
+    assert resolved[-1] == (("Face-1", (inactive, inactive_group)),)
+
+
+def test_authored_inactive_non_diffuse_variant_blocks_bake(
+        tmp_path, monkeypatch):
+    source = tmp_path / "body.dds"
+    source.write_bytes(b"fixture")
+    selected = DrawCall(label="Body-1", count=3,
+                        texture_default_file="body.dds")
+    inactive = DrawCall(
+        label="Face-1", count=3, texture_default_file="face.dds",
+        normal_map_variants=[{
+            "conditions": [[{"var": "toggle", "value": "1"}]],
+            "file": "body.dds",
+        }])
+    selected_group = {"draws": [selected]}
+    inactive_group = {"draws": [inactive]}
+    parsed = SimpleNamespace(
+        game=SimpleNamespace(game="unknown"),
+        groups=[selected_group, inactive_group],
+    )
+    monkeypatch.setattr(
+        texture_bake, "resolved_draws",
+        lambda *_args: (parsed, {
+            "Body-1": (selected, selected_group),
+            "Face-1": (inactive, inactive_group),
+        }))
+    monkeypatch.setattr(texture_bake, "_inspect_color_texture", lambda _: _info())
+
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, {"Body-1"}, "Body-1",
+        "diffuse::body.dds", [_role_usage("Body-1", "diffuse::body.dds")])
+
+    assert result["code"] == "cross_role_texture_usage"
+    assert "Normal Map" in result["error"]
+
+
+def test_destructive_bake_rejects_stale_metadata_identity_before_write(
+        tmp_path, monkeypatch):
+    source = tmp_path / "body.dds"
+    source.write_bytes(b"fixture")
+    draw = DrawCall(label="Body-1", count=3, start=0, base=0,
+                    texture_default_file="body.dds")
+    group = {"name": "Body", "source": "Root.ini", "draws": [draw]}
+    parsed = SimpleNamespace(game=SimpleNamespace(game="unknown"), groups=[])
+    monkeypatch.setattr(
+        texture_bake, "resolved_draws",
+        lambda *_args: (parsed, {"Body-1": (draw, group)}))
+    monkeypatch.setattr(texture_bake, "_inspect_color_texture", lambda _: _info())
+
+    with pytest.raises(texture_bake.TextureBakeAnalysisError) as raised:
+        texture_bake._prepare_texture_bake(
+            _context(tmp_path), {}, {"Body-1"}, "Body-1",
+            "diffuse::body.dds", [_role_usage("Body-1", "diffuse::body.dds")],
+            require_file_layout=False, metadata_key="mesh:stale")
+
+    assert raised.value.code == "stale_mesh_state"
+
+
 def test_affected_texture_keys_include_role_assignments_and_dedupe_keys(
         tmp_path):
     source = tmp_path / "body.dds"

--- a/src/tests/app/mods/test_texture_bake.py
+++ b/src/tests/app/mods/test_texture_bake.py
@@ -232,6 +232,74 @@ def test_authored_inactive_diffuse_variant_is_a_texture_consumer(
     assert resolved[-1] == (("Face-1", (inactive, inactive_group)),)
 
 
+def test_authored_diffuse_variant_protects_following_run_consumers(
+        tmp_path, monkeypatch):
+    for name in ("shared.dds", "a.dds", "c.dds"):
+        (tmp_path / name).write_bytes(b"fixture")
+    selected = DrawCall(
+        label="Selected-1", count=3, start=0,
+        texture_default_file="shared.dds")
+    first = DrawCall(
+        label="A-1", count=3, start=3, texture_default_file="a.dds",
+        texture_variants=[{
+            "conditions": [[{"var": "toggle", "value": "1"}]],
+            "file": "shared.dds",
+        }])
+    follower = DrawCall(label="B-1", count=3, start=6)
+    longer_follower = DrawCall(label="C-1", count=3, start=9)
+    boundary = DrawCall(
+        label="D-1", count=3, start=12, texture_default_file="c.dds")
+    selected_group = {"draws": [selected]}
+    authored_group = {"draws": [first, follower, longer_follower, boundary]}
+    parsed = SimpleNamespace(
+        game=SimpleNamespace(game="unknown"),
+        groups=[selected_group, authored_group],
+    )
+    draw_map = {
+        draw.label: (draw, group)
+        for group in parsed.groups
+        for draw in group["draws"]
+    }
+    monkeypatch.setattr(
+        texture_bake, "resolved_draws",
+        lambda *_args: (parsed, draw_map))
+    monkeypatch.setattr(texture_bake, "_inspect_color_texture", lambda _: _info())
+    coverage = {
+        "Selected-1": [1, 0, 0, 0],
+        "A-1": [0, 1, 0, 0],
+        "B-1": [1, 0, 0, 0],
+        "C-1": [0, 0, 1, 0],
+        "D-1": [0, 0, 0, 1],
+    }
+    monkeypatch.setattr(
+        texture_bake, "_coverage",
+        lambda draw, *_args: _coverage(coverage[draw.label]))
+    usage = [
+        _role_usage("Selected-1", "diffuse::shared.dds"),
+        _role_usage("A-1", "diffuse::a.dds"),
+        _role_usage("B-1", "diffuse::a.dds"),
+        _role_usage("C-1", "diffuse::a.dds"),
+        _role_usage("D-1", "diffuse::c.dds"),
+    ]
+
+    resolved = texture_bake._resolve_request(
+        _context(tmp_path), {}, set(draw_map), "Selected-1",
+        "diffuse::shared.dds", usage)
+    assert {key for key, _draw in resolved[-1]} >= {
+        "A-1", "B-1", "C-1",
+    }
+
+    result = texture_bake.analyze_texture_bake(
+        _context(tmp_path), {}, set(draw_map), "Selected-1",
+        "diffuse::shared.dds", usage)
+
+    assert result["status"] == "ok"
+    assert result["safety"] == "shared"
+    assert result["shared_with"] == [{
+        "semantic_key": "B-1", "shared_units": 1,
+    }]
+
+
 def test_authored_inactive_non_diffuse_variant_blocks_bake(
         tmp_path, monkeypatch):
     source = tmp_path / "body.dds"

--- a/src/tests/app/mods/test_texture_bake_write.py
+++ b/src/tests/app/mods/test_texture_bake_write.py
@@ -1,0 +1,268 @@
+"""Safe DDS color-bake write-path regressions."""
+
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from app.mods import texture_bake
+from core.textures.dds import inspect_dds, inspect_dds_layout
+from core.textures.uv_coverage import UVCoverage
+
+
+def _rgba8_dds(payload):
+    header = bytearray(128)
+    header[:4] = b"DDS "
+    header[4:8] = (124).to_bytes(4, "little")
+    header[12:16] = (1).to_bytes(4, "little")
+    header[16:20] = (2).to_bytes(4, "little")
+    header[76:80] = (32).to_bytes(4, "little")
+    header[80:84] = (0x41).to_bytes(4, "little")
+    header[88:92] = (32).to_bytes(4, "little")
+    for offset, value in zip((92, 96, 100, 104),
+                             (0x000000FF, 0x0000FF00,
+                              0x00FF0000, 0xFF000000)):
+        header[offset:offset + 4] = value.to_bytes(4, "little")
+    return bytes(header) + bytes(payload)
+
+
+def _prepared(path):
+    layout = inspect_dds_layout(path)
+    selected_pixels = SimpleNamespace(mask=bytearray([1, 1]))
+    selected = {"semantic_key": "Body-1", "tex_key": "diffuse::body.dds"}
+    return SimpleNamespace(
+        selected_path=str(path), info=layout.info, layout=layout,
+        selected_pixels=selected_pixels,
+        safe_masks=(bytearray([1, 0]),),
+        shared_masks=(bytearray([0, 1]),),
+        entries=(selected,), unresolved=(),
+    )
+
+
+def test_bake_replaces_only_safe_units_and_keeps_backup(tmp_path, monkeypatch):
+    source = tmp_path / "body.dds"
+    original = _rgba8_dds([10, 20, 30, 40, 50, 60, 70, 80])
+    source.write_bytes(original)
+    prepared = _prepared(source)
+    monkeypatch.setattr(texture_bake, "_prepare_texture_bake",
+                        lambda *args, **kwargs: prepared)
+    monkeypatch.setattr(
+        texture_bake, "load_texture_image_full",
+        lambda *_args, **_kwargs: Image.frombytes(
+            "RGBA", (2, 1), bytes([10, 20, 30, 40, 50, 60, 70, 80])))
+
+    def encode(_png, output, _format, _mips):
+        candidate = Path(output) / "bake.dds"
+        candidate.write_bytes(_rgba8_dds(
+            [200, 201, 202, 203, 50, 60, 70, 81]))
+        return str(candidate)
+
+    monkeypatch.setattr(texture_bake, "encode_png_to_dds", encode)
+    result = texture_bake.bake_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
+        "diffuse::body.dds", [
+            {"semantic_key": "Body-1", "tex_key": "diffuse::body.dds"},
+        ], {"hue": 30})
+
+    assert result["status"] == "ok"
+    assert result["patched"]["mip0_units"] == 1
+    updated = source.read_bytes()
+    assert updated[:128] == original[:128]
+    assert updated[128:132] == bytes([200, 201, 202, 203])
+    assert updated[132:] == original[132:]
+    assert (tmp_path / "body.dds.modviewer.bak").read_bytes() == original
+
+
+def test_bake_aborts_on_stale_source_before_creating_backup(tmp_path, monkeypatch):
+    source = tmp_path / "body.dds"
+    original = _rgba8_dds([10, 20, 30, 40, 50, 60, 70, 80])
+    source.write_bytes(original)
+    prepared = _prepared(source)
+    monkeypatch.setattr(texture_bake, "_prepare_texture_bake",
+                        lambda *args, **kwargs: prepared)
+    monkeypatch.setattr(
+        texture_bake, "load_texture_image_full",
+        lambda *_args, **_kwargs: Image.frombytes(
+            "RGBA", (2, 1), bytes([10, 20, 30, 40, 50, 60, 70, 80])))
+    def encode(_png, output, _format, _mips):
+        candidate = Path(output) / "bake.dds"
+        candidate.write_bytes(_rgba8_dds(
+            [200, 201, 202, 203, 50, 60, 70, 81]))
+        return str(candidate)
+
+    monkeypatch.setattr(texture_bake, "encode_png_to_dds", encode)
+
+    reads = 0
+
+    # Keep the real reader available without recursively calling the patched
+    # function for the candidate path.
+    real_read = texture_bake._read_source
+    def read(path):
+        nonlocal reads
+        if str(path) == str(source):
+            reads += 1
+            return original if reads == 1 else b"changed"
+        return real_read(path)
+    monkeypatch.setattr(texture_bake, "_read_source", read)
+
+    result = texture_bake.bake_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
+        "diffuse::body.dds", [
+            {"semantic_key": "Body-1", "tex_key": "diffuse::body.dds"},
+        ], {"hue": 30})
+
+    assert result["code"] == "texture_changed_during_bake"
+    assert source.read_bytes() == original
+    assert not (tmp_path / "body.dds.modviewer.bak").exists()
+
+
+def test_patch_copies_only_safe_units_at_each_mip(tmp_path):
+    header = bytearray(128)
+    header[:4] = b"DDS "
+    header[4:8] = (124).to_bytes(4, "little")
+    header[12:16] = (4).to_bytes(4, "little")
+    header[16:20] = (4).to_bytes(4, "little")
+    header[28:32] = (2).to_bytes(4, "little")
+    header[76:80] = (32).to_bytes(4, "little")
+    header[80:84] = (0x41).to_bytes(4, "little")
+    header[88:92] = (32).to_bytes(4, "little")
+    for offset, value in zip((92, 96, 100, 104),
+                             (0x000000FF, 0x0000FF00,
+                              0x00FF0000, 0xFF000000)):
+        header[offset:offset + 4] = value.to_bytes(4, "little")
+    original = bytes(header) + bytes(range(80))
+    candidate = bytes(header) + bytes([100 + value for value in range(80)])
+    path = tmp_path / "mipped.dds"
+    path.write_bytes(original)
+    layout = inspect_dds_layout(path)
+
+    final = texture_bake._patch_dds_units(
+        original, candidate, layout,
+        (bytearray([1] + [0] * 15), bytearray([0, 0, 1, 0])))
+
+    assert final[128:132] == candidate[128:132]
+    assert final[132:192] == original[132:192]
+    assert final[192:200] == original[192:200]
+    assert final[200:204] == candidate[200:204]
+    assert final[204:208] == original[204:208]
+
+
+def test_lower_mip_collision_makes_only_that_level_shared(tmp_path, monkeypatch):
+    header = bytearray(148)
+    header[:4] = b"DDS "
+    header[4:8] = (124).to_bytes(4, "little")
+    header[12:16] = (8).to_bytes(4, "little")
+    header[16:20] = (8).to_bytes(4, "little")
+    header[28:32] = (2).to_bytes(4, "little")
+    header[76:80] = (32).to_bytes(4, "little")
+    header[80:84] = (4).to_bytes(4, "little")
+    header[84:88] = b"DX10"
+    header[128:148] = (
+        (71).to_bytes(4, "little") + (3).to_bytes(4, "little")
+        + (0).to_bytes(4, "little") + (1).to_bytes(4, "little")
+        + (0).to_bytes(4, "little"))
+    source = tmp_path / "lower-mip.dds"
+    source.write_bytes(bytes(header) + bytes(40))
+    info = inspect_dds(source)
+    selected_draw = (SimpleNamespace(label="selected"), {})
+    other_draw = (SimpleNamespace(label="other"), {})
+    entries = (
+        {"semantic_key": "selected", "tex_key": "diffuse::lower-mip.dds"},
+        {"semantic_key": "other", "tex_key": "diffuse::lower-mip.dds"},
+    )
+    parsed = SimpleNamespace(game=SimpleNamespace(game="unknown"))
+    monkeypatch.setattr(
+        texture_bake, "_resolve_request",
+        lambda *args: (entries, str(source), info, parsed, selected_draw,
+                       (("other", other_draw),)),
+    )
+    packed = {
+        "selected": SimpleNamespace(semantic="selected"),
+        "other": SimpleNamespace(semantic="other"),
+    }
+    prepare_calls = []
+    def prepare(draw, *_args):
+        prepare_calls.append(draw.label)
+        return packed[draw.label]
+    monkeypatch.setattr(
+        texture_bake, "_prepare_uv_geometry", prepare,
+    )
+
+    def coverage(geometry, width, height, unit_width, unit_height):
+        if geometry.semantic == "selected" and unit_width == 1:
+            return UVCoverage(8, 8, bytearray([1] + [0] * 63), 1,
+                              (0, 0, 0, 0), 1, 0)
+        if geometry.semantic == "selected" and width == 8:
+            return UVCoverage(2, 2, bytearray([1, 0, 0, 0]), 1,
+                              (0, 0, 0, 0), 1, 0)
+        if geometry.semantic == "other" and width == 8:
+            return UVCoverage(2, 2, bytearray([0, 1, 0, 0]), 1,
+                              (1, 0, 1, 0), 1, 0)
+        return UVCoverage(1, 1, bytearray([1]), 1, (0, 0, 0, 0), 1, 0)
+
+    monkeypatch.setattr(texture_bake, "_rasterize_geometry", coverage)
+    prepared = texture_bake._prepare_texture_bake(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"selected", "other"},
+        "selected", "diffuse::lower-mip.dds", list(entries))
+
+    assert [sum(mask) for mask in prepared.shared_masks] == [0, 1]
+    assert [sum(mask) for mask in prepared.safe_masks] == [1, 0]
+    assert prepared.safety == "shared"
+    assert prepare_calls == ["selected", "other"]
+
+
+def test_backup_names_never_overwrite_previous_backup(tmp_path):
+    source = tmp_path / "body.dds"
+    source.write_bytes(b"original")
+
+    first = texture_bake._write_backup(str(source), b"first")
+    second = texture_bake._write_backup(str(source), b"second")
+
+    assert first.endswith("body.dds.modviewer.bak")
+    assert second.endswith("body.dds.modviewer.2.bak")
+    assert Path(first).read_bytes() == b"first"
+    assert Path(second).read_bytes() == b"second"
+
+
+@pytest.mark.parametrize(("texture_key", "code"), [
+    ("diffuse::asset/root/body.dds", "asset_texture_read_only"),
+    ("diffuse::../outside.dds", "texture_not_found"),
+])
+def test_bake_rejects_non_mod_texture_paths_before_encoder(
+        tmp_path, monkeypatch, texture_key, code):
+    called = []
+    monkeypatch.setattr(
+        texture_bake, "encode_png_to_dds", lambda *args: called.append(args))
+
+    result = texture_bake.bake_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
+        texture_key, [{"semantic_key": "Body-1", "tex_key": texture_key}],
+        {"hue": 30})
+
+    assert result["code"] == code
+    assert called == []
+
+
+def test_bake_refuses_when_no_top_level_unit_is_unique(tmp_path, monkeypatch):
+    source = tmp_path / "body.dds"
+    source.write_bytes(_rgba8_dds([10, 20, 30, 40, 50, 60, 70, 80]))
+    prepared = _prepared(source)
+    prepared.safe_masks = (bytearray([0, 0]),)
+    monkeypatch.setattr(texture_bake, "_prepare_texture_bake",
+                        lambda *args, **kwargs: prepared)
+    called = []
+    monkeypatch.setattr(
+        texture_bake, "load_texture_image_full",
+        lambda *args: called.append(args))
+    monkeypatch.setattr(
+        texture_bake, "encode_png_to_dds", lambda *args: called.append(args))
+
+    result = texture_bake.bake_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
+        "diffuse::body.dds", [
+            {"semantic_key": "Body-1", "tex_key": "diffuse::body.dds"},
+        ], {"hue": 30})
+
+    assert result["code"] == "no_unique_texture_coverage"
+    assert called == []

--- a/src/tests/app/mods/test_texture_bake_write.py
+++ b/src/tests/app/mods/test_texture_bake_write.py
@@ -1,6 +1,7 @@
 """Safe DDS color-bake write-path regressions."""
 
 from types import SimpleNamespace
+from datetime import datetime
 from pathlib import Path
 import struct
 
@@ -10,6 +11,10 @@ from PIL import Image
 from app.mods import texture_bake
 from core.textures.dds import inspect_dds, inspect_dds_layout
 from core.textures.uv_coverage import UVCoverage
+
+
+def _backups(directory, stem):
+    return sorted(directory.glob(f"{stem}-??????????????.dds"))
 
 
 def _rgba8_dds(payload, format_name="rgba8"):
@@ -85,7 +90,9 @@ def test_bake_replaces_only_safe_units_and_keeps_backup(tmp_path, monkeypatch):
     assert updated[:128] == original[:128]
     assert updated[128:132] == bytes([200, 201, 202, 40])
     assert updated[132:] == original[132:]
-    assert (tmp_path / "body.dds.modviewer.bak").read_bytes() == original
+    backups = _backups(tmp_path, "body")
+    assert len(backups) == 1
+    assert backups[0].read_bytes() == original
 
 
 def test_bake_aborts_on_stale_source_before_creating_backup(tmp_path, monkeypatch):
@@ -128,7 +135,7 @@ def test_bake_aborts_on_stale_source_before_creating_backup(tmp_path, monkeypatc
 
     assert result["code"] == "texture_changed_during_bake"
     assert source.read_bytes() == original
-    assert not (tmp_path / "body.dds.modviewer.bak").exists()
+    assert not _backups(tmp_path, "body")
 
 
 def test_patch_copies_only_safe_units_at_each_mip(tmp_path):
@@ -274,10 +281,10 @@ def test_bake_validates_candidate_bc1_alpha_before_backup(
     if candidate_transparent:
         assert result["code"] == "alpha_preservation_unsupported"
         assert source.read_bytes() == original
-        assert not (tmp_path / "bc1-candidate.dds.modviewer.bak").exists()
+        assert not _backups(tmp_path, "bc1-candidate")
     else:
         assert result["status"] == "ok"
-        assert (tmp_path / "bc1-candidate.dds.modviewer.bak").exists()
+        assert _backups(tmp_path, "bc1-candidate")
 
 
 def test_bc7_alpha_validation_checks_only_safe_blocks_at_each_mip(
@@ -353,7 +360,7 @@ def test_bake_rejects_transparent_bc7_candidate_before_backup(
 
     assert result["code"] == "alpha_preservation_unsupported"
     assert source.read_bytes() == original
-    assert not (tmp_path / "bc7-candidate.dds.modviewer.bak").exists()
+    assert not _backups(tmp_path, "bc7-candidate")
 
 
 def test_bc7_transparency_is_rejected_before_backup_or_encoder(
@@ -390,7 +397,7 @@ def test_bc7_transparency_is_rejected_before_backup_or_encoder(
 
     assert result["code"] == "alpha_preservation_unsupported"
     assert called == []
-    assert not (tmp_path / "transparent-bc7.dds.modviewer.bak").exists()
+    assert not _backups(tmp_path, "transparent-bc7")
 
 
 def test_opaque_bc7_can_be_baked(tmp_path, monkeypatch):
@@ -522,6 +529,14 @@ def test_lower_mip_collision_makes_only_that_level_shared(tmp_path, monkeypatch)
         return UVCoverage(1, 1, bytearray([1]), 1, (0, 0, 0, 0), 1, 0)
 
     monkeypatch.setattr(texture_bake, "_rasterize_geometry", coverage)
+    # The collision fixture supplies edit-unit masks directly; the dedicated
+    # consumer-padding behavior is covered by the pixel-mask tests.
+    monkeypatch.setattr(
+        texture_bake, "_protected_consumer_coverages",
+        lambda geometry, layout, _info: tuple(
+            coverage(geometry, mip.width, mip.height, 4, 4)
+            for mip in layout.mips),
+    )
     prepared = texture_bake._prepare_texture_bake(
         SimpleNamespace(mod_dir=str(tmp_path)), {}, {"selected", "other"},
         "selected", "diffuse::lower-mip.dds", list(entries))
@@ -532,15 +547,23 @@ def test_lower_mip_collision_makes_only_that_level_shared(tmp_path, monkeypatch)
     assert prepare_calls == ["selected", "other"]
 
 
-def test_backup_names_never_overwrite_previous_backup(tmp_path):
+def test_backup_names_never_overwrite_previous_backup(tmp_path, monkeypatch):
     source = tmp_path / "body.dds"
     source.write_bytes(b"original")
+    monkeypatch.setattr(
+        texture_bake, "datetime",
+        SimpleNamespace(now=lambda: datetime(2026, 9, 1, 15, 22, 30)))
 
     first = texture_bake._write_backup(str(source), b"first")
     second = texture_bake._write_backup(str(source), b"second")
 
-    assert first.endswith("body.dds.modviewer.bak")
-    assert second.endswith("body.dds.modviewer.2.bak")
+    assert Path(first).name.endswith(".dds")
+    assert Path(second).name.endswith(".dds")
+    assert Path(first).stem.startswith("body-")
+    assert Path(second).stem.startswith("body-")
+    assert Path(first).name == "body-20260901152230.dds"
+    assert Path(second).name == "body-20260901152231.dds"
+    assert first != second
     assert Path(first).read_bytes() == b"first"
     assert Path(second).read_bytes() == b"second"
 
@@ -561,7 +584,7 @@ def test_bake_rejects_non_mod_texture_paths_before_encoder(
         texture_key, [{"semantic_key": "Body-1", "tex_key": texture_key}],
         {"hue": 30})
 
-    assert result["code"] == code
+    assert result["code"] == "stale_mesh_state"
     assert called == []
 
 

--- a/src/tests/app/mods/test_texture_bake_write.py
+++ b/src/tests/app/mods/test_texture_bake_write.py
@@ -229,6 +229,57 @@ def test_bc1_alpha_validation_rejects_transparent_safe_block(tmp_path):
     assert error.value.code == "alpha_preservation_unsupported"
 
 
+@pytest.mark.parametrize("candidate_transparent", [False, True])
+def test_bake_validates_candidate_bc1_alpha_before_backup(
+        tmp_path, monkeypatch, candidate_transparent):
+    source = tmp_path / "bc1-candidate.dds"
+    original = _dx10_dds(
+        _bc1_block(0xffff, 0) + _bc1_block(0xffff, 0),
+        71, width=4, height=4, mip_count=2)
+    candidate_lower = (_bc1_block(0, 0, 0xffffffff)
+                       if candidate_transparent
+                       else _bc1_block(0x7bef, 0))
+    candidate = _dx10_dds(
+        _bc1_block(0xffff, 0) + candidate_lower,
+        71, width=4, height=4, mip_count=2)
+    source.write_bytes(original)
+    layout = inspect_dds_layout(source)
+    prepared = SimpleNamespace(
+        selected_path=str(source), info=layout.info, layout=layout,
+        selected_pixels=SimpleNamespace(mask=bytearray([1] * 16)),
+        safe_masks=(bytearray([1]), bytearray([1])),
+        shared_masks=(bytearray([0]), bytearray([0])),
+        entries=({"semantic_key": "Body-1",
+                  "tex_key": "diffuse::bc1-candidate.dds"},),
+        unresolved=(),
+    )
+    monkeypatch.setattr(texture_bake, "_prepare_texture_bake",
+                        lambda *args, **kwargs: prepared)
+    monkeypatch.setattr(
+        texture_bake, "load_texture_image_full",
+        lambda *_args, **_kwargs: Image.new("RGBA", (4, 4), (10, 20, 30, 255)))
+
+    def encode(_png, output, _format, _mips, **_kwargs):
+        candidate_path = Path(output) / "bake.dds"
+        candidate_path.write_bytes(candidate)
+        return str(candidate_path)
+
+    monkeypatch.setattr(texture_bake, "encode_png_to_dds", encode)
+    result = texture_bake.bake_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
+        "diffuse::bc1-candidate.dds", [
+            {"semantic_key": "Body-1", "tex_key": "diffuse::bc1-candidate.dds"},
+        ], {"hue": 30})
+
+    if candidate_transparent:
+        assert result["code"] == "alpha_preservation_unsupported"
+        assert source.read_bytes() == original
+        assert not (tmp_path / "bc1-candidate.dds.modviewer.bak").exists()
+    else:
+        assert result["status"] == "ok"
+        assert (tmp_path / "bc1-candidate.dds.modviewer.bak").exists()
+
+
 def test_bc7_alpha_validation_checks_only_safe_blocks_at_each_mip(
         tmp_path, monkeypatch):
     source = tmp_path / "bc7-mipped.dds"
@@ -255,6 +306,54 @@ def test_bc7_alpha_validation_checks_only_safe_blocks_at_each_mip(
         texture_bake._validate_alpha_preservation(
             source.read_bytes(), layout, (bytearray([1, 0]), bytearray([1])))
     assert error.value.code == "alpha_preservation_unsupported"
+
+
+def test_bake_rejects_transparent_bc7_candidate_before_backup(
+        tmp_path, monkeypatch):
+    source = tmp_path / "bc7-candidate.dds"
+    original = _dx10_dds(bytes([1]) * 32, 98, width=4, height=4,
+                          mip_count=2)
+    candidate = _dx10_dds(
+        bytes([1]) * 16 + bytes([0xee]) * 16, 98, width=4, height=4,
+        mip_count=2)
+    source.write_bytes(original)
+    layout = inspect_dds_layout(source)
+    prepared = SimpleNamespace(
+        selected_path=str(source), info=layout.info, layout=layout,
+        selected_pixels=SimpleNamespace(mask=bytearray([1] * 16)),
+        safe_masks=(bytearray([1]), bytearray([1])),
+        shared_masks=(bytearray([0]), bytearray([0])),
+        entries=({"semantic_key": "Body-1",
+                  "tex_key": "diffuse::bc7-candidate.dds"},),
+        unresolved=(),
+    )
+    monkeypatch.setattr(texture_bake, "_prepare_texture_bake",
+                        lambda *args, **kwargs: prepared)
+    monkeypatch.setattr(
+        texture_bake, "load_texture_image_full",
+        lambda *_args, **_kwargs: Image.new("RGBA", (4, 4), (10, 20, 30, 255)))
+
+    def decode(data, _layout, mip):
+        alpha = 0 if data[mip.offset] == 0xee else 255
+        return Image.new("RGBA", (mip.width, mip.height), (0, 0, 0, alpha))
+
+    monkeypatch.setattr(texture_bake, "_decode_dds_mip_rgba", decode)
+
+    def encode(_png, output, _format, _mips, **_kwargs):
+        candidate_path = Path(output) / "bake.dds"
+        candidate_path.write_bytes(candidate)
+        return str(candidate_path)
+
+    monkeypatch.setattr(texture_bake, "encode_png_to_dds", encode)
+    result = texture_bake.bake_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
+        "diffuse::bc7-candidate.dds", [
+            {"semantic_key": "Body-1", "tex_key": "diffuse::bc7-candidate.dds"},
+        ], {"hue": 30})
+
+    assert result["code"] == "alpha_preservation_unsupported"
+    assert source.read_bytes() == original
+    assert not (tmp_path / "bc7-candidate.dds.modviewer.bak").exists()
 
 
 def test_bc7_transparency_is_rejected_before_backup_or_encoder(

--- a/src/tests/app/mods/test_texture_bake_write.py
+++ b/src/tests/app/mods/test_texture_bake_write.py
@@ -66,7 +66,7 @@ def test_bake_replaces_only_safe_units_and_keeps_backup(tmp_path, monkeypatch):
         lambda *_args, **_kwargs: Image.frombytes(
             "RGBA", (2, 1), bytes([10, 20, 30, 40, 50, 60, 70, 80])))
 
-    def encode(_png, output, _format, _mips):
+    def encode(_png, output, _format, _mips, **_kwargs):
         candidate = Path(output) / "bake.dds"
         candidate.write_bytes(_rgba8_dds(
             [200, 201, 202, 203, 50, 60, 70, 81]))
@@ -99,7 +99,7 @@ def test_bake_aborts_on_stale_source_before_creating_backup(tmp_path, monkeypatc
         texture_bake, "load_texture_image_full",
         lambda *_args, **_kwargs: Image.frombytes(
             "RGBA", (2, 1), bytes([10, 20, 30, 40, 50, 60, 70, 80])))
-    def encode(_png, output, _format, _mips):
+    def encode(_png, output, _format, _mips, **_kwargs):
         candidate = Path(output) / "bake.dds"
         candidate.write_bytes(_rgba8_dds(
             [200, 201, 202, 203, 50, 60, 70, 81]))
@@ -194,6 +194,69 @@ def test_patch_preserves_bc3_alpha_sub_block(tmp_path):
     assert final[156:164] == candidate[156:164]
 
 
+def _bc1_block(color0, color1, selectors=0):
+    return struct.pack("<HHI", color0, color1, selectors)
+
+
+def test_bc1_alpha_validation_is_per_safe_block_and_per_mip(tmp_path):
+    source = tmp_path / "bc1-mipped.dds"
+    source.write_bytes(_dx10_dds(
+        _bc1_block(0xffff, 0) + _bc1_block(0, 0, 0xffffffff)
+        + _bc1_block(0, 0, 0xffffffff),
+        71, width=8, height=4, mip_count=2))
+    layout = inspect_dds_layout(source)
+
+    # The unrelated transparent block does not prevent changing the opaque
+    # block that coverage marked safe.
+    texture_bake._validate_alpha_preservation(
+        source.read_bytes(), layout, (bytearray([1, 0]), bytearray([0])))
+
+    with pytest.raises(texture_bake.TextureBakeAnalysisError) as error:
+        texture_bake._validate_alpha_preservation(
+            source.read_bytes(), layout, (bytearray([1, 0]), bytearray([1])))
+    assert error.value.code == "alpha_preservation_unsupported"
+
+
+def test_bc1_alpha_validation_rejects_transparent_safe_block(tmp_path):
+    source = tmp_path / "bc1-transparent-safe.dds"
+    source.write_bytes(_dx10_dds(
+        _bc1_block(0, 0, 0xffffffff), 71, width=4, height=4))
+    layout = inspect_dds_layout(source)
+
+    with pytest.raises(texture_bake.TextureBakeAnalysisError) as error:
+        texture_bake._validate_alpha_preservation(
+            source.read_bytes(), layout, (bytearray([1]),))
+    assert error.value.code == "alpha_preservation_unsupported"
+
+
+def test_bc7_alpha_validation_checks_only_safe_blocks_at_each_mip(
+        tmp_path, monkeypatch):
+    source = tmp_path / "bc7-mipped.dds"
+    source.write_bytes(_dx10_dds(bytes(48), 98, width=8, height=4,
+                                 mip_count=2))
+    layout = inspect_dds_layout(source)
+
+    def decode(_source, _layout, mip):
+        image = Image.new("RGBA", (mip.width, mip.height), (0, 0, 0, 255))
+        if mip.level == 0:
+            for y in range(mip.height):
+                for x in range(4, mip.width):
+                    image.putpixel((x, y), (0, 0, 0, 0))
+        elif mip.level == 1:
+            image.putpixel((0, 0), (0, 0, 0, 0))
+        return image
+
+    monkeypatch.setattr(texture_bake, "_decode_dds_mip_rgba", decode)
+    # A transparent block outside the safe mask is allowed.
+    texture_bake._validate_alpha_preservation(
+        source.read_bytes(), layout, (bytearray([1, 0]), bytearray([0])))
+
+    with pytest.raises(texture_bake.TextureBakeAnalysisError) as error:
+        texture_bake._validate_alpha_preservation(
+            source.read_bytes(), layout, (bytearray([1, 0]), bytearray([1])))
+    assert error.value.code == "alpha_preservation_unsupported"
+
+
 def test_bc7_transparency_is_rejected_before_backup_or_encoder(
         tmp_path, monkeypatch):
     source = tmp_path / "transparent-bc7.dds"
@@ -212,9 +275,13 @@ def test_bc7_transparency_is_rejected_before_backup_or_encoder(
     monkeypatch.setattr(
         texture_bake, "load_texture_image_full",
         lambda *_args, **_kwargs: Image.new("RGBA", (4, 4), (10, 20, 30, 128)))
+    monkeypatch.setattr(
+        texture_bake, "_decode_dds_mip_rgba",
+        lambda *_args: Image.new("RGBA", (4, 4), (10, 20, 30, 128)))
     called = []
     monkeypatch.setattr(
-        texture_bake, "encode_png_to_dds", lambda *args: called.append(args))
+        texture_bake, "encode_png_to_dds",
+        lambda *args, **kwargs: called.append((args, kwargs)))
 
     result = texture_bake.bake_texture_color(
         SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
@@ -244,8 +311,11 @@ def test_opaque_bc7_can_be_baked(tmp_path, monkeypatch):
     monkeypatch.setattr(
         texture_bake, "load_texture_image_full",
         lambda *_args, **_kwargs: Image.new("RGBA", (4, 4), (10, 20, 30, 255)))
+    monkeypatch.setattr(
+        texture_bake, "_decode_dds_mip_rgba",
+        lambda *_args: Image.new("RGBA", (4, 4), (10, 20, 30, 255)))
 
-    def encode(_png, output, _format, _mips):
+    def encode(_png, output, _format, _mips, **_kwargs):
         candidate = Path(output) / "bake.dds"
         candidate.write_bytes(_dx10_dds(bytes(range(100, 116)), 98))
         return str(candidate)
@@ -274,7 +344,7 @@ def test_bake_reports_committed_state_when_replace_raises_after_replacing(
         lambda *_args, **_kwargs: Image.frombytes(
             "RGBA", (2, 1), bytes([10, 20, 30, 40, 50, 60, 70, 80])))
 
-    def encode(_png, output, _format, _mips):
+    def encode(_png, output, _format, _mips, **_kwargs):
         candidate = Path(output) / "bake.dds"
         candidate.write_bytes(_rgba8_dds(
             [200, 201, 202, 203, 50, 60, 70, 81]))
@@ -384,7 +454,8 @@ def test_bake_rejects_non_mod_texture_paths_before_encoder(
         tmp_path, monkeypatch, texture_key, code):
     called = []
     monkeypatch.setattr(
-        texture_bake, "encode_png_to_dds", lambda *args: called.append(args))
+        texture_bake, "encode_png_to_dds",
+        lambda *args, **kwargs: called.append((args, kwargs)))
 
     result = texture_bake.bake_texture_color(
         SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
@@ -407,7 +478,8 @@ def test_bake_refuses_when_no_top_level_unit_is_unique(tmp_path, monkeypatch):
         texture_bake, "load_texture_image_full",
         lambda *args: called.append(args))
     monkeypatch.setattr(
-        texture_bake, "encode_png_to_dds", lambda *args: called.append(args))
+        texture_bake, "encode_png_to_dds",
+        lambda *args, **kwargs: called.append((args, kwargs)))
 
     result = texture_bake.bake_texture_color(
         SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",

--- a/src/tests/app/mods/test_texture_bake_write.py
+++ b/src/tests/app/mods/test_texture_bake_write.py
@@ -2,6 +2,7 @@
 
 from types import SimpleNamespace
 from pathlib import Path
+import struct
 
 import pytest
 from PIL import Image
@@ -11,7 +12,7 @@ from core.textures.dds import inspect_dds, inspect_dds_layout
 from core.textures.uv_coverage import UVCoverage
 
 
-def _rgba8_dds(payload):
+def _rgba8_dds(payload, format_name="rgba8"):
     header = bytearray(128)
     header[:4] = b"DDS "
     header[4:8] = (124).to_bytes(4, "little")
@@ -20,10 +21,23 @@ def _rgba8_dds(payload):
     header[76:80] = (32).to_bytes(4, "little")
     header[80:84] = (0x41).to_bytes(4, "little")
     header[88:92] = (32).to_bytes(4, "little")
-    for offset, value in zip((92, 96, 100, 104),
-                             (0x000000FF, 0x0000FF00,
-                              0x00FF0000, 0xFF000000)):
+    masks = ((0x000000FF, 0x0000FF00, 0x00FF0000, 0xFF000000)
+             if format_name == "rgba8" else
+             (0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000))
+    for offset, value in zip((92, 96, 100, 104), masks):
         header[offset:offset + 4] = value.to_bytes(4, "little")
+    return bytes(header) + bytes(payload)
+
+
+def _dx10_dds(payload, dxgi_format, width=4, height=4, mip_count=1):
+    header = bytearray(148)
+    header[:4] = b"DDS "
+    struct.pack_into("<I", header, 4, 124)
+    struct.pack_into("<II", header, 12, height, width)
+    struct.pack_into("<I", header, 28, mip_count)
+    struct.pack_into("<I", header, 76, 32)
+    struct.pack_into("<II", header, 80, 4, int.from_bytes(b"DX10", "little"))
+    struct.pack_into("<IIIII", header, 128, dxgi_format, 3, 0, 1, 0)
     return bytes(header) + bytes(payload)
 
 
@@ -69,7 +83,7 @@ def test_bake_replaces_only_safe_units_and_keeps_backup(tmp_path, monkeypatch):
     assert result["patched"]["mip0_units"] == 1
     updated = source.read_bytes()
     assert updated[:128] == original[:128]
-    assert updated[128:132] == bytes([200, 201, 202, 203])
+    assert updated[128:132] == bytes([200, 201, 202, 40])
     assert updated[132:] == original[132:]
     assert (tmp_path / "body.dds.modviewer.bak").read_bytes() == original
 
@@ -141,11 +155,148 @@ def test_patch_copies_only_safe_units_at_each_mip(tmp_path):
         original, candidate, layout,
         (bytearray([1] + [0] * 15), bytearray([0, 0, 1, 0])))
 
-    assert final[128:132] == candidate[128:132]
+    assert final[128:131] == candidate[128:131]
+    assert final[131:132] == original[131:132]
     assert final[132:192] == original[132:192]
     assert final[192:200] == original[192:200]
-    assert final[200:204] == candidate[200:204]
+    assert final[200:203] == candidate[200:203]
+    assert final[203:204] == original[203:204]
     assert final[204:208] == original[204:208]
+
+
+@pytest.mark.parametrize("format_name", ["rgba8", "bgra8"])
+def test_patch_preserves_uncompressed_alpha(tmp_path, format_name):
+    source = tmp_path / f"{format_name}.dds"
+    original = _rgba8_dds(
+        [10, 20, 30, 40, 50, 60, 70, 80], format_name)
+    candidate = _rgba8_dds(
+        [200, 201, 202, 203, 210, 211, 212, 213], format_name)
+    source.write_bytes(original)
+    layout = inspect_dds_layout(source)
+
+    final = texture_bake._patch_dds_units(
+        original, candidate, layout, (bytearray([1, 1]),))
+
+    assert final[128:136] == bytes([200, 201, 202, 40, 210, 211, 212, 80])
+
+
+def test_patch_preserves_bc3_alpha_sub_block(tmp_path):
+    source = tmp_path / "bc3.dds"
+    original = _dx10_dds(bytes(range(16)), 77)
+    candidate = _dx10_dds(bytes(range(100, 116)), 77)
+    source.write_bytes(original)
+    layout = inspect_dds_layout(source)
+
+    final = texture_bake._patch_dds_units(
+        original, candidate, layout, (bytearray([1]),))
+
+    assert final[148:156] == original[148:156]
+    assert final[156:164] == candidate[156:164]
+
+
+def test_bc7_transparency_is_rejected_before_backup_or_encoder(
+        tmp_path, monkeypatch):
+    source = tmp_path / "transparent-bc7.dds"
+    source.write_bytes(_dx10_dds(bytes(16), 98))
+    layout = inspect_dds_layout(source)
+    prepared = SimpleNamespace(
+        selected_path=str(source), info=layout.info, layout=layout,
+        selected_pixels=SimpleNamespace(mask=bytearray(16)),
+        safe_masks=(bytearray([1]),), shared_masks=(bytearray([0]),),
+        entries=({"semantic_key": "Body-1", "tex_key": "diffuse::transparent-bc7.dds"},),
+        unresolved=(),
+    )
+    prepared.selected_pixels.mask[0] = 1
+    monkeypatch.setattr(texture_bake, "_prepare_texture_bake",
+                        lambda *args, **kwargs: prepared)
+    monkeypatch.setattr(
+        texture_bake, "load_texture_image_full",
+        lambda *_args, **_kwargs: Image.new("RGBA", (4, 4), (10, 20, 30, 128)))
+    called = []
+    monkeypatch.setattr(
+        texture_bake, "encode_png_to_dds", lambda *args: called.append(args))
+
+    result = texture_bake.bake_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
+        "diffuse::transparent-bc7.dds", [
+            {"semantic_key": "Body-1", "tex_key": "diffuse::transparent-bc7.dds"},
+        ], {"hue": 30})
+
+    assert result["code"] == "alpha_preservation_unsupported"
+    assert called == []
+    assert not (tmp_path / "transparent-bc7.dds.modviewer.bak").exists()
+
+
+def test_opaque_bc7_can_be_baked(tmp_path, monkeypatch):
+    source = tmp_path / "opaque-bc7.dds"
+    original = _dx10_dds(bytes(16), 98)
+    source.write_bytes(original)
+    layout = inspect_dds_layout(source)
+    prepared = SimpleNamespace(
+        selected_path=str(source), info=layout.info, layout=layout,
+        selected_pixels=SimpleNamespace(mask=bytearray([1] + [0] * 15)),
+        safe_masks=(bytearray([1]),), shared_masks=(bytearray([0]),),
+        entries=({"semantic_key": "Body-1", "tex_key": "diffuse::opaque-bc7.dds"},),
+        unresolved=(),
+    )
+    monkeypatch.setattr(texture_bake, "_prepare_texture_bake",
+                        lambda *args, **kwargs: prepared)
+    monkeypatch.setattr(
+        texture_bake, "load_texture_image_full",
+        lambda *_args, **_kwargs: Image.new("RGBA", (4, 4), (10, 20, 30, 255)))
+
+    def encode(_png, output, _format, _mips):
+        candidate = Path(output) / "bake.dds"
+        candidate.write_bytes(_dx10_dds(bytes(range(100, 116)), 98))
+        return str(candidate)
+
+    monkeypatch.setattr(texture_bake, "encode_png_to_dds", encode)
+
+    result = texture_bake.bake_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
+        "diffuse::opaque-bc7.dds", [
+            {"semantic_key": "Body-1", "tex_key": "diffuse::opaque-bc7.dds"},
+        ], {"hue": 30})
+
+    assert result["status"] == "ok"
+
+
+def test_bake_reports_committed_state_when_replace_raises_after_replacing(
+        tmp_path, monkeypatch):
+    source = tmp_path / "replace-race.dds"
+    original = _rgba8_dds([10, 20, 30, 40, 50, 60, 70, 80])
+    source.write_bytes(original)
+    prepared = _prepared(source)
+    monkeypatch.setattr(texture_bake, "_prepare_texture_bake",
+                        lambda *args, **kwargs: prepared)
+    monkeypatch.setattr(
+        texture_bake, "load_texture_image_full",
+        lambda *_args, **_kwargs: Image.frombytes(
+            "RGBA", (2, 1), bytes([10, 20, 30, 40, 50, 60, 70, 80])))
+
+    def encode(_png, output, _format, _mips):
+        candidate = Path(output) / "bake.dds"
+        candidate.write_bytes(_rgba8_dds(
+            [200, 201, 202, 203, 50, 60, 70, 81]))
+        return str(candidate)
+
+    monkeypatch.setattr(texture_bake, "encode_png_to_dds", encode)
+    real_replace = texture_bake.os.replace
+
+    def replace_then_raise(source_path, target_path):
+        real_replace(source_path, target_path)
+        raise OSError("reported after replacement")
+
+    monkeypatch.setattr(texture_bake.os, "replace", replace_then_raise)
+
+    result = texture_bake.bake_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Body-1"}, "Body-1",
+        "diffuse::body.dds", [
+            {"semantic_key": "Body-1", "tex_key": "diffuse::body.dds"},
+        ], {"hue": 30})
+
+    assert result["status"] == "ok"
+    assert source.read_bytes() != original
 
 
 def test_lower_mip_collision_makes_only_that_level_shared(tmp_path, monkeypatch):

--- a/src/tests/build/test_security.py
+++ b/src/tests/build/test_security.py
@@ -109,6 +109,14 @@ def test_sky_mesh_is_pinned_in_the_vendor_manifest():
         "a44cb7c543d04b2690b0079b8b473da9a36660629b2eb091f7eab8b4111d7b7a")
 
 
+def test_texconv_is_pinned_as_a_runtime_tool():
+    spec = build.RUNTIME_TOOL_FILES["texconv.exe"]
+
+    assert spec["url"].endswith("/DirectXTex/releases/download/may2026/texconv.exe")
+    assert spec["sha256"] == (
+        "dcfdec10244e02cf5037fba089c55fb7e1326b1c8181742d77d15fa5cb5eef06")
+
+
 def test_verify_web_uses_refactored_frontend_paths(tmp_path, monkeypatch):
     for relative_path in (
         "index.html",

--- a/src/tests/build/test_security.py
+++ b/src/tests/build/test_security.py
@@ -1,6 +1,7 @@
 """Security contracts for build-time downloaded and extracted inputs."""
 
 import io
+import os
 import tarfile
 
 import pytest
@@ -115,6 +116,22 @@ def test_texconv_is_pinned_as_a_runtime_tool():
     assert spec["url"].endswith("/DirectXTex/releases/download/may2026/texconv.exe")
     assert spec["sha256"] == (
         "dcfdec10244e02cf5037fba089c55fb7e1326b1c8181742d77d15fa5cb5eef06")
+
+
+def test_pyinstaller_command_bundles_third_party_notices(monkeypatch):
+    commands = []
+    monkeypatch.setattr(build, "write_baked_features", lambda _features: None)
+    monkeypatch.setattr(build, "clean_baked_features", lambda: None)
+    monkeypatch.setattr(build, "write_version_file", lambda: "version.txt")
+    monkeypatch.setattr(build, "run", lambda command: commands.append(command))
+
+    build.build(python="python", onedir=True, console=True)
+
+    command = commands[0]
+    notice_data = f"{build.THIRD_PARTY_NOTICES}{os.pathsep}."
+    notice_index = command.index("--add-data", command.index("--add-binary"))
+    assert command[notice_index:notice_index + 2] == [
+        "--add-data", notice_data]
 
 
 def test_verify_web_uses_refactored_frontend_paths(tmp_path, monkeypatch):

--- a/src/tests/core/ini/test_health.py
+++ b/src/tests/core/ini/test_health.py
@@ -116,6 +116,7 @@ def test_file_classification_and_overrides():
         _write(os.path.join(tmp, "inactive.dds"), b"x", binary=True)
         _write(os.path.join(tmp, "viewer.png"), b"x", binary=True)
         _write(os.path.join(tmp, "orphan.tga"), b"x", binary=True)
+        _write(os.path.join(tmp, "active-20260901152230.dds"), b"x", binary=True)
         with open(os.path.join(tmp, ".mod_viewer.json"), "w", encoding="utf-8") as fh:
             json.dump({"textures": {"Body::whole": {
                 "tex_key": "viewer.png", "label": "viewer", "manual": True,
@@ -126,7 +127,7 @@ def test_file_classification_and_overrides():
             "[ResourceIB]\nfilename = active.buf\n")
         report = analyze_mod(tmp, overrides={ini: staged})
 
-    assert (report["files"] == {"unreferenced": 1, "inactive_only": 1,
+    assert (report["files"] == {"unreferenced": 2, "inactive_only": 1,
                               "viewer_only": 1, "referenced": 1}), (f"active, inactive-only, viewer-only and unused assets classify separately ({report['files']})")
     assert ("malformed_condition_nesting" in _codes(report)), ("staged in-memory INI text is analyzed instead of stale disk text")
 

--- a/src/tests/core/textures/test_color_adjustment.py
+++ b/src/tests/core/textures/test_color_adjustment.py
@@ -1,0 +1,45 @@
+"""CPU color-bake math and alpha/mask invariants."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.textures.color_adjustment import (
+    COLOR_DEFAULTS, adjust_rgba_bytes, apply_color_adjustment,
+    is_neutral_color_adjustment, normalize_color_adjustment,
+)
+
+
+@pytest.fixture
+def vectors():
+    path = Path(__file__).parents[2] / "fixtures" / "color_adjustment_vectors.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_shader_order_vectors(vectors):
+    for vector in vectors:
+        actual = apply_color_adjustment(vector["rgb"], vector["adjustment"])
+        assert actual == pytest.approx(vector["expected"], abs=1e-7), vector["name"]
+
+
+def test_normalization_accepts_frontend_tint_name_and_rejects_bad_values():
+    assert normalize_color_adjustment({"tintStrength": 0.25})[
+        "tint_strength"] == 0.25
+    assert normalize_color_adjustment({"hue": True}, reject_invalid=True) is None
+    assert normalize_color_adjustment({"tint": "blue"}, reject_invalid=True) is None
+
+
+def test_neutral_state_is_identity():
+    assert is_neutral_color_adjustment(COLOR_DEFAULTS)
+    assert apply_color_adjustment((0.23, 0.45, 0.91), COLOR_DEFAULTS) == \
+        pytest.approx((0.23, 0.45, 0.91))
+
+
+def test_adjust_rgba_preserves_alpha_and_only_changes_selected_pixels():
+    source = bytes([255, 0, 0, 7, 0, 255, 0, 129])
+
+    result = adjust_rgba_bytes(
+        source, 2, 1, {"hue": 120}, pixel_mask=[True, False])
+
+    assert result == bytes([0, 255, 0, 7, 0, 255, 0, 129])

--- a/src/tests/core/textures/test_color_adjustment.py
+++ b/src/tests/core/textures/test_color_adjustment.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from core.textures import color_adjustment
 from core.textures.color_adjustment import (
     COLOR_DEFAULTS, adjust_rgba_bytes, apply_color_adjustment,
     is_neutral_color_adjustment, normalize_color_adjustment,
@@ -43,3 +44,20 @@ def test_adjust_rgba_preserves_alpha_and_only_changes_selected_pixels():
         source, 2, 1, {"hue": 120}, pixel_mask=[True, False])
 
     assert result == bytes([0, 255, 0, 7, 0, 255, 0, 129])
+
+
+def test_adjust_rgba_skips_transform_for_unselected_pixels(monkeypatch):
+    calls = []
+    real_apply = color_adjustment._apply_normalized
+
+    def counting_apply(rgb, normalized):
+        calls.append(rgb)
+        return real_apply(rgb, normalized)
+
+    monkeypatch.setattr(color_adjustment, "_apply_normalized", counting_apply)
+
+    color_adjustment.adjust_rgba_bytes(
+        bytes([10, 20, 30, 7, 40, 50, 60, 8, 70, 80, 90, 9]),
+        3, 1, {"hue": 30}, pixel_mask=[True, False, False])
+
+    assert len(calls) == 1

--- a/src/tests/core/textures/test_dds.py
+++ b/src/tests/core/textures/test_dds.py
@@ -4,11 +4,12 @@ import struct
 
 import pytest
 
-from core.textures.dds import inspect_dds, native_dds_info
+from core.textures.dds import inspect_dds, inspect_dds_layout, native_dds_info
 
 
 _DXGI = {
-    "bc1_unorm": 71, "bc7_unorm": 98, "bc7_srgb": 99,
+    "bc1_unorm": 71, "bc2_unorm": 74, "bc3_unorm": 77,
+    "bc7_unorm": 98, "bc7_srgb": 99,
 }
 _LEGACY = {
     "DXT1": "bc1_unorm",
@@ -127,3 +128,41 @@ def test_ordinary_dx10_header_uses_zero_misc_flag_and_one_array(tmp_path):
     assert struct.unpack_from("<I", raw, 136)[0] == 0
     assert struct.unpack_from("<I", raw, 140)[0] == 1
     assert native_dds_info(path) is not None
+
+
+@pytest.mark.parametrize(("format_name", "width", "height", "expected"), [
+    ("rgba8", 3, 5, [(3, 5, 60, 128), (1, 2, 8, 188), (1, 1, 4, 196)]),
+    ("bc1_unorm", 5, 7, [(5, 7, 32, 148), (2, 3, 8, 180), (1, 1, 8, 188)]),
+])
+def test_layout_reports_exact_odd_dimension_mip_offsets(
+        tmp_path, format_name, width, height, expected):
+    path = tmp_path / "layout.dds"
+    path.write_bytes(_dds(width, height, format_name, mip_count=3))
+
+    layout = inspect_dds_layout(path)
+
+    assert layout is not None
+    assert [(mip.width, mip.height, mip.length, mip.offset)
+            for mip in layout.mips] == expected
+    assert layout.payload_end == len(path.read_bytes())
+
+
+@pytest.mark.parametrize("format_name", [
+    "bc1_unorm", "bc2_unorm", "bc3_unorm", "bc7_unorm", "rgba8", "bgra8",
+])
+def test_layout_uses_format_specific_unit_sizes(tmp_path, format_name):
+    path = tmp_path / f"{format_name}.dds"
+    path.write_bytes(_dds(5, 7, format_name, mip_count=2))
+
+    layout = inspect_dds_layout(path)
+    bytes_per_unit = (4 if not format_name.startswith("bc")
+                      else 8 if format_name.startswith("bc1") else 16)
+
+    assert [mip.bytes_per_unit for mip in layout.mips] == [
+        bytes_per_unit, bytes_per_unit]
+    units = ([(2, 2), (1, 1)] if format_name.startswith("bc")
+             else [(5, 7), (2, 3)])
+    assert [mip.length for mip, (units_x, units_y) in zip(
+        layout.mips, units)] == [
+            units_x * units_y * bytes_per_unit
+            for units_x, units_y in units]

--- a/src/tests/core/textures/test_pipeline.py
+++ b/src/tests/core/textures/test_pipeline.py
@@ -97,6 +97,22 @@ def test_typed_srgb_retry_does_not_read_failed_non_dds(tmp_path, monkeypatch):
     assert textures.load_texture_image(path) is None
 
 
+def test_full_texture_decode_keeps_authored_dimensions_and_alpha(monkeypatch):
+    from PIL import Image
+
+    source = Image.new("RGBA", (4096, 1), (1, 2, 3, 129))
+    monkeypatch.setattr(
+        "core.textures.pipeline._open_texture_image",
+        lambda *_args: source,
+    )
+
+    image = textures.load_texture_image_full("fixture.dds")
+
+    assert image.size == (4096, 1)
+    assert image.mode == "RGBA"
+    assert image.getpixel((0, 0)) == (1, 2, 3, 129)
+
+
 def test_texture_module_does_not_depend_on_mesh_builder():
     root = Path(__file__).resolve().parents[4]
     texture_result = subprocess.run(

--- a/src/tests/core/textures/test_texconv.py
+++ b/src/tests/core/textures/test_texconv.py
@@ -1,10 +1,14 @@
 """Deterministic tests for the native DDS encoder adapter."""
 
 from types import SimpleNamespace
+import os
+import struct
 
 import pytest
+from PIL import Image
 
 from core.textures import texconv
+from core.textures.dds import inspect_dds_layout
 
 
 def test_build_texconv_command_preserves_format_and_mip_count():
@@ -15,8 +19,21 @@ def test_build_texconv_command_preserves_format_and_mip_count():
     assert command[command.index("-f") + 1] == "BC7_UNORM_SRGB"
     assert command[command.index("-m") + 1] == "5"
     assert command[command.index("-if") + 1] == "LINEAR"
+    assert "-srgb" in command
     assert "-resize" not in command
     assert "-flip" not in command
+
+
+@pytest.mark.parametrize(("format_name", "expects_srgb"), [
+    ("bc7_srgb", True), ("bc3_srgb", True),
+    ("bc7_unorm", False), ("rgba8", False),
+])
+def test_build_texconv_command_sets_srgb_colorspace_explicitly(
+        format_name, expects_srgb):
+    command = texconv.build_texconv_command(
+        "texconv.exe", "bake.png", "out", format_name, 2)
+
+    assert ("-srgb" in command) is expects_srgb
 
 
 def test_encode_png_to_dds_uses_no_shell_and_checks_candidate(tmp_path):
@@ -47,3 +64,44 @@ def test_encode_png_to_dds_reports_missing_encoder(monkeypatch, tmp_path):
 
     with pytest.raises(texconv.TexconvUnavailableError):
         texconv.encode_png_to_dds(tmp_path / "bake.png", tmp_path, "rgba8", 1)
+
+
+def test_real_pinned_texconv_uses_srgb_mip_filtering_when_available(tmp_path):
+    """Exercise the bundled encoder's colorspace behavior when packaged."""
+    from app.settings.paths import texconv_path
+
+    executable = texconv_path()
+    if not executable or not os.path.isfile(executable):
+        pytest.skip("bundled texconv is unavailable")
+
+    source = tmp_path / "high-contrast.png"
+    image = Image.new("RGBA", (2, 2))
+    image.putdata([
+        (0, 0, 0, 255), (255, 255, 255, 255),
+        (255, 255, 255, 255), (0, 0, 0, 255),
+    ])
+    image.save(source)
+    output = tmp_path / "out"
+    output.mkdir()
+
+    candidate = texconv.encode_png_to_dds(
+        source, output, "bc7_srgb", 2, executable=executable)
+    layout = inspect_dds_layout(candidate)
+    assert layout is not None
+    mip = layout.mips[1]
+    raw = bytearray(open(candidate, "rb").read(layout.data_offset))
+    struct.pack_into("<II", raw, 12, 1, 1)
+    struct.pack_into("<I", raw, 28, 1)
+    one_mip = tmp_path / "mip1.dds"
+    with open(candidate, "rb") as stream:
+        stream.seek(mip.offset)
+        mip_bytes = stream.read(mip.length)
+    one_mip.write_bytes(bytes(raw) + mip_bytes)
+    try:
+        decoded = Image.open(one_mip).convert("RGBA")
+    except Exception as error:
+        pytest.skip(f"Pillow cannot decode BC7 in this environment: {error}")
+
+    red = decoded.getpixel((0, 0))[0]
+    assert 170 <= red <= 205
+    assert abs(red - 128) > 25

--- a/src/tests/core/textures/test_texconv.py
+++ b/src/tests/core/textures/test_texconv.py
@@ -13,7 +13,7 @@ from core.textures.dds import inspect_dds_layout
 
 def test_build_texconv_command_preserves_format_and_mip_count():
     command = texconv.build_texconv_command(
-        "texconv.exe", "bake.png", "out", "bc7_srgb", 5)
+        "texconv.exe", "bake.png", "out", "bc7_srgb", 5, srgb=True)
 
     assert command[:2] == ["texconv.exe", "-nologo"]
     assert command[command.index("-f") + 1] == "BC7_UNORM_SRGB"
@@ -24,16 +24,25 @@ def test_build_texconv_command_preserves_format_and_mip_count():
     assert "-flip" not in command
 
 
-@pytest.mark.parametrize(("format_name", "expects_srgb"), [
-    ("bc7_srgb", True), ("bc3_srgb", True),
-    ("bc7_unorm", False), ("rgba8", False),
+@pytest.mark.parametrize(("format_name", "dxgi_format"), [
+    ("bc7_unorm", "BC7_UNORM"),
+    ("bc7_srgb", "BC7_UNORM_SRGB"),
+    ("rgba8", "R8G8B8A8_UNORM"),
 ])
-def test_build_texconv_command_sets_srgb_colorspace_explicitly(
-        format_name, expects_srgb):
+def test_build_texconv_command_uses_diffuse_srgb_semantics(
+        format_name, dxgi_format):
     command = texconv.build_texconv_command(
-        "texconv.exe", "bake.png", "out", format_name, 2)
+        "texconv.exe", "bake.png", "out", format_name, 2, srgb=True)
 
-    assert ("-srgb" in command) is expects_srgb
+    assert command[command.index("-f") + 1] == dxgi_format
+    assert "-srgb" in command
+
+
+def test_build_texconv_command_leaves_colorspace_unspecified_for_data():
+    command = texconv.build_texconv_command(
+        "texconv.exe", "bake.png", "out", "bc7_unorm", 2, srgb=False)
+
+    assert "-srgb" not in command
 
 
 def test_encode_png_to_dds_uses_no_shell_and_checks_candidate(tmp_path):
@@ -49,7 +58,8 @@ def test_encode_png_to_dds_uses_no_shell_and_checks_candidate(tmp_path):
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     result = texconv.encode_png_to_dds(
-        source, output, "rgba8", 3, executable="texconv.exe", runner=runner)
+        source, output, "rgba8", 3, executable="texconv.exe", runner=runner,
+        srgb=True)
 
     assert result == str(output / "bake.dds")
     command, kwargs = calls[0]
@@ -57,6 +67,7 @@ def test_encode_png_to_dds_uses_no_shell_and_checks_candidate(tmp_path):
     assert kwargs["shell"] is False
     assert kwargs["check"] is False
     assert kwargs["timeout"] == texconv.DEFAULT_TIMEOUT
+    assert "-srgb" in command
 
 
 def test_encode_png_to_dds_reports_missing_encoder(monkeypatch, tmp_path):
@@ -66,7 +77,9 @@ def test_encode_png_to_dds_reports_missing_encoder(monkeypatch, tmp_path):
         texconv.encode_png_to_dds(tmp_path / "bake.png", tmp_path, "rgba8", 1)
 
 
-def test_real_pinned_texconv_uses_srgb_mip_filtering_when_available(tmp_path):
+@pytest.mark.parametrize("format_name", ["bc7_srgb", "bc7_unorm"])
+def test_real_pinned_texconv_uses_srgb_mip_filtering_when_available(
+        tmp_path, format_name):
     """Exercise the bundled encoder's colorspace behavior when packaged."""
     from app.settings.paths import texconv_path
 
@@ -85,9 +98,10 @@ def test_real_pinned_texconv_uses_srgb_mip_filtering_when_available(tmp_path):
     output.mkdir()
 
     candidate = texconv.encode_png_to_dds(
-        source, output, "bc7_srgb", 2, executable=executable)
+        source, output, format_name, 2, executable=executable, srgb=True)
     layout = inspect_dds_layout(candidate)
     assert layout is not None
+    assert layout.info.format == format_name
     mip = layout.mips[1]
     raw = bytearray(open(candidate, "rb").read(layout.data_offset))
     struct.pack_into("<II", raw, 12, 1, 1)

--- a/src/tests/core/textures/test_texconv.py
+++ b/src/tests/core/textures/test_texconv.py
@@ -1,0 +1,49 @@
+"""Deterministic tests for the native DDS encoder adapter."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.textures import texconv
+
+
+def test_build_texconv_command_preserves_format_and_mip_count():
+    command = texconv.build_texconv_command(
+        "texconv.exe", "bake.png", "out", "bc7_srgb", 5)
+
+    assert command[:2] == ["texconv.exe", "-nologo"]
+    assert command[command.index("-f") + 1] == "BC7_UNORM_SRGB"
+    assert command[command.index("-m") + 1] == "5"
+    assert command[command.index("-if") + 1] == "LINEAR"
+    assert "-resize" not in command
+    assert "-flip" not in command
+
+
+def test_encode_png_to_dds_uses_no_shell_and_checks_candidate(tmp_path):
+    source = tmp_path / "bake.png"
+    source.write_bytes(b"png fixture")
+    output = tmp_path / "out"
+    output.mkdir()
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append((command, kwargs))
+        (output / "bake.dds").write_bytes(b"DDS candidate")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    result = texconv.encode_png_to_dds(
+        source, output, "rgba8", 3, executable="texconv.exe", runner=runner)
+
+    assert result == str(output / "bake.dds")
+    command, kwargs = calls[0]
+    assert command[-1] == str(source)
+    assert kwargs["shell"] is False
+    assert kwargs["check"] is False
+    assert kwargs["timeout"] == texconv.DEFAULT_TIMEOUT
+
+
+def test_encode_png_to_dds_reports_missing_encoder(monkeypatch, tmp_path):
+    monkeypatch.setattr(texconv, "texconv_path", lambda: None)
+
+    with pytest.raises(texconv.TexconvUnavailableError):
+        texconv.encode_png_to_dds(tmp_path / "bake.png", tmp_path, "rgba8", 1)

--- a/src/tests/core/textures/test_uv_coverage.py
+++ b/src/tests/core/textures/test_uv_coverage.py
@@ -3,7 +3,8 @@
 import pytest
 
 from core.textures.uv_coverage import (
-    UVCoverageError, _supercover_segment, rasterize_uv_coverage,
+    UVCoverageError, _supercover_segment, collapse_pixel_mask_to_units,
+    dilate_pixel_mask, rasterize_uv_coverage,
 )
 
 
@@ -40,12 +41,38 @@ def test_degenerate_triangles_are_skipped_and_reported():
     assert result.count > 0
 
 
-def test_all_degenerate_triangles_report_no_coverage():
-    with pytest.raises(UVCoverageError) as raised:
-        rasterize_uv_coverage(
-            [0, 1, 2], [(0, 0), (0.5, 0), (1, 0)], 8, 8)
+def test_all_degenerate_triangles_retain_conservative_segment_coverage():
+    result = rasterize_uv_coverage(
+        [0, 1, 2], [(0, 0), (0.5, 0), (1, 0)], 8, 8)
 
-    assert raised.value.code == "no_uv_coverage"
+    assert result.degenerate_triangle_count == 1
+    assert result.count > 0
+    assert result.bounds[1] == result.bounds[3] == 0
+
+
+def test_repeated_degenerate_point_retains_point_supercover():
+    result = rasterize_uv_coverage(
+        [0, 1, 2], [(0.5, 0.5), (0.5, 0.5), (0.5, 0.5)], 4, 4)
+
+    assert result.count == 4
+    assert result.bounds == (1, 1, 2, 2)
+
+
+def test_pixel_dilation_is_clamped_to_edges_and_corners():
+    corner = dilate_pixel_mask(bytearray([1, 0, 0, 0, 0, 0, 0, 0, 0]), 3, 3)
+    center = dilate_pixel_mask(bytearray([0, 0, 0, 0, 1, 0, 0, 0, 0]), 3, 3)
+
+    assert list(corner) == [1, 1, 0, 1, 1, 0, 0, 0, 0]
+    assert list(center) == [1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+
+def test_pixel_masks_collapse_to_partial_edge_units():
+    pixels = bytearray(5 * 3)
+    pixels[2 * 5 + 2] = 1
+
+    assert list(collapse_pixel_mask_to_units(pixels, 5, 3, 2, 2)) == [
+        0, 0, 0, 0, 1, 0,
+    ]
 
 
 def test_thin_triangle_crossing_a_unit_is_not_lost_to_center_sampling():

--- a/src/tests/fixtures/color_adjustment_vectors.json
+++ b/src/tests/fixtures/color_adjustment_vectors.json
@@ -1,0 +1,83 @@
+[
+  {
+    "name": "black",
+    "rgb": [0.0, 0.0, 0.0],
+    "adjustment": {"hue": 180, "brightness": 2},
+    "expected": [0.0, 0.0, 0.0]
+  },
+  {
+    "name": "white",
+    "rgb": [1.0, 1.0, 1.0],
+    "adjustment": {"saturation": 0, "contrast": 2},
+    "expected": [1.0, 1.0, 1.0]
+  },
+  {
+    "name": "gray",
+    "rgb": [0.4, 0.4, 0.4],
+    "adjustment": {"hue": -180},
+    "expected": [0.4, 0.4, 0.4]
+  },
+  {
+    "name": "neutral",
+    "rgb": [0.1, 0.5, 0.9],
+    "adjustment": {},
+    "expected": [0.1, 0.5, 0.9]
+  },
+  {
+    "name": "hue-red-to-green",
+    "rgb": [1.0, 0.0, 0.0],
+    "adjustment": {"hue": 120},
+    "expected": [0.0, 1.0, 0.0]
+  },
+  {
+    "name": "hue-plus-minus-180",
+    "rgb": [1.0, 0.0, 0.0],
+    "adjustment": {"hue": -180},
+    "expected": [0.0, 1.0, 1.0]
+  },
+  {
+    "name": "saturation-to-gray",
+    "rgb": [0.2, 0.4, 0.8],
+    "adjustment": {"saturation": 0},
+    "expected": [0.8, 0.8, 0.8]
+  },
+  {
+    "name": "brightness-half",
+    "rgb": [0.2, 0.4, 0.8],
+    "adjustment": {"brightness": 0.5},
+    "expected": [0.1, 0.2, 0.4]
+  },
+  {
+    "name": "contrast-zero",
+    "rgb": [0.2, 0.4, 0.8],
+    "adjustment": {"contrast": 0},
+    "expected": [0.5, 0.5, 0.5]
+  },
+  {
+    "name": "channel-multipliers",
+    "rgb": [0.2, 0.4, 0.6],
+    "adjustment": {"red": 2, "green": 0.5, "blue": 0},
+    "expected": [0.4, 0.2, 0.0]
+  },
+  {
+    "name": "half-blue-tint",
+    "rgb": [1.0, 0.0, 0.0],
+    "adjustment": {"tint": "#0000ff", "tint_strength": 0.5},
+    "expected": [0.5, 0.0, 0.5]
+  },
+  {
+    "name": "full-green-tint",
+    "rgb": [1.0, 0.0, 0.0],
+    "adjustment": {"tint": "#00ff00", "tint_strength": 1},
+    "expected": [0.0, 1.0, 0.0]
+  },
+  {
+    "name": "combined-controls",
+    "rgb": [0.2, 0.4, 0.6],
+    "adjustment": {"hue": 60, "saturation": 1.5,
+                   "brightness": 0.75, "contrast": 1.2,
+                   "red": 1.2, "green": 0.8, "blue": 0.5,
+                   "tint": "#ff8000", "tint_strength": 0.25},
+    "expected": [0.403, 0.1254901961, 0.165]
+  }
+]

--- a/src/tests/web/support.py
+++ b/src/tests/web/support.py
@@ -336,7 +336,8 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                    "panelOpacity": [], "presentState": [],
                    "controlState": [], "meshSemantics": [],
                    "deleteToggle": [], "exportChanges": [],
-                   "saveMeshColorAdjustment": [], "analyzeTextureBake": []},
+                   "saveMeshColorAdjustment": [], "analyzeTextureBake": [],
+                   "bakeMeshTextureColor": []},
     }
     encoded_state = json.dumps(json.dumps(state))
     context.add_init_script(
@@ -454,6 +455,20 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                   shared_percent_of_selected: 0,
                 },
                 shared_with: [], unresolved_consumers: [],
+              });
+            },
+            bake_mesh_texture_color: async (path, semanticKey, metadataKey,
+                                             texKey, usage, adjustment) => {
+              state.calls.bakeMeshTextureColor.push([
+                path, semanticKey, metadataKey, texKey, usage, adjustment]);
+              return copy(state.responses[path]?.textureBakeResult || {
+                status: 'ok',
+                semantic_key: semanticKey,
+                tex_key: texKey,
+                affected_tex_keys: texKey ? [texKey] : [],
+                texture: {file: 'body.dds'},
+                patched: {mip0_units: 1, shared_units_preserved: 0},
+                backup: {file: 'body.dds.modviewer.bak'},
               });
             },
             get_model_skinning_preview: async path => {

--- a/src/tests/web/support.py
+++ b/src/tests/web/support.py
@@ -346,6 +346,11 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
           const state = window.__fakeApi = JSON.parse(__STATE__);
           const copy = value => value == null ? value : structuredClone(value);
           const loadWaiters = {};
+          const colorSaveWaiters = [];
+          state.releaseColorSaves = () => {
+            state.blockColorSaves = false;
+            colorSaveWaiters.splice(0).forEach(resolve => resolve());
+          };
           state.releaseLoad = path => {
             state.blockLoads = state.blockLoads || {};
             state.blockLoads[path] = false;
@@ -601,6 +606,9 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
             save_mesh_textures: async () => ({}),
             save_mesh_color_adjustment: async (path, key, adjustment) => {
               state.calls.saveMeshColorAdjustment.push([path, key, adjustment]);
+              if (state.blockColorSaves) {
+                await new Promise(resolve => colorSaveWaiters.push(resolve));
+              }
               return {};
             },
             save_mesh_names: async () => ({}),

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -1542,6 +1542,57 @@ def test_texture_bake_confirmation_resets_color_and_refreshes_affected_keys(
         context.close()
 
 
+def test_forced_health_refresh_keeps_newer_backup_report(
+        edge_browser, frontend_url):
+    context, page = _page(edge_browser, frontend_url,
+                           {"HealthRace": _payload("HealthRace")})
+    try:
+        _open(page, "HealthRace")
+        page.locator(".draw-item").first.wait_for()
+        page.wait_for_function(
+            "window.__fakeApi.calls.diagnostics.length >= 1")
+        page.evaluate("""async () => {
+          const health = await import('./js/panels/health-report.js');
+          window.__healthResolvers = [];
+          health.setHealthLoader(() => new Promise(resolve => {
+            window.__healthResolvers.push(resolve);
+          }));
+          window.__healthOld = health.refreshHealthReport();
+          window.dispatchEvent(new Event('mod-viewer-texture-baked'));
+        }""")
+        page.wait_for_function("window.__healthResolvers.length === 2")
+
+        page.evaluate("""() => {
+          window.__healthResolvers[1]({
+            summary: {issues: 1, warnings: 1, errors: 0},
+            files: {referenced: 0, inactive_only: 0, viewer_only: 0},
+            issues: [{severity: 'warning', category: 'asset',
+              message: 'Fresh timestamped backup is unreferenced.'}],
+          });
+        }""")
+        page.wait_for_function("""() =>
+          document.querySelector('#health-count').textContent === '1' &&
+          document.querySelector('#health-btn').classList.contains('warning')""")
+
+        page.evaluate("""() => {
+          window.__healthResolvers[0]({
+            summary: {issues: 0, warnings: 0, errors: 0},
+            files: {referenced: 0, inactive_only: 0, viewer_only: 0},
+            issues: [],
+          });
+        }""")
+        page.wait_for_timeout(100)
+        assert page.locator("#health-count").inner_text() == "1"
+        assert page.locator("#health-btn").get_attribute("class").find(
+            "warning") >= 0
+
+        page.locator("#health-btn").click()
+        assert page.locator("#health-list .health-message").inner_text() == (
+            "Fresh timestamped backup is unreferenced.")
+    finally:
+        context.close()
+
+
 def test_texture_coverage_error_clears_loading_message(
         edge_browser, frontend_url):
     payload = _payload("Error")

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -956,6 +956,9 @@ def test_inspector_color_controls_gate_asset_textures_and_persist_on_change(
 def test_texture_coverage_action_is_read_only_and_includes_hidden_meshes(
         edge_browser, frontend_url):
     payload = _payload("Bake")
+    payload["metadata"]["mesh_color_adjustments"] = {
+        "Body Bake::3,0,0": {"hue": 30},
+    }
     first = payload["meshes"]["Body-Bake-0"]
     old_key = first["tex_key"]
     dds_key = "diffuse::Bake-one.dds"
@@ -1004,6 +1007,9 @@ def test_texture_coverage_action_is_read_only_and_includes_hidden_meshes(
         assert page.locator("#texture-bake-body").inner_text().find(
             "Coverage overlaps") >= 0
         assert "Friendly Face" in page.locator("#texture-bake-body").inner_text()
+        assert page.locator("#texture-bake-confirm").inner_text() == \
+            "Bake Unique Areas Only"
+        assert page.locator("#texture-bake-confirm").is_visible()
         usage = page.evaluate("window.__fakeApi.calls.analyzeTextureBake[0][3]")
         assert len(usage) == 2
         assert {item["semantic_key"] for item in usage} == {
@@ -1019,6 +1025,9 @@ def test_texture_coverage_action_is_read_only_and_includes_hidden_meshes(
 def test_texture_coverage_unknown_state_does_not_claim_unique_units(
         edge_browser, frontend_url):
     payload = _payload("Unknown")
+    payload["metadata"]["mesh_color_adjustments"] = {
+        "Body Unknown::3,0,0": {"hue": 30},
+    }
     old_key = payload["meshes"]["Body-Unknown-0"]["tex_key"]
     dds_key = "diffuse::Unknown-one.dds"
     payload["meshes"]["Body-Unknown-0"]["tex_key"] = dds_key
@@ -1045,6 +1054,89 @@ def test_texture_coverage_unknown_state_does_not_claim_unique_units(
         details = page.locator("#texture-bake-body").inner_text()
         assert "Safety is unknown" in details
         assert "Unknown" in details
+        assert page.locator("#texture-bake-confirm").is_hidden()
+    finally:
+        context.close()
+
+
+def test_texture_bake_action_is_disabled_for_neutral_color_state(
+        edge_browser, frontend_url):
+    payload = _payload("NeutralBake")
+    first = payload["meshes"]["Body-NeutralBake-0"]
+    old_key = first["tex_key"]
+    dds_key = "diffuse::NeutralBake-one.dds"
+    first["tex_key"] = dds_key
+    payload["texture_pools"]["p0"][0]["tex_key"] = dds_key
+    payload["textures"][dds_key] = payload["textures"].pop(old_key)
+    context, page = _page(edge_browser, frontend_url, {"NeutralBake": payload})
+    try:
+        _open(page, "NeutralBake")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        button = page.locator(".inspector-texture-bake")
+        assert button.is_disabled()
+        assert button.get_attribute("title") == \
+            "Adjust the mesh color before baking."
+        assert page.evaluate(
+            "window.__fakeApi.calls.analyzeTextureBake.length") == 0
+    finally:
+        context.close()
+
+
+def test_texture_bake_confirmation_resets_color_and_refreshes_affected_keys(
+        edge_browser, frontend_url):
+    payload = _payload("BakeConfirm")
+    first = payload["meshes"]["Body-BakeConfirm-0"]
+    old_key = first["tex_key"]
+    dds_key = "diffuse::BakeConfirm-one.dds"
+    first["tex_key"] = dds_key
+    payload["texture_pools"]["p0"][0]["tex_key"] = dds_key
+    payload["textures"][dds_key] = payload["textures"].pop(old_key)
+    payload["metadata"]["mesh_color_adjustments"] = {
+        "Body BakeConfirm::3,0,0": {"hue": 30},
+    }
+    payload["textureBakeResponse"] = {
+        "status": "ok", "safety": "safe",
+        "texture": {"file": "BakeConfirm-one.dds", "width": 8,
+                     "height": 8, "format": "bc7_unorm"},
+        "coverage": {"unit": "block", "selected_units": 1,
+                     "total_units": 4, "unique_units": 1, "shared_units": 0,
+                     "selected_percent": 25, "shared_percent_of_selected": 0},
+        "shared_with": [], "unresolved_consumers": [],
+    }
+    payload["textureBakeResult"] = {
+        "status": "ok", "tex_key": dds_key,
+        "affected_tex_keys": [dds_key],
+        "texture": {"file": "BakeConfirm-one.dds"},
+        "patched": {"mip0_units": 1, "shared_units_preserved": 0},
+        "backup": {"file": "BakeConfirm-one.dds.modviewer.bak"},
+    }
+    context, page = _page(edge_browser, frontend_url, {"BakeConfirm": payload})
+    try:
+        _open(page, "BakeConfirm")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        bake = page.locator(".inspector-texture-bake")
+        assert bake.is_enabled()
+        bake.click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.locator("#texture-bake-confirm").click()
+        page.locator("#texture-bake-body", has_text="TEXTURE BAKED").wait_for()
+        assert page.evaluate(
+            "window.__fakeApi.calls.bakeMeshTextureColor[0]") == [
+                "BakeConfirm", "Body-BakeConfirm-0",
+                "Body BakeConfirm::3,0,0", dds_key,
+                [{"semantic_key": "Body-BakeConfirm-0", "tex_key": dds_key}],
+                {"hue": 30, "saturation": 1, "brightness": 1, "contrast": 1,
+                 "red": 1, "green": 1, "blue": 1, "tint": "#ffffff",
+                 "tint_strength": 0},
+            ]
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue") == 0
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 0
     finally:
         context.close()
 
@@ -1052,6 +1144,9 @@ def test_texture_coverage_unknown_state_does_not_claim_unique_units(
 def test_texture_coverage_error_clears_loading_message(
         edge_browser, frontend_url):
     payload = _payload("Error")
+    payload["metadata"]["mesh_color_adjustments"] = {
+        "Body Error::3,0,0": {"hue": 30},
+    }
     old_key = payload["meshes"]["Body-Error-0"]["tex_key"]
     dds_key = "diffuse::Error-one.dds"
     payload["meshes"]["Body-Error-0"]["tex_key"] = dds_key
@@ -1096,6 +1191,9 @@ def test_texture_coverage_action_explains_non_dds_without_backend_call(
 def test_texture_coverage_stale_response_is_discarded(
         edge_browser, frontend_url):
     payload = _payload("Stale")
+    payload["metadata"]["mesh_color_adjustments"] = {
+        "Body Stale::3,0,0": {"hue": 30},
+    }
     key = "diffuse::Stale-one.dds"
     old_key = payload["meshes"]["Body-Stale-0"]["tex_key"]
     payload["meshes"]["Body-Stale-0"]["tex_key"] = key

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -1,3 +1,7 @@
+import base64
+import copy
+import json
+
 from .support import *
 
 def test_left_dock_tabs_toggle_and_keep_aria_state(edge_browser, frontend_url):
@@ -875,6 +879,12 @@ def test_inspector_follows_component_and_mesh_selection(
 def test_inspector_color_controls_gate_asset_textures_and_persist_on_change(
         edge_browser, frontend_url):
     payload = _payload("ColorUI")
+    first = payload["meshes"]["Body-ColorUI-0"]
+    old_key = first["tex_key"]
+    dds_key = "diffuse::ColorUI-one.dds"
+    first["tex_key"] = dds_key
+    payload["texture_pools"]["p0"][0]["tex_key"] = dds_key
+    payload["textures"][dds_key] = payload["textures"].pop(old_key)
     payload["metadata"]["mesh_color_adjustments"] = {
         "Body ColorUI::3,0,0": {
             "hue": 30, "saturation": 1.15, "brightness": 1,
@@ -937,6 +947,11 @@ def test_inspector_color_controls_gate_asset_textures_and_persist_on_change(
         page.locator(".inspector-color-slider").first.wait_for()
         assert page.locator(
             "[data-color-field='hue'] .inspector-color-slider").input_value() == "55"
+
+        color.locator(".inspector-color-reset").click()
+        assert page.locator(
+            "[data-color-field='hue'] .inspector-color-slider").input_value() == "0"
+        assert color.locator(".inspector-texture-bake").is_disabled()
 
         page.evaluate("""async () => {
           const {setMeshTextureState} = await import('./js/mesh/mesh-factory.js');
@@ -1080,6 +1095,162 @@ def test_texture_bake_action_is_disabled_for_neutral_color_state(
             "Adjust the mesh color before baking."
         assert page.evaluate(
             "window.__fakeApi.calls.analyzeTextureBake.length") == 0
+    finally:
+        context.close()
+
+
+def _bake_test_payload(label, texture_uri, hue=30):
+    payload = _payload(label)
+    first = payload["meshes"][f"Body-{label}-0"]
+    tex_key = f"diffuse::{label}-bake.dds"
+    first["uv"] = _f32(0, 0, 1, 0, 0, 1)
+    first["tex_key"] = tex_key
+    payload["texture_pools"]["p0"][0]["tex_key"] = tex_key
+    payload["textures"] = {tex_key: texture_uri}
+    payload["metadata"]["mesh_color_adjustments"] = {
+        f"Body {label}::3,0,0": {"hue": hue},
+    }
+    payload["textureBakeResponse"] = {
+        "status": "ok", "safety": "safe",
+        "texture": {"file": f"{label}-bake.dds", "width": 8,
+                     "height": 8, "format": "bc7_unorm"},
+        "coverage": {"unit": "block", "selected_units": 1,
+                     "total_units": 4, "unique_units": 1, "shared_units": 0,
+                     "selected_percent": 25, "shared_percent_of_selected": 0},
+        "shared_with": [], "unresolved_consumers": [],
+    }
+    payload["textureBakeResult"] = {
+        "status": "ok", "tex_key": tex_key,
+        "affected_tex_keys": [tex_key],
+        "texture": {"file": f"{label}-bake.dds"},
+        "patched": {"mip0_units": 1, "shared_units_preserved": 0},
+        "backup": {"file": f"{label}-bake.dds.modviewer.bak"},
+    }
+    return payload, tex_key
+
+
+def test_successful_bake_syncs_stale_mesh_after_selection_changes(
+        edge_browser, frontend_url):
+    payload, tex_key = _bake_test_payload(
+        "BakeSelectionRace", f"{frontend_url}/bake-selection-race.png")
+    first = payload["meshes"]["Body-BakeSelectionRace-0"]
+    second = copy.deepcopy(first)
+    second["component"] = "Face BakeSelectionRace"
+    second["display_name"] = "Face target"
+    payload["meshes"]["Face-BakeSelectionRace-0"] = second
+    context, page = _page(edge_browser, frontend_url,
+                           {"BakeSelectionRace": payload})
+    try:
+        page.route("**/bake-selection-race.png", lambda route: (
+            route.fulfill(
+                body=base64.b64decode(_PNG_URI.split(",", 1)[1]),
+                content_type="image/png",
+                headers={"Cache-Control": "no-store"})))
+        page.evaluate("""async () => {
+          const THREE = await import('three');
+          THREE.Cache.enabled = false;
+        }""")
+        _open(page, "BakeSelectionRace")
+        page.locator(".draw-item").nth(1).wait_for()
+        page.wait_for_function(
+            "window.modViewer.getMaterialState(0).diffuseBound")
+        page.evaluate("""async () => {
+          const {getGameMaterialTexture} =
+            await import('./js/mesh/material-profile.js');
+          window.__initialBakeTextureUuid = getGameMaterialTexture(
+            window.modViewer.activeMeshes[0].material, 'diffuse').uuid;
+        }""")
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").nth(0).click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.evaluate("""() => {
+          window.pywebview.api.bake_mesh_texture_color = async () =>
+            new Promise(resolve => { window.__releaseTextureBake = resolve; });
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function("window.__releaseTextureBake !== undefined")
+        page.locator("#texture-bake-close").click()
+        page.locator(".draw-item").nth(1).click()
+        assert "Face BakeSelectionRace" in page.locator(
+            "#selected-mesh-status").inner_text()
+
+        page.evaluate("""() => window.__releaseTextureBake({
+          status: 'ok', tex_key: %s, affected_tex_keys: [%s],
+          texture: {file: 'BakeSelectionRace-bake.dds'},
+          patched: {mip0_units: 1, shared_units_preserved: 0},
+          backup: {file: 'BakeSelectionRace-bake.dds.modviewer.bak'},
+        })""" % (json.dumps(tex_key), json.dumps(tex_key)))
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue === 0")
+        page.wait_for_function("""async () => {
+          const {getGameMaterialTexture} =
+            await import('./js/mesh/material-profile.js');
+          const texture = getGameMaterialTexture(
+            window.modViewer.activeMeshes[0].material, 'diffuse');
+          return texture?.uuid !== window.__initialBakeTextureUuid;
+        }""")
+        assert "Face BakeSelectionRace" in page.locator(
+            "#selected-mesh-status").inner_text()
+    finally:
+        context.close()
+
+
+def test_successful_bake_does_not_reload_a_new_mod_after_switch(
+        edge_browser, frontend_url):
+    first_payload, first_key = _bake_test_payload(
+        "BakeSwitchA", f"{frontend_url}/bake-switch-a.png")
+    second_payload, _second_key = _bake_test_payload(
+        "BakeSwitchB", f"{frontend_url}/bake-switch-b.png", hue=0)
+    requests = {"a": 0, "b": 0}
+    context, page = _page(edge_browser, frontend_url, {
+        "BakeSwitchA": first_payload, "BakeSwitchB": second_payload,
+    })
+    try:
+        page.route("**/bake-switch-a.png", lambda route: (
+            requests.__setitem__("a", requests["a"] + 1),
+            route.fulfill(
+                body=base64.b64decode(_PNG_URI.split(",", 1)[1]),
+                content_type="image/png",
+                headers={"Cache-Control": "no-store"})))
+        page.route("**/bake-switch-b.png", lambda route: (
+            requests.__setitem__("b", requests["b"] + 1),
+            route.fulfill(
+                body=base64.b64decode(_PNG_URI.split(",", 1)[1]),
+                content_type="image/png",
+                headers={"Cache-Control": "no-store"})))
+        _open(page, "BakeSwitchA")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.evaluate("""() => {
+          window.pywebview.api.bake_mesh_texture_color = async () =>
+            new Promise(resolve => { window.__releaseTextureBake = resolve; });
+        }""")
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function("window.__releaseTextureBake !== undefined")
+
+        page.evaluate("""async () => {
+          await window.modViewer.switchMod('BakeSwitchB');
+        }""")
+        page.locator(".draw-item").first.wait_for()
+        page.wait_for_timeout(300)
+        b_requests_after_load = requests["b"]
+        assert page.evaluate("window.modViewer.getCurrentSource().path") == (
+            "BakeSwitchB")
+
+        page.evaluate("""() => window.__releaseTextureBake({
+          status: 'ok', tex_key: %s, affected_tex_keys: [%s],
+          texture: {file: 'BakeSwitchA-bake.dds'},
+          patched: {mip0_units: 1, shared_units_preserved: 0},
+          backup: {file: 'BakeSwitchA-bake.dds.modviewer.bak'},
+        })""" % (json.dumps(first_key), json.dumps(first_key)))
+        page.wait_for_function(
+            "document.querySelector('#texture-bake-modal-backdrop').classList.contains('show') === false")
+        page.wait_for_timeout(300)
+        assert requests["b"] == b_requests_after_load
     finally:
         context.close()
 

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -968,6 +968,66 @@ def test_inspector_color_controls_gate_asset_textures_and_persist_on_change(
         context.close()
 
 
+def test_color_persistence_serializes_updates_and_flushes_before_bake(
+        edge_browser, frontend_url):
+    payload = _payload("ColorQueue")
+    first = payload["meshes"]["Body-ColorQueue-0"]
+    old_key = first["tex_key"]
+    dds_key = "diffuse::ColorQueue-one.dds"
+    first["tex_key"] = dds_key
+    payload["texture_pools"]["p0"][0]["tex_key"] = dds_key
+    payload["textures"][dds_key] = payload["textures"].pop(old_key)
+    payload["metadata"]["mesh_color_adjustments"] = {
+        "Body ColorQueue::3,0,0": {"hue": 30},
+    }
+    context, page = _page(edge_browser, frontend_url, {"ColorQueue": payload})
+    try:
+        _open(page, "ColorQueue")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.evaluate("window.__fakeApi.blockColorSaves = true")
+        page.evaluate("""() => {
+          const slider = document.querySelector(
+            '[data-color-field="hue"] .inspector-color-slider');
+          slider.value = '40';
+          slider.dispatchEvent(new Event('input', {bubbles: true}));
+          slider.dispatchEvent(new Event('change', {bubbles: true}));
+        }""")
+        page.wait_for_function(
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length === 1")
+        page.evaluate("""() => {
+          const slider = document.querySelector(
+            '[data-color-field="hue"] .inspector-color-slider');
+          slider.value = '55';
+          slider.dispatchEvent(new Event('input', {bubbles: true}));
+          slider.dispatchEvent(new Event('change', {bubbles: true}));
+        }""")
+        page.wait_for_timeout(50)
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 1
+        page.evaluate("""async () => {
+          const {flushMeshColorAdjustmentPersistence} =
+            await import('./js/mesh/mesh-color-state.js');
+          const mesh = window.modViewer.activeMeshes[0];
+          window.__colorFlushDone = false;
+          flushMeshColorAdjustmentPersistence(mesh).then(() => {
+            window.__colorFlushDone = true;
+          });
+        }""")
+        page.wait_for_timeout(50)
+        assert not page.evaluate("window.__colorFlushDone")
+        page.evaluate("window.__fakeApi.releaseColorSaves()")
+        page.wait_for_function(
+            "window.__colorFlushDone && "
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length === 2")
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment.map(item => item[2].hue)") == [
+                40, 55]
+    finally:
+        context.close()
+
+
 def test_texture_coverage_action_is_read_only_and_includes_hidden_meshes(
         edge_browser, frontend_url):
     payload = _payload("Bake")
@@ -1020,7 +1080,7 @@ def test_texture_coverage_action_is_read_only_and_includes_hidden_meshes(
         assert page.locator("#texture-bake-close").count() == 1
         assert page.locator("#texture-bake-close-x").count() == 1
         assert page.locator("#texture-bake-body").inner_text().find(
-            "Coverage overlaps") >= 0
+            "Shared blocks will remain unchanged") >= 0
         assert "Friendly Face" in page.locator("#texture-bake-body").inner_text()
         assert page.locator("#texture-bake-confirm").inner_text() == \
             "Bake Unique Areas Only"
@@ -1219,6 +1279,34 @@ def test_texture_bake_modal_blocks_dismissal_while_baking(
         page.locator("#texture-bake-body", has_text="TEXTURE BAKED").wait_for()
         page.locator("#texture-bake-close").click()
         assert page.locator("#texture-bake-modal-backdrop.show").count() == 0
+    finally:
+        context.close()
+
+
+def test_texture_bake_requires_fresh_confirmation_after_color_change(
+        edge_browser, frontend_url):
+    payload, _tex_key = _bake_test_payload("BakeStale", _PNG_URI)
+    context, page = _page(edge_browser, frontend_url, {"BakeStale": payload})
+    try:
+        _open(page, "BakeStale")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.evaluate("""async () => {
+          const {setMeshColorAdjustment} =
+            await import('./js/mesh/mesh-color-state.js');
+          setMeshColorAdjustment(window.modViewer.activeMeshes[0], {hue: 75}, {
+            persist: false,
+          });
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function(
+            "window.__fakeApi.calls.analyzeTextureBake.length === 2")
+        assert page.evaluate(
+            "window.__fakeApi.calls.bakeMeshTextureColor.length") == 0
+        assert page.locator("#texture-bake-confirm").is_visible()
     finally:
         context.close()
 
@@ -1448,6 +1536,8 @@ def test_texture_bake_confirmation_resets_color_and_refreshes_affected_keys(
             "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue") == 0
         assert page.evaluate(
             "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 0
+        page.wait_for_function(
+            "window.__fakeApi.calls.diagnostics.length >= 2")
     finally:
         context.close()
 

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -1171,6 +1171,42 @@ def test_texture_bake_modal_blocks_dismissal_while_baking(
         context.close()
 
 
+def test_texture_bake_error_hides_consumed_bake_action(
+        edge_browser, frontend_url):
+    payload, _tex_key = _bake_test_payload("BakeFailure", _PNG_URI)
+    context, page = _page(edge_browser, frontend_url,
+                           {"BakeFailure": payload})
+    try:
+        _open(page, "BakeFailure")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.evaluate("""() => {
+          window.pywebview.api.bake_mesh_texture_color = async () => ({
+            status: 'error', error: 'Temporary bake failure.',
+          });
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function("""() => document.querySelector(
+          '#texture-bake-error').textContent === 'Temporary bake failure.'""")
+        assert page.locator("#texture-bake-confirm").is_hidden()
+
+        page.locator("#texture-bake-close").click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.evaluate("""() => {
+          window.pywebview.api.bake_mesh_texture_color = undefined;
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function("""() => document.querySelector(
+          '#texture-bake-error').textContent === 'Texture baking is unavailable.'""")
+        assert page.locator("#texture-bake-confirm").is_hidden()
+    finally:
+        context.close()
+
+
 def test_successful_bake_syncs_stale_mesh_after_selection_changes(
         edge_browser, frontend_url):
     payload, tex_key = _bake_test_payload(

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -1129,6 +1129,48 @@ def _bake_test_payload(label, texture_uri, hue=30):
     return payload, tex_key
 
 
+def test_texture_bake_modal_blocks_dismissal_while_baking(
+        edge_browser, frontend_url):
+    payload, tex_key = _bake_test_payload("BakeModal", _PNG_URI)
+    context, page = _page(edge_browser, frontend_url, {"BakeModal": payload})
+    try:
+        _open(page, "BakeModal")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.evaluate("""() => {
+          window.pywebview.api.bake_mesh_texture_color = async () =>
+            new Promise(resolve => { window.__releaseTextureBake = resolve; });
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function("window.__releaseTextureBake !== undefined")
+
+        page.locator("#texture-bake-close").click()
+        assert page.locator("#texture-bake-modal-backdrop.show").count() == 1
+        page.locator("#texture-bake-close-x").click()
+        assert page.locator("#texture-bake-modal-backdrop.show").count() == 1
+        page.keyboard.press("Escape")
+        assert page.locator("#texture-bake-modal-backdrop.show").count() == 1
+        page.evaluate("""() => document.querySelector(
+          '#texture-bake-modal-backdrop').dispatchEvent(
+            new MouseEvent('click', {bubbles: true}))""")
+        assert page.locator("#texture-bake-modal-backdrop.show").count() == 1
+
+        page.evaluate("""() => window.__releaseTextureBake({
+          status: 'ok', tex_key: %s, affected_tex_keys: [%s],
+          texture: {file: 'BakeModal-bake.dds'},
+          patched: {mip0_units: 1, shared_units_preserved: 0},
+          backup: {file: 'BakeModal-bake.dds.modviewer.bak'},
+        })""" % (json.dumps(tex_key), json.dumps(tex_key)))
+        page.locator("#texture-bake-body", has_text="TEXTURE BAKED").wait_for()
+        page.locator("#texture-bake-close").click()
+        assert page.locator("#texture-bake-modal-backdrop.show").count() == 0
+    finally:
+        context.close()
+
+
 def test_successful_bake_syncs_stale_mesh_after_selection_changes(
         edge_browser, frontend_url):
     payload, tex_key = _bake_test_payload(
@@ -1170,8 +1212,8 @@ def test_successful_bake_syncs_stale_mesh_after_selection_changes(
         }""")
         page.locator("#texture-bake-confirm").click()
         page.wait_for_function("window.__releaseTextureBake !== undefined")
-        page.locator("#texture-bake-close").click()
-        page.locator(".draw-item").nth(1).click()
+        page.evaluate("import('./js/scene/selection.js').then(({selectMesh}) => "
+                      "selectMesh(window.modViewer.activeMeshes[1]))")
         assert "Face BakeSelectionRace" in page.locator(
             "#selected-mesh-status").inner_text()
 

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -1030,6 +1030,14 @@ def test_texture_coverage_action_is_read_only_and_includes_hidden_meshes(
         assert {item["semantic_key"] for item in usage} == {
             "Body-Bake-0", "Face-Bake-0"}
         assert usage[1]["tex_key"] == "diffuse::Bake-two.dds"
+        assert usage[1]["texture_keys"] == {
+            "diffuse": "diffuse::Bake-two.dds",
+            "normal_map": None,
+            "normal_data": None,
+            "light_map": None,
+            "material_map": None,
+            "emission_map": None,
+        }
         assert page.evaluate("window.__fakeApi.calls.saveMeshColorAdjustment.length") == 0
         page.locator("#texture-bake-close").click()
         assert page.locator("#texture-bake-modal-backdrop.show").count() == 0
@@ -1095,6 +1103,50 @@ def test_texture_bake_action_is_disabled_for_neutral_color_state(
             "Adjust the mesh color before baking."
         assert page.evaluate(
             "window.__fakeApi.calls.analyzeTextureBake.length") == 0
+    finally:
+        context.close()
+
+
+def test_texture_coverage_cross_role_usage_keeps_bake_unavailable(
+        edge_browser, frontend_url):
+    payload = _payload("CrossRole")
+    payload["metadata"]["mesh_color_adjustments"] = {
+        "Body CrossRole::3,0,0": {"hue": 30},
+    }
+    first = payload["meshes"]["Body-CrossRole-0"]
+    old_key = first["tex_key"]
+    dds_key = "diffuse::CrossRole-one.dds"
+    first["tex_key"] = dds_key
+    payload["texture_pools"]["p0"][0]["tex_key"] = dds_key
+    payload["textures"][dds_key] = payload["textures"].pop(old_key)
+    second = copy.deepcopy(first)
+    second["component"] = "Face CrossRole"
+    second["display_name"] = "Friendly Face"
+    second["normal_map_key"] = dds_key.replace("diffuse::", "normal_map::")
+    payload["meshes"]["Face-CrossRole-0"] = second
+    payload["textureBakeResponse"] = {
+        "status": "unsupported",
+        "code": "cross_role_texture_usage",
+        "error": "This DDS is also used as a Normal Map by Face-CrossRole-0.",
+    }
+    context, page = _page(edge_browser, frontend_url, {"CrossRole": payload})
+    try:
+        _open(page, "CrossRole")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-modal-backdrop.show").wait_for()
+        assert page.locator("#texture-bake-error").inner_text() == (
+            "This DDS is also used as a Normal Map by Face-CrossRole-0.")
+        assert page.locator("#texture-bake-confirm").is_hidden()
+        usage = page.evaluate("window.__fakeApi.calls.analyzeTextureBake[0][3]")
+        face = next(item for item in usage
+                    if item["semantic_key"] == "Face-CrossRole-0")
+        assert face["texture_keys"]["normal_map"] == (
+            "normal_map::CrossRole-one.dds")
+        assert page.evaluate(
+            "window.__fakeApi.calls.bakeMeshTextureColor.length") == 0
     finally:
         context.close()
 
@@ -1377,7 +1429,17 @@ def test_texture_bake_confirmation_resets_color_and_refreshes_affected_keys(
             "window.__fakeApi.calls.bakeMeshTextureColor[0]") == [
                 "BakeConfirm", "Body-BakeConfirm-0",
                 "Body BakeConfirm::3,0,0", dds_key,
-                [{"semantic_key": "Body-BakeConfirm-0", "tex_key": dds_key}],
+                [{
+                    "semantic_key": "Body-BakeConfirm-0", "tex_key": dds_key,
+                    "texture_keys": {
+                        "diffuse": dds_key,
+                        "normal_map": None,
+                        "normal_data": None,
+                        "light_map": None,
+                        "material_map": None,
+                        "emission_map": None,
+                    },
+                }],
                 {"hue": 30, "saturation": 1, "brightness": 1, "contrast": 1,
                  "red": 1, "green": 1, "blue": 1, "tint": "#ffffff",
                  "tint_strength": 0},

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -492,13 +492,14 @@
   <div class="modal texture-bake-modal" role="dialog" aria-modal="true"
        aria-labelledby="texture-bake-title">
     <div class="texture-bake-title-row">
-      <h4 id="texture-bake-title">Texture Coverage</h4>
+      <h4 id="texture-bake-title">Bake to Texture</h4>
       <button type="button" id="texture-bake-close-x" class="icon-btn"
               aria-label="Close texture coverage">×</button>
     </div>
     <div id="texture-bake-error" class="modal-error"></div>
     <div id="texture-bake-body" class="texture-bake-body"></div>
     <div class="modal-actions">
+      <button type="button" id="texture-bake-confirm" hidden>Bake Color</button>
       <button type="button" id="texture-bake-close">Close</button>
     </div>
   </div>

--- a/src/web/js/mesh/mesh-color-state.js
+++ b/src/web/js/mesh/mesh-color-state.js
@@ -8,6 +8,8 @@ import {
 } from './color-adjustment.js';
 import { requestRender } from '../scene/render-scheduler.js';
 
+const persistenceTails = new WeakMap();
+
 export function getMeshColorAdjustment(mesh) {
   return normalizeColorAdjustment(mesh?.userData?.colorAdjustment);
 }
@@ -26,15 +28,24 @@ function persistenceValue(adjustment) {
   };
 }
 
-function persistMeshColorAdjustment(mesh) {
+function persistMeshColorAdjustment(mesh, adjustment = getMeshColorAdjustment(mesh)) {
   const path = mesh?.userData?.modPath;
   const key = mesh?.userData?.metadataKey;
   const save = window.pywebview?.api?.save_mesh_color_adjustment;
   if (!path || !key || typeof save !== 'function') return null;
-  const adjustment = getMeshColorAdjustment(mesh);
-  const request = save(path, key, persistenceValue(adjustment));
-  if (request && typeof request.catch === 'function') request.catch(() => {});
+  const value = persistenceValue(adjustment);
+  const previous = persistenceTails.get(mesh) || Promise.resolve();
+  const request = previous
+    .catch(() => {})
+    .then(() => save(path, key, value));
+  const settled = request.catch(() => {});
+  persistenceTails.set(mesh, settled);
   return request;
+}
+
+/** Wait until all queued color writes for this mesh have settled. */
+export function flushMeshColorAdjustmentPersistence(mesh) {
+  return (persistenceTails.get(mesh) || Promise.resolve()).catch(() => {});
 }
 
 /** Return the active diffuse editability and the reason when it is blocked. */
@@ -69,7 +80,11 @@ export function setMeshColorAdjustment(mesh, adjustment, {
   mesh.userData.colorAdjustment = normalized;
   if (sync) syncMeshColorAdjustment(mesh, { render });
   const eligibility = canEditMeshColor(mesh);
-  if (persist && eligibility.editable) persistMeshColorAdjustment(mesh);
+  if (persist && eligibility.editable) {
+    // Capture the normalized value before another UI event can mutate the
+    // mesh while the serialized persistence queue is waiting.
+    persistMeshColorAdjustment(mesh, normalized);
+  }
   return normalized;
 }
 

--- a/src/web/js/mesh/mesh-factory.js
+++ b/src/web/js/mesh/mesh-factory.js
@@ -76,6 +76,23 @@ export function removeTextures(keys) {
   return removed;
 }
 
+/** Invalidate only baked texture loaders while preserving registry users. */
+export function reloadTextures(keys) {
+  const users = new Set();
+  for (const key of keys || []) {
+    if (!Object.hasOwn(registry, key)) continue;
+    for (const mesh of textureUsers.get(key) || []) users.add(mesh);
+    disposeTexture(loaders[key]);
+    delete loaders[key];
+    readyTextures.delete(key);
+    failedTextures.delete(key);
+    nativeDDSFallbacks.delete(key);
+  }
+  for (const mesh of users) refreshMeshTexture(mesh, { render: false });
+  if ([...users].some(mesh => mesh.visible)) requestRender();
+  return users.size;
+}
+
 export function hasTexture(key) {
   return !!(splitTextureKey(key) && registry[key]
     && !failedTextures.has(key));

--- a/src/web/js/mesh/texture-bake-analysis.js
+++ b/src/web/js/mesh/texture-bake-analysis.js
@@ -119,6 +119,7 @@ export function formatBakeAnalysis(result, displayName = key => key) {
     ['Texture', result.texture?.file || 'Unknown'],
     ['Format', result.texture?.format || 'Unknown'],
     ['Texture size', `${result.texture?.width || 0} × ${result.texture?.height || 0}`],
+    ['Mip levels', result.mip_summary?.levels || result.texture?.mip_count || 1],
     ['Selected coverage', `${coverage.selected_percent?.toFixed?.(1) ?? 0}% (${coverage.selected_units || 0} ${coverage.unit || 'units'})`],
     ['Unique coverage', uniqueUnits],
     ['Shared coverage', `${coverage.shared_percent_of_selected?.toFixed?.(1) ?? 0}% (${coverage.shared_units || 0} ${coverage.unit || 'units'})`],
@@ -135,6 +136,10 @@ export function formatBakeAnalysis(result, displayName = key => key) {
     warning = shared.length
       ? `Coverage overlaps: ${shared.join(', ')}.`
       : 'Coverage overlaps another active draw using this texture.';
+    const levels = result.mip_summary?.shared_levels || [];
+    if (levels.length) {
+      warning += ` Shared units were found at mip level${levels.length === 1 ? '' : 's'} ${levels.join(', ')}.`;
+    }
   }
   return {
     kind: result.safety === 'unknown' ? 'unknown' : 'ok',

--- a/src/web/js/mesh/texture-bake-analysis.js
+++ b/src/web/js/mesh/texture-bake-analysis.js
@@ -22,10 +22,23 @@ function reasonText(reason) {
 export function buildTextureUsageSnapshot() {
   return activeMeshes
     .filter(mesh => mesh?.userData?.assetFill !== true)
-    .map(mesh => ({
-      semantic_key: mesh.userData?.semanticKey || '',
-      tex_key: mesh.userData?.texKey || null,
-    }));
+    .map(mesh => {
+      const data = mesh.userData || {};
+      const textureKeys = {
+        diffuse: data.texKey || null,
+        normal_map: data.normalMapKey || null,
+        normal_data: data.normalDataKey || null,
+        light_map: data.lightMapKey || null,
+        material_map: data.materialMapKey || null,
+        emission_map: data.emissionMapKey || null,
+      };
+      return {
+        semantic_key: data.semanticKey || '',
+        // Keep the legacy alias for callers that only consume diffuse usage.
+        tex_key: textureKeys.diffuse,
+        texture_keys: textureKeys,
+      };
+    });
 }
 
 /** Check the selected mesh without touching the backend or material state. */

--- a/src/web/js/mesh/texture-bake-analysis.js
+++ b/src/web/js/mesh/texture-bake-analysis.js
@@ -41,6 +41,18 @@ export function buildTextureUsageSnapshot() {
     });
 }
 
+/** Capture every identity and role binding used by a bake request. */
+export function captureTextureBakeState(mesh) {
+  const data = mesh?.userData || {};
+  return {
+    modPath: viewerState.currentModPath,
+    semanticKey: data.semanticKey || null,
+    metadataKey: data.metadataKey || null,
+    texKey: data.texKey || null,
+    textureUsage: buildTextureUsageSnapshot(),
+  };
+}
+
 /** Check the selected mesh without touching the backend or material state. */
 export function canAnalyzeTextureBake(mesh) {
   const data = mesh?.userData;
@@ -68,20 +80,28 @@ export function canAnalyzeTextureBake(mesh) {
   return { editable: true, reason: null, message: '' };
 }
 
-function currentSelectionStillMatches(mesh, semanticKey, texKey, modPath, isCurrent) {
+export function textureBakeStateMatches(mesh, snapshot) {
+  if (!snapshot) return false;
+  const current = captureTextureBakeState(mesh);
+  return samePath(current.modPath, snapshot.modPath)
+    && current.semanticKey === snapshot.semanticKey
+    && current.metadataKey === snapshot.metadataKey
+    && current.texKey === snapshot.texKey
+    && JSON.stringify(current.textureUsage)
+      === JSON.stringify(snapshot.textureUsage)
+    && activeMeshes.includes(mesh);
+}
+
+function currentSelectionStillMatches(mesh, snapshot, isCurrent) {
   if (typeof isCurrent === 'function' && !isCurrent()) return false;
-  return activeMeshes.includes(mesh)
-    && mesh.userData?.semanticKey === semanticKey
-    && (mesh.userData?.texKey || null) === (texKey || null)
-    && samePath(mesh.userData?.modPath, modPath)
-    && samePath(viewerState.currentModPath, modPath);
+  return textureBakeStateMatches(mesh, snapshot);
 }
 
 /**
  * Request selected-mesh coverage using only semantic texture identities.
  * A stale response is discarded and returned as null.
  */
-export async function analyzeMeshTextureBake(mesh, { isCurrent } = {}) {
+export async function analyzeMeshTextureBake(mesh, { isCurrent, snapshot } = {}) {
   const token = ++requestToken;
   const eligibility = canAnalyzeTextureBake(mesh);
   if (!eligibility.editable) {
@@ -92,9 +112,7 @@ export async function analyzeMeshTextureBake(mesh, { isCurrent } = {}) {
     };
   }
 
-  const semanticKey = mesh.userData.semanticKey;
-  const texKey = mesh.userData.texKey || null;
-  const modPath = viewerState.currentModPath;
+  const state = snapshot || captureTextureBakeState(mesh);
   const api = window.pywebview?.api?.analyze_mesh_texture_bake;
   if (typeof api !== 'function') {
     return {
@@ -103,10 +121,10 @@ export async function analyzeMeshTextureBake(mesh, { isCurrent } = {}) {
       error: 'Texture coverage analysis is unavailable.',
     };
   }
-  const textureUsage = buildTextureUsageSnapshot();
-  const result = await api(modPath, semanticKey, texKey, textureUsage);
+  const result = await api(
+    state.modPath, state.semanticKey, state.texKey, state.textureUsage);
   if (token !== requestToken || !currentSelectionStillMatches(
-      mesh, semanticKey, texKey, modPath, isCurrent)) {
+      mesh, state, isCurrent)) {
     return null;
   }
   return result;
@@ -146,12 +164,15 @@ export function formatBakeAnalysis(result, displayName = key => key) {
       ? `Safety is unknown because coverage could not be analyzed for: ${unresolved.join(', ')}.`
       : 'Safety is unknown because one or more consumers could not be analyzed.';
   } else if (result.safety === 'shared') {
-    warning = shared.length
-      ? `Coverage overlaps: ${shared.join(', ')}.`
-      : 'Coverage overlaps another active draw using this texture.';
+    warning = 'Only unique texture blocks will be baked. Shared blocks will '
+      + 'remain unchanged. The live Color adjustment will be reset after a '
+      + 'successful bake, so shared areas may return to their original '
+      + 'texture color.';
+    if (shared.length) warning += ` Shared with: ${shared.join(', ')}.`;
     const levels = result.mip_summary?.shared_levels || [];
     if (levels.length) {
-      warning += ` Shared units were found at mip level${levels.length === 1 ? '' : 's'} ${levels.join(', ')}.`;
+      warning += ` Some mip levels contain shared blocks, so appearance may `
+        + `differ at farther viewing distances (levels ${levels.join(', ')}).`;
     }
   }
   return {

--- a/src/web/js/panels/health-report.js
+++ b/src/web/js/panels/health-report.js
@@ -183,11 +183,13 @@ function fallbackReport(message = 'The INI diagnostics could not be completed.')
 // Run diagnostics without opening the modal. Loads are tied to the current
 // loader generation so a slower report for the previous mod cannot overwrite
 // the badge after the user switches folders.
-export function refreshHealthReport() {
+export function refreshHealthReport({force = false} = {}) {
   const loader = reportLoader;
   const generation = reportGeneration;
   if (!loader) return Promise.resolve(null);
-  if (activeReportLoad?.generation === generation) return activeReportLoad.promise;
+  if (!force && activeReportLoad?.generation === generation) {
+    return activeReportLoad.promise;
+  }
 
   const entry = { generation, promise: null };
   entry.promise = (async () => {
@@ -244,4 +246,8 @@ bindModalDismiss({
   backdrop: $('health-modal-backdrop'),
   close: closeReport,
   buttons: [$('health-close'), $('health-close-x')],
+});
+
+window.addEventListener('mod-viewer-texture-baked', () => {
+  void refreshHealthReport({force: true});
 });

--- a/src/web/js/panels/health-report.js
+++ b/src/web/js/panels/health-report.js
@@ -10,6 +10,7 @@ let currentReport = null;
 let currentFilter = 'all';
 let reportLoader = null;
 let reportGeneration = 0;
+let healthRequestId = 0;
 let activeReportLoad = null;
 let currentAssetResolution = null;
 
@@ -191,6 +192,7 @@ export function refreshHealthReport({force = false} = {}) {
     return activeReportLoad.promise;
   }
 
+  const requestId = ++healthRequestId;
   const entry = { generation, promise: null };
   entry.promise = (async () => {
     const button = $('health-btn');
@@ -198,12 +200,14 @@ export function refreshHealthReport({force = false} = {}) {
     button.title = 'Running INI diagnostics…';
     try {
       const report = await loader();
-      if (generation !== reportGeneration || loader !== reportLoader) return null;
+      if (generation !== reportGeneration || loader !== reportLoader
+          || requestId !== healthRequestId) return null;
       const normalized = report && !report.error ? report : fallbackReport();
       setHealthReport(normalized);
       return normalized;
     } catch (error) {
-      if (generation !== reportGeneration || loader !== reportLoader) return null;
+      if (generation !== reportGeneration || loader !== reportLoader
+          || requestId !== healthRequestId) return null;
       const detail = error?.message ? `: ${error.message}` : '';
       const fallback = fallbackReport(
         `The INI diagnostics could not be completed${detail}`);

--- a/src/web/js/panels/inspector-panel.js
+++ b/src/web/js/panels/inspector-panel.js
@@ -269,16 +269,20 @@ function buildRangeControl({
   return row;
 }
 
-function updateColorAdjustment(mesh, field, controlValue, persist = false) {
+function syncTextureBakeAction(section, mesh) {
+  const action = section?.querySelector('.inspector-texture-bake');
+  if (!action) return;
+  const neutral = isNeutralColorAdjustment(getMeshColorAdjustment(mesh));
+  action.disabled = neutral;
+  action.title = neutral ? 'Adjust the mesh color before baking.' : '';
+}
+
+function updateColorAdjustment(section, mesh, field, controlValue,
+                               persist = false) {
   const next = getMeshColorAdjustment(mesh);
   next[field] = colorAdjustmentValue(field, controlValue);
   setMeshColorAdjustment(mesh, next, { persist, render: true });
-  const action = document.querySelector('.inspector-texture-bake');
-  if (action) {
-    const neutral = isNeutralColorAdjustment(getMeshColorAdjustment(mesh));
-    action.disabled = neutral;
-    action.title = neutral ? 'Adjust the mesh color before baking.' : '';
-  }
+  syncTextureBakeAction(section, mesh);
 }
 
 function buildTextureBakeAction(section, mesh) {
@@ -303,6 +307,7 @@ function buildTextureBakeAction(section, mesh) {
       }
     });
     section.appendChild(bake);
+    syncTextureBakeAction(section, mesh);
   } else if (eligibility.reason === 'unsupported-texture-type') {
     addText(section, 'inspector-texture-bake-hint', eligibility.message);
   }
@@ -338,8 +343,9 @@ function buildColorSection(content, mesh) {
     section.appendChild(buildRangeControl({
       field, label, min, max, step,
       value: colorControlValue(field, adjustment), formatValue,
-      onInput: value => updateColorAdjustment(mesh, field, value),
-      onChange: value => updateColorAdjustment(mesh, field, value, true),
+      onInput: value => updateColorAdjustment(section, mesh, field, value),
+      onChange: value => updateColorAdjustment(
+        section, mesh, field, value, true),
     }));
   };
   addSlider('hue', 'Hue', -180, 180, 1, formatHue);
@@ -373,12 +379,7 @@ function buildColorSection(content, mesh) {
     const next = getMeshColorAdjustment(mesh);
     next.tint = tintInput.value;
     setMeshColorAdjustment(mesh, next, { persist, render: true });
-    const action = section.querySelector('.inspector-texture-bake');
-    if (action) {
-      const neutral = isNeutralColorAdjustment(getMeshColorAdjustment(mesh));
-      action.disabled = neutral;
-      action.title = neutral ? 'Adjust the mesh color before baking.' : '';
-    }
+    syncTextureBakeAction(section, mesh);
   };
   tintInput.addEventListener('input', () => applyTint(false));
   tintInput.addEventListener('change', () => applyTint(true));
@@ -425,6 +426,7 @@ function updateColorControlState(content, mesh) {
   const tintValue = section.querySelector('[data-color-tint-value]');
   if (tintInput) tintInput.value = adjustment.tint;
   if (tintValue) tintValue.textContent = adjustment.tint.toUpperCase();
+  syncTextureBakeAction(section, mesh);
   return true;
 }
 

--- a/src/web/js/panels/inspector-panel.js
+++ b/src/web/js/panels/inspector-panel.js
@@ -9,6 +9,7 @@ import {
 } from '../mesh/mesh-color-state.js';
 import { canAnalyzeTextureBake } from '../mesh/texture-bake-analysis.js';
 import { openTextureBakeModal } from '../ui/texture-bake-modal.js';
+import { isNeutralColorAdjustment } from '../mesh/color-adjustment.js';
 
 const meshRecords = new WeakMap();
 let current = null;
@@ -272,26 +273,36 @@ function updateColorAdjustment(mesh, field, controlValue, persist = false) {
   const next = getMeshColorAdjustment(mesh);
   next[field] = colorAdjustmentValue(field, controlValue);
   setMeshColorAdjustment(mesh, next, { persist, render: true });
+  const action = document.querySelector('.inspector-texture-bake');
+  if (action) {
+    const neutral = isNeutralColorAdjustment(getMeshColorAdjustment(mesh));
+    action.disabled = neutral;
+    action.title = neutral ? 'Adjust the mesh color before baking.' : '';
+  }
 }
 
 function buildTextureBakeAction(section, mesh) {
   const eligibility = canAnalyzeTextureBake(mesh);
   if (eligibility.editable) {
-    const analyze = document.createElement('button');
-    analyze.type = 'button';
-    analyze.className = 'ui-button inspector-texture-bake';
-    analyze.textContent = 'Analyze Texture Coverage';
-    analyze.addEventListener('click', async () => {
-      analyze.disabled = true;
+    const bake = document.createElement('button');
+    bake.type = 'button';
+    bake.className = 'ui-button inspector-texture-bake';
+    bake.textContent = 'Bake to Texture…';
+    const neutral = isNeutralColorAdjustment(getMeshColorAdjustment(mesh));
+    bake.disabled = neutral;
+    if (neutral) bake.title = 'Adjust the mesh color before baking.';
+    bake.addEventListener('click', async () => {
+      bake.disabled = true;
       try {
         await openTextureBakeModal(mesh, {
           isCurrent: () => current?.type === 'mesh' && current.mesh === mesh,
         });
       } finally {
-        analyze.disabled = false;
+        bake.disabled = isNeutralColorAdjustment(
+          getMeshColorAdjustment(mesh));
       }
     });
-    section.appendChild(analyze);
+    section.appendChild(bake);
   } else if (eligibility.reason === 'unsupported-texture-type') {
     addText(section, 'inspector-texture-bake-hint', eligibility.message);
   }
@@ -362,6 +373,12 @@ function buildColorSection(content, mesh) {
     const next = getMeshColorAdjustment(mesh);
     next.tint = tintInput.value;
     setMeshColorAdjustment(mesh, next, { persist, render: true });
+    const action = section.querySelector('.inspector-texture-bake');
+    if (action) {
+      const neutral = isNeutralColorAdjustment(getMeshColorAdjustment(mesh));
+      action.disabled = neutral;
+      action.title = neutral ? 'Adjust the mesh color before baking.' : '';
+    }
   };
   tintInput.addEventListener('input', () => applyTint(false));
   tintInput.addEventListener('change', () => applyTint(true));

--- a/src/web/js/ui/texture-bake-modal.js
+++ b/src/web/js/ui/texture-bake-modal.js
@@ -1,15 +1,26 @@
-// Read-only texture coverage result modal.
+// Coverage preflight and the destructive Safe Bake confirmation.
 
 import { bindModalDismiss, setModalError } from './modal-shell.js';
 import {
-  analyzeMeshTextureBake, cancelTextureBakeAnalysis, formatBakeAnalysis,
+  analyzeMeshTextureBake, buildTextureUsageSnapshot,
+  cancelTextureBakeAnalysis, formatBakeAnalysis,
 } from '../mesh/texture-bake-analysis.js';
 import { activeMeshes } from '../mesh/mesh-state.js';
+import {
+  getMeshColorAdjustment, resetMeshColorAdjustment,
+} from '../mesh/mesh-color-state.js';
+import { isNeutralColorAdjustment } from '../mesh/color-adjustment.js';
+import { reloadTextures } from '../mesh/mesh-factory.js';
+import { notifyMeshStateChanged } from '../mesh/mesh-state-events.js';
 
 const $ = id => document.getElementById(id);
 const backdrop = $('texture-bake-modal-backdrop');
 const body = $('texture-bake-body');
 const error = $('texture-bake-error');
+const bakeButton = $('texture-bake-confirm');
+
+let pendingBake = null;
+let baking = false;
 
 function displayNameForSemanticKey(semanticKey) {
   const mesh = activeMeshes.find(item =>
@@ -18,19 +29,27 @@ function displayNameForSemanticKey(semanticKey) {
 }
 
 function closeTextureBakeModal() {
-  cancelTextureBakeAnalysis();
+  if (!baking) {
+    cancelTextureBakeAnalysis();
+    pendingBake = null;
+  }
   backdrop?.classList.remove('show');
 }
 
-function setLoading(loading) {
+function setLoading(message = 'Analyzing texture coverage…') {
   if (!body) return;
   body.replaceChildren();
-  if (loading) {
-    const message = document.createElement('div');
-    message.className = 'texture-bake-loading';
-    message.textContent = 'Analyzing texture coverage…';
-    body.appendChild(message);
-  }
+  const node = document.createElement('div');
+  node.className = 'texture-bake-loading';
+  node.textContent = message;
+  body.appendChild(node);
+}
+
+function setBakeAction({visible = false, disabled = true, label = 'Bake Color'} = {}) {
+  if (!bakeButton) return;
+  bakeButton.hidden = !visible;
+  bakeButton.disabled = disabled;
+  bakeButton.textContent = label;
 }
 
 function renderResult(result, displayName = displayNameForSemanticKey) {
@@ -38,7 +57,8 @@ function renderResult(result, displayName = displayNameForSemanticKey) {
   body.replaceChildren();
   const formatted = formatBakeAnalysis(result, displayName);
   if (!formatted) return false;
-  if (formatted.kind === 'error') {
+  setBakeAction();
+  if (formatted.kind === 'error' || formatted.kind === 'unsupported') {
     setModalError(error, formatted.summary);
     return true;
   }
@@ -70,16 +90,109 @@ function renderResult(result, displayName = displayNameForSemanticKey) {
   return true;
 }
 
-/** Open the read-only analysis modal and resolve after the request settles. */
+function renderBakeSuccess(result) {
+  setModalError(error, '');
+  body.replaceChildren();
+  const state = document.createElement('div');
+  state.className = 'texture-bake-state';
+  state.textContent = 'TEXTURE BAKED';
+  body.appendChild(state);
+  const summary = document.createElement('p');
+  summary.className = 'texture-bake-summary';
+  summary.textContent = `${result.texture?.file || 'Texture'} was updated. `
+    + 'The viewer-only Color adjustment was reset.';
+  body.appendChild(summary);
+  const rows = document.createElement('dl');
+  rows.className = 'texture-bake-details';
+  [
+    ['Top-level units changed', result.patched?.mip0_units || 0],
+    ['Shared units preserved', result.patched?.shared_units_preserved || 0],
+    ['Backup', result.backup?.file || 'Created'],
+  ].forEach(([label, value]) => {
+    const term = document.createElement('dt');
+    term.textContent = label;
+    const description = document.createElement('dd');
+    description.textContent = String(value);
+    rows.append(term, description);
+  });
+  body.appendChild(rows);
+  setBakeAction();
+}
+
+function bakeRequestFor(mesh) {
+  const adjustment = getMeshColorAdjustment(mesh);
+  return {
+    semanticKey: mesh.userData?.semanticKey,
+    metadataKey: mesh.userData?.metadataKey,
+    texKey: mesh.userData?.texKey || null,
+    textureUsage: buildTextureUsageSnapshot(),
+    adjustment: {
+      hue: adjustment.hue,
+      saturation: adjustment.saturation,
+      brightness: adjustment.brightness,
+      contrast: adjustment.contrast,
+      red: adjustment.red,
+      green: adjustment.green,
+      blue: adjustment.blue,
+      tint: adjustment.tint,
+      tint_strength: adjustment.tintStrength,
+    },
+  };
+}
+
+async function runBake(mesh, isCurrent) {
+  const request = bakeRequestFor(mesh);
+  const api = window.pywebview?.api?.bake_mesh_texture_color;
+  if (typeof api !== 'function') {
+    setModalError(error, 'Texture baking is unavailable.');
+    setBakeAction({visible: true, disabled: false, label: 'Bake Color'});
+    return null;
+  }
+  baking = true;
+  setBakeAction({visible: true, disabled: true, label: 'Baking…'});
+  setLoading(`Baking color into ${request.texKey || 'the texture'}…`);
+  let result;
+  try {
+    result = await api(
+      mesh.userData.modPath, request.semanticKey, request.metadataKey,
+      request.texKey, request.textureUsage, request.adjustment);
+  } catch (_requestError) {
+    result = {status: 'error', error: 'Texture baking failed.'};
+  }
+  baking = false;
+  if (typeof isCurrent === 'function' && !isCurrent()) {
+    closeTextureBakeModal();
+    return null;
+  }
+  if (result?.status !== 'ok') {
+    setModalError(error, result?.error || 'Texture baking failed.');
+    setBakeAction({visible: true, disabled: false,
+      label: 'Bake Color'});
+    return result;
+  }
+  resetMeshColorAdjustment(mesh, {persist: false, render: false});
+  if (result.warning === 'color_state_reset_failed') {
+    // Retry through the normal persistence boundary; texture_bake.py never
+    // edits viewer metadata directly.
+    resetMeshColorAdjustment(mesh, {persist: true, render: false});
+  }
+  reloadTextures(result.affected_tex_keys || [result.tex_key]);
+  notifyMeshStateChanged([mesh]);
+  renderBakeSuccess(result);
+  return result;
+}
+
+/** Open the bake preflight modal and wait for analysis to settle. */
 export async function openTextureBakeModal(mesh, { isCurrent } = {}) {
   if (!backdrop || !body) return null;
   setModalError(error, '');
-  setLoading(true);
+  setBakeAction();
+  setLoading();
   backdrop.classList.add('show');
   let result;
   try {
-    result = await analyzeMeshTextureBake(mesh, { isCurrent });
-  } catch (requestError) {
+    result = await analyzeMeshTextureBake(mesh, {isCurrent});
+  } catch (_requestError) {
     result = {
       status: 'error',
       error: 'Texture coverage could not be analyzed safely.',
@@ -90,8 +203,26 @@ export async function openTextureBakeModal(mesh, { isCurrent } = {}) {
     return null;
   }
   renderResult(result);
+  if (result.status === 'ok' && (result.safety === 'safe'
+      || result.safety === 'shared')) {
+    if (!isNeutralColorAdjustment(getMeshColorAdjustment(mesh))) {
+      pendingBake = {mesh, isCurrent};
+      setBakeAction({
+        visible: true, disabled: false,
+        label: result.safety === 'shared'
+          ? 'Bake Unique Areas Only' : 'Bake Color',
+      });
+    }
+  }
   return result;
 }
+
+bakeButton?.addEventListener('click', async () => {
+  if (!pendingBake || baking) return;
+  const job = pendingBake;
+  pendingBake = null;
+  await runBake(job.mesh, job.isCurrent);
+});
 
 bindModalDismiss({
   backdrop,
@@ -100,7 +231,9 @@ bindModalDismiss({
 });
 
 window.addEventListener('mod-viewer-mesh-selected', () => {
-  if (backdrop?.classList.contains('show')) closeTextureBakeModal();
+  if (backdrop?.classList.contains('show') && !baking) {
+    closeTextureBakeModal();
+  }
 });
 
 export { closeTextureBakeModal };

--- a/src/web/js/ui/texture-bake-modal.js
+++ b/src/web/js/ui/texture-bake-modal.js
@@ -12,6 +12,7 @@ import {
 import { isNeutralColorAdjustment } from '../mesh/color-adjustment.js';
 import { reloadTextures } from '../mesh/mesh-factory.js';
 import { notifyMeshStateChanged } from '../mesh/mesh-state-events.js';
+import { viewerState, samePath } from '../app/state.js';
 
 const $ = id => document.getElementById(id);
 const backdrop = $('texture-bake-modal-backdrop');
@@ -140,6 +141,23 @@ function bakeRequestFor(mesh) {
   };
 }
 
+function synchronizeCommittedBake(mesh, result) {
+  const sameLoadedMod = activeMeshes.includes(mesh)
+    && viewerState.currentSource?.kind === 'mod'
+    && samePath(mesh.userData?.modPath, viewerState.currentModPath);
+  if (!sameLoadedMod) return false;
+
+  resetMeshColorAdjustment(mesh, {persist: false, render: false});
+  if (result.warning === 'color_state_reset_failed') {
+    // Retry through the normal persistence boundary; texture_bake.py never
+    // edits viewer metadata directly.
+    resetMeshColorAdjustment(mesh, {persist: true, render: false});
+  }
+  reloadTextures(result.affected_tex_keys || [result.tex_key]);
+  notifyMeshStateChanged([mesh]);
+  return true;
+}
+
 async function runBake(mesh, isCurrent) {
   const request = bakeRequestFor(mesh);
   const api = window.pywebview?.api?.bake_mesh_texture_color;
@@ -160,9 +178,10 @@ async function runBake(mesh, isCurrent) {
     result = {status: 'error', error: 'Texture baking failed.'};
   }
   baking = false;
+  if (result?.status === 'ok') synchronizeCommittedBake(mesh, result);
   if (typeof isCurrent === 'function' && !isCurrent()) {
     closeTextureBakeModal();
-    return null;
+    return result;
   }
   if (result?.status !== 'ok') {
     setModalError(error, result?.error || 'Texture baking failed.');
@@ -170,14 +189,6 @@ async function runBake(mesh, isCurrent) {
       label: 'Bake Color'});
     return result;
   }
-  resetMeshColorAdjustment(mesh, {persist: false, render: false});
-  if (result.warning === 'color_state_reset_failed') {
-    // Retry through the normal persistence boundary; texture_bake.py never
-    // edits viewer metadata directly.
-    resetMeshColorAdjustment(mesh, {persist: true, render: false});
-  }
-  reloadTextures(result.affected_tex_keys || [result.tex_key]);
-  notifyMeshStateChanged([mesh]);
   renderBakeSuccess(result);
   return result;
 }

--- a/src/web/js/ui/texture-bake-modal.js
+++ b/src/web/js/ui/texture-bake-modal.js
@@ -165,7 +165,7 @@ async function runBake(mesh, isCurrent) {
   const api = window.pywebview?.api?.bake_mesh_texture_color;
   if (typeof api !== 'function') {
     setModalError(error, 'Texture baking is unavailable.');
-    setBakeAction({visible: true, disabled: false, label: 'Bake Color'});
+    setBakeAction();
     return null;
   }
   baking = true;
@@ -187,8 +187,10 @@ async function runBake(mesh, isCurrent) {
   }
   if (result?.status !== 'ok') {
     setModalError(error, result?.error || 'Texture baking failed.');
-    setBakeAction({visible: true, disabled: false,
-      label: 'Bake Color'});
+    // A failed destructive request must go through a fresh preflight. The
+    // captured job has been consumed, so an enabled action here would be
+    // misleading and inert; the user can close and start analysis again.
+    setBakeAction();
     return result;
   }
   renderBakeSuccess(result);

--- a/src/web/js/ui/texture-bake-modal.js
+++ b/src/web/js/ui/texture-bake-modal.js
@@ -30,10 +30,12 @@ function displayNameForSemanticKey(semanticKey) {
 }
 
 function closeTextureBakeModal() {
-  if (!baking) {
-    cancelTextureBakeAnalysis();
-    pendingBake = null;
-  }
+  // The modal is the guard around the destructive request. Keep it visible
+  // until the write settles so the user cannot edit another color state while
+  // the backend is committing the captured adjustment.
+  if (baking) return;
+  cancelTextureBakeAnalysis();
+  pendingBake = null;
   backdrop?.classList.remove('show');
 }
 

--- a/src/web/js/ui/texture-bake-modal.js
+++ b/src/web/js/ui/texture-bake-modal.js
@@ -2,12 +2,13 @@
 
 import { bindModalDismiss, setModalError } from './modal-shell.js';
 import {
-  analyzeMeshTextureBake, buildTextureUsageSnapshot,
-  cancelTextureBakeAnalysis, formatBakeAnalysis,
+  analyzeMeshTextureBake, cancelTextureBakeAnalysis, captureTextureBakeState,
+  formatBakeAnalysis, textureBakeStateMatches,
 } from '../mesh/texture-bake-analysis.js';
 import { activeMeshes } from '../mesh/mesh-state.js';
 import {
-  getMeshColorAdjustment, resetMeshColorAdjustment,
+  flushMeshColorAdjustmentPersistence, getMeshColorAdjustment,
+  resetMeshColorAdjustment,
 } from '../mesh/mesh-color-state.js';
 import { isNeutralColorAdjustment } from '../mesh/color-adjustment.js';
 import { reloadTextures } from '../mesh/mesh-factory.js';
@@ -22,6 +23,7 @@ const bakeButton = $('texture-bake-confirm');
 
 let pendingBake = null;
 let baking = false;
+let preparing = false;
 
 function displayNameForSemanticKey(semanticKey) {
   const mesh = activeMeshes.find(item =>
@@ -33,7 +35,7 @@ function closeTextureBakeModal() {
   // The modal is the guard around the destructive request. Keep it visible
   // until the write settles so the user cannot edit another color state while
   // the backend is committing the captured adjustment.
-  if (baking) return;
+  if (baking || preparing) return;
   cancelTextureBakeAnalysis();
   pendingBake = null;
   backdrop?.classList.remove('show');
@@ -122,70 +124,108 @@ function renderBakeSuccess(result) {
   setBakeAction();
 }
 
-function bakeRequestFor(mesh) {
-  const adjustment = getMeshColorAdjustment(mesh);
+function copyAdjustment(adjustment) {
   return {
-    semanticKey: mesh.userData?.semanticKey,
-    metadataKey: mesh.userData?.metadataKey,
-    texKey: mesh.userData?.texKey || null,
-    textureUsage: buildTextureUsageSnapshot(),
-    adjustment: {
-      hue: adjustment.hue,
-      saturation: adjustment.saturation,
-      brightness: adjustment.brightness,
-      contrast: adjustment.contrast,
-      red: adjustment.red,
-      green: adjustment.green,
-      blue: adjustment.blue,
-      tint: adjustment.tint,
-      tint_strength: adjustment.tintStrength,
-    },
+    hue: adjustment.hue,
+    saturation: adjustment.saturation,
+    brightness: adjustment.brightness,
+    contrast: adjustment.contrast,
+    red: adjustment.red,
+    green: adjustment.green,
+    blue: adjustment.blue,
+    tint: adjustment.tint,
+    tint_strength: adjustment.tintStrength,
   };
 }
 
-function synchronizeCommittedBake(mesh, result) {
+function sameAdjustment(left, right) {
+  return left.hue === right.hue
+    && left.saturation === right.saturation
+    && left.brightness === right.brightness
+    && left.contrast === right.contrast
+    && left.red === right.red
+    && left.green === right.green
+    && left.blue === right.blue
+    && left.tint === right.tint
+    && left.tintStrength === right.tintStrength;
+}
+
+function bakeRequestFor(state, adjustment) {
+  return {
+    modPath: state.modPath,
+    semanticKey: state.semanticKey,
+    metadataKey: state.metadataKey,
+    texKey: state.texKey,
+    textureUsage: state.textureUsage,
+    adjustment: copyAdjustment(adjustment),
+  };
+}
+
+async function synchronizeCommittedBake(mesh, result) {
+  if (result.warning === 'color_state_reset_failed') {
+    // Retry through the normal persistence boundary; texture_bake.py never
+    // edits viewer metadata directly.
+    resetMeshColorAdjustment(mesh, {persist: true, render: false});
+    await flushMeshColorAdjustmentPersistence(mesh);
+  }
   const sameLoadedMod = activeMeshes.includes(mesh)
     && viewerState.currentSource?.kind === 'mod'
     && samePath(mesh.userData?.modPath, viewerState.currentModPath);
   if (!sameLoadedMod) return false;
 
   resetMeshColorAdjustment(mesh, {persist: false, render: false});
-  if (result.warning === 'color_state_reset_failed') {
-    // Retry through the normal persistence boundary; texture_bake.py never
-    // edits viewer metadata directly.
-    resetMeshColorAdjustment(mesh, {persist: true, render: false});
-  }
   reloadTextures(result.affected_tex_keys || [result.tex_key]);
   notifyMeshStateChanged([mesh]);
+  window.dispatchEvent(new CustomEvent('mod-viewer-texture-baked', {
+    detail: {
+      texKey: result.tex_key,
+      affectedTexKeys: result.affected_tex_keys || [],
+    },
+  }));
   return true;
 }
 
-async function runBake(mesh, isCurrent) {
-  const request = bakeRequestFor(mesh);
+async function runBake(job) {
+  const {mesh, isCurrent, analyzedState, adjustment} = job;
   const api = window.pywebview?.api?.bake_mesh_texture_color;
   if (typeof api !== 'function') {
     setModalError(error, 'Texture baking is unavailable.');
     setBakeAction();
     return null;
   }
+  preparing = true;
+  setBakeAction({visible: true, disabled: true, label: 'Preparing…'});
+  setLoading('Preparing the bake…');
+  await flushMeshColorAdjustmentPersistence(mesh);
+  const currentState = captureTextureBakeState(mesh);
+  const currentAdjustment = getMeshColorAdjustment(mesh);
+  if (!textureBakeStateMatches(mesh, analyzedState)
+      || !sameAdjustment(currentAdjustment, adjustment)) {
+    preparing = false;
+    setBakeAction();
+    return openTextureBakeModal(mesh, {isCurrent});
+  }
+  const request = bakeRequestFor(currentState, currentAdjustment);
+  preparing = false;
   baking = true;
   setBakeAction({visible: true, disabled: true, label: 'Baking…'});
   setLoading(`Baking color into ${request.texKey || 'the texture'}…`);
   let result;
   try {
     result = await api(
-      mesh.userData.modPath, request.semanticKey, request.metadataKey,
+      request.modPath, request.semanticKey, request.metadataKey,
       request.texKey, request.textureUsage, request.adjustment);
   } catch (_requestError) {
     result = {status: 'error', error: 'Texture baking failed.'};
   }
   baking = false;
-  if (result?.status === 'ok') synchronizeCommittedBake(mesh, result);
+  if (result?.status === 'ok') await synchronizeCommittedBake(mesh, result);
   if (typeof isCurrent === 'function' && !isCurrent()) {
     closeTextureBakeModal();
     return result;
   }
   if (result?.status !== 'ok') {
+    body.replaceChildren();
     setModalError(error, result?.error || 'Texture baking failed.');
     // A failed destructive request must go through a fresh preflight. The
     // captured job has been consumed, so an enabled action here would be
@@ -204,9 +244,13 @@ export async function openTextureBakeModal(mesh, { isCurrent } = {}) {
   setBakeAction();
   setLoading();
   backdrop.classList.add('show');
+  const analyzedState = captureTextureBakeState(mesh);
+  const analyzedAdjustment = getMeshColorAdjustment(mesh);
   let result;
   try {
-    result = await analyzeMeshTextureBake(mesh, {isCurrent});
+    result = await analyzeMeshTextureBake(mesh, {
+      isCurrent, snapshot: analyzedState,
+    });
   } catch (_requestError) {
     result = {
       status: 'error',
@@ -221,7 +265,9 @@ export async function openTextureBakeModal(mesh, { isCurrent } = {}) {
   if (result.status === 'ok' && (result.safety === 'safe'
       || result.safety === 'shared')) {
     if (!isNeutralColorAdjustment(getMeshColorAdjustment(mesh))) {
-      pendingBake = {mesh, isCurrent};
+      pendingBake = {
+        mesh, isCurrent, analyzedState, adjustment: analyzedAdjustment,
+      };
       setBakeAction({
         visible: true, disabled: false,
         label: result.safety === 'shared'
@@ -233,10 +279,10 @@ export async function openTextureBakeModal(mesh, { isCurrent } = {}) {
 }
 
 bakeButton?.addEventListener('click', async () => {
-  if (!pendingBake || baking) return;
+  if (!pendingBake || baking || preparing) return;
   const job = pendingBake;
   pendingBake = null;
-  await runBake(job.mesh, job.isCurrent);
+  await runBake(job);
 });
 
 bindModalDismiss({
@@ -246,7 +292,7 @@ bindModalDismiss({
 });
 
 window.addEventListener('mod-viewer-mesh-selected', () => {
-  if (backdrop?.classList.contains('show') && !baking) {
+  if (backdrop?.classList.contains('show') && !baking && !preparing) {
     closeTextureBakeModal();
   }
 });


### PR DESCRIPTION
## Summary\n- Add conservative color baking for mod-owned DDS textures across the mip chain.\n- Bundle and invoke pinned DirectXTex texconv for candidate generation while preserving source layout and atomic backups.\n- Add backend bridge, targeted texture invalidation, and confirmation UI with metadata reset handling.\n\n## Verification\n- .venv-test\\Scripts\\python.exe -m pytest -q