### PR TITLE
Reduce BC7 fixed-index fitting overhead

### DIFF
--- a/src/core/textures/bc7.py
+++ b/src/core/textures/bc7.py
@@ -396,7 +396,16 @@ def recolor_separate(block, target_pixels, valid_width, valid_height):
         scalar_indices = second_indices
         vector_precision = scalar_precision = 2
         precisions = (7, 7, 7, 8)
+    vector_weights = (WEIGHTS_3 if vector_precision == 3
+                      else WEIGHTS_2)
+    scalar_weights = (WEIGHTS_3 if scalar_precision == 3
+                      else WEIGHTS_2)
     alpha_internal = 3 if not rotation else rotation - 1
+    vector_basis = _prepare_fixed_index_fit_basis(
+        vector_indices, vector_weights)
+    scalar_basis = (
+        _prepare_fixed_index_fit_basis(scalar_indices, scalar_weights)
+        if alpha_internal != 3 else None)
     targets_by_channel = [[] for _channel in range(4)]
     indices_by_channel = [vector_indices] * 3 + [scalar_indices]
     for row in range(valid_height):
@@ -422,7 +431,8 @@ def recolor_separate(block, target_pixels, valid_width, valid_height):
                 (1 << precision) - 1,
                 lambda raw, _pbit: _unquantize(raw, precision)),
             original_raw=(raw_endpoints[0][channel],
-                          raw_endpoints[1][channel]))
+                          raw_endpoints[1][channel]),
+            basis=(vector_basis if channel < 3 else scalar_basis))
         bits = set_bits(bits, endpoint_offset, precision, raw0)
         bits = set_bits(bits, endpoint_offset + precision, precision, raw1)
         endpoint_offset += precision * 2
@@ -558,6 +568,26 @@ class _EndpointCodec:
 
 
 @dataclass(frozen=True)
+class _FixedIndexFitBasis:
+    """Index-only terms shared by channels with one fixed index stream."""
+
+    fractions: tuple
+    aa: float
+    ab: float
+    bb: float
+    determinant: float
+
+
+def _prepare_fixed_index_fit_basis(indices, weights):
+    fractions = tuple(weights[index] / 64.0 for index in indices)
+    aa = sum((1.0 - fraction) ** 2 for fraction in fractions)
+    ab = sum((1.0 - fraction) * fraction for fraction in fractions)
+    bb = sum(fraction ** 2 for fraction in fractions)
+    return _FixedIndexFitBasis(
+        fractions, aa, ab, bb, aa * bb - ab * ab)
+
+
+@dataclass(frozen=True)
 class BC7RecolorResult:
     """The source-preserving result of recoloring one BC7 block."""
 
@@ -689,20 +719,22 @@ def _quantize_endpoint(value, codec, pbit):
 
 def _fit_fixed_index_endpoints(targets, indices, weights, endpoint_codec,
                                *, original_raw=(0, 0), pbit0=None,
-                               pbit1=None, neighborhood=2):
+                               pbit1=None, neighborhood=2, basis=None):
     """Fit a legal endpoint pair with a small deterministic local search."""
     if not targets:
         return original_raw
-    fractions = tuple(weights[index] / 64.0 for index in indices)
-    aa = sum((1.0 - fraction) ** 2 for fraction in fractions)
-    ab = sum((1.0 - fraction) * fraction for fraction in fractions)
-    bb = sum(fraction ** 2 for fraction in fractions)
+    if basis is None:
+        basis = _prepare_fixed_index_fit_basis(indices, weights)
+    fractions = basis.fractions
+    aa = basis.aa
+    ab = basis.ab
+    bb = basis.bb
     at = sum((1.0 - fraction) * target
              for fraction, target in zip(fractions, targets))
     bt = sum(fraction * target
              for fraction, target in zip(fractions, targets))
     tt = sum(target * target for target in targets)
-    determinant = aa * bb - ab * ab
+    determinant = basis.determinant
     if determinant > 1e-9:
         estimate0 = (at * bb - bt * ab) / determinant
         estimate1 = (bt * aa - at * ab) / determinant
