### PR TITLE
Extend lower-mip compact BC7 jobs to multi-adjustment saves

### DIFF
--- a/src/app/mods/texture_save.py
+++ b/src/app/mods/texture_save.py
@@ -828,30 +828,121 @@ def _bc7_block_intent_info(state, mip, block_index):
         multi_intent=len(ordered_classes) > 1)
 
 
+def _bc7_validate_lower_single_state(state, mip):
+    """Return validated one-adjustment lower-mip weight planes."""
+    if (state.get("level", 0) <= 0
+            or state.get("width") != mip.width
+            or state.get("height") != mip.height):
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Lower-mip BC7 weighted intent state is invalid.")
+    changed = state.get("changed_counts")
+    total = state.get("total_counts")
+    expected = mip.width * mip.height
+    try:
+        changed_length = len(changed)
+        total_length = len(total)
+    except TypeError as error:
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Lower-mip color intent does not match the source texture size.") \
+            from error
+    if changed_length != expected or total_length != expected:
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Lower-mip color intent does not match the source texture size.")
+    return changed, total
+
+
+def _bc7_validate_lower_multi_counts(state, mip):
+    """Return validated per-class lower-mip count planes."""
+    if (state.get("level", 0) <= 0
+            or state.get("width") != mip.width
+            or state.get("height") != mip.height):
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Lower-mip BC7 weighted intent state is invalid.")
+    counts = state.get("counts")
+    expected = mip.width * mip.height
+    try:
+        count_plane_count = len(counts)
+    except (TypeError, AttributeError) as error:
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Lower-mip color intent does not match the source texture size.") \
+            from error
+    class_count = state.get("class_count", count_plane_count)
+    if (not isinstance(class_count, int) or class_count <= 0
+            or count_plane_count != class_count):
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Lower-mip color intent contains an invalid class count.")
+    for count_values in counts:
+        try:
+            count_length = len(count_values)
+        except TypeError as error:
+            raise TextureSaveError(
+                "texture_validation_failed",
+                "Lower-mip color intent does not match the source texture size.") \
+                from error
+        if count_length != expected:
+            raise TextureSaveError(
+                "texture_validation_failed",
+                "Lower-mip color intent does not match the source texture size.")
+    return counts
+
+
 def _bc7_weighted_block_intent_info(state, mip, block_index):
     """Classify one lower-mip block's weighted logical intent."""
     source_x, source_y, valid_width, valid_height = _unit_bounds(
         mip, block_index)
     classes = set()
     full = True
+    if state.get("single"):
+        changed_counts, total_counts = _bc7_validate_lower_single_state(
+            state, mip)
+        counts = None
+    else:
+        counts = _bc7_validate_lower_multi_counts(state, mip)
+        changed_counts = total_counts = None
     for row in range(valid_height):
         for column in range(valid_width):
             pixel = ((source_y + row) * mip.width + source_x + column)
             if state["single"]:
-                changed = state["changed_counts"][pixel]
-                total = state["total_counts"][pixel]
+                changed = changed_counts[pixel]
+                total = total_counts[pixel]
+                if (not isinstance(changed, int)
+                        or not isinstance(total, int)
+                        or changed < 0 or total < 0):
+                    raise TextureSaveError(
+                        "texture_validation_failed",
+                        "Lower-mip color intent contains an invalid count.")
+                if changed > total:
+                    raise TextureSaveError(
+                        "texture_validation_failed",
+                        "Changed color intent exceeds total mip weight.")
                 if changed:
                     classes.add(1)
                 if not changed or changed != total:
                     full = False
                 continue
+            base_count = counts[0][pixel]
+            if (not isinstance(base_count, int) or base_count < 0):
+                raise TextureSaveError(
+                    "texture_validation_failed",
+                    "Lower-mip color intent contains an invalid count.")
             pixel_class_count = 0
             for intent_class, count_values in enumerate(
-                    state["counts"][1:], 1):
-                if count_values[pixel]:
+                    counts[1:], 1):
+                count = count_values[pixel]
+                if (not isinstance(count, int) or count < 0):
+                    raise TextureSaveError(
+                        "texture_validation_failed",
+                        "Lower-mip color intent contains an invalid count.")
+                if count:
                     classes.add(intent_class)
                     pixel_class_count += 1
