### PR TITLE
perf: eliminate redundant geometry vertex decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /build/
 /dist/
 /src/assets/
-/src/runtime_tools/texconv.exe
 /src/build/
 /src/dist/
 *.spec

--- a/src/core/geometry/packing.py
+++ b/src/core/geometry/packing.py
@@ -36,6 +36,8 @@ class PreparedDrawVertices:
     raw_indices: list[int]
     used_vertices: list[int]
     remap: dict[int, int]
+    decoded_vertices: dict[
+        int, tuple[float, float, float, float | None, float | None] | None]
     streams: VertexStreams
     position_path: str
     texcoord_path: str
@@ -96,27 +98,39 @@ def _prepare_draw_vertices(
     uv_offset = draw_streams.uv_offset
     uv_format = draw_streams.uv_format
     uv_size = struct.calcsize(uv_format)
+    decoded_vertices = {}
+    missing = object()
 
-    def finite_vertex(index):
+    def decode_vertex(index):
+        cached = decoded_vertices.get(index, missing)
+        if cached is not missing:
+            return cached
         pos_offset = index * draw_streams.position_stride + POSITION_OFFSET
         if pos_offset < 0 or pos_offset + 12 > len(pos_data):
-            return False
+            decoded_vertices[index] = None
+            return None
         position = struct.unpack_from("<fff", pos_data, pos_offset)
         if not all(math.isfinite(value) for value in position):
-            return False
+            decoded_vertices[index] = None
+            return None
+        texcoord = (None, None)
         if tc_data:
             tc_offset = index * draw_streams.texcoord_stride + uv_offset
             if tc_offset < 0 or tc_offset + uv_size > len(tc_data):
-                return False
+                decoded_vertices[index] = None
+                return None
             texcoord = struct.unpack_from(uv_format, tc_data, tc_offset)
             if not all(math.isfinite(value) for value in texcoord):
-                return False
-        return True
+                decoded_vertices[index] = None
+                return None
+        decoded = (*position, *texcoord)
+        decoded_vertices[index] = decoded
+        return decoded
 
     valid_raw = []
     for triangle_start in range(0, len(raw) - 2, 3):
         triangle = raw[triangle_start:triangle_start + 3]
-        if all(finite_vertex(index) for index in triangle):
+        if all(decode_vertex(index) is not None for index in triangle):
             valid_raw.extend(triangle)
     if not valid_raw:
         return None
@@ -130,6 +144,7 @@ def _prepare_draw_vertices(
     return PreparedDrawVertices(
         raw_indices=raw, used_vertices=used,
         remap={old: new for new, old in enumerate(used)},
+        decoded_vertices=decoded_vertices,
         streams=draw_streams, position_path=draw_pos_path,
         texcoord_path=draw_tc_path)
 
@@ -232,9 +247,6 @@ def pack_draw_geometry(
     draw_streams = prepared.streams
     pos_data = draw_streams.position_data
     tc_data = draw_streams.texcoord_data
-    uv_offset = draw_streams.uv_offset
-    uv_format = draw_streams.uv_format
-    uv_size = struct.calcsize(uv_format)
     pos_bytes = bytearray(len(used) * 12)
     normal_bytes = None
     normal_source = draw.normal_source
@@ -250,11 +262,7 @@ def pack_draw_geometry(
         buffers, sparse_shape_cache)
     uv_bytes = bytearray(len(used) * 8) if tc_data else None
     for output_index, vertex_index in enumerate(used):
-        pos_offset = vertex_index * draw_streams.position_stride + POSITION_OFFSET
-        if pos_offset + 12 <= len(pos_data):
-            x, y, z = struct.unpack_from("<fff", pos_data, pos_offset)
-        else:
-            x, y, z = 0., 0., 0.
+        x, y, z, u, v = prepared.decoded_vertices[vertex_index]
         struct.pack_into("<fff", pos_bytes, output_index * 12, x, y, z)
         for item in shape_buffers:
             shape = item.shape
@@ -280,11 +288,6 @@ def pack_draw_geometry(
                 struct.pack_into("<fff", item.low_bytes, output_index * 12,
                                  lx, ly, lz)
         if tc_data:
-            tc_offset = vertex_index * draw_streams.texcoord_stride + uv_offset
-            if tc_offset + uv_size <= len(tc_data):
-                u, v = struct.unpack_from(uv_format, tc_data, tc_offset)
-            else:
-                u, v = 0., 0.
             struct.pack_into("<ff", uv_bytes, output_index * 8,
                              u, 1.0 - v)  # flip V for Three.js
 

--- a/src/core/geometry/vertex_attributes.py
+++ b/src/core/geometry/vertex_attributes.py
@@ -62,38 +62,47 @@ def decode_normals(source, data, vertex_indices):
     The result is all-or-nothing: a truncated, non-finite, zero or implausible
     stream returns ``None`` so the caller can use geometric reconstruction.
     """
-    indices = tuple(vertex_indices)
-    if not indices:
+    try:
+        count = len(vertex_indices)
+        indices = vertex_indices
+    except TypeError:
+        indices = tuple(vertex_indices)
+        count = len(indices)
+    if not count:
         return bytearray()
-    decoded = []
-    raw_lengths = []
-    for vertex_index in indices:
-        offset = vertex_index * source.stride + source.offset
-        if source.encoding == "f32x3":
+
+    if source.encoding == "f32x3":
+        output = bytearray(count * 12)
+        plausible = 0
+        for output_index, vertex_index in enumerate(indices):
+            offset = vertex_index * source.stride + source.offset
             if vertex_index < 0 or offset + 12 > len(data):
                 return None
             raw = struct.unpack_from("<fff", data, offset)
+            if not all(math.isfinite(value) for value in raw):
+                return None
             raw_length = math.sqrt(sum(value * value for value in raw))
-            raw_lengths.append(raw_length)
+            if not math.isfinite(raw_length) or raw_length <= 1e-12:
+                return None
+            # A genuine normal stream is generally unit length. Allow modest
+            # authoring/format error because values are normalized below, but
+            # reject arbitrary finite data such as position or color payloads.
+            if raw_length < 0.1 or raw_length > 4.0:
+                return None
+            if 0.5 <= raw_length <= 1.5:
+                plausible += 1
+            normal = tuple(value / raw_length for value in raw)
+            struct.pack_into("<fff", output, output_index * 12, *normal)
+
+        if count >= 8 and plausible / count < 0.75:
+            return None
+        return output
+
+    output = bytearray(count * 12)
+    for output_index, vertex_index in enumerate(indices):
         normal = decode_normal(source, data, vertex_index)
         if normal is None:
             return None
-        decoded.append(normal)
-
-    if source.encoding == "f32x3":
-        # A genuine normal stream is generally unit length. Allow modest
-        # authoring/format error because values are normalized below, but
-        # reject arbitrary finite data such as position or color payloads.
-        if any(not math.isfinite(length) or length < 0.1 or length > 4.0
-               for length in raw_lengths):
-            return None
-        if len(raw_lengths) >= 8:
-            plausible = sum(0.5 <= length <= 1.5 for length in raw_lengths)
-            if plausible / len(raw_lengths) < 0.75:
-                return None
-
-    output = bytearray(len(decoded) * 12)
-    for output_index, normal in enumerate(decoded):
         struct.pack_into("<fff", output, output_index * 12, *normal)
     return output
 

--- a/src/tests/core/geometry/test_authored_normals.py
+++ b/src/tests/core/geometry/test_authored_normals.py
@@ -4,6 +4,8 @@ import os
 import struct
 import math
 
+import pytest
+
 from core.geometry.draw_call import DrawCall
 from core.geometry.conventions import geometry_convention_for
 from core.ini.parser import (build_draw_groups, extract_resources,
@@ -326,3 +328,68 @@ def test_normal_decoder_boundaries_truncation_and_zero_vectors():
     assert decode_normals(source, bytes(8), [0]) is None
     f32_source = VertexAttributeSource("position.buf", 12, 0, "f32x3")
     assert decode_normals(f32_source, struct.pack("<3f", 100., 0., 0.), [0]) is None
+
+
+def test_bulk_normals_match_the_canonical_single_normal_decoder():
+    f32_source = VertexAttributeSource("normal.buf", 16, 4, "f32x3")
+    f32_data = b"".join(struct.pack("<f3f", 9., *values) for values in (
+        (1., 0., 0.), (0., 2., 0.), (.6, 0., .8)))
+    f32_indices = [2, 0, 1]
+    f32_expected = b"".join(
+        struct.pack("<fff", *decode_normal(f32_source, f32_data, index))
+        for index in f32_indices)
+    assert bytes(decode_normals(
+        f32_source, f32_data, f32_indices)) == f32_expected
+
+    snorm_source = VertexAttributeSource("normal.buf", 5, 1, "snorm8x3")
+    snorm_data = bytes((
+        99, 127, 0, 0, 88,
+        99, 0, 127, 0, 88,
+        99, 0, 0, 128, 88,
+    ))
+    snorm_indices = [2, 0, 1]
+    snorm_expected = b"".join(
+        struct.pack("<fff", *decode_normal(
+            snorm_source, snorm_data, index))
+        for index in snorm_indices)
+    assert bytes(decode_normals(
+        snorm_source, snorm_data, snorm_indices)) == snorm_expected
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(b"\0" * 8, id="truncated-record"),
+        pytest.param(struct.pack("<3f", float("nan"), 0., 0.), id="nan"),
+        pytest.param(struct.pack("<3f", float("inf"), 0., 0.), id="inf"),
+        pytest.param(struct.pack("<3f", 0., 0., 0.), id="zero"),
+        pytest.param(struct.pack("<3f", .05, 0., 0.), id="too-short"),
+        pytest.param(struct.pack("<3f", 4.01, 0., 0.), id="too-long"),
+    ],
+)
+def test_f32_bulk_normals_reject_invalid_records(data):
+    source = VertexAttributeSource("normal.buf", 12, 0, "f32x3")
+
+    assert decode_normals(source, data, [0]) is None
+
+
+def test_f32_bulk_normals_reject_less_than_75_percent_plausible():
+    source = VertexAttributeSource("normal.buf", 12, 0, "f32x3")
+    data = b"".join(struct.pack("<3f", *(
+        (1., 0., 0.) if index < 5 else (.2, 0., 0.)
+    )) for index in range(8))
+
+    assert decode_normals(source, data, list(range(8))) is None
+
+
+def test_f32_bulk_normals_accept_exactly_75_percent_plausible():
+    source = VertexAttributeSource("normal.buf", 12, 0, "f32x3")
+    data = b"".join(struct.pack("<3f", *(
+        (1., 0., 0.) if index < 6 else (.2, 0., 0.)
+    )) for index in range(8))
+    indices = list(range(8))
+    expected = b"".join(
+        struct.pack("<fff", *decode_normal(source, data, index))
+        for index in indices)
+
+    assert bytes(decode_normals(source, data, indices)) == expected

--- a/src/tests/core/geometry/test_packing.py
+++ b/src/tests/core/geometry/test_packing.py
@@ -1,0 +1,203 @@
+"""Per-draw geometry validation, compaction, and packing regressions."""
+
+import struct
+from unittest.mock import patch
+
+import pytest
+
+from core.geometry.buffers import BufferStore, VertexStreams
+from core.geometry.conventions import GeometryConvention
+from core.geometry.draw_call import DrawCall
+from core.geometry import packing
+from core.geometry.packing import pack_draw_geometry
+
+
+def _unpack_f32(data):
+    return struct.unpack(f"<{len(data) // 4}f", data)
+
+
+def _unpack_indices(data):
+    return struct.unpack(f"<{len(data) // 4}I", data)
+
+
+def _pack_fixture(tmp_path, indices, positions, *, uvs=None, base=0,
+                  reverse_winding=False, position_data=None, uv_data=None):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    if position_data is None:
+        position_data = b"".join(struct.pack("<3f", *point)
+                                  for point in positions)
+    if uv_data is None:
+        uv_data = (b"" if uvs is None else b"".join(
+            struct.pack("<2f", *uv) for uv in uvs))
+
+    position_path = tmp_path / "position.buf"
+    texcoord_path = tmp_path / "texcoord.buf"
+    index_path = tmp_path / "body.ib"
+    position_path.write_bytes(position_data)
+    texcoord_path.write_bytes(uv_data)
+    index_path.write_bytes(struct.pack(f"<{len(indices)}I", *indices))
+
+    position_data = position_path.read_bytes()
+    uv_data = texcoord_path.read_bytes()
+    streams = VertexStreams(
+        position_data, 12, uv_data, 8, 0, "<ff")
+    draw = DrawCall(
+        label="Body-1", count=len(indices), ib_file="body.ib",
+        index_size=4, base=base, position_file="position.buf",
+        position_stride=12, texcoord_file="texcoord.buf",
+        texcoord_stride=8)
+    group = {
+        "position_file": "position.buf",
+        "texcoord_file": "texcoord.buf",
+    }
+    return pack_draw_geometry(
+        draw, group, mod_dir=str(tmp_path), default_streams=streams,
+        default_index_size=4, buffers=BufferStore(),
+        geometry_convention=GeometryConvention(reverse_winding=reverse_winding),
+        sparse_shape_cache={})
+
+
+def test_repeated_vertices_keep_exact_packed_positions_uvs_and_indices(
+        tmp_path):
+    positions = [(float(index), 0., 0.) for index in range(6)]
+    uvs = [(0., 0.), (1., 0.), (2., .25), (3., 0.), (4., .5), (5., .75)]
+
+    packed = _pack_fixture(
+        tmp_path, (5, 2, 5, 4, 5, 2), positions, uvs=uvs)
+
+    assert _unpack_f32(packed.positions) == (
+        2., 0., 0., 4., 0., 0., 5., 0., 0.)
+    assert _unpack_f32(packed.texcoords) == (
+        2., .75, 4., .5, 5., .25)
+    assert _unpack_indices(packed.indices) == (2, 0, 2, 1, 2, 0)
+
+
+def test_compaction_remains_sorted_by_source_vertex_index(tmp_path):
+    positions = [(float(index),) * 3 for index in range(6)]
+
+    packed = _pack_fixture(tmp_path, (5, 2, 4), positions)
+
+    assert _unpack_f32(packed.positions) == (
+        2., 2., 2., 4., 4., 4., 5., 5., 5.)
+    assert _unpack_indices(packed.indices) == (2, 0, 1)
+
+
+def test_base_vertex_location_is_applied_before_packing(tmp_path):
+    positions = [(float(index), 0., 0.) for index in range(6)]
+
+    packed = _pack_fixture(tmp_path, (0, 1, 2), positions, base=3)
+
+    assert _unpack_f32(packed.positions) == (
+        3., 0., 0., 4., 0., 0., 5., 0., 0.)
+    assert _unpack_indices(packed.indices) == (0, 1, 2)
+
+
+def test_negative_effective_index_rejects_the_draw(tmp_path):
+    positions = [(float(index), 0., 0.) for index in range(3)]
+
+    packed = _pack_fixture(tmp_path, (0, 1, 2), positions, base=-1)
+
+    assert packed is None
+
+
+def test_truncated_position_removes_only_the_affected_triangle(tmp_path):
+    positions = [(0., 0., 0.), (1., 0., 0.), (0., 1., 0.)]
+
+    packed = _pack_fixture(
+        tmp_path, (0, 1, 2, 0, 3, 4), positions,
+        uvs=[(0., 0.)] * 5)
+
+    assert _unpack_indices(packed.indices) == (0, 1, 2)
+
+
+def test_invalid_vertex_decode_is_cached_across_triangles(tmp_path):
+    positions = [
+        (0., 0., 0.), (1., 0., 0.), (0., 1., 0.),
+        (float("nan"), 0., 0.), (1., 1., 0.),
+    ]
+    position_unpack_offsets = []
+    original_unpack_from = struct.unpack_from
+
+    def track_position_unpack(format_string, data, offset=0):
+        if format_string == "<fff":
+            position_unpack_offsets.append(offset)
+        return original_unpack_from(format_string, data, offset)
+
+    with patch.object(
+            packing.struct, "unpack_from", side_effect=track_position_unpack):
+        packed = _pack_fixture(
+            tmp_path, (0, 3, 4, 1, 3, 2), positions)
+
+    assert packed is None
+    assert position_unpack_offsets == [0, 36, 12]
+
+
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf")])
+def test_nonfinite_position_removes_only_the_affected_triangle(
+        tmp_path, invalid):
+    positions = [
+        (0., 0., 0.), (1., 0., 0.), (0., 1., 0.),
+        (invalid, 0., 0.), (1., 1., 0.),
+    ]
+
+    packed = _pack_fixture(
+        tmp_path, (0, 1, 2, 0, 3, 4), positions,
+        uvs=[(0., 0.)] * 5)
+
+    assert _unpack_indices(packed.indices) == (0, 1, 2)
+
+
+def test_truncated_uv_removes_only_the_affected_triangle(tmp_path):
+    positions = [(float(index), 0., 0.) for index in range(5)]
+
+    packed = _pack_fixture(
+        tmp_path, (0, 1, 2, 0, 3, 4), positions,
+        uvs=[(0., 0.)] * 3)
+
+    assert _unpack_indices(packed.indices) == (0, 1, 2)
+
+
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf")])
+def test_nonfinite_uv_removes_only_the_affected_triangle(tmp_path, invalid):
+    positions = [(float(index), 0., 0.) for index in range(5)]
+    uvs = [(0., 0.), (0., 0.), (0., 0.), (invalid, 0.), (0., 0.)]
+
+    packed = _pack_fixture(
+        tmp_path, (0, 1, 2, 0, 3, 4), positions, uvs=uvs)
+
+    assert _unpack_indices(packed.indices) == (0, 1, 2)
+
+
+def test_reverse_winding_preserves_compact_vertex_order_and_output_shape(
+        tmp_path):
+    positions = [(0., 0., 0.), (1., 0., 0.), (0., 1., 0.)]
+    uvs = [(0., 0.), (1., 0.), (0., 1.)]
+
+    forward = _pack_fixture(
+        tmp_path / "forward", (0, 1, 2), positions, uvs=uvs)
+    reverse = _pack_fixture(
+        tmp_path / "reverse", (0, 2, 1), positions, uvs=uvs,
+        reverse_winding=True)
+
+    assert reverse.positions == forward.positions
+    assert reverse.texcoords == forward.texcoords
+    assert reverse.indices == forward.indices
+
+
+def test_incomplete_trailing_indices_are_ignored(tmp_path):
+    positions = [(0., 0., 0.), (1., 0., 0.), (0., 1., 0.)]
+
+    packed = _pack_fixture(tmp_path, (0, 1, 2, 0, 1), positions)
+
+    assert _unpack_indices(packed.indices) == (0, 1, 2)
+
+
+def test_no_uv_path_remains_valid_without_a_texcoord_payload(tmp_path):
+    positions = [(0., 0., 0.), (1., 0., 0.), (0., 1., 0.)]
+
+    packed = _pack_fixture(tmp_path, (0, 1, 2), positions, uvs=None)
+
+    assert packed is not None
+    assert packed.texcoords is None
+    assert _unpack_f32(packed.positions) == (
+        0., 0., 0., 1., 0., 0., 0., 1., 0.)

--- a/src/tests/test_benchmark_texture_pipeline.py
+++ b/src/tests/test_benchmark_texture_pipeline.py
@@ -40,3 +40,33 @@ def test_summarize_runs_reports_timing_statistics(
         "min": expected_min,
         "max": expected_max,
     }
+
+
+def test_summarize_runs_reports_geometry_packing_substages():
+    run = {
+        "concurrency": 2,
+        "backend": {
+            "pack_draw_geometry_seconds": 10.0,
+            "prepare_draw_vertices_seconds": 4.0,
+            "index_decode_seconds": 1.0,
+            "decode_normals_seconds": 2.0,
+            "build_shape_buffers_seconds": 1.5,
+            "pack_other_seconds": 2.5,
+        },
+    }
+
+    summary = benchmark._summarize_runs([run], 2)
+
+    for field, value in {
+        "backend.pack_draw_geometry_seconds": 10.0,
+        "backend.prepare_draw_vertices_seconds": 4.0,
+        "backend.index_decode_seconds": 1.0,
+        "backend.decode_normals_seconds": 2.0,
+        "backend.build_shape_buffers_seconds": 1.5,
+        "backend.pack_other_seconds": 2.5,
+    }.items():
+        assert summary["timings"][field] == {
+            "median": value,
+            "min": value,
+            "max": value,
+        }

--- a/tools/benchmark_texture_pipeline.py
+++ b/tools/benchmark_texture_pipeline.py
@@ -62,6 +62,16 @@ _SUMMARY_TIMING_FIELDS = (
      ("backend", "build_mesh_result_seconds")),
     ("backend.pack_draw_geometry_seconds",
      ("backend", "pack_draw_geometry_seconds")),
+    ("backend.prepare_draw_vertices_seconds",
+     ("backend", "prepare_draw_vertices_seconds")),
+    ("backend.index_decode_seconds",
+     ("backend", "index_decode_seconds")),
+    ("backend.decode_normals_seconds",
+     ("backend", "decode_normals_seconds")),
+    ("backend.build_shape_buffers_seconds",
+     ("backend", "build_shape_buffers_seconds")),
+    ("backend.pack_other_seconds",
+     ("backend", "pack_other_seconds")),
     ("backend.metadata_hydrate_textures_seconds",
      ("backend", "metadata_hydrate_textures_seconds")),
     ("backend.geometry_publication_seconds",
@@ -187,6 +197,7 @@ def _install_load_instrumentation(timings, counters):
     from app.assets import index as asset_index
     from core.geometry import buffers as geometry_buffers
     from core.geometry import mesh_builder
+    from core.geometry import packing as geometry_packing
 
     patches = []
 
@@ -213,6 +224,12 @@ def _install_load_instrumentation(timings, counters):
     timing(mod_loader, "build_mesh_result", "build_mesh_result")
     timing(metadata, "hydrate_textures", "metadata_hydrate_textures")
     timing(server, "publish_payload_geometry", "geometry_publication")
+    timing(geometry_packing, "_prepare_draw_vertices",
+           "prepare_draw_vertices")
+    timing(geometry_buffers.BufferStore, "indices", "index_decode")
+    timing(geometry_packing, "decode_normals", "decode_normals")
+    timing(geometry_packing, "_build_shape_buffers",
+           "build_shape_buffers")
 
     original_index_load = asset_index.load_index
 
@@ -834,6 +851,10 @@ def _run_once(mod_path, concurrency, browser_channel):
         (payload.get("geometry") or {}).get("length", 0)
         if isinstance(payload.get("geometry"), dict) else 0)
     counters["structured_bridge_payload_bytes"] = payload_bytes
+    pack_draw_geometry_seconds = sum(timings["pack_draw_geometry"])
+    prepare_draw_vertices_seconds = sum(timings["prepare_draw_vertices"])
+    decode_normals_seconds = sum(timings["decode_normals"])
+    build_shape_buffers_seconds = sum(timings["build_shape_buffers"])
     return {
         "concurrency": concurrency,
         "backend": {
@@ -847,8 +868,17 @@ def _run_once(mod_path, concurrency, browser_channel):
             "asset_index_load_seconds": sum(timings["asset_index_load"]),
             "asset_enrichment_seconds": sum(timings["asset_enrichment"]),
             "build_mesh_result_seconds": sum(timings["build_mesh_result"]),
-            "pack_draw_geometry_seconds": sum(
-                timings["pack_draw_geometry"]),
+            "pack_draw_geometry_seconds": pack_draw_geometry_seconds,
+            "prepare_draw_vertices_seconds": prepare_draw_vertices_seconds,
+            "index_decode_seconds": sum(timings["index_decode"]),
+            "decode_normals_seconds": decode_normals_seconds,
+            "build_shape_buffers_seconds": build_shape_buffers_seconds,
+            "pack_other_seconds": max(
+                0.0,
+                pack_draw_geometry_seconds
+                - prepare_draw_vertices_seconds
+                - decode_normals_seconds
+                - build_shape_buffers_seconds),
             "metadata_hydrate_textures_seconds": sum(
                 timings["metadata_hydrate_textures"]),
             "geometry_publication_seconds": sum(


### PR DESCRIPTION
## Summary

- Cache validated position/UV decodes per draw and reuse them for packed geometry and shape targets.
- Decode f32x3 authored normals in one pass while preserving existing validation and fallback behavior.
- Add nested geometry-packing benchmark timings and focused regression coverage.
- Remove the obsolete texconv ignore rule.

## Scope

Compact ordering, triangle filtering, winding, BaseVertexLocation handling, skinning source selection, shape-target layouts, and frontend behavior remain unchanged.