### PR TITLE
Fix BC7 partial-block color saving

### DIFF
--- a/src/app/mods/texture_save.py
+++ b/src/app/mods/texture_save.py
@@ -92,6 +92,22 @@ class BC7SaveStats:
     source_rgb_error: int
     final_rgb_error: int
     modes: dict
+    source_blocks_kept: int = 0
+    partial_blocks: int = 0
+    full_blocks: int = 0
+    single_intent_partial_blocks: int = 0
+    multi_intent_blocks: int = 0
+
+
+@dataclass(frozen=True)
+class _BC7BlockIntent:
+    """Logical intent classification shared by BC7 fitting and diagnostics."""
+
+    classes: tuple
+    partial: bool
+    full: bool
+    single_intent_partial: bool
+    multi_intent: bool
 
 
 def _error(code, message, status="error", **details):
@@ -534,6 +550,7 @@ def _bc7_intent_level(prepared):
         "level": 0,
         "width": base_mip.width,
         "height": base_mip.height,
+        "class_count": class_count,
         "claims": claims,
         "changed_counts": changed_counts,
         "total_counts": total_counts,
@@ -569,6 +586,7 @@ def _bc7_next_intent_level(state, target_width, target_height, class_count):
         "level": state["level"] + 1,
         "width": target_width,
         "height": target_height,
+        "class_count": class_count,
         "claims": None,
         "changed_counts": changed_counts,
         "total_counts": total_counts if state["single"] else None,
@@ -643,8 +661,96 @@ def _bc7_intent_rgb(source_rgb, state, pixel, adjustments):
         value / total_count * 255.0))) for value in weighted)
 
 
+def _bc7_block_intent_classes(state, mip, block_index):
+    """Return explicit mip-0 Color intents in one valid BC7 block."""
+    if state.get("level") != 0:
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "BC7 block intent classes are only defined for mip 0.")
+    return set(_bc7_block_intent_info(state, mip, block_index).classes)
+
+
+def _bc7_block_intent_info(state, mip, block_index):
+    """Classify one block's logical intent without changing the claims."""
+    if state.get("level") != 0:
+        return _bc7_weighted_block_intent_info(state, mip, block_index)
+    claims = state.get("claims")
+    width, height = state.get("width"), state.get("height")
+    class_count = state.get("class_count")
+    if (claims is None or width != mip.width or height != mip.height
+            or len(claims) != width * height
+            or (class_count is not None
+                and (not isinstance(class_count, int) or class_count <= 0))):
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Mip-0 color intent does not match the source texture size.")
+    source_x, source_y, valid_width, valid_height = _unit_bounds(
+        mip, block_index)
+    classes = set()
+    first = None
+    all_same = True
+    for row in range(valid_height):
+        for column in range(valid_width):
+            value = claims[(source_y + row) * width + source_x + column]
+            if (not isinstance(value, int) or value < 0
+                    or (class_count is not None and value >= class_count)):
+                raise TextureSaveError(
+                    "texture_validation_failed",
+                    "Mip-0 color intent contains an invalid class.")
+            if value:
+                classes.add(value)
+                if first is None:
+                    first = value
+                elif value != first:
+                    all_same = False
+            else:
+                all_same = False
+    full = bool(classes) and len(classes) == 1 and all_same
+    ordered_classes = tuple(sorted(classes))
+    return _BC7BlockIntent(
+        classes=ordered_classes, partial=bool(classes) and not full,
+        full=full,
+        single_intent_partial=len(ordered_classes) == 1 and not full,
+        multi_intent=len(ordered_classes) > 1)
+
+
+def _bc7_weighted_block_intent_info(state, mip, block_index):
+    """Classify one lower-mip block's weighted logical intent."""
+    source_x, source_y, valid_width, valid_height = _unit_bounds(
+        mip, block_index)
+    classes = set()
+    full = True
+    for row in range(valid_height):
+        for column in range(valid_width):
+            pixel = ((source_y + row) * mip.width + source_x + column)
+            if state["single"]:
+                changed = state["changed_counts"][pixel]
+                total = state["total_counts"][pixel]
+                if changed:
+                    classes.add(1)
+                if not changed or changed != total:
+                    full = False
+                continue
+            pixel_class_count = 0
+            for intent_class, count_values in enumerate(
+                    state["counts"][1:], 1):
+                if count_values[pixel]:
+                    classes.add(intent_class)
+                    pixel_class_count += 1
+            if (not pixel_class_count or state["counts"][0][pixel]
+                    or pixel_class_count != 1):
+                full = False
+    if not classes:
+        return _BC7BlockIntent((), False, False, False, False)
+    ordered_classes = tuple(sorted(classes))
+    return _BC7BlockIntent(
+        classes=ordered_classes, partial=not full, full=full,
+        single_intent_partial=len(ordered_classes) == 1 and not full,
+        multi_intent=len(ordered_classes) > 1)
+
+
 def _bc7_target_block_pixels(source_block, mip, block_index, state,
-                             adjustments):
+                             adjustments, block_intent=None):
     """Build one sixteen-pixel BC7 target without a reconstructed image."""
     try:
         source_pixels = _bc7_codec.decode_block(source_block)
