### PR TITLE
Move single-adjustment lower-mip BC7 preparation into workers

### DIFF
--- a/src/app/mods/texture_save.py
+++ b/src/app/mods/texture_save.py
@@ -141,6 +141,19 @@ class _BC7SingleIntentJob:
 
 
 @dataclass(frozen=True)
+class _BC7WeightedSingleIntentJob:
+    """Compact lower-mip job with worker-prepared weighted intent."""
+
+    start: int
+    source_block: bytes
+    adjustment: PreparedColorAdjustment
+    changed_counts: tuple
+    total_counts: tuple
+    valid_width: int
+    valid_height: int
+
+
+@dataclass(frozen=True)
 class _BC7BlockResult:
     """Compact worker result applied by the parent save operation."""
 
@@ -707,6 +720,24 @@ def _bc7_affected_blocks(changed, width, height, mip):
     return sorted(affected)
 
 
+def _bc7_weighted_single_rgb(
+        source_rgb, adjustment, changed_count, total_count):
+    """Resolve one RGB value from one lower-mip adjustment weight."""
+    if changed_count > total_count:
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Changed color intent exceeds total mip weight.")
+    if not changed_count or not total_count:
+        return source_rgb
+    base = tuple(channel / 255.0 for channel in source_rgb)
+    adjusted = apply_prepared_color_adjustment(base, adjustment)
+    return tuple(min(255, max(0, round(value * 255.0)))
+                  for value in (
+                      (base[channel] * (total_count - changed_count)
+                       + adjusted[channel] * changed_count) / total_count
+                      for channel in range(3)))
+
+
 def _bc7_intent_rgb(source_rgb, state, pixel, adjustments):
     """Resolve one target RGB value from the current mip's intent state."""
     base = tuple(channel / 255.0 for channel in source_rgb)
@@ -723,20 +754,9 @@ def _bc7_intent_rgb(source_rgb, state, pixel, adjustments):
             source_rgb, adjustments[intent_class])
 
     if state["single"]:
-        changed_count = state["changed_counts"][pixel]
-        total_count = state["total_counts"][pixel]
-        if changed_count > total_count:
-            raise TextureSaveError(
-                "texture_validation_failed",
-                "Changed color intent exceeds total mip weight.")
-        if not changed_count or not total_count:
-            return source_rgb
-        adjusted = apply_prepared_color_adjustment(base, adjustments[1])
-        return tuple(min(255, max(0, round(value * 255.0)))
-                      for value in (
-                          (base[channel] * (total_count - changed_count)
-                           + adjusted[channel] * changed_count) / total_count
-                          for channel in range(3)))
+        return _bc7_weighted_single_rgb(
+            source_rgb, adjustments[1], state["changed_counts"][pixel],
+            state["total_counts"][pixel])
 
     counts = [count[pixel] for count in state["counts"]]
     total_count = sum(counts)
