### PR TITLE
Show Save to Texture progress and profile the parallel pipeline

### DIFF
--- a/src/app/bridge/api.py
+++ b/src/app/bridge/api.py
@@ -5,6 +5,8 @@ orchestration live in underscore-private collaborators so pywebview exposes
 only this class's deliberate bridge contract.
 """
 
+import json
+import logging
 import traceback
 
 import webview
@@ -16,6 +18,9 @@ from app.bridge import present as present_api
 from app.bridge.mod_preview import ModPreview
 from app.bridge.registry import AssetFolderRegistry, ModFolderRegistry
 from app.bridge import toggle as toggle_api
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ModViewerAPI:
@@ -157,9 +162,30 @@ class ModViewerAPI:
     def get_mesh_semantics(self, folder_path):
         return self._mod_preview.get_mesh_semantics(folder_path)
 
-    def save_texture_color(self, folder_path, tex_key, targets, texture_usage):
+    def _emit_ui_event(self, name, detail):
+        """Push one structured event to the current WebView, if available."""
+        if self._window is None:
+            return
+        try:
+            event_name = json.dumps(name)
+            payload = json.dumps(detail, separators=(",", ":"))
+            self._window.run_js(
+                "window.dispatchEvent(new CustomEvent(%s, {detail: %s}));"
+                % (event_name, payload))
+        except Exception:
+            _LOGGER.debug("UI event dispatch failed", exc_info=True)
+
+    def save_texture_color(
+            self, folder_path, tex_key, targets, texture_usage,
+            request_id=None):
+        def progress(event):
+            self._emit_ui_event(
+                "mod-viewer-texture-save-progress",
+                {"request_id": request_id, **event})
+
         return self._mod_preview.save_texture_color(
-            folder_path, tex_key, targets, texture_usage)
+            folder_path, tex_key, targets, texture_usage,
+            progress_callback=progress)
 
     def get_model_skinning_preview(self, folder_path):
         return self._mod_preview.get_model_skinning_preview(folder_path)

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -154,14 +154,18 @@ class ModPreview:
             return self._semantic_read_error()
 
     def save_texture_color(
-            self, folder_path, tex_key, targets, texture_usage):
+            self, folder_path, tex_key, targets, texture_usage,
+            progress_callback=None):
         """Save all captured Color changes that target one physical DDS."""
         try:
             folder_path, overrides, _pending, context = \
                 self.authoritative_context(folder_path)
+            save_kwargs = {} if progress_callback is None else {
+                "progress_callback": progress_callback,
+            }
             result = save_texture_color(
                 context, overrides, self._active_mesh_keys.get(folder_path),
-                tex_key, targets, texture_usage)
+                tex_key, targets, texture_usage, **save_kwargs)
             if result.get("status") == "ok":
                 keys = [
                     item.get("metadata_key")

--- a/src/app/mods/texture_save.py
+++ b/src/app/mods/texture_save.py
@@ -51,6 +51,7 @@ _BC7_PARALLEL_THRESHOLD = 4096
 _BC7_CHUNK_SIZE = 256
 _BC7_MAX_WORKERS = 6
 _BC7_MAX_IN_FLIGHT_FACTOR = 2
+_SAVE_PROGRESS_INTERVAL = 0.15
 
 
 class TextureSaveError(ValueError):
@@ -145,6 +146,56 @@ def _error(code, message, status="error", **details):
     result = {"status": status, "code": code, "error": message}
     result.update(details)
     return result
+
+
+def _report_progress(callback, event):
+    """Deliver best-effort domain progress without affecting the save."""
+    if callback is None:
+        return
+    try:
+        callback(dict(event))
+    except Exception:
+        _LOGGER.debug("Texture save progress callback failed", exc_info=True)
+
+
+class _SaveProgressReporter:
+    """Throttle progress callbacks while keeping stage changes immediate."""
+
+    def __init__(self, callback):
+        self._callback = callback
+        self._last_emit = None
+        self._last_stage = None
+        self._last_mip = None
+
+    def stage(self, value):
+        if value == self._last_stage:
+            return
+        self._last_stage = value
+        self._emit({"stage": value}, force=True)
+
+    def processing(self, mip, mip_count, completed, total):
+        now = time.perf_counter()
+        force = mip != self._last_mip or completed >= total
+        self._last_mip = mip
+        if (not force and self._last_emit is not None
+                and now - self._last_emit < _SAVE_PROGRESS_INTERVAL):
+            return
+        self._last_emit = now
+        _report_progress(self._callback, {
+            "stage": "processing",
+            "mip": mip,
+            "mip_count": mip_count,
+            "completed_blocks": completed,
+            "total_blocks": total,
+        })
+
+    def _emit(self, event, force=False):
+        now = time.perf_counter()
+        if (not force and self._last_emit is not None
+                and now - self._last_emit < _SAVE_PROGRESS_INTERVAL):
+            return
+        self._last_emit = now
+        _report_progress(self._callback, event)
 
 
 def _canonical_mod_path(mod_dir, relative_path):
@@ -898,18 +949,21 @@ def _record_bc7_result(final, result, totals, modes, mip_stats):
 
 
 def _process_bc7_serial(final, original, mip, affected, state, adjustments,
-                        record_intent, totals, modes, mip_stats):
+                        record_intent, totals, modes, mip_stats,
+                        record_progress=None):
     """Fit BC7 jobs serially through the same job/result path."""
     for job in _iter_bc7_jobs(
             original, mip, affected, state, adjustments, record_intent):
         results = _recolor_bc7_chunk((job,))
         for result in results:
             _record_bc7_result(final, result, totals, modes, mip_stats)
+            if record_progress is not None:
+                record_progress()
 
 
 def _process_bc7_parallel(final, original, mip, affected, state, adjustments,
                           record_intent, totals, modes, mip_stats, executor,
-                          worker_count):
+                          worker_count, record_progress=None):
     """Fit BC7 jobs with bounded outstanding work on a reused process pool."""
     chunks = iter(_iter_bc7_job_chunks(
         original, mip, affected, state, adjustments, record_intent,
@@ -949,10 +1003,13 @@ def _process_bc7_parallel(final, original, mip, affected, state, adjustments,
             for result in results:
                 _record_bc7_result(
                     final, result, totals, modes, mip_stats)
+                if record_progress is not None:
+                    record_progress()
         submit_available()
 
 
-def _save_bc7_blocks(original, prepared, timings=None, stage_callback=None):
+def _save_bc7_blocks(original, prepared, timings=None, stage_callback=None,
+                     progress_reporter=None):
     """Edit authorized BC7 blocks in-place while preserving all other bytes."""
     timings = {} if timings is None else timings
     if not prepared.info.format.startswith("bc7"):
@@ -997,11 +1054,22 @@ def _save_bc7_blocks(original, prepared, timings=None, stage_callback=None):
             started = time.perf_counter()
             if stage_callback is not None:
                 stage_callback("bc7_decode_fit")
+            if progress_reporter is not None:
+                progress_reporter.processing(
+                    level, len(prepared.layout.mips), 0, len(affected))
             mip_stats = {
                 "partial": 0, "full": 0,
                 "single_intent_partial": 0, "multi_intent": 0,
                 "source_blocks_kept": 0,
             }
+            mip_completed = 0
+
+            def record_progress():
+                nonlocal mip_completed
+                mip_completed += 1
+                progress_reporter.processing(
+                    level, len(prepared.layout.mips), mip_completed,
+                    len(affected))
 
             def record_intent(block_intent):
                 totals["partial"] += block_intent.partial
@@ -1032,11 +1100,13 @@ def _save_bc7_blocks(original, prepared, timings=None, stage_callback=None):
                 _process_bc7_parallel(
                     final, original, mip, affected, state, adjustments,
                     record_intent, totals, modes, mip_stats, executor,
-                    worker_count)
+                    worker_count,
+                    record_progress if progress_reporter is not None else None)
             else:
                 _process_bc7_serial(
                     final, original, mip, affected, state, adjustments,
-                    record_intent, totals, modes, mip_stats)
+                    record_intent, totals, modes, mip_stats,
+                    record_progress if progress_reporter is not None else None)
             timings["bc7_decode_fit"] = timings.get("bc7_decode_fit", 0.0) + (
                 time.perf_counter() - started)
             _LOGGER.debug(
@@ -1344,12 +1414,16 @@ def _replacement_completed(source_path, temporary_path, final):
 
 def save_texture_color(
         context, overrides, active_mesh_keys, selected_texture_key, targets,
-        texture_usage):
+        texture_usage, progress_callback=None):
     """Save captured Color changes by editing authorized BC7 blocks."""
     committed = False
     success_result = None
     timings = {}
     stage = "prepare"
+    progress = (_SaveProgressReporter(progress_callback)
+                if progress_callback is not None else None)
+    if progress is not None:
+        progress.stage("preparing")
     try:
         started = time.perf_counter()
         prepared = _prepare_texture_save(
@@ -1358,6 +1432,8 @@ def save_texture_color(
         timings["prepare"] = time.perf_counter() - started
 
         stage = "read"
+        if progress is not None:
+            progress.stage("reading")
         original = _read_source(prepared.selected_path)
         original_hash = _sha256_bytes(original)
         affected = _affected_texture_keys(context, prepared)
@@ -1367,8 +1443,11 @@ def save_texture_color(
             stage = value
 
         candidate, bc7_stats = _save_bc7_blocks(
-            original, prepared, timings, stage_callback=set_stage)
+            original, prepared, timings, stage_callback=set_stage,
+            progress_reporter=progress)
         stage = "write"
+        if progress is not None:
+            progress.stage("writing")
         temporary = _write_temp(prepared.selected_path, candidate)
         try:
             candidate_layout = inspect_dds_layout(temporary)
@@ -1430,6 +1509,8 @@ def save_texture_color(
             "texture save timing_ms=%s",
             {key: round(value * 1000.0, 2)
              for key, value in timings.items()})
+        if progress is not None:
+            progress.stage("complete")
         return success_result
     except TextureSaveError as error:
         if committed and success_result is not None:

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -175,7 +175,8 @@ def test_texture_save_forwards_targets_and_usage(monkeypatch):
     calls = []
     monkeypatch.setattr(
         api._mod_preview, "save_texture_color",
-        lambda *args: calls.append(args) or {"status": "ok"},
+        lambda *args, **kwargs: calls.append((args, kwargs))
+        or {"status": "ok"},
     )
     targets = [{"semantic_key": "Body-1", "metadata_key": "Body::one",
                 "adjustment": {"hue": 30}}]
@@ -192,4 +193,40 @@ def test_texture_save_forwards_targets_and_usage(monkeypatch):
         "mod", "diffuse::body.dds", targets, usage)
 
     assert result == {"status": "ok"}
-    assert calls == [("mod", "diffuse::body.dds", targets, usage)]
+    assert calls[0][0] == ("mod", "diffuse::body.dds", targets, usage)
+    assert callable(calls[0][1]["progress_callback"])
+
+
+def test_texture_save_progress_event_includes_request_id_and_is_best_effort():
+    api = ModViewerAPI()
+    captured = []
+
+    class Window:
+        def run_js(self, script):
+            captured.append(script)
+
+    def save(*_args, **kwargs):
+        kwargs["progress_callback"]({
+            "stage": "processing", "mip": 0, "mip_count": 1,
+            "completed_blocks": 3, "total_blocks": 7,
+        })
+        return {"status": "ok"}
+
+    api._mod_preview.save_texture_color = save
+    api._window = Window()
+    result = api.save_texture_color(
+        "mod", "diffuse::body.dds", [], [], "request-7")
+
+    assert result == {"status": "ok"}
+    assert len(captured) == 1
+    assert "mod-viewer-texture-save-progress" in captured[0]
+    assert '"request_id":"request-7"' in captured[0]
+    assert '"completed_blocks":3' in captured[0]
+
+    class BrokenWindow:
+        def run_js(self, _script):
+            raise RuntimeError("closed WebView")
+
+    api._window = BrokenWindow()
+    assert api.save_texture_color(
+        "mod", "diffuse::body.dds", [], [], "request-8") == {"status": "ok"}

--- a/src/tests/app/bridge/test_mod_preview.py
+++ b/src/tests/app/bridge/test_mod_preview.py
@@ -285,7 +285,7 @@ def test_save_texture_color_forwards_complete_target_request(monkeypatch):
         lambda _folder: ("mod", {"override": 1}, {}, context))
     monkeypatch.setattr(
         "app.bridge.mod_preview.save_texture_color",
-        lambda *args: captured.append(args) or {
+        lambda *args, **kwargs: captured.append((args, kwargs)) or {
             "status": "ok", "tex_key": "diffuse::body.dds",
             "saved_meshes": [{
                 "semantic_key": "Body-1", "metadata_key": "Body::one",
@@ -311,6 +311,29 @@ def test_save_texture_color_forwards_complete_target_request(monkeypatch):
         "mod", "diffuse::body.dds", targets, usage)
 
     assert result["status"] == "ok"
-    assert captured == [(context, {"override": 1}, {"Body-1", "Body-2"},
-                         "diffuse::body.dds", targets, usage)]
+    assert captured[0][0] == (
+        context, {"override": 1}, {"Body-1", "Body-2"},
+        "diffuse::body.dds", targets, usage)
+    assert captured[0][1] == {}
     assert cleared == [("mod", ["Body::one"])]
+
+
+def test_save_texture_color_forwards_progress_callback(monkeypatch):
+    preview = ModPreview(_Access())
+    preview._active_mesh_keys["mod"] = {"Body-1"}
+    context = _context()
+    callback = object()
+    captured = []
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {}, {}, context))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.save_texture_color",
+        lambda *args, **kwargs: captured.append((args, kwargs)) or {
+            "status": "error",
+        })
+
+    preview.save_texture_color(
+        "mod", "diffuse::body.dds", [], [], progress_callback=callback)
+
+    assert captured[0][1] == {"progress_callback": callback}

--- a/src/tests/app/mods/test_texture_save.py
+++ b/src/tests/app/mods/test_texture_save.py
@@ -124,6 +124,52 @@ def test_save_is_bc7_only_and_returns_a_clean_public_result(tmp_path, monkeypatc
     assert backups[0].read_bytes() == original
 
 
+def test_save_progress_reports_stages_and_ignores_callback_errors(
+        tmp_path, monkeypatch):
+    source = tmp_path / "body.dds"
+    original = _dx10_dds(bytes(16))
+    source.write_bytes(original)
+    prepared = _write_prepared_save(source)
+    monkeypatch.setattr(
+        texture_save, "_prepare_texture_save",
+        lambda *args, **kwargs: prepared)
+
+    def save_blocks(*args, **kwargs):
+        reporter = kwargs["progress_reporter"]
+        reporter.processing(0, 1, 1, 1)
+        return original, _write_stats()
+
+    monkeypatch.setattr(texture_save, "_save_bc7_blocks", save_blocks)
+    events = []
+
+    def callback(event):
+        events.append(event)
+        raise RuntimeError("synthetic progress listener failure")
+
+    result = texture_save.save_texture_color(
+        SimpleNamespace(mod_dir=str(tmp_path)), {}, {"Anchor"},
+        "diffuse::body.dds", [], [], progress_callback=callback)
+
+    assert result["status"] == "ok"
+    assert [event["stage"] for event in events] == [
+        "preparing", "reading", "processing", "writing", "complete",
+    ]
+    assert all("request_id" not in event for event in events)
+
+
+def test_save_progress_throttles_intermediate_blocks_but_keeps_final(
+        monkeypatch):
+    events = []
+    reporter = texture_save._SaveProgressReporter(events.append)
+    monkeypatch.setattr(texture_save, "_SAVE_PROGRESS_INTERVAL", 60.0)
+
+    reporter.processing(0, 1, 0, 10)
+    reporter.processing(0, 1, 1, 10)
+    reporter.processing(0, 1, 10, 10)
+
+    assert [event["completed_blocks"] for event in events] == [0, 10]
+
+
 def test_save_aborts_on_stale_source_before_creating_backup(tmp_path, monkeypatch):
     source = tmp_path / "body.dds"
     original = _dx10_dds(bytes(16))
@@ -622,16 +668,31 @@ def test_parallel_bc7_save_matches_serial_bytes_and_stats(tmp_path, monkeypatch)
     )
     monkeypatch.setattr(texture_save, "_bc7_worker_count", lambda: 2)
     monkeypatch.setattr(texture_save, "_BC7_CHUNK_SIZE", 2)
+    monkeypatch.setattr(texture_save, "_SAVE_PROGRESS_INTERVAL", 0)
     monkeypatch.setattr(texture_save, "_BC7_PARALLEL_THRESHOLD", 10000)
+    serial_events = []
+    serial_progress = texture_save._SaveProgressReporter(
+        serial_events.append)
     serial_bytes, serial_stats = texture_save._save_bc7_blocks(
-        original, prepared)
+        original, prepared, progress_reporter=serial_progress)
 
     monkeypatch.setattr(texture_save, "_BC7_PARALLEL_THRESHOLD", 0)
+    parallel_events = []
+    parallel_progress = texture_save._SaveProgressReporter(
+        parallel_events.append)
     parallel_bytes, parallel_stats = texture_save._save_bc7_blocks(
-        original, prepared)
+        original, prepared, progress_reporter=parallel_progress)
 
     assert parallel_bytes == serial_bytes
     assert parallel_stats == serial_stats
+    for events in (serial_events, parallel_events):
+        processing = [event for event in events
+                      if event["stage"] == "processing"]
+        assert processing[0]["completed_blocks"] == 0
+        assert [event["completed_blocks"] for event in processing] == \
+            list(range(8))
+        assert processing[-1]["completed_blocks"] == \
+            processing[-1]["total_blocks"]
 
 
 def test_bc7_result_application_uses_block_offsets():

--- a/src/tests/web/support.py
+++ b/src/tests/web/support.py
@@ -486,8 +486,10 @@ def _page(edge_browser, frontend_url, responses, pending=None, picks=None,
                   ?? payload.asset_resolution ?? null,
               });
             },
-            save_texture_color: async (path, texKey, targets, usage) => {
-              state.calls.saveTextureColor.push([path, texKey, targets, usage]);
+            save_texture_color: async (path, texKey, targets, usage, requestId) => {
+              state.calls.saveTextureColor.push([
+                path, texKey, targets, usage, requestId,
+              ]);
               return copy(state.responses[path]?.textureSaveResult || {
                 status: 'ok',
                 tex_key: texKey,

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -1304,6 +1304,83 @@ def test_texture_save_modal_blocks_dismissal_while_saving(
         context.close()
 
 
+def test_texture_save_modal_displays_progress_and_ignores_stale_events(
+        edge_browser, frontend_url):
+    payload, tex_key = _bake_test_payload("BakeProgress", _PNG_URI)
+    context, page = _page(edge_browser, frontend_url, {"BakeProgress": payload})
+    try:
+        _open(page, "BakeProgress")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.evaluate("""() => {
+          window.pywebview.api.save_texture_color = async (...args) => {
+            window.__textureSaveArgs = args;
+            return new Promise(resolve => {
+              window.__releaseTextureSave = resolve;
+            });
+          };
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function("window.__textureSaveArgs !== undefined")
+        request_id = page.evaluate("window.__textureSaveArgs[4]")
+        assert isinstance(request_id, str)
+        assert page.locator(".texture-bake-progress-status").inner_text() == (
+            "Preparing texture…")
+        assert page.locator("#texture-bake-progress").get_attribute("value") is None
+
+        page.evaluate("""detail => window.dispatchEvent(new CustomEvent(
+          'mod-viewer-texture-save-progress', {detail}))""", {
+            "request_id": request_id, "stage": "processing", "mip": 0,
+            "mip_count": 1, "completed_blocks": 500, "total_blocks": 1000,
+        })
+        assert page.locator(".texture-bake-progress-status").inner_text() == (
+            "Processing texture…")
+        assert page.locator(".texture-bake-progress-detail").inner_text() == (
+            "500 / 1000 blocks")
+        assert page.evaluate(
+            "document.querySelector('#texture-bake-progress').value") == 50
+
+        page.evaluate("""detail => window.dispatchEvent(new CustomEvent(
+          'mod-viewer-texture-save-progress', {detail}))""", {
+            "request_id": "stale-request", "stage": "processing", "mip": 0,
+            "mip_count": 1, "completed_blocks": 900, "total_blocks": 1000,
+        })
+        assert page.locator(".texture-bake-progress-detail").inner_text() == (
+            "500 / 1000 blocks")
+
+        page.evaluate("""detail => window.dispatchEvent(new CustomEvent(
+          'mod-viewer-texture-save-progress', {detail}))""", {
+            "request_id": request_id, "stage": "processing", "mip": 1,
+            "mip_count": 3, "completed_blocks": 25, "total_blocks": 50,
+        })
+        assert page.locator(".texture-bake-progress-detail").inner_text() == (
+            "Mip 2 of 3 · 25 / 50 blocks")
+        assert page.evaluate(
+            "document.querySelector('#texture-bake-progress').value") == 50
+
+        page.evaluate("""detail => window.dispatchEvent(new CustomEvent(
+          'mod-viewer-texture-save-progress', {detail}))""", {
+            "request_id": request_id, "stage": "writing",
+        })
+        assert page.locator(".texture-bake-progress-status").inner_text() == (
+            "Writing texture…")
+        assert page.locator("#texture-bake-progress").get_attribute("value") is None
+
+        page.evaluate("""() => window.__releaseTextureSave({
+          status: 'ok', tex_key: %s, affected_tex_keys: [%s],
+          saved_meshes: [{semantic_key: 'Body-BakeProgress-0',
+            metadata_key: 'Body BakeProgress::3,0,0'}],
+          texture: {file: 'BakeProgress-bake.dds'},
+          backup: {file: 'BakeProgress-bake.dds.modviewer.bak'},
+        })""" % (json.dumps(tex_key), json.dumps(tex_key)))
+        page.locator("#texture-bake-body", has_text="TEXTURE SAVED").wait_for()
+    finally:
+        context.close()
+
+
 def test_texture_save_refreshes_targets_after_color_change(
         edge_browser, frontend_url):
     payload, _tex_key = _bake_test_payload("BakeStale", _PNG_URI)
@@ -1546,8 +1623,9 @@ def test_texture_save_resets_all_committed_meshes_and_refreshes_affected_keys(
         page.locator("#texture-bake-confirm").wait_for()
         page.locator("#texture-bake-confirm").click()
         page.locator("#texture-bake-body", has_text="TEXTURE SAVED").wait_for()
-        assert page.evaluate(
-            "window.__fakeApi.calls.saveTextureColor[0]") == [
+        request = page.evaluate(
+            "window.__fakeApi.calls.saveTextureColor[0]")
+        assert request[:4] == [
                 "BakeConfirm", dds_key,
                 [{
                     "semantic_key": "Body-BakeConfirm-0",
@@ -1586,6 +1664,7 @@ def test_texture_save_resets_all_committed_meshes_and_refreshes_affected_keys(
                     },
                 }],
             ]
+        assert isinstance(request[4], str)
         assert page.evaluate(
             "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue") == 0
         assert page.evaluate(

--- a/src/web/css/app.css
+++ b/src/web/css/app.css
@@ -717,6 +717,10 @@ body.right-dock-mounted #view-gizmo { top: 52px; right: 338px; }
 .texture-bake-title-row h4 { margin-bottom: 0; }
 .texture-bake-body { min-height: 58px; color: var(--text-muted); font-size: 11px; line-height: 1.45; }
 .texture-bake-loading { padding: 12px 0; }
+.texture-bake-progress-view { padding: 12px 0; }
+.texture-bake-progress-status { margin: 0 0 8px; color: var(--text); }
+.texture-bake-progress { display: block; width: 100%; height: 10px; }
+.texture-bake-progress-detail { margin: 7px 0 0; min-height: 16px; }
 .texture-bake-state { color: var(--success); font-size: 12px; font-weight: 600; }
 .texture-bake-state-unknown { color: var(--warning); }
 .texture-bake-summary { margin: 7px 0 10px; }

--- a/src/web/js/ui/texture-save-modal.js
+++ b/src/web/js/ui/texture-save-modal.js
@@ -21,6 +21,18 @@ const saveButton = $('texture-bake-confirm');
 
 let pendingSave = null;
 let saving = false;
+let saveRequestSequence = 0;
+let activeSaveRequestId = null;
+let saveProgressElements = null;
+
+const saveStageLabels = {
+  preparing: 'Preparing texture…',
+  reading: 'Reading source texture…',
+  processing: 'Processing texture…',
+  writing: 'Writing texture…',
+  refreshing: 'Refreshing viewer…',
+  complete: 'Texture saved…',
+};
 
 function displayNameForTarget(target) {
   return target?.mesh?.userData?.displayName
@@ -33,6 +45,7 @@ function closeTextureSaveModal() {
   // Keep the modal open while the destructive request and post-commit state
   // synchronization are in flight.
   if (saving) return;
+  activeSaveRequestId = null;
   pendingSave = null;
   backdrop?.classList.remove('show');
 }
@@ -59,6 +72,7 @@ function textureFileForKey(key) {
 
 function renderSavePrompt(state) {
   setModalError(error, '');
+  saveProgressElements = null;
   body.replaceChildren();
   const heading = document.createElement('div');
   heading.className = 'texture-bake-state';
@@ -106,6 +120,7 @@ function affectedTextureKeys(result) {
 }
 
 function renderSaveError(result) {
+  saveProgressElements = null;
   body.replaceChildren();
   setModalError(error, formatSaveError(result));
   setSaveAction();
@@ -113,6 +128,7 @@ function renderSaveError(result) {
 
 function renderSaveSuccess(result, targetCount) {
   setModalError(error, '');
+  saveProgressElements = null;
   body.replaceChildren();
   const heading = document.createElement('div');
   heading.className = 'texture-bake-state';
@@ -141,6 +157,67 @@ function renderSaveSuccess(result, targetCount) {
     body.appendChild(warning);
   }
   setSaveAction();
+}
+
+function renderSaveProgress(detail = {stage: 'preparing'}) {
+  if (!saveProgressElements) {
+    body.replaceChildren();
+    const view = document.createElement('div');
+    view.className = 'texture-bake-progress-view';
+    const heading = document.createElement('div');
+    heading.className = 'texture-bake-state';
+    heading.textContent = 'SAVING TO TEXTURE';
+    const status = document.createElement('p');
+    status.className = 'texture-bake-progress-status';
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    const progress = document.createElement('progress');
+    progress.id = 'texture-bake-progress';
+    progress.className = 'texture-bake-progress';
+    progress.max = 100;
+    progress.setAttribute('aria-label', 'Texture save progress');
+    const progressDetail = document.createElement('p');
+    progressDetail.className = 'texture-bake-progress-detail';
+    view.append(heading, status, progress, progressDetail);
+    body.appendChild(view);
+    saveProgressElements = {
+      status, progress, progressDetail, stage: null,
+    };
+  }
+
+  const stage = typeof detail?.stage === 'string'
+    ? detail.stage : 'preparing';
+  const label = saveStageLabels[stage] || 'Saving texture…';
+  if (saveProgressElements.stage !== stage) {
+    saveProgressElements.status.textContent = label;
+    saveProgressElements.stage = stage;
+  }
+  const completed = Number(detail?.completed_blocks);
+  const total = Number(detail?.total_blocks);
+  if (stage === 'processing' && Number.isFinite(completed)
+      && Number.isFinite(total) && total > 0) {
+    const boundedCompleted = Math.max(0, Math.min(completed, total));
+    saveProgressElements.progress.value = boundedCompleted / total * 100;
+    saveProgressElements.progress.setAttribute(
+      'aria-valuetext', `${boundedCompleted} of ${total} blocks`);
+    const mip = Number(detail?.mip);
+    const mipCount = Number(detail?.mip_count);
+    const mipLabel = mipCount > 1 && Number.isInteger(mip)
+      ? `Mip ${mip + 1} of ${mipCount} · ` : '';
+    saveProgressElements.progressDetail.textContent =
+      `${mipLabel}${boundedCompleted} / ${total} blocks`;
+  } else {
+    saveProgressElements.progress.removeAttribute('value');
+    saveProgressElements.progress.removeAttribute('aria-valuetext');
+    saveProgressElements.progressDetail.textContent = '';
+  }
+}
+
+function handleTextureSaveProgress(event) {
+  const detail = event?.detail;
+  if (!saving || activeSaveRequestId === null
+      || detail?.request_id !== activeSaveRequestId) return;
+  renderSaveProgress(detail);
 }
 
 async function synchronizeCommittedSave(state, result) {
@@ -190,18 +267,17 @@ async function runSave(job) {
     return null;
   }
   saving = true;
+  const requestId = String(++saveRequestSequence);
+  activeSaveRequestId = requestId;
   setSaveAction({visible: true, disabled: true, label: 'Saving…'});
-  body.replaceChildren();
-  const loading = document.createElement('div');
-  loading.className = 'texture-bake-loading';
-  loading.textContent = 'Saving color changes to the texture…';
-  body.appendChild(loading);
+  renderSaveProgress({stage: 'preparing'});
 
   try {
     await Promise.all((job.state.targets || []).map(target =>
       flushMeshColorAdjustmentPersistence(target.mesh)));
   } catch (_persistenceError) {
     saving = false;
+    activeSaveRequestId = null;
     renderSaveError({
       status: 'error',
       error: 'The pending Color metadata could not be saved. '
@@ -213,6 +289,7 @@ async function runSave(job) {
   if ((typeof job.isCurrent === 'function' && !job.isCurrent())
       || !textureSaveStateMatches(job.mesh, job.state, currentState)) {
     saving = false;
+    activeSaveRequestId = null;
     pendingSave = {mesh: job.mesh, isCurrent: job.isCurrent, state: currentState};
     renderSavePrompt(currentState);
     return null;
@@ -225,15 +302,18 @@ async function runSave(job) {
   try {
     result = await api(
       job.state.modPath, job.state.texKey,
-      textureSaveTargetsPayload(job.state), job.state.textureUsage);
+      textureSaveTargetsPayload(job.state), job.state.textureUsage,
+      requestId);
   } catch (_requestError) {
     result = {status: 'error', error: 'Texture save failed.'};
   }
   if (result?.status !== 'ok') {
     saving = false;
+    activeSaveRequestId = null;
     renderSaveError(result);
     return result;
   }
+  renderSaveProgress({stage: 'refreshing'});
   try {
     await synchronizeCommittedSave(job.state, result);
   } catch (_refreshError) {
@@ -244,6 +324,7 @@ async function runSave(job) {
     return result;
   } finally {
     saving = false;
+    activeSaveRequestId = null;
   }
   if (typeof job.isCurrent === 'function' && !job.isCurrent()) {
     closeTextureSaveModal();
@@ -256,6 +337,7 @@ async function runSave(job) {
 /** Open the Save to Texture modal without performing a backend preflight. */
 export function openTextureSaveModal(mesh, {isCurrent} = {}) {
   if (!backdrop || !body) return null;
+  activeSaveRequestId = null;
   const state = captureTextureSaveState(mesh);
   pendingSave = {mesh, isCurrent, state};
   backdrop.classList.add('show');
@@ -287,5 +369,8 @@ window.addEventListener('mod-viewer-mesh-selected', () => {
     closeTextureSaveModal();
   }
 });
+
+window.addEventListener(
+  'mod-viewer-texture-save-progress', handleTextureSaveProgress);
 
 export { closeTextureSaveModal };


### PR DESCRIPTION
Summary

- Stream request-scoped Save to Texture stages from the domain through the bridge into the existing modal.
- Show indeterminate preparation/read/write/refresh states and throttled current-mip BC7 block progress.
- Ignore stale progress events, preserve dismissal/error/refresh behavior, and keep callback failures best-effort.
- Add domain, bridge, and browser coverage for serial/parallel reporting and progress rendering.

Validation

- python -m pytest -q
- python src/build.py --onedir --skip-deps
- python src/build.py --skip-deps