-            if (not pixel_class_count or state["counts"][0][pixel]
+            if (not pixel_class_count or base_count
                     or pixel_class_count != 1):
                 full = False
     if not classes:
@@ -983,23 +1074,30 @@ def _prepare_bc7_single_intent_job(
         valid_width=valid_width, valid_height=valid_height)
 
 
-def _bc7_single_weighted_block_counts(state, mip, block_index):
+def _bc7_single_weighted_block_counts(
+        state, mip, block_index, block_intent=None):
     """Extract valid lower-mip weights for one worker job."""
-    if (state.get("level", 0) <= 0 or not state.get("single")
-            or state.get("width") != mip.width
-            or state.get("height") != mip.height):
-        raise TextureSaveError(
-            "texture_validation_failed",
-            "Lower-mip BC7 weighted intent state is invalid.")
-    changed = state.get("changed_counts")
-    total = state.get("total_counts")
-    expected_state_size = mip.width * mip.height
-    if (changed is None or total is None
-            or len(changed) != expected_state_size
-            or len(total) != expected_state_size):
-        raise TextureSaveError(
-            "texture_validation_failed",
-            "Lower-mip color intent does not match the source texture size.")
+    if state.get("single"):
+        changed, total = _bc7_validate_lower_single_state(state, mip)
+        changed_values = changed
+        total_values = total
+    else:
+        if (block_intent is None
+                or len(block_intent.classes) != 1
+                or not isinstance(block_intent.classes[0], int)
+                or block_intent.classes[0] <= 0):
+            raise TextureSaveError(
+                "texture_validation_failed",
+                "Lower-mip BC7 block does not have one adjustment class.")
+        counts = _bc7_validate_lower_multi_counts(state, mip)
+        intent_class = block_intent.classes[0]
+        if intent_class >= len(counts):
+            raise TextureSaveError(
+                "texture_validation_failed",
+                "Lower-mip BC7 block contains an invalid adjustment class.")
+        changed_values = counts[intent_class]
+        base_values = counts[0]
+        total_values = None
     source_x, source_y, valid_width, valid_height = _unit_bounds(
         mip, block_index)
     changed_counts = []
@@ -1007,8 +1105,30 @@ def _bc7_single_weighted_block_counts(state, mip, block_index):
     for row in range(valid_height):
         start = (source_y + row) * mip.width + source_x
         end = start + valid_width
-        changed_counts.extend(int(value) for value in changed[start:end])
-        total_counts.extend(int(value) for value in total[start:end])
+        if total_values is None:
+            for base, changed in zip(
+                    base_values[start:end], changed_values[start:end]):
+                if (not isinstance(base, int) or not isinstance(changed, int)
+                        or base < 0 or changed < 0):
+                    raise TextureSaveError(
+                        "texture_validation_failed",
+                        "Lower-mip color intent contains an invalid count.")
+                changed_counts.append(changed)
+                total_counts.append(base + changed)
+        else:
+            for changed, total in zip(
+                    changed_values[start:end], total_values[start:end]):
+                if (not isinstance(changed, int) or not isinstance(total, int)
+                        or changed < 0 or total < 0):
+                    raise TextureSaveError(
+                        "texture_validation_failed",
+                        "Lower-mip color intent contains an invalid count.")
+                if changed > total:
+                    raise TextureSaveError(
+                        "texture_validation_failed",
+                        "Changed color intent exceeds total mip weight.")
+                changed_counts.append(changed)
+                total_counts.append(total)
     return (tuple(changed_counts), tuple(total_counts),
             valid_width, valid_height)
 
@@ -1016,13 +1136,22 @@ def _bc7_single_weighted_block_counts(state, mip, block_index):
 def _prepare_bc7_weighted_single_intent_job(
         original, mip, block_index, state, adjustments, block_intent):
     """Prepare a compact lower-mip job with worker-side target generation."""
+    if (len(block_intent.classes) != 1
+            or not isinstance(block_intent.classes[0], int)
+            or block_intent.classes[0] <= 0
+            or block_intent.classes[0] >= len(adjustments)):
+        raise TextureSaveError(
+            "texture_validation_failed",
+            "Lower-mip BC7 block contains an invalid adjustment class.")
+    intent_class = block_intent.classes[0]
     start, source_block, valid_width, valid_height = (
         _bc7_source_block_and_bounds(original, mip, block_index))
     changed_counts, total_counts, valid_width, valid_height = (
-        _bc7_single_weighted_block_counts(state, mip, block_index))
+        _bc7_single_weighted_block_counts(
+            state, mip, block_index, block_intent))
     return _BC7WeightedSingleIntentJob(
         start=start, source_block=source_block,
-        adjustment=adjustments[1], changed_counts=changed_counts,
+        adjustment=adjustments[intent_class], changed_counts=changed_counts,
         total_counts=total_counts, valid_width=valid_width,
         valid_height=valid_height)
 