@@ -724,14 +756,6 @@ def _fit_fixed_index_endpoints(targets, indices, weights, endpoint_codec,
         raw0_values.add(_quantize_endpoint(value, endpoint_codec, pbit0))
         raw1_values.add(_quantize_endpoint(value, endpoint_codec, pbit1))
 
-    def error(endpoint0, endpoint1):
-        return (aa * endpoint0 * endpoint0
-                + 2.0 * ab * endpoint0 * endpoint1
-                + bb * endpoint1 * endpoint1
-                - 2.0 * at * endpoint0
-                - 2.0 * bt * endpoint1
-                + tt)
-
     raw0_candidates = sorted(raw0_values)
     raw1_candidates = sorted(raw1_values)
     decoded0 = tuple(
@@ -740,13 +764,26 @@ def _fit_fixed_index_endpoints(targets, indices, weights, endpoint_codec,
     decoded1 = tuple(
         (raw1, endpoint_codec.decode(raw1, pbit1))
         for raw1 in raw1_candidates)
+    original_endpoint0 = endpoint_codec.decode(original_raw[0], pbit0)
+    original_endpoint1 = endpoint_codec.decode(original_raw[1], pbit1)
     best = (
-        error(endpoint_codec.decode(original_raw[0], pbit0),
-              endpoint_codec.decode(original_raw[1], pbit1)),
+        (aa * original_endpoint0 * original_endpoint0
+         + 2.0 * ab * original_endpoint0 * original_endpoint1
+         + bb * original_endpoint1 * original_endpoint1
+         - 2.0 * at * original_endpoint0
+         - 2.0 * bt * original_endpoint1
+         + tt),
         original_raw[0], original_raw[1])
     for raw0, endpoint0 in decoded0:
         for raw1, endpoint1 in decoded1:
-            candidate = (error(endpoint0, endpoint1), raw0, raw1)
+            candidate = (
+                aa * endpoint0 * endpoint0
+                + 2.0 * ab * endpoint0 * endpoint1
+                + bb * endpoint1 * endpoint1
+                - 2.0 * at * endpoint0
+                - 2.0 * bt * endpoint1
+                + tt,
+                raw0, raw1)
             if candidate < best:
                 best = candidate
     return best[1], best[2]

--- a/src/tests/core/textures/test_bc7.py
+++ b/src/tests/core/textures/test_bc7.py
@@ -98,13 +98,14 @@ def _mode7_block():
     return bits.to_bytes(16, "little")
 
 
-def _separate_block(mode, rotation):
+def _separate_block(mode, rotation, index_mode=None):
     bits = 1 << mode
     start = mode + 1
     bits = _put(bits, start, 2, rotation)
     start += 2
-    index_mode = 1 if mode == 4 and rotation % 2 else 0
     if mode == 4:
+        if index_mode is None:
+            index_mode = 1 if rotation % 2 else 0
         bits = _put(bits, start, 1, index_mode)
         start += 1
     precisions = (5, 5, 5, 6) if mode == 4 else (7, 7, 7, 8)
@@ -331,7 +332,105 @@ def test_fixed_index_fitter_empty_and_degenerate_inputs_match_reference():
             targets, indices, bc7.WEIGHTS_3, codec, original_raw=(7, 19))
         actual = bc7._fit_fixed_index_endpoints(
             targets, indices, bc7.WEIGHTS_3, codec, original_raw=(7, 19))
+        prepared = bc7._fit_fixed_index_endpoints(
+            targets, indices, bc7.WEIGHTS_3, codec, original_raw=(7, 19),
+            basis=bc7._prepare_fixed_index_fit_basis(
+                indices, bc7.WEIGHTS_3))
         assert actual == expected
+        assert prepared == expected
+
+
+@pytest.mark.parametrize(
+    ("weights", "indices", "targets"),
+    ((
+        (bc7.WEIGHTS_2, (0, 1, 2, 3), (0, 255, 128, 64)),
+        (bc7.WEIGHTS_3, (0, 1, 2, 3, 4), (17, 42, 201, 88, 254)),
+        (bc7.WEIGHTS_4, (0, 3, 6, 9), (255, 3, 127, 64)),
+    )),
+    ids=("weights2", "weights3", "weights4"))
+@pytest.mark.parametrize(
+    "codec_case", _ENDPOINT_CASES,
+    ids=lambda case: case[0])
+def test_fixed_index_prepared_basis_matches_reference(
+        weights, indices, targets, codec_case):
+    _codec_name, codec, pbit0, pbit1 = codec_case
+    original_raw = (
+        min(codec.raw_max, 7), min(codec.raw_max, 19))
+    expected = _reference_fit_fixed_index_endpoints(
+        targets, indices, weights, codec,
+        original_raw=original_raw, pbit0=pbit0, pbit1=pbit1)
+    generic = bc7._fit_fixed_index_endpoints(
+        targets, indices, weights, codec,
+        original_raw=original_raw, pbit0=pbit0, pbit1=pbit1)
+    prepared = bc7._prepare_fixed_index_fit_basis(indices, weights)
+    optimized = bc7._fit_fixed_index_endpoints(
+        targets, indices, weights, codec,
+        original_raw=original_raw, pbit0=pbit0, pbit1=pbit1,
+        basis=prepared)
+
+    assert generic == expected
+    assert optimized == generic
+
+
+@pytest.mark.parametrize("rotation", range(4))
+@pytest.mark.parametrize("index_mode", range(2))
+@pytest.mark.parametrize("valid_width, valid_height", _EDGE_SIZES)
+def test_mode4_rotation_and_index_mode_match_reference(
+        monkeypatch, rotation, index_mode, valid_width, valid_height):
+    block = _separate_block(4, rotation, index_mode)
+    source = bc7.decode_block(block)
+    target = tuple(
+        (min(255, red + 31), max(0, green - 17),
+         min(255, blue + 23), alpha)
+        for red, green, blue, alpha in source)
+    optimized = bc7.recolor_block(
+        block, target, valid_width=valid_width, valid_height=valid_height)
+
+    def reference_fitter(*args, **kwargs):
+        kwargs.pop("basis", None)
+        return _reference_fit_fixed_index_endpoints(*args, **kwargs)
+
+    monkeypatch.setattr(bc7, "_fit_fixed_index_endpoints", reference_fitter)
+    reference = bc7.recolor_block(
+        block, target, valid_width=valid_width, valid_height=valid_height)
+
+    assert optimized.block == reference.block
+    assert optimized.candidate_pixels == reference.candidate_pixels
+    assert optimized.source_error == reference.source_error
+    assert optimized.candidate_error == reference.candidate_error
+
+
+def test_mode4_deterministic_corpus_matches_reference(monkeypatch):
+    cases = []
+    for case in range(96):
+        rotation = case % 4
+        index_mode = (case // 4) % 2
+        valid_width = 1 + (case * 3) % 4
+        valid_height = 1 + (case * 5) % 4
+        block = _separate_block(4, rotation, index_mode)
+        source = bc7.decode_block(block)
+        target = tuple(
+            ((red + case * 7 + pixel * 3) & 0xff,
+             (green - case * 5 - pixel * 2) & 0xff,
+             (blue + case * 11 + pixel) & 0xff,
+             alpha)
+            for pixel, (red, green, blue, alpha) in enumerate(source))
+        cases.append((block, target, valid_width, valid_height))
+
+    optimized = [bc7.recolor_block(
+        block, target, valid_width, valid_height)
+        for block, target, valid_width, valid_height in cases]
+
+    def reference_fitter(*args, **kwargs):
+        kwargs.pop("basis", None)
+        return _reference_fit_fixed_index_endpoints(*args, **kwargs)
+
+    monkeypatch.setattr(bc7, "_fit_fixed_index_endpoints", reference_fitter)
+    reference = [bc7.recolor_block(
+        block, target, valid_width, valid_height)
+        for block, target, valid_width, valid_height in cases]
+
+    assert optimized == reference
 
 
 @pytest.mark.parametrize("mode", range(8))
@@ -347,9 +446,12 @@ def test_recolor_block_matches_reference_fitter(
         for red, green, blue, alpha in source)
     optimized = bc7.recolor_block(
         block, target, valid_width=valid_width, valid_height=valid_height)
-    monkeypatch.setattr(
-        bc7, "_fit_fixed_index_endpoints",
-        _reference_fit_fixed_index_endpoints)
+
+    def reference_fitter(*args, **kwargs):
+        kwargs.pop("basis", None)
+        return _reference_fit_fixed_index_endpoints(*args, **kwargs)
+
+    monkeypatch.setattr(bc7, "_fit_fixed_index_endpoints", reference_fitter)
     reference = bc7.recolor_block(
         block, target, valid_width=valid_width, valid_height=valid_height)
 


### PR DESCRIPTION
## Summary

- Inline the fixed-index candidate error calculation while preserving the existing floating-point expression and tuple ordering.
- Reuse block-local fixed-index fit terms across the fitted channels in the separate-alpha recolor path.
- Keep the independent reference fitter unchanged and add exact parity coverage for prepared bases, Mode 4 rotations/index modes, edge blocks, and a deterministic corpus.

## Validation

- .venv-test\\Scripts\\python.exe -m pytest -q
- 1665 passed, 1 skipped