@@ -654,12 +760,24 @@ def _bc7_target_block_pixels(source_block, mip, block_index, state,
     source_x, source_y, valid_width, valid_height = _unit_bounds(
         mip, block_index)
     target_pixels = list(source_pixels)
+    single_intent_class = None
+    if state["level"] == 0:
+        if block_intent is None:
+            block_intent = _bc7_block_intent_info(
+                state, mip, block_index)
+        if len(block_intent.classes) == 1:
+            single_intent_class = block_intent.classes[0]
     for row in range(valid_height):
         for column in range(valid_width):
             local = row * 4 + column
             pixel = ((source_y + row) * mip.width + source_x + column)
-            rgb = _bc7_intent_rgb(
-                source_pixels[local][:3], state, pixel, adjustments)
+            if single_intent_class is not None:
+                rgb = apply_prepared_color_u8(
+                    source_pixels[local][:3],
+                    adjustments[single_intent_class])
+            else:
+                rgb = _bc7_intent_rgb(
+                    source_pixels[local][:3], state, pixel, adjustments)
             target_pixels[local] = rgb + (source_pixels[local][3],)
     return (source_pixels, tuple(target_pixels), valid_width, valid_height)
 
@@ -684,7 +802,8 @@ def _save_bc7_blocks(original, prepared, timings=None, stage_callback=None):
         for adjustment in raw_adjustments)
     final = bytearray(original)
     state = _bc7_intent_level(prepared)
-    touched = improved = unchanged = 0
+    touched = improved = unchanged = source_blocks_kept = 0
+    partial = full = single_intent_partial = multi_intent = 0
     source_error = final_error = 0
     modes = {}
     for level, mip in enumerate(prepared.layout.mips):
@@ -701,12 +820,25 @@ def _save_bc7_blocks(original, prepared, timings=None, stage_callback=None):
         started = time.perf_counter()
         if stage_callback is not None:
             stage_callback("bc7_decode_fit")
+        mip_partial = mip_full = mip_single_intent_partial = 0
+        mip_multi_intent = mip_source_blocks_kept = 0
         for block_index in affected:
             start = mip.offset + block_index * mip.bytes_per_unit
             source_block = bytes(original[start:start + 16])
+            block_intent = _bc7_block_intent_info(
+                state, mip, block_index)
+            partial += block_intent.partial
+            full += block_intent.full
+            single_intent_partial += block_intent.single_intent_partial
+            multi_intent += block_intent.multi_intent
+            mip_partial += block_intent.partial
+            mip_full += block_intent.full
+            mip_single_intent_partial += block_intent.single_intent_partial
+            mip_multi_intent += block_intent.multi_intent
             source_pixels, target_pixels, valid_width, valid_height = (
                 _bc7_target_block_pixels(
-                    source_block, mip, block_index, state, adjustments))
+                    source_block, mip, block_index, state, adjustments,
+                    block_intent))
             result = _bc7_codec_call(
                 _bc7_codec.recolor_block, source_block, target_pixels,
                 valid_width, valid_height, source_pixels)
@@ -714,18 +846,28 @@ def _save_bc7_blocks(original, prepared, timings=None, stage_callback=None):
             touched += 1
             improved += result.candidate_error < result.source_error
             unchanged += result.candidate_error == result.source_error
