### PR TITLE
Make Save to Texture completion race-safe

### DIFF
--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -26,6 +26,79 @@ from app.runtime import server
 from app.session import edit as edit_session
 
 
+def _unique_strings(values):
+    return list(dict.fromkeys(value for value in values
+                              if isinstance(value, str) and value))
+
+
+def _clear_committed_color_adjustments(folder_path, targets, saved_meshes):
+    """Compare only committed targets before clearing their metadata."""
+    captured = {}
+    for target in targets if isinstance(targets, list) else []:
+        if not isinstance(target, dict):
+            continue
+        semantic_key = target.get("semantic_key")
+        metadata_key = target.get("metadata_key")
+        if (isinstance(semantic_key, str) and semantic_key
+                and isinstance(metadata_key, str) and metadata_key):
+            captured.setdefault((semantic_key, metadata_key), []).append(target)
+
+    expected = {}
+    failed = []
+    invalid_saved_identity = False
+    for saved in saved_meshes if isinstance(saved_meshes, list) else []:
+        if not isinstance(saved, dict):
+            invalid_saved_identity = True
+            continue
+        semantic_key = saved.get("semantic_key")
+        metadata_key = saved.get("metadata_key")
+        if not (isinstance(semantic_key, str) and semantic_key
+                and isinstance(metadata_key, str) and metadata_key):
+            invalid_saved_identity = True
+            if isinstance(metadata_key, str) and metadata_key:
+                failed.append(metadata_key)
+            continue
+        if metadata_key in failed:
+            continue
+        candidates = captured.get((semantic_key, metadata_key), [])
+        if len(candidates) != 1:
+            failed.append(metadata_key)
+            continue
+        if metadata_key in expected:
+            expected.pop(metadata_key, None)
+            failed.append(metadata_key)
+            continue
+        expected[metadata_key] = candidates[0].get("adjustment")
+
+    receipt = {"cleared": [], "preserved": [], "failed": failed}
+    helper_failed = False
+    if expected:
+        try:
+            reset = metadata.clear_mesh_color_adjustments_if_unchanged(
+                folder_path, expected)
+        except Exception:
+            reset = None
+            helper_failed = True
+        if not isinstance(reset, dict):
+            helper_failed = True
+        else:
+            for status in ("cleared", "preserved", "failed"):
+                receipt[status].extend(reset.get(status, []))
+            if reset.get("error") and not reset.get("failed"):
+                helper_failed = True
+
+        if helper_failed:
+            receipt["cleared"] = [
+                key for key in receipt["cleared"] if key not in expected]
+            receipt["preserved"] = [
+                key for key in receipt["preserved"] if key not in expected]
+            receipt["failed"].extend(expected)
+
+    for status in receipt:
+        receipt[status] = _unique_strings(receipt[status])
+    return receipt, invalid_saved_identity or helper_failed
+
+
 class ModPreview:
     def __init__(self, access):
         self._access = access
@@ -167,17 +240,10 @@ class ModPreview:
                 context, overrides, self._active_mesh_keys.get(folder_path),
                 tex_key, targets, texture_usage, **save_kwargs)
             if result.get("status") == "ok":
-                keys = [
-                    item.get("metadata_key")
-                    for item in (result.get("saved_meshes") or [])
-                    if isinstance(item, dict)
-                ]
-                try:
-                    cleared = metadata.clear_mesh_color_adjustments(
-                        folder_path, keys)
-                    if cleared.get("error"):
-                        result["warning"] = "color_state_reset_failed"
-                except Exception:
+                receipt, cleanup_failed = _clear_committed_color_adjustments(
+                    folder_path, targets, result.get("saved_meshes"))
+                result["metadata_reset"] = receipt
+                if cleanup_failed or receipt["failed"]:
                     result["warning"] = "color_state_reset_failed"
             return result
         except Exception:

--- a/src/app/mods/metadata.py
+++ b/src/app/mods/metadata.py
@@ -172,6 +172,77 @@ def clear_mesh_color_adjustments(folder_path, mesh_keys):
         return _save(folder_path, data)
 
 