@@ -856,6 +876,35 @@ def _bc7_single_adjustment_target_pixels(
     return tuple(target_pixels)
 
 
+def _bc7_weighted_single_target_pixels(
+        source_pixels, adjustment, changed_counts, total_counts,
+        valid_width, valid_height):
+    """Apply weighted intent while preserving alpha and block padding."""
+    expected = valid_width * valid_height
+    try:
+        changed_length = len(changed_counts)
+        total_length = len(total_counts)
+    except TypeError as error:
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Weighted BC7 job counts do not match the valid block area.") \
+            from error
+    if (changed_length != expected or total_length != expected):
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Weighted BC7 job counts do not match the valid block area.")
+    target_pixels = list(source_pixels)
+    for row in range(valid_height):
+        for column in range(valid_width):
+            index = row * valid_width + column
+            local = row * 4 + column
+            rgb = _bc7_weighted_single_rgb(
+                source_pixels[local][:3], adjustment,
+                changed_counts[index], total_counts[index])
+            target_pixels[local] = rgb + (source_pixels[local][3],)
+    return tuple(target_pixels)
+
+
 def _bc7_target_block_pixels(source_block, mip, block_index, state,
                              adjustments, block_intent=None):
     """Build one sixteen-pixel BC7 target without a reconstructed image."""
@@ -934,6 +983,68 @@ def _prepare_bc7_single_intent_job(
         valid_width=valid_width, valid_height=valid_height)
 
 
+def _bc7_single_weighted_block_counts(state, mip, block_index):
+    """Extract valid lower-mip weights for one worker job."""
+    if (state.get("level", 0) <= 0 or not state.get("single")
+            or state.get("width") != mip.width
+            or state.get("height") != mip.height):
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Lower-mip BC7 weighted intent state is invalid.")
+    changed = state.get("changed_counts")
+    total = state.get("total_counts")
+    expected_state_size = mip.width * mip.height
+    if (changed is None or total is None
+            or len(changed) != expected_state_size
+            or len(total) != expected_state_size):
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Lower-mip color intent does not match the source texture size.")
+    source_x, source_y, valid_width, valid_height = _unit_bounds(
+        mip, block_index)
+    changed_counts = []
+    total_counts = []
+    for row in range(valid_height):
+        start = (source_y + row) * mip.width + source_x
+        end = start + valid_width
+        changed_counts.extend(int(value) for value in changed[start:end])
+        total_counts.extend(int(value) for value in total[start:end])
+    return (tuple(changed_counts), tuple(total_counts),
+            valid_width, valid_height)
+
+
+def _prepare_bc7_weighted_single_intent_job(
+        original, mip, block_index, state, adjustments, block_intent):
+    """Prepare a compact lower-mip job with worker-side target generation."""
+    start, source_block, valid_width, valid_height = (
+        _bc7_source_block_and_bounds(original, mip, block_index))
+    changed_counts, total_counts, valid_width, valid_height = (
+        _bc7_single_weighted_block_counts(state, mip, block_index))
+    return _BC7WeightedSingleIntentJob(
+        start=start, source_block=source_block,
+        adjustment=adjustments[1], changed_counts=changed_counts,
+        total_counts=total_counts, valid_width=valid_width,
+        valid_height=valid_height)
+
+
+def _prepare_bc7_parallel_job(
+        original, mip, block_index, state, adjustments, block_intent):
+    """Choose the smallest safe worker input for one BC7 block."""
+    if state.get("level") == 0 and len(block_intent.classes) == 1:
+        return _prepare_bc7_single_intent_job(
+            original, mip, block_index, adjustments, block_intent)
+    if (state.get("level", 0) > 0 and state.get("single")
+            and state.get("width") == mip.width
+            and state.get("height") == mip.height
+            and state.get("changed_counts") is not None
+            and state.get("total_counts") is not None
+            and block_intent.classes == (1,)):
+        return _prepare_bc7_weighted_single_intent_job(
+            original, mip, block_index, state, adjustments, block_intent)
+    return _prepare_bc7_block_job(
+        original, mip, block_index, state, adjustments, block_intent)
+
+
 def _iter_bc7_jobs(original, mip, affected, state, adjustments,
                     record_intent, defer_single_intent=False):
     """Yield parent-prepared BC7 jobs while recording intent diagnostics."""
@@ -941,10 +1052,9 @@ def _iter_bc7_jobs(original, mip, affected, state, adjustments,
         block_intent = _bc7_block_intent_info(
             state, mip, block_index)
         record_intent(block_intent)
-        if (defer_single_intent and state["level"] == 0
-                and len(block_intent.classes) == 1):
-            yield _prepare_bc7_single_intent_job(
-                original, mip, block_index, adjustments, block_intent)
+        if defer_single_intent:
+            yield _prepare_bc7_parallel_job(
+                original, mip, block_index, state, adjustments, block_intent)
         else:
             yield _prepare_bc7_block_job(
                 original, mip, block_index, state, adjustments, block_intent)
@@ -993,12 +1103,53 @@ def _recolor_bc7_single_intent(job):
         source_kept=result.block == job.source_block)
 
 
+def _recolor_bc7_weighted_single_intent(job):
+    """Decode, target, and recolor one weighted lower-mip job."""
+    try:
+        source_pixels = _bc7_codec.decode_block(job.source_block)
+    except _bc7_codec.BC7Error:
+        return _BC7BlockResult(
+            start=job.start, block=b"", source_error=0,
+            candidate_error=0, mode=0, source_kept=False,
+            error="The texture contains invalid BC7 data.",
+            error_code="invalid_bc7")
+    try:
+        target_pixels = _bc7_weighted_single_target_pixels(
+            source_pixels, job.adjustment, job.changed_counts,
+            job.total_counts, job.valid_width, job.valid_height)
+    except TextureSaveError as error:
+        return _BC7BlockResult(
+            start=job.start, block=b"", source_error=0,
+            candidate_error=0, mode=0, source_kept=False,
+            error=error.message, error_code=error.code)
+    try:
+        result = _bc7_codec.recolor_block(
+            job.source_block, target_pixels,
+            job.valid_width, job.valid_height, source_pixels)
+    except _bc7_codec.BC7Error as error:
+        return _BC7BlockResult(
+            start=job.start, block=b"", source_error=0,
+            candidate_error=0, mode=0, source_kept=False,
+            error=str(error))
+    return _BC7BlockResult(
+        start=job.start, block=result.block,
+        source_error=result.source_error,
+        candidate_error=result.candidate_error, mode=result.mode,
+        source_kept=result.block == job.source_block)
+
+
 def _recolor_bc7_chunk(jobs):
     """Fit one compact chunk in a spawned worker process."""
     results = []
     for job in jobs:
         if isinstance(job, _BC7SingleIntentJob):
             result = _recolor_bc7_single_intent(job)
+            results.append(result)
+            if result.error is not None:
+                break
+            continue
+        if isinstance(job, _BC7WeightedSingleIntentJob):
+            result = _recolor_bc7_weighted_single_intent(job)
             results.append(result)
             if result.error is not None:
                 break

--- a/src/tests/app/mods/test_texture_save.py
+++ b/src/tests/app/mods/test_texture_save.py
@@ -119,6 +119,68 @@ def _mode5_block():
     return bits.to_bytes(16, "little")
 
 
+def _separate_block(mode, rotation=1):
+    bits = 1 << mode
+    start = mode + 1
+    bits = bc7.set_bits(bits, start, 2, rotation)
+    start += 2
+    index_mode = 1 if mode == 4 and rotation % 2 else 0
+    if mode == 4:
+        bits = bc7.set_bits(bits, start, 1, index_mode)
+        start += 1
+    precisions = (5, 5, 5, 6) if mode == 4 else (7, 7, 7, 8)
+    for channel, precision in enumerate(precisions):
+        for endpoint in range(2):
+            bits = bc7.set_bits(
+                bits, start, precision,
+                (channel * 7 + endpoint * 15 + 3)
+                & ((1 << precision) - 1))
+            start += precision
+    first = [0, 1, 2, 3] * 4
+    second = ([0, 1, 2, 3, 4, 5, 6, 7] * 2
+              if mode == 4 else [0, 1, 2, 3] * 4)
+    bits = bc7.set_bits(bits, start, 1, first[0])
+    start += 1
+    for value in first[1:]:
+        bits = bc7.set_bits(bits, start, 2, value)
+        start += 2
+    second_precision = 3 if mode == 4 else 2
+    bits = bc7.set_bits(bits, start, second_precision - 1, second[0])
+    start += second_precision - 1
+    for value in second[1:]:
+        bits = bc7.set_bits(bits, start, second_precision, value)
+        start += second_precision
+    assert start == 128
+    return bits.to_bytes(16, "little")
+
+
+def _mode7_block():
+    partition = 13
+    anchor = bc7._PARTITION_2_ANCHORS[partition]
+    bits = bc7.set_bits(1 << 7, 8, 6, partition)
+    endpoints = (
+        (3, 6, 9, 4), (22, 18, 25, 30),
+        (8, 15, 5, 20), (28, 26, 30, 31),
+    )
+    start = 14
+    for channel in range(4):
+        for endpoint in endpoints:
+            bits = bc7.set_bits(bits, start, 5, endpoint[channel])
+            start += 5
+    for pbit in (0, 1, 1, 0):
+        bits = bc7.set_bits(bits, start, 1, pbit)
+        start += 1
+    indices = [0, 1, 2, 3] * 4
+    indices[0] = 0
+    indices[anchor] = 1
+    for pixel, index in enumerate(indices):
+        width = 1 if pixel in {0, anchor} else 2
+        bits = bc7.set_bits(bits, start, width, index)
+        start += width
+    assert start == 128
+    return bits.to_bytes(16, "little")
+
+
 def _role_keys(diffuse="diffuse::body.dds"):
     return {
         "diffuse": diffuse,
@@ -561,6 +623,18 @@ def _bc7_block_state(width, height, claims, adjustments=None):
     return texture_save._bc7_intent_level(prepared)
 
 
+def _bc7_lower_single_state(
+        width, height, changed_counts, total_counts, level=1):
+    return {
+        "level": level,
+        "width": width,
+        "height": height,
+        "single": True,
+        "changed_counts": changed_counts,
+        "total_counts": total_counts,
+    }
+
+
 def test_bc7_block_intent_classes_only_report_explicit_mip0_claims():
     claims = bytearray([0] * 16)
     claims[5] = 1
@@ -671,6 +745,162 @@ def test_shared_single_intent_target_matches_parent_target(
 
 
 @pytest.mark.parametrize(
+    "counts",
+    [(0, 1), (1, 1), (1, 2), (3, 4), (7, 16), (31, 64),
+     (255, 1024), (1023, 4096)],
+)
+@pytest.mark.parametrize(
+    "adjustment",
+    [
+        {"hue": 30},
+        {"saturation": 0.25},
+        {"brightness": 1.5},
+        {"contrast": 1.75},
+        {"red": 0.5, "green": 1.5, "blue": 2.0},
+        {"tint": "#4080c0"},
+        {
+            "hue": 30, "saturation": 0.5, "brightness": 1.5,
+            "contrast": 1.25,
+        },
+        {
+            "hue": 30, "saturation": 0.5, "brightness": 1.5,
+            "contrast": 1.25, "red": 0.75, "green": 1.5,
+            "blue": 0.5, "tint": "#d08040",
+        },
+    ],
+)
+def test_weighted_single_rgb_matches_exact_reference_matrix(
+        counts, adjustment):
+    source_rgb = (37, 101, 203)
+    changed_count, total_count = counts
+    prepared_adjustment = prepare_color_adjustment(adjustment)
+    actual = texture_save._bc7_weighted_single_rgb(
+        source_rgb, prepared_adjustment, changed_count, total_count)
+
+    if not changed_count or not total_count:
+        expected = source_rgb
+    else:
+        base = tuple(channel / 255.0 for channel in source_rgb)
+        adjusted = apply_prepared_color_adjustment(base, prepared_adjustment)
+        expected = tuple(min(255, max(0, round(value * 255.0)))
+                         for value in (
+                             (base[channel] * (total_count - changed_count)
+                              + adjusted[channel] * changed_count)
+                             / total_count
+                             for channel in range(3)))
+    assert actual == expected
+
+
+def test_weighted_single_target_validates_count_parity_and_preserves_padding():
+    source_pixels = bc7.decode_block(_mode6_block())
+    adjustment = prepare_color_adjustment({"brightness": 1.5})
+
+    with pytest.raises(texture_save.TextureSaveError) as raised:
+        texture_save._bc7_weighted_single_target_pixels(
+            source_pixels, adjustment, (1, 2), (1,), 1, 1)
+    assert raised.value.code == "texture_validation_failed"
+
+    target = texture_save._bc7_weighted_single_target_pixels(
+        source_pixels, adjustment, (0, 1), (1, 1), 1, 2)
+    assert target[0] == source_pixels[0]
+    assert target[4][:3] != source_pixels[4][:3]
+    assert target[4][3] == source_pixels[4][3]
+    for local in range(16):
+        if local not in {0, 4}:
+            assert target[local] == source_pixels[local]
+
+
+def test_weighted_single_rgb_keeps_source_for_zero_total_weight():
+    adjustment = prepare_color_adjustment({"tint": "#ffdd00"})
+    assert texture_save._bc7_weighted_single_rgb(
+        (37, 101, 203), adjustment, 0, 0) == (37, 101, 203)
+
+
+def test_weighted_single_full_weights_do_not_use_mip0_shortcut(monkeypatch):
+    source_block = _mode6_block()
+    source_pixels = bc7.decode_block(source_block)
+    adjustment = prepare_color_adjustment({"hue": 120})
+    job = texture_save._BC7WeightedSingleIntentJob(
+        start=0, source_block=source_block, adjustment=adjustment,
+        changed_counts=(1,) * 16, total_counts=(1,) * 16,
+        valid_width=4, valid_height=4)
+
+    def unexpected_shortcut(*_args, **_kwargs):
+        raise AssertionError("weighted jobs must not use the mip-0 shortcut")
+
+    monkeypatch.setattr(
+        texture_save, "_bc7_single_adjustment_target_pixels",
+        unexpected_shortcut)
+    real_decode = texture_save._bc7_codec.decode_block
+    decode_calls = []
+
+    def counting_decode(block):
+        decode_calls.append(block)
+        return real_decode(block)
+
+    monkeypatch.setattr(
+        texture_save._bc7_codec, "decode_block", counting_decode)
+    result = texture_save._recolor_bc7_chunk((job,))[0]
+
+    assert result.error is None
+    assert result.mode == 6
+    assert len(decode_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("block", "valid_width", "valid_height"),
+    [
+        (_separate_block(4), 4, 4),
+        (_mode5_block(), 4, 4),
+        (_mode6_block(), 4, 4),
+        (_mode7_block(), 4, 4),
+        (_separate_block(4), 3, 2),
+        (_mode5_block(), 3, 2),
+        (_mode6_block(), 3, 2),
+        (_mode7_block(), 3, 2),
+        (_separate_block(4), 1, 1),
+        (_mode5_block(), 1, 1),
+        (_mode6_block(), 1, 1),
+        (_mode7_block(), 1, 1),
+    ],
+)
+def test_weighted_single_worker_matches_parent_prepared_worker(
+        block, valid_width, valid_height):
+    source = bytearray(block)
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16,
+        width=valid_width, height=valid_height, units_x=1)
+    adjustment = prepare_color_adjustment({"hue": 120, "brightness": 1.5})
+    area = valid_width * valid_height
+    state = _bc7_lower_single_state(
+        valid_width, valid_height, (1,) * area, (2,) * area)
+    block_intent = texture_save._bc7_block_intent_info(state, mip, 0)
+
+    legacy_job = texture_save._prepare_bc7_block_job(
+        source, mip, 0, state, (None, adjustment), block_intent)
+    weighted_job = texture_save._prepare_bc7_weighted_single_intent_job(
+        source, mip, 0, state, (None, adjustment), block_intent)
+    legacy_result = texture_save._recolor_bc7_chunk((legacy_job,))[0]
+    weighted_result = texture_save._recolor_bc7_chunk((weighted_job,))[0]
+
+    assert isinstance(weighted_job, texture_save._BC7WeightedSingleIntentJob)
+    assert weighted_result == legacy_result
+
+
+def test_weighted_single_worker_reports_validation_errors():
+    job = texture_save._BC7WeightedSingleIntentJob(
+        start=0, source_block=_mode6_block(),
+        adjustment=prepare_color_adjustment({"hue": 30}),
+        changed_counts=(2,), total_counts=(1,),
+        valid_width=1, valid_height=1)
+
+    result = texture_save._recolor_bc7_chunk((job,))[0]
+
+    assert result.error_code == "texture_validation_failed"
+    assert result.error == "Changed color intent exceeds total mip weight."
+
+
+@pytest.mark.parametrize(
     ("block", "valid_width", "valid_height"),
     [
         (_color_mode_block(3), 4, 4),
@@ -735,10 +965,10 @@ def test_compact_single_intent_worker_decodes_once_and_preserves_source_pixels(
         (bytearray([1] * 16), 0, "compact"),
         (bytearray([1] * 15 + [2]), 0, "legacy"),
         (bytearray([0] * 16), 0, "legacy"),
-        (None, 1, "legacy"),
+        (None, 1, "weighted"),
     ],
 )
-def test_parallel_job_selection_only_defers_mip0_single_intent(
+def test_parallel_job_selection_chooses_compact_single_intent_paths(
         claims, level, expected_kind, monkeypatch):
     mip = SimpleNamespace(
         offset=0, bytes_per_unit=16, width=4, height=4, units_x=1)
@@ -749,6 +979,7 @@ def test_parallel_job_selection_only_defers_mip0_single_intent(
     else:
         state = {
             "level": 1, "single": True,
+            "width": 4, "height": 4,
             "changed_counts": [1] * 16,
             "total_counts": [1] * 16,
         }
@@ -756,6 +987,9 @@ def test_parallel_job_selection_only_defers_mip0_single_intent(
     monkeypatch.setattr(
         texture_save, "_prepare_bc7_single_intent_job",
         lambda *args: selected.append("compact") or "compact")
+    monkeypatch.setattr(
+        texture_save, "_prepare_bc7_weighted_single_intent_job",
+        lambda *args: selected.append("weighted") or "weighted")
     monkeypatch.setattr(
         texture_save, "_prepare_bc7_block_job",
         lambda *args: selected.append("legacy") or "legacy")
@@ -768,6 +1002,32 @@ def test_parallel_job_selection_only_defers_mip0_single_intent(
     assert selected == [expected_kind]
 
 
+def test_parallel_lower_mip_multi_intent_keeps_parent_prepared_job(
+        monkeypatch):
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16, width=4, height=4, units_x=1)
+    adjustment = prepare_color_adjustment({"hue": 30})
+    state = {
+        "level": 1, "width": 4, "height": 4, "single": False,
+        "counts": ([0] * 16, [1] * 16, [0] * 16),
+    }
+    selected = []
+    monkeypatch.setattr(
+        texture_save, "_prepare_bc7_weighted_single_intent_job",
+        lambda *args: selected.append("weighted") or "weighted")
+    monkeypatch.setattr(
+        texture_save, "_prepare_bc7_block_job",
+        lambda *args: selected.append("legacy") or "legacy")
+
+    jobs = list(texture_save._iter_bc7_jobs(
+        b"", mip, (0,), state,
+        (None, adjustment, adjustment), lambda _intent: None,
+        defer_single_intent=True))
+
+    assert jobs == ["legacy"]
+    assert selected == ["legacy"]
+
+
 def test_worker_chunk_accepts_compact_and_parent_prepared_jobs_in_order():
     source_block = _mode6_block()
     mip = SimpleNamespace(
@@ -778,22 +1038,30 @@ def test_worker_chunk_accepts_compact_and_parent_prepared_jobs_in_order():
     block_intent = texture_save._bc7_block_intent_info(state, mip, 0)
     compact_job = texture_save._prepare_bc7_single_intent_job(
         bytearray(source_block), mip, 0, (None, adjustment), block_intent)
+    weighted_job = texture_save._BC7WeightedSingleIntentJob(
+        start=16, source_block=source_block, adjustment=adjustment,
+        changed_counts=(1,) * 16, total_counts=(1,) * 16,
+        valid_width=4, valid_height=4)
     legacy_job = texture_save._prepare_bc7_block_job(
         bytearray(source_block), mip, 0, state, (None, adjustment),
         block_intent)
     legacy_job = texture_save._BC7BlockJob(
-        start=16, source_block=legacy_job.source_block,
+        start=32, source_block=legacy_job.source_block,
         source_pixels=legacy_job.source_pixels,
         target_pixels=legacy_job.target_pixels,
         valid_width=legacy_job.valid_width,
         valid_height=legacy_job.valid_height)
 
-    results = texture_save._recolor_bc7_chunk((compact_job, legacy_job))
+    results = texture_save._recolor_bc7_chunk(
+        (compact_job, weighted_job, legacy_job))
 
-    assert [result.start for result in results] == [0, 16]
+    assert [result.start for result in results] == [0, 16, 32]
     assert results[0].block == results[1].block
-    assert results[0].source_error == results[1].source_error
-    assert results[0].candidate_error == results[1].candidate_error
+    assert results[1].block == results[2].block
+    assert results[0].source_error == results[1].source_error == \
+        results[2].source_error
+    assert results[0].candidate_error == results[1].candidate_error == \
+        results[2].candidate_error
 
 
 def test_invalid_bc7_has_the_same_save_error_in_serial_and_parallel_paths(
@@ -974,6 +1242,59 @@ def test_parallel_bc7_save_matches_serial_bytes_and_stats(tmp_path, monkeypatch)
             list(range(8))
         assert processing[-1]["completed_blocks"] == \
             processing[-1]["total_blocks"]
+
+
+def test_parallel_bc7_multi_mip_weighted_jobs_match_serial_results(
+        tmp_path, monkeypatch):
+    blocks = _mode6_block() * 3
+    original = _dx10_dds(blocks, width=4, height=4, mip_count=3)
+    source = tmp_path / "body.dds"
+    source.write_bytes(original)
+    layout = inspect_dds_layout(source)
+    prepared = SimpleNamespace(
+        selected_path="body.dds", info=layout.info, layout=layout,
+        mip0_claims=bytearray([1] * 16),
+        intent_adjustments=(None, prepare_color_adjustment({"hue": 120})),
+        mip0_affected_blocks=(0,))
+    monkeypatch.setattr(texture_save, "_bc7_worker_count", lambda: 2)
+    monkeypatch.setattr(texture_save, "_BC7_CHUNK_SIZE", 2)
+    monkeypatch.setattr(texture_save, "_SAVE_PROGRESS_INTERVAL", 0)
+
+    class InlineExecutor:
+        def submit(self, function, argument):
+            future = Future()
+            future.set_result(function(argument))
+            return future
+
+        def shutdown(self, **_kwargs):
+            pass
+
+    monkeypatch.setattr(
+        texture_save, "ProcessPoolExecutor", lambda **_kwargs: InlineExecutor())
+    serial_events = []
+    monkeypatch.setattr(texture_save, "_BC7_PARALLEL_THRESHOLD", 10000)
+    serial_bytes, serial_stats = texture_save._save_bc7_blocks(
+        original, prepared,
+        progress_reporter=texture_save._SaveProgressReporter(
+            serial_events.append))
+
+    parallel_events = []
+    monkeypatch.setattr(texture_save, "_BC7_PARALLEL_THRESHOLD", 0)
+    parallel_bytes, parallel_stats = texture_save._save_bc7_blocks(
+        original, prepared,
+        progress_reporter=texture_save._SaveProgressReporter(
+            parallel_events.append))
+
+    assert parallel_bytes == serial_bytes
+    assert parallel_stats == serial_stats
+    for events in (serial_events, parallel_events):
+        processing = [event for event in events
+                      if event["stage"] == "processing"]
+        assert [(event["mip"], event["completed_blocks"])
+                for event in processing if event["completed_blocks"]]
+        assert [event["mip"] for event in processing
+                if event["completed_blocks"] == event["total_blocks"]] == [
+                    0, 1, 2]
 
 
 def test_bc7_result_application_uses_block_offsets():


### PR DESCRIPTION
## Summary

- Move single-adjustment lower-mip BC7 target generation into a compact worker job.
- Keep parent-owned intent state, serial fallback, BC7 mode handling, diagnostics, progress, and stable worker errors.
- Add weighted RGB parity, edge-block, mode, selection, mixed-chunk, and multi-mip serial/parallel regression coverage.

## Validation

- python -m pytest -q
- python -m py_compile src/app/mods/texture_save.py
- python src/build.py --onedir --skip-deps
- python src/build.py --skip-deps