+            source_kept = int(result.block == source_block)
+            source_blocks_kept += source_kept
+            mip_source_blocks_kept += source_kept
             source_error += result.source_error
             final_error += result.candidate_error
             modes[result.mode] = modes.get(result.mode, 0) + 1
         timings["bc7_decode_fit"] = timings.get("bc7_decode_fit", 0.0) + (
             time.perf_counter() - started)
         _LOGGER.debug(
-            "texture save bc7 mip=%s size=%sx%s affected_blocks=%s",
-            level, mip.width, mip.height, len(affected))
+            "texture save bc7 mip=%s %sx%s affected=%s partial=%s full=%s "
+            "single_intent_partial=%s multi_intent=%s source_kept=%s",
+            level, mip.width, mip.height, len(affected), mip_partial,
+            mip_full, mip_single_intent_partial, mip_multi_intent,
+            mip_source_blocks_kept)
     stats = BC7SaveStats(
         touched_blocks=touched, improved_blocks=improved,
         unchanged_blocks=unchanged, source_rgb_error=source_error,
-        final_rgb_error=final_error, modes=dict(sorted(modes.items())))
+        final_rgb_error=final_error, modes=dict(sorted(modes.items())),
+        source_blocks_kept=source_blocks_kept, partial_blocks=partial,
+        full_blocks=full,
+        single_intent_partial_blocks=single_intent_partial,
+        multi_intent_blocks=multi_intent)
     if not touched:
         raise TextureSaveError(
             "incompatible_texture_color_usage",
@@ -738,6 +880,11 @@ def _save_bc7_blocks(original, prepared, timings=None, stage_callback=None):
             "the source BC7 blocks.", "unsupported", {
                 "touched_blocks": touched,
                 "improved_blocks": improved,
+                "source_blocks_kept": source_blocks_kept,
+                "partial_blocks": partial,
+                "full_blocks": full,
+                "single_intent_partial_blocks": single_intent_partial,
+                "multi_intent_blocks": multi_intent,
                 "source_rgb_error": source_error,
                 "final_rgb_error": final_error,
             })