+def clear_mesh_color_adjustments_if_unchanged(
+        folder_path, expected_adjustments):
+    """Remove only color states that still match the completed save request."""
+    result = {"cleared": [], "preserved": [], "failed": [], "saved": False}
+    if not isinstance(expected_adjustments, dict):
+        result["error"] = "Invalid expected mesh color adjustments."
+        return result
+
+    expected = {}
+    invalid_input = False
+    for mesh_key, adjustment in expected_adjustments.items():
+        if not isinstance(mesh_key, str) or not mesh_key:
+            invalid_input = True
+            continue
+        normalized = _normalize_mesh_color_adjustment(
+            adjustment, reject_invalid=True)
+        if normalized is None:
+            result["failed"].append(mesh_key)
+            invalid_input = True
+        else:
+            expected[mesh_key] = normalized
+    if invalid_input:
+        result["failed"] = [
+            key for key in expected_adjustments
+            if isinstance(key, str) and key]
+        result["error"] = "Invalid expected mesh color adjustment."
+        return result
+
+    with _LOCK:
+        data = load(folder_path)
+        raw_adjustments = data.get(MESH_COLOR_ADJUSTMENTS_KEY)
+        if not isinstance(raw_adjustments, dict):
+            result["cleared"].extend(expected)
+            return result
+
+        removable = []
+        for mesh_key, expected_adjustment in expected.items():
+            if mesh_key not in raw_adjustments:
+                result["cleared"].append(mesh_key)
+                continue
+            current = _normalize_mesh_color_adjustment(
+                raw_adjustments[mesh_key])
+            if current is None or current != expected_adjustment:
+                result["preserved"].append(mesh_key)
+                continue
+            removable.append(mesh_key)
+
+        if not removable:
+            return result
+
+        updated_adjustments = dict(raw_adjustments)
+        for mesh_key in removable:
+            updated_adjustments.pop(mesh_key, None)
+        updated_data = dict(data)
+        if updated_adjustments:
+            updated_data[MESH_COLOR_ADJUSTMENTS_KEY] = updated_adjustments
+        else:
+            updated_data.pop(MESH_COLOR_ADJUSTMENTS_KEY, None)
+        try:
+            saved = _save(folder_path, updated_data)
+        except Exception as exc:
+            result["failed"].extend(removable)
+            result["error"] = str(exc)
+            return result
+
+        result["cleared"].extend(removable)
+        result["saved"] = (bool(saved.get("saved"))
+                           if isinstance(saved, dict) else True)
+        return result
+
+
 def hydrate_mesh_color_adjustments(payload, data=None):
     """Project saved color state through canonical/legacy mesh identities."""
     saved = mesh_color_adjustments(data=data)

--- a/src/tests/app/bridge/test_mod_preview.py
+++ b/src/tests/app/bridge/test_mod_preview.py
@@ -279,7 +279,7 @@ def test_save_texture_color_forwards_complete_target_request(monkeypatch):
     preview._active_mesh_keys["mod"] = {"Body-1", "Body-2"}
     context = _context()
     captured = []
-    cleared = []
+    compared = []
     monkeypatch.setattr(
         preview, "authoritative_context",
         lambda _folder: ("mod", {"override": 1}, {}, context))
