### PR TITLE
Move single-intent BC7 target preparation into workers

### DIFF
--- a/src/app/mods/texture_save.py
+++ b/src/app/mods/texture_save.py
@@ -130,6 +130,17 @@ class _BC7BlockJob:
 
 
 @dataclass(frozen=True)
+class _BC7SingleIntentJob:
+    """Compact mip-0 job whose source and target are worker-prepared."""
+
+    start: int
+    source_block: bytes
+    adjustment: PreparedColorAdjustment
+    valid_width: int
+    valid_height: int
+
+
+@dataclass(frozen=True)
 class _BC7BlockResult:
     """Compact worker result applied by the parent save operation."""
 
@@ -140,6 +151,7 @@ class _BC7BlockResult:
     mode: int
     source_kept: bool
     error: str = None
+    error_code: str = None
 
 
 def _error(code, message, status="error", **details):
@@ -831,6 +843,19 @@ def _bc7_weighted_block_intent_info(state, mip, block_index):
         multi_intent=len(ordered_classes) > 1)
 
 
+def _bc7_single_adjustment_target_pixels(
+        source_pixels, adjustment, valid_width, valid_height):
+    """Apply one Color adjustment while preserving alpha and block padding."""
+    target_pixels = list(source_pixels)
+    for row in range(valid_height):
+        for column in range(valid_width):
+            local = row * 4 + column
+            rgb = apply_prepared_color_u8(
+                source_pixels[local][:3], adjustment)
+            target_pixels[local] = rgb + (source_pixels[local][3],)
+    return tuple(target_pixels)
+
+
 def _bc7_target_block_pixels(source_block, mip, block_index, state,
                              adjustments, block_intent=None):
     """Build one sixteen-pixel BC7 target without a reconstructed image."""
@@ -849,17 +874,21 @@ def _bc7_target_block_pixels(source_block, mip, block_index, state,
                 state, mip, block_index)
         if len(block_intent.classes) == 1:
             single_intent_class = block_intent.classes[0]
+    if single_intent_class is not None:
+        return (
+            source_pixels,
+            _bc7_single_adjustment_target_pixels(
+                source_pixels, adjustments[single_intent_class],
+                valid_width, valid_height),
+            valid_width,
+            valid_height,
+        )
     for row in range(valid_height):
         for column in range(valid_width):
             local = row * 4 + column
             pixel = ((source_y + row) * mip.width + source_x + column)
-            if single_intent_class is not None:
-                rgb = apply_prepared_color_u8(
-                    source_pixels[local][:3],
-                    adjustments[single_intent_class])
-            else:
-                rgb = _bc7_intent_rgb(
-                    source_pixels[local][:3], state, pixel, adjustments)
+            rgb = _bc7_intent_rgb(
+                source_pixels[local][:3], state, pixel, adjustments)
             target_pixels[local] = rgb + (source_pixels[local][3],)
     return (source_pixels, tuple(target_pixels), valid_width, valid_height)
 
@@ -870,11 +899,20 @@ def _bc7_worker_count():
     return max(1, min(_BC7_MAX_WORKERS, cpu_count - 1))
 
 
-def _prepare_bc7_block_job(original, mip, block_index, state, adjustments,
-                           block_intent):
-    """Prepare the compact, parent-owned input sent to one worker."""
+def _bc7_source_block_and_bounds(original, mip, block_index):
+    """Return the one block slice and valid pixel bounds shared by job types."""
     start = mip.offset + block_index * mip.bytes_per_unit
     source_block = bytes(original[start:start + 16])