@@ -1033,12 +1162,7 @@ def _prepare_bc7_parallel_job(
     if state.get("level") == 0 and len(block_intent.classes) == 1:
         return _prepare_bc7_single_intent_job(
             original, mip, block_index, adjustments, block_intent)
-    if (state.get("level", 0) > 0 and state.get("single")
-            and state.get("width") == mip.width
-            and state.get("height") == mip.height
-            and state.get("changed_counts") is not None
-            and state.get("total_counts") is not None
-            and block_intent.classes == (1,)):
+    if state.get("level", 0) > 0 and len(block_intent.classes) == 1:
         return _prepare_bc7_weighted_single_intent_job(
             original, mip, block_index, state, adjustments, block_intent)
     return _prepare_bc7_block_job(

--- a/src/tests/app/mods/test_texture_save.py
+++ b/src/tests/app/mods/test_texture_save.py
@@ -1009,7 +1009,9 @@ def test_parallel_lower_mip_multi_intent_keeps_parent_prepared_job(
     adjustment = prepare_color_adjustment({"hue": 30})
     state = {
         "level": 1, "width": 4, "height": 4, "single": False,
-        "counts": ([0] * 16, [1] * 16, [0] * 16),
+        "class_count": 3,
+        "counts": ([0] * 16, [1] * 8 + [0] * 8,
+                    [0] * 8 + [1] * 8),
     }
     selected = []
     monkeypatch.setattr(
@@ -1026,6 +1028,180 @@ def test_parallel_lower_mip_multi_intent_keeps_parent_prepared_job(
 
     assert jobs == ["legacy"]
     assert selected == ["legacy"]
+
+
+@pytest.mark.parametrize("intent_class", [1, 2, 3])
+def test_parallel_lower_mip_single_class_uses_that_weighted_adjustment(
+        intent_class):
+    source = bytearray(_mode6_block())
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16, width=4, height=4, units_x=1)
+    adjustments = tuple(
+        [None] + [prepare_color_adjustment({"hue": 30 * index})
+                  for index in range(1, 4)])
+    counts = [[0] * 16 for _ in range(4)]
+    counts[0] = [3] * 16
+    counts[intent_class] = [2] * 16
+    state = {
+        "level": 1, "width": 4, "height": 4, "single": False,
+        "class_count": 4, "counts": tuple(counts),
+    }
+    block_intent = texture_save._bc7_block_intent_info(state, mip, 0)
+
+    job = texture_save._prepare_bc7_parallel_job(
+        source, mip, 0, state, adjustments, block_intent)
+
+    assert isinstance(job, texture_save._BC7WeightedSingleIntentJob)
+    assert job.adjustment is adjustments[intent_class]
+    assert job.changed_counts == (2,) * 16
+    assert job.total_counts == (5,) * 16
+
+
+@pytest.mark.parametrize(
+    ("base_counts", "changed_counts", "expected_full"),
+    [([0] * 16, [1] * 16, True),
+     ([0] * 16, [1] * 8 + [0] * 8, False)],
+)
+def test_parallel_lower_mip_compacts_full_and_partial_single_class_blocks(
+        base_counts, changed_counts, expected_full):
+    source = bytearray(_mode6_block())
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16, width=4, height=4, units_x=1)
+    adjustment = prepare_color_adjustment({"brightness": 1.5})
+    state = {
+        "level": 1, "width": 4, "height": 4, "single": False,
+        "class_count": 3,
+        "counts": (base_counts, changed_counts, [0] * 16),
+    }
+    block_intent = texture_save._bc7_block_intent_info(state, mip, 0)
+    job = texture_save._prepare_bc7_parallel_job(
+        source, mip, 0, state, (None, adjustment, adjustment), block_intent)
+
+    assert block_intent.classes == (1,)
+    assert block_intent.full is expected_full
+    assert isinstance(job, texture_save._BC7WeightedSingleIntentJob)
+
+
+@pytest.mark.parametrize(
+    ("source_rgb", "changed_count", "total_count"),
+    [((0, 0, 0), 1, 2), ((37, 101, 203), 3, 7),
+     ((255, 128, 1), 1023, 4096)],
+)
+@pytest.mark.parametrize("intent_class", [1, 2, 3])
+@pytest.mark.parametrize(
+    "adjustment",
+    [{"hue": 30}, {"brightness": 1.5, "contrast": 1.25},
+     {"red": 0.5, "green": 1.5, "blue": 2.0, "tint": "#4080c0"}],
+)
+def test_lower_mip_single_class_weighted_rgb_matches_generic_intent(
+        source_rgb, changed_count, total_count, intent_class, adjustment):
+    prepared_adjustment = prepare_color_adjustment(adjustment)
+    counts = [[0] for _ in range(4)]
+    counts[0][0] = total_count - changed_count
+    counts[intent_class][0] = changed_count
+    state = {
+        "level": 1, "width": 1, "height": 1, "single": False,
+        "class_count": 4, "counts": tuple(counts),
+    }
+
+    generic = texture_save._bc7_intent_rgb(
+        source_rgb, state, 0,
+        (None, prepared_adjustment, prepared_adjustment, prepared_adjustment))
+    weighted = texture_save._bc7_weighted_single_rgb(
+        source_rgb, prepared_adjustment, changed_count, total_count)
+
+    assert weighted == generic
+
+
+@pytest.mark.parametrize(
+    ("block", "valid_width", "valid_height"),
+    [(_separate_block(4), 4, 4), (_mode5_block(), 3, 4),
+     (_mode6_block(), 4, 3), (_mode7_block(), 3, 2),
+     (_separate_block(4), 1, 1)],
+)
+def test_lower_mip_weighted_multi_class_worker_matches_parent_prepared_worker(
+        block, valid_width, valid_height):
+    source = bytearray(block)
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16, width=valid_width, height=valid_height,
+        units_x=1)
+    area = valid_width * valid_height
+    adjustments = (None, prepare_color_adjustment({"hue": 30}),
+                   prepare_color_adjustment({"hue": 120}))
+    state = {
+        "level": 1, "width": valid_width, "height": valid_height,
+        "single": False, "class_count": 3,
+        "counts": ([0] * area, [0] * area, [1] * area),
+    }
+    block_intent = texture_save._bc7_block_intent_info(state, mip, 0)
+
+    legacy_job = texture_save._prepare_bc7_block_job(
+        source, mip, 0, state, adjustments, block_intent)
+    weighted_job = texture_save._prepare_bc7_weighted_single_intent_job(
+        source, mip, 0, state, adjustments, block_intent)
+    legacy_result = texture_save._recolor_bc7_chunk((legacy_job,))[0]
+    weighted_result = texture_save._recolor_bc7_chunk((weighted_job,))[0]
+
+    assert weighted_job.adjustment is adjustments[2]
+    assert weighted_result == legacy_result
+
+
+def test_lower_mip_weighted_multi_class_job_preserves_wide_counts():
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16, width=1, height=1, units_x=1)
+    state = {
+        "level": 1, "width": 1, "height": 1, "single": False,
+        "class_count": 3,
+        "counts": ([65535], [0], [1]),
+    }
+    block_intent = texture_save._bc7_block_intent_info(state, mip, 0)
+
+    changed, total, valid_width, valid_height = \
+        texture_save._bc7_single_weighted_block_counts(
+            state, mip, 0, block_intent)
+
+    assert (changed, total, valid_width, valid_height) == ((1,), (65536,), 1, 1)
+
+
+@pytest.mark.parametrize(
+    "state",
+    [{
+        "level": 1, "width": 4, "height": 4, "single": False,
+        "class_count": 3, "counts": ([0] * 16, [1] * 15, [0] * 16),
+    }, {
+        "level": 1, "width": 4, "height": 4, "single": False,
+        "class_count": 2, "counts": ([0] * 16, [1] * 16, [0] * 16),
+    }, {
+        "level": 1, "width": 4, "height": 4, "single": False,
+        "class_count": 3, "counts": ([0] * 16, [-1] * 16, [0] * 16),
+    }],
+)
+def test_lower_mip_malformed_multi_class_counts_are_stable(state):
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16, width=4, height=4, units_x=1)
+
+    with pytest.raises(texture_save.TextureSaveError) as raised:
+        texture_save._bc7_block_intent_info(state, mip, 0)
+
+    assert raised.value.code == "texture_validation_failed"
+
+
+def test_lower_mip_weighted_job_rejects_invalid_adjustment_class():
+    mip = SimpleNamespace(
+        offset=0, bytes_per_unit=16, width=4, height=4, units_x=1)
+    state = {
+        "level": 1, "width": 4, "height": 4, "single": False,
+        "class_count": 3,
+        "counts": ([0] * 16, [1] * 16, [0] * 16),
+    }
+    block_intent = SimpleNamespace(classes=(3,))
+
+    with pytest.raises(texture_save.TextureSaveError) as raised:
+        texture_save._prepare_bc7_weighted_single_intent_job(
+            bytearray(_mode6_block()), mip, 0, state,
+            (None, prepare_color_adjustment({"hue": 30})), block_intent)
+
+    assert raised.value.code == "texture_validation_failed"
 
 
 def test_worker_chunk_accepts_compact_and_parent_prepared_jobs_in_order():