@@ -292,11 +292,13 @@ def test_save_texture_color_forwards_complete_target_request(monkeypatch):
             }],
         })
     monkeypatch.setattr(
-        "app.bridge.mod_preview.metadata.clear_mesh_color_adjustments",
-        lambda folder, keys: cleared.append((folder, keys)) or {"saved": True})
+        "app.bridge.mod_preview.metadata.clear_mesh_color_adjustments_if_unchanged",
+        lambda folder, expected: compared.append((folder, expected)) or {
+            "cleared": ["Body::one"], "preserved": [], "failed": [],
+        })
 
     targets = [{
-        "semantic_key": "Body-1", "metadata_key": "Request::not-committed",
+        "semantic_key": "Body-1", "metadata_key": "Body::one",
         "adjustment": {"hue": 30},
     }]
     usage = [{
@@ -315,7 +317,168 @@ def test_save_texture_color_forwards_complete_target_request(monkeypatch):
         context, {"override": 1}, {"Body-1", "Body-2"},
         "diffuse::body.dds", targets, usage)
     assert captured[0][1] == {}
-    assert cleared == [("mod", ["Body::one"])]
+    assert compared == [("mod", {"Body::one": {"hue": 30}})]
+    assert result["metadata_reset"] == {
+        "cleared": ["Body::one"], "preserved": [], "failed": [],
+    }
+
+
+def test_save_texture_color_compares_only_committed_targets(monkeypatch):
+    preview = ModPreview(_Access())
+    preview._active_mesh_keys["mod"] = {"Body-1", "Body-2"}
+    context = _context()
+    compared = []
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {}, {}, context))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.save_texture_color",
+        lambda *args, **kwargs: {
+            "status": "ok", "saved_meshes": [{
+                "semantic_key": "Body-1", "metadata_key": "Body::one",
+            }],
+        })
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.clear_mesh_color_adjustments_if_unchanged",
+        lambda folder, expected: compared.append((folder, expected)) or {
+            "cleared": ["Body::one"], "preserved": [], "failed": [],
+        })
+
+    targets = [
+        {"semantic_key": "Body-1", "metadata_key": "Body::one",
+         "adjustment": {"hue": 30}},
+        {"semantic_key": "Body-2", "metadata_key": "Body::two",
+         "adjustment": {"hue": 45}},
+    ]
+    result = preview.save_texture_color("mod", "diffuse::body.dds", targets, [])
+
+    assert compared == [("mod", {"Body::one": {"hue": 30}})]
+    assert result.get("warning") is None
+
+
+def test_save_texture_color_reports_structured_cleanup_status(monkeypatch):
+    preview = ModPreview(_Access())
+    context = _context()
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {}, {}, context))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.save_texture_color",
+        lambda *args, **kwargs: {
+            "status": "ok", "saved_meshes": [
+                {"semantic_key": "Body-1", "metadata_key": "Body::one"},
+                {"semantic_key": "Body-2", "metadata_key": "Body::two"},
+            ],
+        })
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.clear_mesh_color_adjustments_if_unchanged",
+        lambda *_args: {
+            "cleared": ["Body::one"], "preserved": ["Body::two"],
+            "failed": [],
+        })
+
+    result = preview.save_texture_color("mod", "diffuse::body.dds", [
+        {"semantic_key": "Body-1", "metadata_key": "Body::one",
+         "adjustment": {"hue": 30}},
+        {"semantic_key": "Body-2", "metadata_key": "Body::two",
+         "adjustment": {"hue": 45}},
+    ], [])
+
+    assert result["metadata_reset"] == {
+        "cleared": ["Body::one"], "preserved": ["Body::two"],
+        "failed": [],
+    }
+    assert "warning" not in result
+
+
+def test_save_texture_color_mapping_failure_is_fail_safe(monkeypatch):
+    preview = ModPreview(_Access())
+    context = _context()
+    compared = []
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {}, {}, context))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.save_texture_color",
+        lambda *args, **kwargs: {
+            "status": "ok", "saved_meshes": [{
+                "semantic_key": "Body-1", "metadata_key": "Body::missing",
+            }],
+        })
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.clear_mesh_color_adjustments_if_unchanged",
+        lambda *_args: compared.append(True))
+
+    result = preview.save_texture_color("mod", "diffuse::body.dds", [
+        {"semantic_key": "Body-1", "metadata_key": "Body::one",
+         "adjustment": {"hue": 30}},
+    ], [])
+
+    assert compared == []
+    assert result["metadata_reset"] == {
+        "cleared": [], "preserved": [], "failed": ["Body::missing"],
+    }
+    assert result["warning"] == "color_state_reset_failed"
+
+
+def test_save_texture_color_duplicate_metadata_is_fail_safe(monkeypatch):
+    preview = ModPreview(_Access())
+    context = _context()
+    compared = []
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {}, {}, context))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.save_texture_color",
+        lambda *args, **kwargs: {
+            "status": "ok", "saved_meshes": [
+                {"semantic_key": "Body-1", "metadata_key": "Shared::one"},
+                {"semantic_key": "Body-2", "metadata_key": "Shared::one"},
+            ],
+        })
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.clear_mesh_color_adjustments_if_unchanged",
+        lambda *_args: compared.append(True))
+
+    result = preview.save_texture_color("mod", "diffuse::body.dds", [
+        {"semantic_key": "Body-1", "metadata_key": "Shared::one",
+         "adjustment": {"hue": 30}},
+        {"semantic_key": "Body-2", "metadata_key": "Shared::one",
+         "adjustment": {"hue": 45}},
+    ], [])
+
+    assert compared == []
+    assert result["metadata_reset"]["failed"] == ["Shared::one"]
+    assert result["warning"] == "color_state_reset_failed"
+
+
+def test_save_texture_color_cleanup_exception_keeps_save_success(monkeypatch):
+    preview = ModPreview(_Access())
+    context = _context()
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _folder: ("mod", {}, {}, context))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.save_texture_color",
+        lambda *args, **kwargs: {
+            "status": "ok", "saved_meshes": [{
+                "semantic_key": "Body-1", "metadata_key": "Body::one",
+            }],
+        })
+    def fail_cleanup(*_args):
+        raise RuntimeError("unexpected cleanup error")
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.metadata.clear_mesh_color_adjustments_if_unchanged",
+        fail_cleanup)
+
+    result = preview.save_texture_color("mod", "diffuse::body.dds", [
+        {"semantic_key": "Body-1", "metadata_key": "Body::one",
+         "adjustment": {"hue": 30}},
+    ], [])
+
+    assert result["status"] == "ok"
+    assert result["metadata_reset"]["failed"] == ["Body::one"]
+    assert result["warning"] == "color_state_reset_failed"
 
 
 def test_save_texture_color_forwards_progress_callback(monkeypatch):