+    _source_x, _source_y, valid_width, valid_height = _unit_bounds(
+        mip, block_index)
+    return start, source_block, valid_width, valid_height
+
+
+def _prepare_bc7_block_job(original, mip, block_index, state, adjustments,
+                           block_intent):
+    """Prepare the parent-owned input sent to one worker."""
+    start, source_block, valid_width, valid_height = (
+        _bc7_source_block_and_bounds(original, mip, block_index))
     source_pixels, target_pixels, valid_width, valid_height = (
         _bc7_target_block_pixels(
             source_block, mip, block_index, state, adjustments,
@@ -885,15 +923,31 @@ def _prepare_bc7_block_job(original, mip, block_index, state, adjustments,
         valid_width=valid_width, valid_height=valid_height)
 
 
+def _prepare_bc7_single_intent_job(
+        original, mip, block_index, adjustments, block_intent):
+    """Prepare a compact mip-0 job for one explicit Color adjustment."""
+    start, source_block, valid_width, valid_height = (
+        _bc7_source_block_and_bounds(original, mip, block_index))
+    return _BC7SingleIntentJob(
+        start=start, source_block=source_block,
+        adjustment=adjustments[block_intent.classes[0]],
+        valid_width=valid_width, valid_height=valid_height)
+
+
 def _iter_bc7_jobs(original, mip, affected, state, adjustments,
-                    record_intent):
+                    record_intent, defer_single_intent=False):
     """Yield parent-prepared BC7 jobs while recording intent diagnostics."""
     for block_index in affected:
         block_intent = _bc7_block_intent_info(
             state, mip, block_index)
         record_intent(block_intent)
-        yield _prepare_bc7_block_job(
-            original, mip, block_index, state, adjustments, block_intent)
+        if (defer_single_intent and state["level"] == 0
+                and len(block_intent.classes) == 1):
+            yield _prepare_bc7_single_intent_job(
+                original, mip, block_index, adjustments, block_intent)
+        else:
+            yield _prepare_bc7_block_job(
+                original, mip, block_index, state, adjustments, block_intent)
 
 
 def _iter_bc7_job_chunks(original, mip, affected, state, adjustments,
@@ -901,7 +955,8 @@ def _iter_bc7_job_chunks(original, mip, affected, state, adjustments,
     """Group compact jobs into bounded worker submissions."""
     chunk = []
     for job in _iter_bc7_jobs(
-            original, mip, affected, state, adjustments, record_intent):
+            original, mip, affected, state, adjustments, record_intent,
+            defer_single_intent=True):
         chunk.append(job)
         if len(chunk) >= chunk_size:
             yield tuple(chunk)
@@ -910,10 +965,44 @@ def _iter_bc7_job_chunks(original, mip, affected, state, adjustments,
         yield tuple(chunk)
 
 
+def _recolor_bc7_single_intent(job):
+    """Decode, target, and recolor one compact single-intent job."""
+    try:
+        source_pixels = _bc7_codec.decode_block(job.source_block)
+    except _bc7_codec.BC7Error:
+        return _BC7BlockResult(
+            start=job.start, block=b"", source_error=0,
+            candidate_error=0, mode=0, source_kept=False,
+            error="The texture contains invalid BC7 data.",
+            error_code="invalid_bc7")
+    target_pixels = _bc7_single_adjustment_target_pixels(
+        source_pixels, job.adjustment, job.valid_width, job.valid_height)
+    try:
+        result = _bc7_codec.recolor_block(
+            job.source_block, target_pixels,
+            job.valid_width, job.valid_height, source_pixels)
+    except _bc7_codec.BC7Error as error:
+        return _BC7BlockResult(
+            start=job.start, block=b"", source_error=0,
+            candidate_error=0, mode=0, source_kept=False,
+            error=str(error))
+    return _BC7BlockResult(
+        start=job.start, block=result.block,
+        source_error=result.source_error,
+        candidate_error=result.candidate_error, mode=result.mode,
+        source_kept=result.block == job.source_block)
+
+
 def _recolor_bc7_chunk(jobs):
     """Fit one compact chunk in a spawned worker process."""
     results = []
     for job in jobs:
+        if isinstance(job, _BC7SingleIntentJob):
+            result = _recolor_bc7_single_intent(job)
+            results.append(result)
+            if result.error is not None:
+                break
+            continue
         try:
             result = _bc7_codec.recolor_block(
                 job.source_block, job.target_pixels,
@@ -936,7 +1025,8 @@ def _record_bc7_result(final, result, totals, modes, mip_stats):
     """Apply one worker result and update all parent-owned diagnostics."""
     if result.error is not None:
         raise TextureSaveError(
-            "texture_validation_failed", result.error)
+            getattr(result, "error_code", None)
+            or "texture_validation_failed", result.error)
     final[result.start:result.start + 16] = result.block
     totals["touched"] += 1
     totals["improved"] += result.candidate_error < result.source_error

--- a/src/tests/app/mods/test_texture_save.py
+++ b/src/tests/app/mods/test_texture_save.py
@@ -45,6 +45,80 @@ def _mode6_block(endpoints=((20, 110), (40, 140), (60, 170))):
     return bits.to_bytes(16, "little")
 
 
+def _color_mode_block(mode):
+    subsets = 3 if mode in {0, 2} else 2
+    partition_bits = 4 if mode == 0 else 6
+    endpoint_bits = {0: 4, 1: 6, 2: 5, 3: 7}[mode]
+    index_bits = 3 if mode in {0, 1} else 2
+    partition = 0 if mode == 0 else 13
+    endpoints = []
+    for endpoint in range(subsets * 2):
+        endpoints.append(tuple(
+            (8 + endpoint * 7 + channel * 5)
+            & ((1 << endpoint_bits) - 1)
+            for channel in range(3)))
+    bits = 1 << mode
+    bits = bc7.set_bits(bits, mode + 1, partition_bits, partition)
+    endpoint_start = mode + 1 + partition_bits
+    for channel in range(3):
+        for endpoint, values in enumerate(endpoints):
+            bits = bc7.set_bits(
+                bits,
+                endpoint_start
+                + channel * subsets * 2 * endpoint_bits
+                + endpoint * endpoint_bits,
+                endpoint_bits, values[channel])
+    if mode == 0:
+        pbits = tuple(endpoint & 1 for endpoint in range(subsets * 2))
+    elif mode == 1:
+        pbits = (0, 1)
+    elif mode == 3:
+        pbits = (0, 1, 1, 0)
+    else:
+        pbits = ()
+    pbit_start = endpoint_start + 3 * subsets * 2 * endpoint_bits
+    for index, pbit in enumerate(pbits):
+        bits = bc7.set_bits(bits, pbit_start + index, 1, pbit)
+    indices = [(index + mode) % (1 << index_bits) for index in range(16)]
+    anchors = bc7.anchors_for_partition(subsets, partition)
+    for anchor in anchors:
+        indices[anchor] = 1
+    index_start = pbit_start + len(pbits)
+    for pixel, index in enumerate(indices):
+        width = index_bits - (pixel in anchors)
+        bits = bc7.set_bits(bits, index_start, width, index)
+        index_start += width
+    assert index_start == 128
+    return bits.to_bytes(16, "little")
+
+
+def _mode5_block():
+    bits = 1 << 5
+    bits = bc7.set_bits(bits, 6, 2, 1)
+    start = 8
+    for channel, precision in enumerate((7, 7, 7, 8)):
+        for endpoint in range(2):
+            bits = bc7.set_bits(
+                bits, start, precision,
+                (channel * 7 + endpoint * 15 + 3)
+                & ((1 << precision) - 1))
+            start += precision
+    first = [0, 1, 2, 3] * 4
+    second = [0, 1, 2, 3] * 4
+    bits = bc7.set_bits(bits, start, 1, first[0])
+    start += 1
+    for value in first[1:]:
+        bits = bc7.set_bits(bits, start, 2, value)
+        start += 2
+    bits = bc7.set_bits(bits, start, 1, second[0])
+    start += 1
+    for value in second[1:]:
+        bits = bc7.set_bits(bits, start, 2, value)
+        start += 2
+    assert start == 128
+    return bits.to_bytes(16, "little")
+
+
 def _role_keys(diffuse="diffuse::body.dds"):
     return {
         "diffuse": diffuse,
@@ -549,6 +623,213 @@ def test_single_intent_partial_block_pads_valid_rgb_without_changing_alpha(
     for y in range(height):
         for x in range(width, 4):
             assert target[y * 4 + x] == source_pixels[y * 4 + x]
+
+
+@pytest.mark.parametrize(
+    "adjustment",
+    [
+        {"hue": 30},
+        {"saturation": 0.25},
+        {"brightness": 1.5},
+        {"contrast": 1.75},
+        {"red": 0.5},
+        {"green": 1.5},
+        {"blue": 2.0},
+        {"tint": "#4080c0"},
+        {
+            "hue": 30, "saturation": 0.5, "brightness": 1.5,
+            "contrast": 1.25, "red": 0.75, "green": 1.5,
+            "blue": 0.5, "tint": "#d08040",
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    ("valid_width", "valid_height"),
+    [(4, 4), (3, 4), (4, 3), (1, 2)],
+)
+def test_shared_single_intent_target_matches_parent_target(
+        adjustment, valid_width, valid_height):
+    source_block = _mode6_block()
+    source_pixels = bc7.decode_block(source_block)
+    prepared_adjustment = prepare_color_adjustment(adjustment)
+    state = _bc7_block_state(
+        valid_width, valid_height,
+        bytearray([1] * (valid_width * valid_height)),
+        (None, prepared_adjustment))
+    mip = SimpleNamespace(
+        width=valid_width, height=valid_height, units_x=1)
+
+    _source, expected, expected_width, expected_height = \
+        texture_save._bc7_target_block_pixels(
+            source_block, mip, 0, state, (None, prepared_adjustment))
+    actual = texture_save._bc7_single_adjustment_target_pixels(
+        source_pixels, prepared_adjustment, valid_width, valid_height)
+
+    assert (expected_width, expected_height) == \
+        (valid_width, valid_height)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("block", "valid_width", "valid_height"),
+    [
+        (_color_mode_block(3), 4, 4),
+        (_mode5_block(), 4, 4),
+        (_mode6_block(), 4, 4),
+        (_color_mode_block(3), 3, 2),
+        (_mode5_block(), 3, 2),
+        (_mode6_block(), 3, 2),
+    ],
+)
+def test_compact_single_intent_worker_matches_parent_prepared_worker(
+        block, valid_width, valid_height):
+    source = bytearray(block)
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16,
+        width=valid_width, height=valid_height, units_x=1)
+    adjustment = prepare_color_adjustment({"hue": 120, "brightness": 1.5})
+    state = _bc7_block_state(
+        valid_width, valid_height,
+        bytearray([1] * (valid_width * valid_height)),
+                             (None, adjustment))
+    block_intent = texture_save._bc7_block_intent_info(state, mip, 0)
+
+    legacy_job = texture_save._prepare_bc7_block_job(
+        source, mip, 0, state, (None, adjustment), block_intent)
+    compact_job = texture_save._prepare_bc7_single_intent_job(
+        source, mip, 0, (None, adjustment), block_intent)
+    legacy_result = texture_save._recolor_bc7_chunk((legacy_job,))[0]
+    compact_result = texture_save._recolor_bc7_chunk((compact_job,))[0]
+
+    assert isinstance(compact_job, texture_save._BC7SingleIntentJob)
+    assert compact_result == legacy_result
+
+
+def test_compact_single_intent_worker_decodes_once_and_preserves_source_pixels(
+        monkeypatch):
+    source_block = _mode6_block()
+    adjustment = prepare_color_adjustment({"brightness": 1.5})
+    job = texture_save._BC7SingleIntentJob(
+        start=16, source_block=source_block, adjustment=adjustment,
+        valid_width=3, valid_height=2)
+    real_decode = texture_save._bc7_codec.decode_block
+    decode_calls = []
+
+    def counting_decode(block):
+        decode_calls.append(block)
+        return real_decode(block)
+
+    monkeypatch.setattr(
+        texture_save._bc7_codec, "decode_block", counting_decode)
+    result = texture_save._recolor_bc7_chunk((job,))[0]
+
+    assert len(decode_calls) == 1
+    assert result.error is None
+    assert result.start == 16
+    assert result.mode == 6
+
+
+@pytest.mark.parametrize(
+    ("claims", "level", "expected_kind"),
+    [
+        (bytearray([1] * 16), 0, "compact"),
+        (bytearray([1] * 15 + [2]), 0, "legacy"),
+        (bytearray([0] * 16), 0, "legacy"),
+        (None, 1, "legacy"),
+    ],
+)
+def test_parallel_job_selection_only_defers_mip0_single_intent(
+        claims, level, expected_kind, monkeypatch):
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16, width=4, height=4, units_x=1)
+    adjustment = prepare_color_adjustment({"hue": 30})
+    if level == 0:
+        state = _bc7_block_state(
+            4, 4, claims, (None, adjustment, adjustment))
+    else:
+        state = {
+            "level": 1, "single": True,
+            "changed_counts": [1] * 16,
+            "total_counts": [1] * 16,
+        }
+    selected = []
+    monkeypatch.setattr(
+        texture_save, "_prepare_bc7_single_intent_job",
+        lambda *args: selected.append("compact") or "compact")
+    monkeypatch.setattr(
+        texture_save, "_prepare_bc7_block_job",
+        lambda *args: selected.append("legacy") or "legacy")
+
+    jobs = list(texture_save._iter_bc7_jobs(
+        b"", mip, (0,), state, (None, adjustment), lambda _intent: None,
+        defer_single_intent=True))
+
+    assert jobs == [expected_kind]
+    assert selected == [expected_kind]
+
+
+def test_worker_chunk_accepts_compact_and_parent_prepared_jobs_in_order():
+    source_block = _mode6_block()
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16, width=4, height=4, units_x=1)
+    adjustment = prepare_color_adjustment({"hue": 30})
+    state = _bc7_block_state(4, 4, bytearray([1] * 16),
+                             (None, adjustment))
+    block_intent = texture_save._bc7_block_intent_info(state, mip, 0)
+    compact_job = texture_save._prepare_bc7_single_intent_job(
+        bytearray(source_block), mip, 0, (None, adjustment), block_intent)
+    legacy_job = texture_save._prepare_bc7_block_job(
+        bytearray(source_block), mip, 0, state, (None, adjustment),
+        block_intent)
+    legacy_job = texture_save._BC7BlockJob(
+        start=16, source_block=legacy_job.source_block,
+        source_pixels=legacy_job.source_pixels,
+        target_pixels=legacy_job.target_pixels,
+        valid_width=legacy_job.valid_width,
+        valid_height=legacy_job.valid_height)
+
+    results = texture_save._recolor_bc7_chunk((compact_job, legacy_job))
+
+    assert [result.start for result in results] == [0, 16]
+    assert results[0].block == results[1].block
+    assert results[0].source_error == results[1].source_error
+    assert results[0].candidate_error == results[1].candidate_error
+
+
+def test_invalid_bc7_has_the_same_save_error_in_serial_and_parallel_paths(
+        tmp_path, monkeypatch):
+    source = tmp_path / "body.dds"
+    source.write_bytes(_dx10_dds(bytes(16)))
+    layout = inspect_dds_layout(source)
+    prepared = SimpleNamespace(
+        selected_path=str(source), info=layout.info, layout=layout,
+        mip0_claims=bytearray([1] * 16),
+        intent_adjustments=(None, prepare_color_adjustment({"hue": 30})),
+        mip0_affected_blocks=(0,),
+    )
+
+    with pytest.raises(texture_save.TextureSaveError) as serial:
+        texture_save._save_bc7_blocks(source.read_bytes(), prepared)
+
+    class InlineExecutor:
+        def submit(self, function, argument):
+            future = Future()
+            future.set_result(function(argument))
+            return future
+
+        def shutdown(self, **_kwargs):
+            pass
+
+    monkeypatch.setattr(
+        texture_save, "ProcessPoolExecutor", lambda **_kwargs: InlineExecutor())
+    monkeypatch.setattr(texture_save, "_BC7_PARALLEL_THRESHOLD", 0)
+
+    with pytest.raises(texture_save.TextureSaveError) as parallel:
+        texture_save._save_bc7_blocks(source.read_bytes(), prepared)
+
+    assert serial.value.code == parallel.value.code == "invalid_bc7"
+    assert serial.value.message == parallel.value.message == \
+        "The texture contains invalid BC7 data."
 
 
 def test_multi_intent_block_keeps_per_pixel_logical_targets_and_no_padding():


### PR DESCRIPTION
## Summary\n\n- Add compact mip-0 jobs for blocks with one explicit Color intent, moving source decode and direct target generation into the worker.\n- Keep classification, diagnostics, result application, progress reporting, validation, and lower-mip or multi-intent fallback behavior in the parent.\n- Preserve serial reference behavior and invalid-BC7 error parity.\n\n## Tests\n\n- python -m pytest -q