@@ -1295,6 +1471,55 @@ def test_parallel_bc7_multi_mip_weighted_jobs_match_serial_results(
         assert [event["mip"] for event in processing
                 if event["completed_blocks"] == event["total_blocks"]] == [
                     0, 1, 2]
+
+
+def test_parallel_bc7_multi_adjustment_lower_mips_match_serial_results(
+        tmp_path, monkeypatch):
+    width, height = 20, 4
+    block_count = 5 + 3 + 2
+    original = _dx10_dds(_mode6_block() * block_count,
+                         width=width, height=height, mip_count=3)
+    source = tmp_path / "body.dds"
+    source.write_bytes(original)
+    layout = inspect_dds_layout(source)
+    claims = bytearray(
+        1 if x < width // 2 else 2
+        for _y in range(height)
+        for x in range(width))
+    adjustments = (
+        None, prepare_color_adjustment({"hue": 60}),
+        prepare_color_adjustment({"brightness": 1.5}),
+    )
+    prepared = SimpleNamespace(
+        selected_path="body.dds", info=layout.info, layout=layout,
+        mip0_claims=claims, intent_adjustments=adjustments,
+        mip0_affected_blocks=tuple(range(5)),)
+    monkeypatch.setattr(texture_save, "_bc7_worker_count", lambda: 2)
+    monkeypatch.setattr(texture_save, "_BC7_CHUNK_SIZE", 2)
+    monkeypatch.setattr(texture_save, "_SAVE_PROGRESS_INTERVAL", 0)
+
+    class InlineExecutor:
+        def submit(self, function, argument):
+            future = Future()
+            future.set_result(function(argument))
+            return future
+
+        def shutdown(self, **_kwargs):
+            pass
+
+    monkeypatch.setattr(
+        texture_save, "ProcessPoolExecutor", lambda **_kwargs: InlineExecutor())
+    monkeypatch.setattr(texture_save, "_BC7_PARALLEL_THRESHOLD", 10000)
+    serial_bytes, serial_stats = texture_save._save_bc7_blocks(
+        original, prepared)
+
+    monkeypatch.setattr(texture_save, "_BC7_PARALLEL_THRESHOLD", 0)
+    parallel_bytes, parallel_stats = texture_save._save_bc7_blocks(
+        original, prepared)
+
+    assert parallel_bytes == serial_bytes
+    assert parallel_stats == serial_stats
+    assert parallel_stats.multi_intent_blocks > 0
 
 
 def test_bc7_result_application_uses_block_offsets():


### PR DESCRIPTION
## Summary\n\n- Reuse the weighted single-intent worker job for lower-mip blocks containing exactly one adjustment class, including multi-adjustment saves.\n- Derive the worker adjustment and changed/total weights from the block's actual class index.\n- Preserve parent-prepared fallback jobs for lower-mip multi-class blocks and keep mip-0 behavior unchanged.\n- Add exact byte/stat/diagnostic parity coverage for class selection, edge blocks, wide weights, malformed states, and full saves.\n\n## Validation\n\n- Targeted texture-save tests cover the new paths and run in the repository test suite.\n- CI should run the full repository test suite.\n- No BC7 codec, frontend, metadata, or public diagnostics changes are included.