--- a/src/tests/app/mods/test_metadata.py
+++ b/src/tests/app/mods/test_metadata.py
@@ -240,6 +240,105 @@ def test_clear_mesh_color_adjustments_is_atomic_and_preserves_other_metadata(
     assert "body" not in saved["mesh_color_adjustments"]
 
 
+def test_clear_mesh_color_adjustments_if_unchanged_clears_committed_state(
+        tmp_path):
+    path = tmp_path / metadata.METADATA_NAME
+    original = {
+        "mesh_names": {"mesh": "Body"},
+        "future": {"keep": True},
+        "mesh_color_adjustments": {
+            "body": {"hue": 30},
+            "other": {"hue": 45},
+        },
+    }
+    path.write_text(json.dumps(original), encoding="utf-8")
+
+    result = metadata.clear_mesh_color_adjustments_if_unchanged(
+        str(tmp_path), {"body": {"hue": 30}})
+
+    assert result["cleared"] == ["body"]
+    assert result["preserved"] == []
+    assert result["failed"] == []
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved["mesh_names"] == original["mesh_names"]
+    assert saved["future"] == original["future"]
+    assert saved["mesh_color_adjustments"] == {"other": {"hue": 45}}
+
+
+def test_clear_mesh_color_adjustments_if_unchanged_preserves_newer_and_malformed(
+        tmp_path):
+    path = tmp_path / metadata.METADATA_NAME
+    current = {
+        "mesh_color_adjustments": {
+            "newer": {"hue": 60},
+            "malformed": {"hue": "later"},
+        },
+    }
+    path.write_text(json.dumps(current), encoding="utf-8")
+
+    result = metadata.clear_mesh_color_adjustments_if_unchanged(
+        str(tmp_path), {
+            "newer": {"hue": 30},
+            "malformed": {"hue": 30},
+        })
+
+    assert result["cleared"] == []
+    assert result["preserved"] == ["newer", "malformed"]
+    assert result["failed"] == []
+    assert json.loads(path.read_text(encoding="utf-8")) == current
+
+
+def test_clear_mesh_color_adjustments_if_unchanged_mixes_and_handles_absent(
+        tmp_path):
+    path = tmp_path / metadata.METADATA_NAME
+    path.write_text(json.dumps({
+        "mesh_color_adjustments": {
+            "matching": {"hue": 30},
+            "newer": {"hue": 60},
+        },
+    }), encoding="utf-8")
+
+    result = metadata.clear_mesh_color_adjustments_if_unchanged(
+        str(tmp_path), {
+            "matching": {"hue": 30},
+            "newer": {"hue": 30},
+            "absent": {"hue": 30},
+        })
+
+    assert result["cleared"] == ["absent", "matching"]
+    assert result["preserved"] == ["newer"]
+    assert result["failed"] == []
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved["mesh_color_adjustments"] == {"newer": {"hue": 60}}
+
+
+def test_clear_mesh_color_adjustments_if_unchanged_reports_save_failure(
+        tmp_path, monkeypatch):
+    path = tmp_path / metadata.METADATA_NAME
+    original = {
+        "mesh_color_adjustments": {
+            "matching": {"hue": 30},
+            "newer": {"hue": 60},
+        },
+    }
+    path.write_text(json.dumps(original), encoding="utf-8")
+
+    def fail_save(*_args, **_kwargs):
+        raise OSError("metadata write failed")
+
+    monkeypatch.setattr(metadata, "_save", fail_save)
+    result = metadata.clear_mesh_color_adjustments_if_unchanged(
+        str(tmp_path), {
+            "matching": {"hue": 30},
+            "newer": {"hue": 30},
+        })
+
+    assert result["cleared"] == []
+    assert result["preserved"] == ["newer"]
+    assert result["failed"] == ["matching"]
+    assert json.loads(path.read_text(encoding="utf-8")) == original
+
+
 def test_hydrate_mesh_color_adjustments_uses_canonical_and_safe_legacy_keys():
     canonical = "mesh:[5,\"A.ini\",\"Body\",null,null,[3,0,0],[]]"
     payload = {"meshes": {

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -1608,7 +1608,9 @@ def test_texture_save_preserves_newer_adjustment_on_reloaded_mesh(
         page.wait_for_function(
             "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue === 75")
         assert page.evaluate(
-            "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 0
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 1
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment[0][2].hue") == 75
     finally:
         context.close()
 
@@ -1655,6 +1657,60 @@ def test_texture_save_preserves_live_state_for_preserved_metadata(
             "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue === 75")
         assert page.evaluate(
             "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 0
+    finally:
+        context.close()
+
+
+def test_texture_save_persists_newer_adjustment_after_failed_cleanup(
+        edge_browser, frontend_url):
+    payload, tex_key = _bake_test_payload("BakeFailedNewer", _PNG_URI)
+    metadata_key = "Body BakeFailedNewer::3,0,0"
+    payload["textureSaveResult"].update({
+        "warning": "color_state_reset_failed",
+        "metadata_reset": {"cleared": [], "preserved": [],
+                            "failed": [metadata_key]},
+    })
+    context, page = _page(edge_browser, frontend_url,
+                           {"BakeFailedNewer": payload})
+    try:
+        _open(page, "BakeFailedNewer")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.evaluate("""() => {
+          window.pywebview.api.save_texture_color = async () =>
+            new Promise(resolve => { window.__releaseTextureSave = resolve; });
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function("window.__releaseTextureSave !== undefined")
+        page.evaluate("""async () => {
+          const {setMeshColorAdjustment} =
+            await import('./js/mesh/mesh-color-state.js');
+          setMeshColorAdjustment(window.modViewer.activeMeshes[0], {hue: 75}, {
+            persist: false, render: false,
+          });
+        }""")
+        page.evaluate("""() => window.__releaseTextureSave({
+          status: 'ok', tex_key: %s, affected_tex_keys: [%s],
+          warning: 'color_state_reset_failed',
+          metadata_reset: {cleared: [], preserved: [], failed: [%s]},
+          saved_meshes: [{semantic_key: 'Body-BakeFailedNewer-0',
+            metadata_key: %s}],
+          texture: {file: 'BakeFailedNewer-bake.dds'},
+          backup: {file: 'BakeFailedNewer-bake.dds.modviewer.bak'},
+        })""" % (json.dumps(tex_key), json.dumps(tex_key),
+                   json.dumps(metadata_key), json.dumps(metadata_key)))
+        page.locator("#texture-bake-body", has_text="TEXTURE SAVED").wait_for()
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue === 75")
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 1
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment[0][2].hue") == 75
+        assert "Color metadata" not in page.locator(
+            "#texture-bake-body").inner_text()
     finally:
         context.close()
 

--- a/src/tests/web/test_ui.py
+++ b/src/tests/web/test_ui.py
@@ -1519,6 +1519,146 @@ def test_successful_texture_save_syncs_stale_mesh_after_selection_changes(
         context.close()
 
 
+def test_texture_save_resets_same_mod_replacement_mesh_after_reload(
+        edge_browser, frontend_url):
+    payload, tex_key = _bake_test_payload(
+        "BakeReloadReplacement", _PNG_URI)
+    context, page = _page(edge_browser, frontend_url,
+                           {"BakeReloadReplacement": payload})
+    try:
+        _open(page, "BakeReloadReplacement")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.evaluate("window.__saveMeshBeforeReload = window.modViewer.activeMeshes[0]")
+        page.evaluate("""() => {
+          window.pywebview.api.save_texture_color = async () =>
+            new Promise(resolve => { window.__releaseTextureSave = resolve; });
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function("window.__releaseTextureSave !== undefined")
+
+        page.evaluate("window.modViewer.reloadCurrentMod()")
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadMod.length === 2")
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0] !== window.__saveMeshBeforeReload")
+        assert page.evaluate(
+            "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue") == 30
+
+        page.evaluate("""() => window.__releaseTextureSave({
+          status: 'ok', tex_key: %s, affected_tex_keys: [%s],
+          saved_meshes: [{semantic_key: 'Body-BakeReloadReplacement-0',
+            metadata_key: 'Body BakeReloadReplacement::3,0,0'}],
+          texture: {file: 'BakeReloadReplacement-bake.dds'},
+          backup: {file: 'BakeReloadReplacement-bake.dds.modviewer.bak'},
+        })""" % (json.dumps(tex_key), json.dumps(tex_key)))
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue === 0")
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 0
+    finally:
+        context.close()
+
+
+def test_texture_save_preserves_newer_adjustment_on_reloaded_mesh(
+        edge_browser, frontend_url):
+    payload, tex_key = _bake_test_payload(
+        "BakeReloadNewer", _PNG_URI)
+    context, page = _page(edge_browser, frontend_url,
+                           {"BakeReloadNewer": payload})
+    try:
+        _open(page, "BakeReloadNewer")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.evaluate("window.__saveMeshBeforeReload = window.modViewer.activeMeshes[0]")
+        page.evaluate("""() => {
+          window.pywebview.api.save_texture_color = async () =>
+            new Promise(resolve => { window.__releaseTextureSave = resolve; });
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function("window.__releaseTextureSave !== undefined")
+        page.evaluate("window.modViewer.reloadCurrentMod()")
+        page.wait_for_function(
+            "window.__fakeApi.calls.loadMod.length === 2")
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0] !== window.__saveMeshBeforeReload")
+        page.evaluate("""async () => {
+          const {setMeshColorAdjustment} =
+            await import('./js/mesh/mesh-color-state.js');
+          setMeshColorAdjustment(window.modViewer.activeMeshes[0], {hue: 75}, {
+            persist: false, render: false,
+          });
+        }""")
+
+        page.evaluate("""() => window.__releaseTextureSave({
+          status: 'ok', tex_key: %s, affected_tex_keys: [%s],
+          metadata_reset: {cleared: [%s], preserved: [], failed: []},
+          saved_meshes: [{semantic_key: 'Body-BakeReloadNewer-0',
+            metadata_key: 'Body BakeReloadNewer::3,0,0'}],
+          texture: {file: 'BakeReloadNewer-bake.dds'},
+          backup: {file: 'BakeReloadNewer-bake.dds.modviewer.bak'},
+        })""" % (json.dumps(tex_key), json.dumps(tex_key),
+                   json.dumps("Body BakeReloadNewer::3,0,0")))
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue === 75")
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 0
+    finally:
+        context.close()
+
+
+def test_texture_save_preserves_live_state_for_preserved_metadata(
+        edge_browser, frontend_url):
+    payload, tex_key = _bake_test_payload("BakePreserved", _PNG_URI)
+    metadata_key = "Body BakePreserved::3,0,0"
+    payload["textureSaveResult"]["metadata_reset"] = {
+        "cleared": [], "preserved": [metadata_key], "failed": [],
+    }
+    context, page = _page(edge_browser, frontend_url,
+                           {"BakePreserved": payload})
+    try:
+        _open(page, "BakePreserved")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.locator("#texture-bake-confirm").wait_for()
+        page.evaluate("""() => {
+          window.pywebview.api.save_texture_color = async () =>
+            new Promise(resolve => { window.__releaseTextureSave = resolve; });
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.wait_for_function("window.__releaseTextureSave !== undefined")
+        page.evaluate("""async () => {
+          const {setMeshColorAdjustment} =
+            await import('./js/mesh/mesh-color-state.js');
+          setMeshColorAdjustment(window.modViewer.activeMeshes[0], {hue: 75}, {
+            persist: false, render: false,
+          });
+        }""")
+        page.evaluate("""() => window.__releaseTextureSave({
+          status: 'ok', tex_key: %s, affected_tex_keys: [%s],
+          metadata_reset: {cleared: [], preserved: [%s], failed: []},
+          saved_meshes: [{semantic_key: 'Body-BakePreserved-0',
+            metadata_key: %s}],
+          texture: {file: 'BakePreserved-bake.dds'},
+          backup: {file: 'BakePreserved-bake.dds.modviewer.bak'},
+        })""" % (json.dumps(tex_key), json.dumps(tex_key),
+                   json.dumps(metadata_key), json.dumps(metadata_key)))
+        page.wait_for_function(
+            "window.modViewer.activeMeshes[0].userData.colorAdjustment.hue === 75")
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 0
+    finally:
+        context.close()
+
+
 def test_successful_texture_save_does_not_reload_a_new_mod_after_switch(
         edge_browser, frontend_url):
     first_payload, first_key = _bake_test_payload(
@@ -1675,6 +1815,65 @@ def test_texture_save_resets_all_committed_meshes_and_refreshes_affected_keys(
             "#texture-bake-body").inner_text()
         page.wait_for_function(
             "window.__fakeApi.calls.diagnostics.length >= 2")
+    finally:
+        context.close()
+
+
+def test_texture_save_keeps_warning_for_one_failed_target_recovery(
+        edge_browser, frontend_url):
+    payload = _payload("BakePartialCleanup")
+    first = payload["meshes"]["Body-BakePartialCleanup-0"]
+    dds_key = "diffuse::BakePartialCleanup-one.dds"
+    first["tex_key"] = dds_key
+    payload["texture_pools"]["p0"][0]["tex_key"] = dds_key
+    payload["textures"][dds_key] = payload["textures"].pop(
+        "diffuse::BakePartialCleanup-one.png")
+    body_key = "Body BakePartialCleanup::3,0,0"
+    face_key = "Face BakePartialCleanup::3,0,0"
+    payload["metadata"]["mesh_color_adjustments"] = {
+        body_key: {"hue": 30}, face_key: {"hue": 45},
+    }
+    second = copy.deepcopy(first)
+    second["component"] = "Face BakePartialCleanup"
+    payload["meshes"]["Face-BakePartialCleanup-0"] = second
+    payload["textureSaveResult"] = {
+        "status": "ok", "warning": "color_state_reset_failed",
+        "tex_key": dds_key, "affected_tex_keys": [dds_key],
+        "metadata_reset": {"cleared": [], "preserved": [],
+                            "failed": [body_key, face_key]},
+        "saved_meshes": [
+            {"semantic_key": "Body-BakePartialCleanup-0",
+             "metadata_key": body_key},
+            {"semantic_key": "Face-BakePartialCleanup-0",
+             "metadata_key": face_key},
+        ],
+        "texture": {"file": "BakePartialCleanup-one.dds"},
+        "backup": {"file": "BakePartialCleanup-one.dds.modviewer.bak"},
+    }
+    context, page = _page(edge_browser, frontend_url,
+                           {"BakePartialCleanup": payload})
+    try:
+        _open(page, "BakePartialCleanup")
+        page.locator(".draw-item").first.wait_for()
+        page.locator("#inspector-tab").click()
+        page.locator(".draw-item").first.click()
+        page.locator(".inspector-texture-bake").click()
+        page.evaluate("""() => {
+          window.pywebview.api.save_mesh_color_adjustment = async (...args) => {
+            window.__fakeApi.calls.saveMeshColorAdjustment.push(args);
+            return args[1] === 'Face BakePartialCleanup::3,0,0'
+              ? {error: 'metadata write failed'} : {};
+          };
+        }""")
+        page.locator("#texture-bake-confirm").click()
+        page.locator("#texture-bake-body", has_text="TEXTURE SAVED").wait_for()
+        assert page.evaluate(
+            "window.modViewer.activeMeshes.every(mesh => "
+            "mesh.userData.colorAdjustment.hue === 0)")
+        details = page.locator("#texture-bake-body").inner_text()
+        assert "Color metadata" in details
+        assert page.evaluate(
+            "window.__fakeApi.calls.saveMeshColorAdjustment.length") == 2
     finally:
         context.close()
 

--- a/src/web/js/mesh/mesh-color-state.js
+++ b/src/web/js/mesh/mesh-color-state.js
@@ -48,6 +48,11 @@ function persistMeshColorAdjustment(mesh, adjustment = getMeshColorAdjustment(me
   return request;
 }
 
+/** Queue the current live color state even when no write is already pending. */
+export function persistCurrentMeshColorAdjustment(mesh) {
+  return persistMeshColorAdjustment(mesh, getMeshColorAdjustment(mesh));
+}
+
 /** Wait for queued color writes and propagate failures to destructive flows. */
 export function flushMeshColorAdjustmentPersistence(mesh) {
   return persistenceResults.get(mesh) || Promise.resolve();

--- a/src/web/js/mesh/texture-save-state.js
+++ b/src/web/js/mesh/texture-save-state.js
@@ -148,16 +148,27 @@ export function textureSaveStateMatches(mesh, snapshot, current = null) {
 }
 
 /** Check one committed target before clearing its live Color state. */
-export function textureSaveTargetMatches(mesh, snapshot, target) {
+function textureSaveTargetIdentityMatches(mesh, snapshot, target) {
   if (!snapshot || !target || !activeMeshes.includes(mesh)) return false;
   const data = mesh.userData || {};
-  if (!samePath(snapshot.modPath, viewerState.currentModPath)
-      || !samePath(data.modPath, snapshot.modPath)
-      || data.semanticKey !== target.semanticKey
-      || data.metadataKey !== target.metadataKey
-      || textureIdentity(data.texKey) !== textureIdentity(snapshot.texKey)) {
-    return false;
-  }
+  return viewerState.currentSource?.kind === 'mod'
+    && samePath(snapshot.modPath, viewerState.currentModPath)
+    && samePath(data.modPath, snapshot.modPath)
+    && data.semanticKey === target.semanticKey
+    && data.metadataKey === target.metadataKey
+    && textureIdentity(data.texKey) === textureIdentity(snapshot.texKey);
+}
+
+/** Find the current replacement for a captured committed target. */
+export function findCurrentTextureSaveTarget(snapshot, target) {
+  if (!snapshot || !target) return null;
+  return activeMeshes.find(mesh =>
+    textureSaveTargetIdentityMatches(mesh, snapshot, target)) || null;
+}
+
+/** Check one committed target before clearing its live Color state. */
+export function textureSaveTargetMatches(mesh, snapshot, target) {
+  if (!textureSaveTargetIdentityMatches(mesh, snapshot, target)) return false;
   return JSON.stringify(publicTargets([targetState(mesh)]))
     === JSON.stringify(publicTargets([target]));
 }

--- a/src/web/js/ui/texture-save-modal.js
+++ b/src/web/js/ui/texture-save-modal.js
@@ -7,7 +7,8 @@ import {
   textureSaveTargetsPayload,
 } from '../mesh/texture-save-state.js';
 import {
-  flushMeshColorAdjustmentPersistence, resetMeshColorAdjustment,
+  flushMeshColorAdjustmentPersistence, persistCurrentMeshColorAdjustment,
+  resetMeshColorAdjustment,
 } from '../mesh/mesh-color-state.js';
 import { reloadTextures } from '../mesh/mesh-factory.js';
 import { notifyMeshStateChanged } from '../mesh/mesh-state-events.js';
@@ -273,6 +274,13 @@ async function synchronizeCommittedSave(state, result) {
       if (textureSaveTargetMatches(mesh, state, record.target)) {
         resetMeshColorAdjustment(mesh, {persist: false, render: false});
         changedMeshes.add(mesh);
+      } else {
+        try {
+          persistCurrentMeshColorAdjustment(mesh);
+          await flushMeshColorAdjustmentPersistence(mesh);
+        } catch (_metadataError) {
+          unresolvedFailedTargets += 1;
+        }
       }
       continue;
     }
@@ -281,6 +289,8 @@ async function synchronizeCommittedSave(state, result) {
       if (textureSaveTargetMatches(mesh, state, record.target)) {
         resetMeshColorAdjustment(mesh, {persist: true, render: false});
         changedMeshes.add(mesh);
+      } else {
+        persistCurrentMeshColorAdjustment(mesh);
       }
       await flushMeshColorAdjustmentPersistence(mesh);
     } catch (_metadataError) {

--- a/src/web/js/ui/texture-save-modal.js
+++ b/src/web/js/ui/texture-save-modal.js
@@ -3,12 +3,12 @@
 import { bindModalDismiss, setModalError } from './modal-shell.js';
 import {
   captureTextureSaveState, textureSaveStateMatches,
-  textureSaveTargetMatches, textureSaveTargetsPayload,
+  findCurrentTextureSaveTarget, textureSaveTargetMatches,
+  textureSaveTargetsPayload,
 } from '../mesh/texture-save-state.js';
 import {
   flushMeshColorAdjustmentPersistence, resetMeshColorAdjustment,
 } from '../mesh/mesh-color-state.js';
-import { activeMeshes } from '../mesh/mesh-state.js';
 import { reloadTextures } from '../mesh/mesh-factory.js';
 import { notifyMeshStateChanged } from '../mesh/mesh-state-events.js';
 import { viewerState, samePath } from '../app/state.js';
@@ -221,35 +221,81 @@ function handleTextureSaveProgress(event) {
 }
 
 async function synchronizeCommittedSave(state, result) {
-  const affectedKeys = affectedTextureKeys(result);
-  const saved = Array.isArray(result.saved_meshes) ? result.saved_meshes : [];
-  const savedKeys = new Set(saved.map(item =>
-    `${item?.semantic_key || ''}\u0000${item?.metadata_key || ''}`));
-  const meshes = (state.targets || [])
-    .filter(target => savedKeys.has(
-      `${target.semanticKey || ''}\u0000${target.metadataKey || ''}`)
-      && textureSaveTargetMatches(target.mesh, state, target))
-    .map(target => target.mesh)
-    .filter(mesh => activeMeshes.includes(mesh));
   const sameLoadedMod = viewerState.currentSource?.kind === 'mod'
     && samePath(viewerState.currentModPath, state.modPath);
   if (!sameLoadedMod) return false;
 
-  const retryMetadataClear = result.warning === 'color_state_reset_failed';
-  meshes.forEach(mesh => resetMeshColorAdjustment(
-    mesh, {persist: retryMetadataClear, render: false}));
-  if (retryMetadataClear) {
+  const affectedKeys = affectedTextureKeys(result);
+  const saved = Array.isArray(result.saved_meshes) ? result.saved_meshes : [];
+  const capturedTargets = new Map((state.targets || []).map(target => [
+    `${target.semanticKey || ''}\u0000${target.metadataKey || ''}`, target,
+  ]));
+  const receipt = result.metadata_reset
+    && typeof result.metadata_reset === 'object'
+    ? result.metadata_reset : null;
+  const receiptKeys = name => Array.isArray(receipt?.[name])
+    ? receipt[name] : [];
+  const fallbackStatus = result.warning === 'color_state_reset_failed'
+    ? 'failed' : 'cleared';
+  const statusFor = metadataKey => {
+    if (!receipt) return fallbackStatus;
+    if (receiptKeys('cleared').includes(metadataKey)) return 'cleared';
+    if (receiptKeys('preserved').includes(metadataKey)) return 'preserved';
+    if (receiptKeys('failed').includes(metadataKey)) return 'failed';
+    return fallbackStatus;
+  };
+  const records = saved.map(item => {
+    const semanticKey = item?.semantic_key;
+    const metadataKey = item?.metadata_key;
+    const target = capturedTargets.get(
+      `${semanticKey || ''}\u0000${metadataKey || ''}`);
+    return {
+      target,
+      metadataKey,
+      status: target ? statusFor(metadataKey) : 'failed',
+    };
+  });
+  const changedMeshes = new Set();
+  let unresolvedFailedTargets = 0;
+
+  for (const record of records) {
+    if (record.status === 'preserved') continue;
+    if (record.status === 'failed' && !record.target) {
+      unresolvedFailedTargets += 1;
+      continue;
+    }
+    const mesh = findCurrentTextureSaveTarget(state, record.target);
+    if (!mesh) {
+      if (record.status === 'failed') unresolvedFailedTargets += 1;
+      continue;
+    }
+    if (record.status === 'cleared') {
+      if (textureSaveTargetMatches(mesh, state, record.target)) {
+        resetMeshColorAdjustment(mesh, {persist: false, render: false});
+        changedMeshes.add(mesh);
+      }
+      continue;
+    }
+
     try {
-      await Promise.all(meshes.map(mesh =>
-        flushMeshColorAdjustmentPersistence(mesh)));
-      if (meshes.length) delete result.warning;
+      if (textureSaveTargetMatches(mesh, state, record.target)) {
+        resetMeshColorAdjustment(mesh, {persist: true, render: false});
+        changedMeshes.add(mesh);
+      }
+      await flushMeshColorAdjustmentPersistence(mesh);
     } catch (_metadataError) {
-      // Keep the warning visible when the per-mesh recovery write also fails.
-      result.warning = 'color_state_reset_failed';
+      unresolvedFailedTargets += 1;
     }
   }
+
+  if (unresolvedFailedTargets
+      && (!result.warning || result.warning === 'color_state_reset_failed')) {
+    result.warning = 'color_state_reset_failed';
+  } else if (result.warning === 'color_state_reset_failed') {
+    delete result.warning;
+  }
   await reloadTextures(affectedKeys, {force: true});
-  notifyMeshStateChanged(meshes);
+  if (changedMeshes.size) notifyMeshStateChanged([...changedMeshes]);
   window.dispatchEvent(new CustomEvent('mod-viewer-texture-saved', {
     detail: {
       texKey: result.tex_key,


### PR DESCRIPTION
## Summary\n\n- Compare captured mesh color adjustments before clearing metadata after a texture save.\n- Reconcile committed targets by stable identity across same-mod reloads.\n- Recover failed metadata resets per target while preserving newer live state and preserved metadata.\n- Add backend and browser regression coverage for partial commits, replacements, failures, and mod switches.\n\n## Scope\n\nThis is a correctness-only change to Save to Texture completion handling. BC7 encoding and texture-processing performance are unchanged.