@@ -1055,6 +1202,12 @@ def save_texture_color(
                         "touched_blocks": bc7_stats.touched_blocks,
                         "improved_blocks": bc7_stats.improved_blocks,
                         "unchanged_blocks": bc7_stats.unchanged_blocks,
+                        "source_blocks_kept": bc7_stats.source_blocks_kept,
+                        "partial_blocks": bc7_stats.partial_blocks,
+                        "full_blocks": bc7_stats.full_blocks,
+                        "single_intent_partial_blocks": (
+                            bc7_stats.single_intent_partial_blocks),
+                        "multi_intent_blocks": bc7_stats.multi_intent_blocks,
                         "source_rgb_error": bc7_stats.source_rgb_error,
                         "final_rgb_error": bc7_stats.final_rgb_error,
                         "modes": {

--- a/src/tests/app/mods/test_texture_save.py
+++ b/src/tests/app/mods/test_texture_save.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.mods import texture_save
 from core.geometry.draw_call import DrawCall
+from core.textures import bc7
 from core.textures.color_adjustment import (
     apply_prepared_color_adjustment, prepare_color_adjustment,
 )
@@ -25,6 +26,22 @@ def _dx10_dds(payload, dxgi_format=98, width=4, height=4, mip_count=1):
     struct.pack_into("<II", header, 80, 4, int.from_bytes(b"DX10", "little"))
     struct.pack_into("<IIIII", header, 128, dxgi_format, 3, 0, 1, 0)
     return bytes(header) + bytes(payload)
+
+
+def _mode6_block(endpoints=((20, 110), (40, 140), (60, 170))):
+    bits = 1 << 6
+    for channel, (low, high) in enumerate(endpoints):
+        bits = bc7.set_bits(bits, 7 + channel * 14, 7, low >> 1)
+        bits = bc7.set_bits(bits, 14 + channel * 14, 7, high >> 1)
+    bits = bc7.set_bits(bits, 49, 7, 0)
+    bits = bc7.set_bits(bits, 56, 7, 127)
+    bits = bc7.set_bits(bits, 63, 1, 0)
+    bits = bc7.set_bits(bits, 64, 1, 1)
+    indices = [0, 1, 2, 3] * 4
+    bits = bc7.set_bits(bits, 65, 3, indices[0])
+    for pixel, index in enumerate(indices[1:], 1):
+        bits = bc7.set_bits(bits, 68 + (pixel - 1) * 4, 4, index)
+    return bits.to_bytes(16, "little")
 
 
 def _role_keys(diffuse="diffuse::body.dds"):
@@ -408,6 +425,183 @@ def _single_intent_claims(width, height, selected):
         for y in range(height)
         for x in range(width)
     ]
+
+
+def _bc7_block_state(width, height, claims, adjustments=None):
+    if adjustments is None:
+        adjustments = (None, prepare_color_adjustment({"brightness": 1.5}))
+    prepared = SimpleNamespace(
+        layout=SimpleNamespace(mips=(SimpleNamespace(
+            width=width, height=height,
+            units_x=(width + 3) // 4),)),
+        mip0_claims=claims,
+        intent_adjustments=adjustments,
+    )
+    return texture_save._bc7_intent_level(prepared)
+
+
+def test_bc7_block_intent_classes_only_report_explicit_mip0_claims():
+    claims = bytearray([0] * 16)
+    claims[5] = 1
+    claims[6] = 1
+    claims[9] = 2
+    original = claims[:]
+    state = _bc7_block_state(
+        4, 4, claims,
+        (None, prepare_color_adjustment({"hue": 30}),
+         prepare_color_adjustment({"hue": 120})))
+    mip = SimpleNamespace(
+        width=4, height=4, units_x=1)
+
+    assert texture_save._bc7_block_intent_classes(
+        state, mip, 0) == {1, 2}
+    assert claims == original
+
+
+@pytest.mark.parametrize(
+    ("width", "height", "selected"),
+    [
+        (4, 4, {(1, 1)}),
+        (4, 4, {(0, 1), (1, 1), (2, 1), (3, 1)}),
+        (4, 4, {(0, 0), (1, 0), (0, 1)}),
+        (4, 4, {(0, 0), (1, 0), (0, 1), (1, 1)}),
+        (2, 2, {(0, 0)}),
+        (1, 1, {(0, 0)}),
+    ],
+)
+def test_single_intent_partial_block_pads_valid_rgb_without_changing_alpha(
+        width, height, selected):
+    source_block = _mode6_block()
+    source_pixels = bc7.decode_block(source_block)
+    adjustment = prepare_color_adjustment({"brightness": 1.5})
+    state = _bc7_block_state(
+        width, height, bytearray(_single_intent_claims(
+            width, height, selected)), (None, adjustment))
+    mip = SimpleNamespace(
+        width=width, height=height, units_x=1)
+
+    _source, target, valid_width, valid_height = \
+        texture_save._bc7_target_block_pixels(
+            source_block, mip, 0, state, (None, adjustment))
+
+    assert (valid_width, valid_height) == (width, height)
+    expected_rgb = {
+        (x, y): texture_save.apply_prepared_color_u8(
+            source_pixels[y * 4 + x][:3], adjustment)
+        for y in range(height)
+        for x in range(width)
+    }
+    for y in range(height):
+        for x in range(width):
+            pixel = target[y * 4 + x]
+            assert pixel[:3] == expected_rgb[(x, y)]
+            assert pixel[3] == source_pixels[y * 4 + x][3]
+    for y in range(height, 4):
+        for x in range(4):
+            assert target[y * 4 + x] == source_pixels[y * 4 + x]
+    for y in range(height):
+        for x in range(width, 4):
+            assert target[y * 4 + x] == source_pixels[y * 4 + x]
+
+
+def test_multi_intent_block_keeps_per_pixel_logical_targets_and_no_padding():
+    source_block = _mode6_block()
+    source_pixels = bc7.decode_block(source_block)
+    adjustments = (
+        None,
+        prepare_color_adjustment({"brightness": 1.5}),
+        prepare_color_adjustment({"hue": 120}),
+    )
+    claims = bytearray([0] * 16)
+    claims[5] = 1
+    claims[6] = 2
+    state = _bc7_block_state(4, 4, claims, adjustments)
+    mip = SimpleNamespace(width=4, height=4, units_x=1)
+
+    _source, target, valid_width, valid_height = \
+        texture_save._bc7_target_block_pixels(
+            source_block, mip, 0, state, adjustments)
+
+    assert (valid_width, valid_height) == (4, 4)
+    for pixel, claim in enumerate(claims):
+        expected = texture_save._bc7_intent_rgb(
+            source_pixels[pixel][:3], state, pixel, adjustments)
+        assert target[pixel][:3] == expected
+        assert target[pixel][3] == source_pixels[pixel][3]
+    assert target[0][:3] == source_pixels[0][:3]
+
+
+def test_bc7_save_pads_single_intent_block_and_preserves_unrelated_blocks(
+        tmp_path, monkeypatch):
+    first = _mode6_block()
+    second = _mode6_block(((30, 120), (50, 150), (70, 180)))
+    original = _dx10_dds(first + second, width=8, height=4)
+    source = tmp_path / "body.dds"
+    source.write_bytes(original)
+    layout = inspect_dds_layout(source)
+    adjustment = prepare_color_adjustment({"hue": 120})
+    claims = bytearray([0] * 32)
+    claims[1] = 1
+    prepared = SimpleNamespace(
+        selected_path=str(source), info=layout.info, layout=layout,
+        entries=({
+            "semantic_key": "Anchor", "texture_keys": _role_keys(),
+        },),
+        targets=(SimpleNamespace(
+            semantic_key="Anchor", metadata_key="Anchor::one"),),
+        mip0_claims=claims, intent_adjustments=(None, adjustment),
+        mip0_affected_blocks=(0,))
+    monkeypatch.setattr(
+        texture_save, "_prepare_texture_save",
+        lambda *args, **kwargs: prepared)
+
+    result = texture_save.save_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Anchor"},
+        "diffuse::body.dds", [], [])
+
+    assert result["status"] == "ok"
+    candidate = source.read_bytes()
+    assert candidate[layout.mips[0].offset:layout.mips[0].offset + 16] != first
+    assert candidate[layout.mips[0].offset + 16:
+                     layout.mips[0].offset + 32] == second
+    assert inspect_dds_layout(source) == layout
+    stats = result["diagnostics"]["bc7"]
+    assert stats["touched_blocks"] == 1
+    assert stats["partial_blocks"] == 1
+    assert stats["full_blocks"] == 0
+    assert stats["single_intent_partial_blocks"] == 1
+    assert stats["multi_intent_blocks"] == 0
+    assert stats["source_blocks_kept"] == 0
+    source_pixels = bc7.decode_block(first)
+    candidate_pixels = bc7.decode_block(candidate[layout.mips[0].offset:
+                                                    layout.mips[0].offset + 16])
+    assert [pixel[3] for pixel in candidate_pixels] == [
+        pixel[3] for pixel in source_pixels]
+
+
+def test_bc7_stats_count_source_blocks_by_block_identity(tmp_path, monkeypatch):
+    source_block = _mode6_block()
+    source = tmp_path / "body.dds"
+    source.write_bytes(_dx10_dds(source_block))
+    layout = inspect_dds_layout(source)
+    adjustment = prepare_color_adjustment({"hue": 30})
+    claims = bytearray([1] * 16)
+    prepared = SimpleNamespace(
+        selected_path=str(source), info=layout.info, layout=layout,
+        mip0_claims=claims, intent_adjustments=(None, adjustment),
+        mip0_affected_blocks=(0,))
+
+    monkeypatch.setattr(
+        texture_save._bc7_codec, "recolor_block",
+        lambda *_args: SimpleNamespace(
+            block=source_block, source_error=10, candidate_error=1, mode=6))
+
+    _candidate, stats = texture_save._save_bc7_blocks(
+        source.read_bytes(), prepared)
+
+    assert stats.source_blocks_kept == 1
+    assert stats.improved_blocks == 1
+    assert stats.unchanged_blocks == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Recolors all valid texels in mip-0 BC7 blocks with exactly one logical Color intent, while preserving source alpha.
- Preserves exact per-pixel handling for multi-intent blocks and keeps logical ownership/conflict semantics unchanged.
- Adds BC7 block diagnostics and focused regression coverage for edge blocks, multi-intent blocks, source fallback identity, and DDS preservation.

## Scope

- Lower-mip weighted intent handling, BC7 codec modes, alpha validation, texture reload behavior, and mip generation are unchanged.