### PR TITLE
Fix attachment-stable model rig roots

### DIFF
--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1338,7 +1338,8 @@ def test_cross_source_neutral_sampling_uses_radius_and_true_mutual_nearest(
         "mutual-left#bone=11", "mutual-right#bone=21"]]
 
 
-def test_cross_source_reconciliation_keeps_accessory_root_as_attachment(module_page):
+def test_cross_source_reconciliation_preserves_host_root_and_reroots_accessory(
+        module_page):
     page = module_page
     result = page.evaluate("""async () => {
       const {buildModelRigReconciliation} = await import(
@@ -1475,6 +1476,12 @@ def test_cross_source_reconciliation_uses_neutral_weights_and_attachment_boundar
         edge.relationshipType === 'attachment');
       const attachmentBoundary = id(first, 'accessory#bone=20');
       const bodyTarget = id(first, 'main#bone=2');
+      const bodyRoot = id(first, 'main#bone=0');
+      const bodyParent = id(first, 'main#bone=1');
+      const accessoryChild = id(first, 'accessory#bone=21');
+      const accessoryRoot = id(first, 'accessory#bone=22');
+      const accessoryBranch = id(first, 'accessory#bone=23');
+      const component = first.components[0];
       const mapKeys = [
         'main#bone=0', 'main#bone=1', 'main#bone=2', 'main#bone=3',
         'partial#bone=7', 'partial#bone=8', 'partial#bone=9',
@@ -1498,7 +1505,13 @@ def test_cross_source_reconciliation_uses_neutral_weights_and_attachment_boundar
           target: attachment.jointA === bodyTarget,
         } : null,
         attachedRoot: first.components.length === 1
-          && first.components[0].rootId === bodyTarget,
+          && component.rootId === bodyRoot,
+        hostOrientation: component.parentById[bodyTarget] === bodyParent
+          && component.parentById[bodyParent] === bodyRoot,
+        accessoryOrientation: component.parentById[attachmentBoundary] === bodyTarget
+          && component.parentById[accessoryChild] === attachmentBoundary
+          && component.parentById[accessoryRoot] === accessoryChild
+          && component.parentById[accessoryBranch] === accessoryChild,
         orderInvariant: mapKeys.every(key =>
           id(first, key) === id(second, key))
           && JSON.stringify(first.edges.map(edge => [
@@ -1518,9 +1531,88 @@ def test_cross_source_reconciliation_uses_neutral_weights_and_attachment_boundar
     assert result["attachment"]["boundary"]
     assert result["attachment"]["target"]
     assert result["attachedRoot"]
+    assert result["hostOrientation"]
+    assert result["accessoryOrientation"]
+
+
+def test_cross_source_reconciliation_preserves_host_for_multiple_attachments(
+        module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const {buildModelRigReconciliation} = await import(
+        './js/mesh/weight-rig-reconcile.js');
+      const make = (sourceKey, entries, rootId, edgeList) => {
+        const nodeIds = entries.map(([id]) => id);
+        const parentById = Object.fromEntries(nodeIds.map(id => [id, null]));
+        const childrenById = Object.fromEntries(nodeIds.map(id => [id, []]));
+        edgeList.forEach(([parent, child]) => {
+          parentById[child] = parent;
+          childrenById[parent].push(child);
+        });
+        return {
+          sourceKey, boneIds: nodeIds,
+          influenceGraph: {nodes: entries.map(([boneId, weightedCenter]) => ({
+            boneId, weightedCenter, weightedRadius: .1,
+            totalWeight: 10, affectedVertexCount: 20,
+          }))},
+          centerByBoneId: new Map(entries),
+          jointPivotByBoneId: new Map(entries.filter(([id]) => id !== rootId)),
+          restDirectionByBoneId: new Map(entries.map(([id]) => [id, [0, 1, 0]])),
+          restFrameByBoneId: new Map(),
+          restFrameEvidenceByBoneId: new Map(),
+          inferredForest: {
+            components: [{componentId: 0, rootId, nodeIds,
+              parentById, childrenById,
+              depthById: Object.fromEntries(nodeIds.map(id => [id, 0])),
+              edges: edgeList.map(([boneA, boneB]) => ({
+                boneA, boneB, treeEdgeScore: 1,
+              }))}],
+            componentByBoneId: Object.fromEntries(nodeIds.map(id => [id, 0])),
+          },
+        };
+      };
+      const host = make('host', [
+        [0, [0, 0, 0]], [1, [0, 1, 0]], [2, [0, 2, 0]],
+      ], 0, [[0, 1], [1, 2]]);
+      const upper = make('upper', [
+        [10, [.05, 2, 0]], [11, [.35, 2.3, 0]],
+      ], 10, [[10, 11]]);
+      const lower = make('lower', [
+        [20, [.05, 0, 0]], [21, [-.3, -.3, 0]],
+      ], 20, [[20, 21]]);
+      const first = buildModelRigReconciliation(
+        [host, upper, lower], {modelReferenceRadius: 1});
+      const second = buildModelRigReconciliation(
+        [lower, host, upper], {modelReferenceRadius: 1});
+      const id = (value, source, bone) =>
+        value.sourceBoneToModelJointId[`${source}#bone=${bone}`];
+      const hostRoot = id(first, 'host', 0);
+      const hostMiddle = id(first, 'host', 1);
+      const hostTop = id(first, 'host', 2);
+      const upperRoot = id(first, 'upper', 10);
+      const lowerRoot = id(first, 'lower', 20);
+      const component = first.components.find(item =>
+        item.nodeIds.includes(hostRoot));
+      const hierarchy = value => value.components.map(item => ({
+        root: item.rootId,
+        parent: Object.entries(item.parentById).sort(),
+      }));
+      return {
+        attachmentCount: first.reconciliation.attachmentCount,
+        root: component?.rootId,
+        hostParent: [component?.parentById[hostMiddle],
+          component?.parentById[hostTop]],
+        accessoryParents: [component?.parentById[upperRoot],
+          component?.parentById[lowerRoot]],
+        orderInvariant: JSON.stringify(hierarchy(first)) ===
+          JSON.stringify(hierarchy(second)),
+      };
+    }""")
+    assert result["attachmentCount"] == 2
+    assert result["root"] == 0
+    assert result["hostParent"] == [0, 1]
+    assert result["accessoryParents"] == [2, 0]
     assert result["orderInvariant"]
-
-
 def test_cross_source_reconciliation_confidence_lanes_and_support(module_page):
     page = module_page
     result = page.evaluate("""async () => {

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1533,6 +1533,7 @@ def test_cross_source_reconciliation_uses_neutral_weights_and_attachment_boundar
     assert result["attachedRoot"]
     assert result["hostOrientation"]
     assert result["accessoryOrientation"]
+    assert result["orderInvariant"]
 
 
 def test_cross_source_reconciliation_preserves_host_for_multiple_attachments(
@@ -1613,6 +1614,177 @@ def test_cross_source_reconciliation_preserves_host_for_multiple_attachments(
     assert result["hostParent"] == [0, 1]
     assert result["accessoryParents"] == [2, 0]
     assert result["orderInvariant"]
+
+
+def test_cross_source_reconciliation_preserves_attachment_chain_order(
+        module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const {buildModelRigReconciliation} = await import(
+        './js/mesh/weight-rig-reconcile.js');
+      const make = (sourceKey, entries, rootId, edgeList, totalWeight) => {
+        const nodeIds = entries.map(([id]) => id);
+        const parentById = Object.fromEntries(nodeIds.map(id => [id, null]));
+        const childrenById = Object.fromEntries(nodeIds.map(id => [id, []]));
+        edgeList.forEach(([parent, child]) => {
+          parentById[child] = parent;
+          childrenById[parent].push(child);
+        });
+        return {
+          sourceKey, boneIds: nodeIds,
+          influenceGraph: {nodes: entries.map(([boneId, weightedCenter]) => ({
+            boneId, weightedCenter, weightedRadius: .1,
+            totalWeight, affectedVertexCount: 20,
+          }))},
+          centerByBoneId: new Map(entries),
+          jointPivotByBoneId: new Map(entries.filter(([id]) => id !== rootId)),
+          restDirectionByBoneId: new Map(nodeIds.map(id => [id, [0, 1, 0]])),
+          restFrameByBoneId: new Map(),
+          restFrameEvidenceByBoneId: new Map(),
+          inferredForest: {
+            components: [{componentId: 0, rootId, nodeIds,
+              parentById, childrenById,
+              depthById: Object.fromEntries(nodeIds.map(id => [id, 0])),
+              edges: edgeList.map(([boneA, boneB]) => ({
+                boneA, boneB, treeEdgeScore: 1,
+              }))}],
+            componentByBoneId: Object.fromEntries(nodeIds.map(id => [id, 0])),
+          },
+        };
+      };
+      const host = make('host', [
+        [0, [0, 0, 0]], [1, [0, 1, 0]], [2, [0, 2, 0]],
+      ], 0, [[0, 1], [1, 2]], 10);
+      const accessoryA = make('accessory-a', [
+        [10, [0, 2.04, 0]], [11, [0, 2.09, 0]],
+      ], 10, [[10, 11]], 10);
+      const accessoryB = make('accessory-b', [
+        [20, [0, 2.14, 0]], [21, [.3, 2.4, 0]],
+      ], 20, [[20, 21]], 5);
+      const first = buildModelRigReconciliation(
+        [host, accessoryA, accessoryB], {modelReferenceRadius: 1});
+      const second = buildModelRigReconciliation(
+        [accessoryB, host, accessoryA], {modelReferenceRadius: 1});
+      const id = (value, source, bone) =>
+        value.sourceBoneToModelJointId[`${source}#bone=${bone}`];
+      const hostRoot = id(first, 'host', 0);
+      const hostMiddle = id(first, 'host', 1);
+      const hostTop = id(first, 'host', 2);
+      const accessoryARoot = id(first, 'accessory-a', 10);
+      const accessoryAEnd = id(first, 'accessory-a', 11);
+      const accessoryBRoot = id(first, 'accessory-b', 20);
+      const component = first.components.find(item =>
+        item.nodeIds.includes(hostRoot));
+      const attachments = first.edges.filter(edge =>
+        edge.relationshipType === 'attachment');
+      const attachmentPairs = attachments.map(edge => [
+        edge.targetJointId, edge.accessoryJointId,
+      ]);
+      const secondPairs = second.edges.filter(edge =>
+        edge.relationshipType === 'attachment').map(edge => [
+        edge.targetJointId, edge.accessoryJointId,
+      ]);
+      const hierarchy = value => value.components.map(item => ({
+        root: item.rootId,
+        parent: Object.entries(item.parentById).sort(),
+      }));
+      return {
+        attachmentCount: attachments.length,
+        hostRoot, hostMiddle, hostTop, accessoryARoot, accessoryAEnd,
+        root: component?.rootId,
+        hostParent: [component?.parentById[hostMiddle],
+          component?.parentById[hostTop]],
+        accessoryAParent: [component?.parentById[accessoryARoot],
+          component?.parentById[accessoryAEnd]],
+        accessoryBParent: component?.parentById[accessoryBRoot],
+        targetChain: attachmentPairs.some(pair =>
+          pair[0] === hostTop && pair[1] === accessoryARoot)
+          && attachmentPairs.some(pair =>
+            pair[0] === accessoryAEnd && pair[1] === accessoryBRoot),
+        orderInvariant: JSON.stringify(hierarchy(first)) ===
+          JSON.stringify(hierarchy(second)),
+        edgeOrderInvariant: JSON.stringify(attachmentPairs) ===
+          JSON.stringify(secondPairs),
+      };
+    }""")
+    assert result["attachmentCount"] == 2, result
+    assert result["root"] == result["hostRoot"]
+    assert result["hostParent"] == [result["hostRoot"], result["hostMiddle"]]
+    assert result["accessoryAParent"] == [
+        result["hostTop"], result["accessoryARoot"],
+    ]
+    assert result["accessoryBParent"] == result["accessoryAEnd"]
+    assert result["targetChain"]
+    assert result["orderInvariant"]
+    assert result["edgeOrderInvariant"]
+
+
+def test_cross_source_reconciliation_equal_support_is_order_invariant(
+        module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const {buildModelRigReconciliation} = await import(
+        './js/mesh/weight-rig-reconcile.js');
+      const make = (sourceKey, entries, rootId) => ({
+        sourceKey, boneIds: entries.map(([id]) => id),
+        influenceGraph: {nodes: entries.map(([boneId, weightedCenter]) => ({
+          boneId, weightedCenter, weightedRadius: .1,
+          totalWeight: 10, affectedVertexCount: 20,
+        }))},
+        centerByBoneId: new Map(entries),
+        jointPivotByBoneId: new Map(entries.filter(([id]) => id !== rootId)),
+        restDirectionByBoneId: new Map(entries.map(([id]) => [
+          id, [0, 1, 0],
+        ])),
+        restFrameByBoneId: new Map(),
+        restFrameEvidenceByBoneId: new Map(),
+        inferredForest: {
+          components: [{
+            componentId: 0, rootId, nodeIds: entries.map(([id]) => id),
+            parentById: Object.fromEntries(entries.map(([id], index) => [
+              id, index ? entries[index - 1][0] : null,
+            ])),
+            childrenById: Object.fromEntries(entries.map(([id], index) => [
+              id, index < entries.length - 1 ? [entries[index + 1][0]] : [],
+            ])),
+            depthById: Object.fromEntries(entries.map(([id]) => [id, 0])),
+            edges: [[entries[0][0], entries[1][0]]].map(([boneA, boneB]) => ({
+              boneA, boneB, treeEdgeScore: 1,
+            })),
+          }],
+          componentByBoneId: Object.fromEntries(entries.map(([id]) => [id, 0])),
+        },
+      });
+      const first = buildModelRigReconciliation([
+        make('alpha', [[0, [0, 0, 0]], [1, [0, .05, 0]]], 0),
+        make('zeta', [[10, [0, .1, 0]], [11, [0, .15, 0]]], 10),
+      ], {modelReferenceRadius: 1});
+      const second = buildModelRigReconciliation([
+        make('zeta', [[10, [0, .1, 0]], [11, [0, .15, 0]]], 10),
+        make('alpha', [[0, [0, 0, 0]], [1, [0, .05, 0]]], 0),
+      ], {modelReferenceRadius: 1});
+      const hierarchy = value => value.components.map(item => ({
+        root: item.rootId,
+        parent: Object.entries(item.parentById).sort(),
+      }));
+      const attachments = value => value.edges
+        .filter(edge => edge.relationshipType === 'attachment')
+        .map(edge => [edge.targetJointId, edge.accessoryJointId]);
+      return {
+        attachmentCount: first.reconciliation.attachmentCount,
+        hierarchy: JSON.stringify(hierarchy(first)) ===
+          JSON.stringify(hierarchy(second)),
+        edges: JSON.stringify(attachments(first)) ===
+          JSON.stringify(attachments(second)),
+        root: first.components[0]?.rootId,
+      };
+    }""")
+    assert result["attachmentCount"] == 1, result
+    assert result["hierarchy"]
+    assert result["edges"]
+    assert result["root"] == 0
+
+
 def test_cross_source_reconciliation_confidence_lanes_and_support(module_page):
     page = module_page
     result = page.evaluate("""async () => {

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -2370,13 +2370,24 @@ def test_loaded_skinning_rebaselines_after_shape_change(
           const {refreshMeshes} = await import('./js/mesh/mesh-state.js');
           await experiment.ensureModelWeightsLoaded();
           await experiment.ensureModelRigLoaded();
-          const rigState = experiment.getModelRigState();
-          const posedJoint = rigState.model.joints.find(joint =>
+          let rigState = experiment.getModelRigState();
+          let debug = experiment.getModelRigDebugState();
+          const rootComponent = rigState.model.components.find(component =>
+            component.nodeIds.some(id => id !== component.rootId));
+          const manualRootId = rootComponent?.nodeIds.find(id =>
+            id !== rootComponent.rootId);
+          const manualRootJoint = debug.joints.find(joint =>
+            joint.jointId === manualRootId);
+          const manualRootSignature = manualRootJoint?.signature;
+          const manualRootApplied = experiment.setRigJointRoot(manualRootId);
+          rigState = experiment.getModelRigState();
+          const posedJoint = debug.joints.find(joint =>
             rigState.model.components.some(component =>
               component.nodeIds.includes(joint.jointId)
               && component.rootId !== joint.jointId));
+          const posedJointSignature = posedJoint?.signature;
+          const THREE = await import('three');
           if (posedJoint) {
-            const THREE = await import('three');
             experiment.setRigJointRotation(posedJoint.jointId,
               new THREE.Quaternion().setFromAxisAngle(
                 new THREE.Vector3(0, 0, 1), Math.PI / 12));
@@ -2385,12 +2396,50 @@ def test_loaded_skinning_rebaselines_after_shape_change(
           setControlValue('shape', '1');
           refreshMeshes();
           const state = experiment.getSkinningState(mesh);
+          const influenceGraph = state.influenceGraph;
+          await experiment.ensureModelRigLoaded();
+          const rebuiltDebug = experiment.getModelRigDebugState();
+          const rebuiltJoint = rebuiltDebug.joints.find(joint =>
+            joint.signature === manualRootSignature);
+          const rebuiltComponent = rebuiltDebug.components.find(component =>
+            component.nodeIds.includes(rebuiltJoint?.jointId));
+          const rebuiltPoseJoint = rebuiltDebug.joints.find(joint =>
+            joint.signature === posedJointSignature);
+          const rootSurvived = rebuiltComponent?.rootId === rebuiltJoint?.jointId
+            && rebuiltDebug.explicitRootSignatures.includes(manualRootSignature);
+          const poseAfterRebuild = experiment.setRigJointRotation(
+            rebuiltPoseJoint?.jointId,
+            new THREE.Quaternion().setFromAxisAngle(
+              new THREE.Vector3(0, 0, 1), Math.PI / 12),
+            {dragging: true});
+          const resetAfterRebuild = experiment.resetRigPose();
+          const resetDebug = experiment.getModelRigDebugState();
+          const resetComponent = resetDebug.components.find(component =>
+            component.nodeIds.includes(rebuiltJoint?.jointId));
+          const resetWorked = resetAfterRebuild
+            && resetDebug.poseJointIds.length === 0
+            && resetDebug.explicitRootSignatures.length === 0
+            && resetComponent?.rootId !== rebuiltJoint?.jointId;
+          experiment.setRigJointRoot(rebuiltJoint?.jointId);
+          experiment.unregisterSkinningMesh(mesh);
+          const unresolvedDebug = experiment.getModelRigDebugState();
+          const unresolvedDropped = !unresolvedDebug.explicitRootSignatures
+            || unresolvedDebug.explicitRootSignatures.length === 0;
+          experiment.destroyModelPhysicsSession();
+          const resetState = experiment.getModelRigState();
           const after = [...mesh.geometry.attributes.position.array];
           const box = mesh.geometry.boundingBox;
           const sphere = mesh.geometry.boundingSphere;
           URL.revokeObjectURL(url);
           return {
             loaded: state.loaded,
+            manualRootApplied,
+            manualRootSignature,
+            rootSurvived,
+            poseAfterRebuild,
+            resetWorked,
+            unresolvedDropped,
+            fullResetCleared: !resetState.loaded,
             baseline: [...state.baselinePositions],
             before, after,
             bounds: {
@@ -2399,7 +2448,7 @@ def test_loaded_skinning_rebaselines_after_shape_change(
             sphere: {
               center: sphere.center.toArray(), radius: sphere.radius,
             },
-            graph: state.influenceGraph,
+            graph: influenceGraph,
           };
         }""")
         assert result["loaded"]
@@ -2411,6 +2460,13 @@ def test_loaded_skinning_rebaselines_after_shape_change(
         assert result["bounds"]["max"] == pytest.approx([1.2, 1.2, 0])
         assert result["sphere"]["center"] == pytest.approx([.6, .6, 0])
         assert result["sphere"]["radius"] == pytest.approx(math.sqrt(.72))
+        assert result["manualRootApplied"]
+        assert result["manualRootSignature"]
+        assert result["rootSurvived"]
+        assert result["poseAfterRebuild"]
+        assert result["resetWorked"]
+        assert result["unresolvedDropped"]
+        assert result["fullResetCleared"]
         for offset in range(0, len(result["after"]), 3):
             point = result["after"][offset:offset + 3]
             assert all(result["bounds"]["min"][axis] - 1e-6 <= point[axis]

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -2483,6 +2483,100 @@ def test_loaded_skinning_rebaselines_after_shape_change(
         context.close()
 
 
+def _multi_mesh_skinning_shape_payload():
+    payload = _payload("SkinningShapePair")
+    template = next(iter(payload["meshes"].values()))
+    second = copy.deepcopy(template)
+    second["component"] = "Body SkinningShapePair second"
+    payload["meshes"]["Body-SkinningShapePair-1"] = second
+    return payload
+
+
+def test_loaded_skinning_rebaselines_all_shape_target_meshes(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"SkinningShapePair": _multi_mesh_skinning_shape_payload()})
+    try:
+        _open(page, "SkinningShapePair")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 2")
+        result = page.evaluate("""async () => {
+          const meshes = [...window.modViewer.activeMeshes];
+          const bytes = new Uint8Array(48);
+          new Uint32Array(bytes.buffer).set([0, 1, 1, 2, 0, 2]);
+          new Float32Array(bytes.buffer, 24).set([.8, .2, .7, .3, .6, .4]);
+          const url = URL.createObjectURL(new Blob([bytes]));
+          window.__testSkinningPreview = async () => ({
+            status: 'ok', vertex_count: 3, influence_count: 2,
+            bone_ids: [0, 1, 2], encoding: 'test', source: {
+              key: 'test/bodyblend.buf|offset=0', file: 'Test/BodyBlend.buf',
+              bone_id_offset: 0,
+            },
+            data: {
+              url, length: 48,
+              indices: {offset: 0, length: 24, type: 'u32'},
+              weights: {offset: 24, length: 24, type: 'f32'},
+            }, diagnostics: {},
+          });
+          const experiment = await import('./js/mesh/weight-experiment.js');
+          const {setControlValue} = await import('./js/editing/control-state.js');
+          const {refreshMeshes} = await import('./js/mesh/mesh-state.js');
+          await experiment.ensureModelWeightsLoaded();
+          await experiment.ensureModelRigLoaded();
+          const rigState = experiment.getModelRigState();
+          const debug = experiment.getModelRigDebugState();
+          const component = rigState.model.components.find(item =>
+            item.nodeIds.some(id => id !== item.rootId));
+          const manualRootId = component?.nodeIds.find(id =>
+            id !== component.rootId);
+          const manualRoot = debug.joints.find(joint =>
+            joint.jointId === manualRootId);
+          const manualRootApplied = experiment.setRigJointRoot(manualRootId);
+          const before = meshes.map(mesh =>
+            [...mesh.geometry.attributes.position.array]);
+          setControlValue('shape', '1');
+          const refresh = refreshMeshes();
+          const after = meshes.map(mesh =>
+            [...mesh.geometry.attributes.position.array]);
+          const states = meshes.map(mesh =>
+            experiment.getSkinningState(mesh));
+          await experiment.ensureModelRigLoaded();
+          const rebuilt = experiment.getModelRigDebugState();
+          const rebuiltJoint = rebuilt.joints.find(joint =>
+            joint.signature === manualRoot?.signature);
+          const rebuiltComponent = rebuilt.components.find(item =>
+            item.nodeIds.includes(rebuiltJoint?.jointId));
+          const rootSurvived = rebuiltComponent?.rootId === rebuiltJoint?.jointId
+            && rebuilt.explicitRootSignatures.includes(manualRoot?.signature);
+          const result = {
+            meshCount: meshes.length,
+            changedMeshCount: refresh.changedMeshes.length,
+            bothLoaded: states.every(state => state.loaded),
+            bothChanged: after.every((positions, index) =>
+              JSON.stringify(positions) !== JSON.stringify(before[index])),
+            manualRootApplied,
+            rootSurvived,
+            explicitRootSignatures: rebuilt.explicitRootSignatures,
+            before, after,
+          };
+          experiment.destroyModelPhysicsSession();
+          URL.revokeObjectURL(url);
+          return result;
+        }""")
+        assert result["meshCount"] == 2
+        assert result["changedMeshCount"] == 2
+        assert result["bothLoaded"]
+        assert result["bothChanged"]
+        assert result["manualRootApplied"]
+        assert result["rootSurvived"], result
+        assert result["explicitRootSignatures"]
+        assert all(positions[3] == pytest.approx(1.2)
+                   and positions[7] == pytest.approx(1.2)
+                   for positions in result["after"])
+    finally:
+        context.close()
+
+
 @pytest.mark.parametrize("stale_failure", [False, True], ids=["success", "failure"])
 def test_stale_rig_load_cannot_publish_after_model_switch(
         edge_browser, frontend_url, stale_failure):

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -2419,12 +2419,14 @@ def test_loaded_skinning_rebaselines_after_shape_change(
           const resetWorked = resetAfterRebuild
             && resetDebug.poseJointIds.length === 0
             && resetDebug.explicitRootSignatures.length === 0
-            && resetComponent?.rootId !== rebuiltJoint?.jointId;
+            && resetComponent
+            && resetComponent.rootId !== rebuiltJoint?.jointId;
           experiment.setRigJointRoot(rebuiltJoint?.jointId);
           experiment.unregisterSkinningMesh(mesh);
           const unresolvedDebug = experiment.getModelRigDebugState();
-          const unresolvedDropped = !unresolvedDebug.explicitRootSignatures
-            || unresolvedDebug.explicitRootSignatures.length === 0;
+          const unresolvedDropped = Array.isArray(
+            unresolvedDebug.explicitRootSignatures)
+            && unresolvedDebug.explicitRootSignatures.length === 0;
           experiment.destroyModelPhysicsSession();
           const resetState = experiment.getModelRigState();
           const after = [...mesh.geometry.attributes.position.array];

--- a/src/web/js/mesh/weight-experiment.js
+++ b/src/web/js/mesh/weight-experiment.js
@@ -1263,8 +1263,8 @@ function restoreDefaultModelRigOrientation(rig) {
 function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
   const started = performanceNow();
   const previousSelectedJointId = modelRigState.selectedJointId;
-  const previousRootSignatures = modelSkinningRig
-    ? new Set(modelRigState.explicitRootSignatures) : new Set();
+  const previousRootSignatures = new Set(
+    modelRigState.explicitRootSignatures);
   if (modelSkinningRig) resetModelPose({request: false});
   const reconciliation = buildModelRigReconciliation(sourceRigs);
   const joints = reconciliation.joints || [];
@@ -3181,6 +3181,8 @@ export function refreshSkinningAfterShapeChange(mesh) {
   const position = mesh?.geometry?.attributes?.position;
   clearPickedPoint();
   if (!state?.loaded || !position) return false;
+  const preservedRootSignatures = modelSkinningRig
+    ? new Set(modelRigState.explicitRootSignatures) : new Set();
   const sourceKey = state.skinningSourceKey;
   // Capture the authoritative shaped geometry before physics detachment or
   // pose reset can restore the previous baseline onto this mesh.
@@ -3212,7 +3214,7 @@ export function refreshSkinningAfterShapeChange(mesh) {
   modelRigState.jointPickIntent = null;
   modelRigState.ikEnabled = false;
   modelRigState.activeLimbRole = 'left_arm';
-  modelRigState.explicitRootSignatures = new Set();
+  modelRigState.explicitRootSignatures = preservedRootSignatures;
   rigPresetState.lastApplyResult = null;
   resolvedLimbMappings = null;
   resolvedLimbMappingsStructureRevision = null;

--- a/src/web/js/mesh/weight-experiment.js
+++ b/src/web/js/mesh/weight-experiment.js
@@ -1263,6 +1263,8 @@ function restoreDefaultModelRigOrientation(rig) {
 function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
   const started = performanceNow();
   const previousSelectedJointId = modelRigState.selectedJointId;
+  const previousRootSignatures = modelSkinningRig
+    ? new Set(modelRigState.explicitRootSignatures) : new Set();
   if (modelSkinningRig) resetModelPose({request: false});
   const reconciliation = buildModelRigReconciliation(sourceRigs);
   const joints = reconciliation.joints || [];
@@ -1322,7 +1324,23 @@ function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
     .map(([jointId, direction]) => [jointId, direction.toArray?.() || [...direction]]));
   rig.defaultRestContinuationChildByJointId = new Map(
     rig.restContinuationChildByJointId);
-  modelRigState.explicitRootSignatures = new Set();
+  let restoredRootSignatures = new Set();
+  if (previousRootSignatures.size) {
+    const rootRestore = modelForestWithRootSignatures(
+      rig, [...previousRootSignatures]);
+    installModelForest(rig, rootRestore.forest);
+    const signatureIndex = buildJointSignatureIndex(rig).resolvedBySignature;
+    restoredRootSignatures = new Set(rootRestore.appliedRoots.filter(signature => {
+      const jointId = signatureIndex.get(signature);
+      const componentId = rig.defaultComponentByJointId.get(jointId);
+      return Number.isInteger(Number(componentId))
+        && rig.defaultRootIdByComponent.get(Number(componentId)) !== jointId;
+    }));
+    if (restoredRootSignatures.size) {
+      rig.structureRevision = ++rigRuntime.structureRevision;
+    }
+  }
+  modelRigState.explicitRootSignatures = restoredRootSignatures;
   rigPresetState.lastApplyResult = null;
   sourceRigs.forEach(sourceRig => {
     rig.sourceTransformAliases.set(sourceRig.sourceKey, new Map());

--- a/src/web/js/mesh/weight-experiment.js
+++ b/src/web/js/mesh/weight-experiment.js
@@ -3181,8 +3181,8 @@ export function refreshSkinningAfterShapeChange(mesh) {
   const position = mesh?.geometry?.attributes?.position;
   clearPickedPoint();
   if (!state?.loaded || !position) return false;
-  const preservedRootSignatures = modelSkinningRig
-    ? new Set(modelRigState.explicitRootSignatures) : new Set();
+  const preservedRootSignatures = new Set(
+    modelRigState.explicitRootSignatures);
   const sourceKey = state.skinningSourceKey;
   // Capture the authoritative shaped geometry before physics detachment or
   // pose reset can restore the previous baseline onto this mesh.

--- a/src/web/js/mesh/weight-rig-reconcile.js
+++ b/src/web/js/mesh/weight-rig-reconcile.js
@@ -1408,6 +1408,285 @@ function orientModelForest(joints, edges, votes, rootOverrides = new Map()) {
   return {components, componentByJointId: componentById};
 }
 
+function cloneForestComponent(component) {
+  return {
+    ...component,
+    nodeIds: [...(component?.nodeIds || [])],
+    parentById: {...(component?.parentById || {})},
+    childrenById: Object.fromEntries(Object.entries(
+      component?.childrenById || {}).map(([id, children]) => [
+      id, [...children],
+    ])),
+    depthById: {...(component?.depthById || {})},
+    edges: (component?.edges || []).map(edge => ({...edge})),
+  };
+}
+
+function componentAdjacency(component) {
+  const adjacency = new Map((component?.nodeIds || []).map(id => [
+    Number(id), [],
+  ]));
+  (component?.edges || []).forEach(edge => {
+    const left = Number(edge.jointA ?? edge.boneA);
+    const right = Number(edge.jointB ?? edge.boneB);
+    if (!adjacency.has(left) || !adjacency.has(right) || left === right) {
+      return;
+    }
+    adjacency.get(left).push(right);
+    adjacency.get(right).push(left);
+  });
+  if (!adjacency.size) return adjacency;
+  adjacency.forEach((neighbors, id) => {
+    if (neighbors.length) return;
+    const parent = Number(component?.parentById?.[id]);
+    if (Number.isFinite(parent) && adjacency.has(parent)) {
+      neighbors.push(parent);
+      adjacency.get(parent).push(id);
+    }
+  });
+  adjacency.forEach(neighbors => {
+    neighbors.sort((left, right) => left - right);
+  });
+  return adjacency;
+}
+
+function orientComponentFromRoot(component, rootId) {
+  const nodeIds = (component?.nodeIds || []).map(Number)
+    .filter(Number.isFinite).sort((left, right) => left - right);
+  const root = nodeIds.includes(Number(rootId))
+    ? Number(rootId) : Number(component?.rootId);
+  const parentById = Object.fromEntries(nodeIds.map(id => [id, null]));
+  const childrenById = Object.fromEntries(nodeIds.map(id => [id, []]));
+  const depthById = Object.fromEntries(nodeIds.map(id => [id, null]));
+  const adjacency = componentAdjacency(component);
+  const queue = Number.isFinite(root) ? [root] : [];
+  const visited = new Set(queue);
+  if (Number.isFinite(root)) depthById[root] = 0;
+  while (queue.length) {
+    const parent = queue.shift();
+    (adjacency.get(parent) || []).forEach(child => {
+      if (visited.has(child)) return;
+      visited.add(child);
+      parentById[child] = parent;
+      childrenById[parent].push(child);
+      depthById[child] = depthById[parent] + 1;
+      queue.push(child);
+    });
+  }
+  return {
+    ...cloneForestComponent(component),
+    rootId: root,
+    nodeIds,
+    parentById,
+    childrenById,
+    depthById,
+    maxDepth: Math.max(0, ...Object.values(depthById)
+      .filter(depth => depth !== null).map(Number)),
+  };
+}
+
+function componentStableKey(component, joints) {
+  const memberKeys = (component?.nodeIds || []).flatMap(jointId =>
+    (joints[Number(jointId)]?.members || []).map(member =>
+      String(member.sourceBoneKey)));
+  return (memberKeys.length ? memberKeys : component?.nodeIds || [])
+    .map(String).sort().join('|');
+}
+
+function compareAttachmentHosts(left, right, joints, votes,
+    incomingCount, outgoingCount) {
+  return componentSupport(right, joints) - componentSupport(left, joints)
+    || (incomingCount.get(left.componentId) || 0)
+      - (incomingCount.get(right.componentId) || 0)
+    || (outgoingCount.get(right.componentId) || 0)
+      - (outgoingCount.get(left.componentId) || 0)
+    || (votes.get(Number(right.rootId)) || 0)
+      - (votes.get(Number(left.rootId)) || 0)
+    || componentStableKey(left, joints).localeCompare(
+      componentStableKey(right, joints))
+    || left.componentId - right.componentId;
+}
+
+function orientModelForestWithAttachments(joints, sourceForest, edges, votes) {
+  const sourceComponents = sourceForest?.components || [];
+  const componentById = new Map(sourceComponents.map(component => [
+    Number(component.componentId), component,
+  ]));
+  const componentForJoint = jointId => sourceForest?.componentByJointId
+    instanceof Map
+    ? sourceForest.componentByJointId.get(Number(jointId))
+    : sourceForest?.componentByJointId?.[Number(jointId)];
+  const attachments = (edges || []).filter(edge =>
+    edge.relationshipType === 'attachment').map(edge => {
+    const targetComponentId = Number(edge.targetComponentId
+      ?? componentForJoint(edge.jointA));
+    const accessoryComponentId = Number(edge.accessoryComponentId
+      ?? componentForJoint(edge.jointB));
+    return {
+      edge,
+      targetComponentId,
+      accessoryComponentId,
+      targetJointId: Number(edge.targetJointId ?? edge.jointA),
+      accessoryJointId: Number(edge.accessoryJointId ?? edge.jointB),
+    };
+  }).filter(item => componentById.has(item.targetComponentId)
+    && componentById.has(item.accessoryComponentId)
+    && item.targetComponentId !== item.accessoryComponentId);
+
+  const adjacency = new Map([...componentById.keys()].map(id => [id, []]));
+  const outgoing = new Map([...componentById.keys()].map(id => [id, []]));
+  const incomingCount = new Map([...componentById.keys()].map(id => [id, 0]));
+  const outgoingCount = new Map([...componentById.keys()].map(id => [id, 0]));
+  attachments.forEach(item => {
+    adjacency.get(item.targetComponentId).push(item);
+    adjacency.get(item.accessoryComponentId).push(item);
+    outgoing.get(item.targetComponentId).push(item);
+    incomingCount.set(item.accessoryComponentId,
+      (incomingCount.get(item.accessoryComponentId) || 0) + 1);
+    outgoingCount.set(item.targetComponentId,
+      (outgoingCount.get(item.targetComponentId) || 0) + 1);
+  });
+  adjacency.forEach(items => items.sort((left, right) =>
+    left.targetComponentId - right.targetComponentId
+      || left.accessoryComponentId - right.accessoryComponentId
+      || left.targetJointId - right.targetJointId
+      || left.accessoryJointId - right.accessoryJointId));
+  outgoing.forEach(items => items.sort((left, right) =>
+    left.accessoryComponentId - right.accessoryComponentId
+      || left.targetJointId - right.targetJointId
+      || left.accessoryJointId - right.accessoryJointId));
+
+  const unseen = new Set(componentById.keys());
+  const orientedGroups = [];
+  while (unseen.size) {
+    const start = Math.min(...unseen);
+    const groupIds = [];
+    const queue = [start];
+    unseen.delete(start);
+    while (queue.length) {
+      const current = queue.shift();
+      groupIds.push(current);
+      (adjacency.get(current) || []).forEach(item => {
+        const other = item.targetComponentId === current
+          ? item.accessoryComponentId : item.targetComponentId;
+        if (!unseen.has(other)) return;
+        unseen.delete(other);
+        queue.push(other);
+      });
+    }
+    const groupSet = new Set(groupIds);
+    const groupAttachments = attachments.filter(item =>
+      groupSet.has(item.targetComponentId)
+      && groupSet.has(item.accessoryComponentId));
+    const groupRoots = groupIds.filter(id => (incomingCount.get(id) || 0) === 0)
+      .map(id => componentById.get(id))
+      .filter(Boolean)
+      .sort((left, right) => compareAttachmentHosts(
+        left, right, joints, votes, incomingCount, outgoingCount));
+    const host = (groupRoots.length ? groupRoots
+      : groupIds.map(id => componentById.get(id)).filter(Boolean)
+        .sort((left, right) => compareAttachmentHosts(
+          left, right, joints, votes, incomingCount, outgoingCount)))[0];
+    const oriented = new Map();
+    const attachmentLinks = [];
+    if (host) {
+      oriented.set(host.componentId, cloneForestComponent(host));
+      const pending = [host.componentId];
+      while (pending.length) {
+        const parentComponentId = pending.shift();
+        (outgoing.get(parentComponentId) || []).forEach(item => {
+          if (!groupSet.has(item.accessoryComponentId)
+              || oriented.has(item.accessoryComponentId)) return;
+          const accessory = componentById.get(item.accessoryComponentId);
+          oriented.set(item.accessoryComponentId,
+            orientComponentFromRoot(accessory, item.accessoryJointId));
+          attachmentLinks.push({
+            ...item,
+            parentComponentId,
+            childComponentId: item.accessoryComponentId,
+          });
+          pending.push(item.accessoryComponentId);
+        });
+      }
+    }
+    // The accepted attachment graph is a forest, so every component should be
+    // reachable from its stable host. Keep a source orientation for any
+    // malformed diagnostic fixture rather than dropping its geometry.
+    groupIds.forEach(componentId => {
+      if (oriented.has(componentId)) return;
+      const component = componentById.get(componentId);
+      if (component) oriented.set(componentId, cloneForestComponent(component));
+    });
+
+    const nodeIds = groupIds.flatMap(componentId =>
+      oriented.get(componentId)?.nodeIds || []).sort((left, right) => left - right);
+    const nodeSet = new Set(nodeIds);
+    const parentById = {};
+    const childrenById = {};
+    groupIds.forEach(componentId => {
+      const component = oriented.get(componentId);
+      (component?.nodeIds || []).forEach(jointId => {
+        parentById[jointId] = component.parentById?.[jointId] ?? null;
+        childrenById[jointId] = [...(component.childrenById?.[jointId] || [])];
+      });
+    });
+    attachmentLinks.forEach(item => {
+      const component = oriented.get(item.childComponentId);
+      const accessoryRoot = component?.rootId;
+      if (!Number.isFinite(accessoryRoot)
+          || !nodeSet.has(item.targetJointId)
+          || !nodeSet.has(accessoryRoot)) return;
+      parentById[accessoryRoot] = item.targetJointId;
+      childrenById[item.targetJointId] ||= [];
+      childrenById[item.targetJointId].push(accessoryRoot);
+    });
+    Object.values(childrenById).forEach(children =>
+      children.sort((left, right) => Number(left) - Number(right)));
+    const rootId = oriented.get(host?.componentId)?.rootId
+      ?? nodeIds[0] ?? null;
+    const depthById = Object.fromEntries(nodeIds.map(id => [id, null]));
+    if (Number.isFinite(rootId) && Object.hasOwn(depthById, rootId)) {
+      depthById[rootId] = 0;
+      const pending = [rootId];
+      while (pending.length) {
+        const parent = pending.shift();
+        (childrenById[parent] || []).forEach(child => {
+          if (depthById[child] !== null) return;
+          depthById[child] = depthById[parent] + 1;
+          pending.push(child);
+        });
+      }
+    }
+    const groupEdges = (edges || []).filter(edge =>
+      nodeSet.has(Number(edge.jointA)) && nodeSet.has(Number(edge.jointB)));
+    orientedGroups.push({
+      componentId: Math.min(...nodeIds),
+      nodeIds,
+      rootId,
+      parentById,
+      childrenById,
+      depthById,
+      maxDepth: Math.max(0, ...Object.values(depthById)
+        .filter(depth => depth !== null).map(Number)),
+      edges: groupEdges,
+    });
+  }
+  orientedGroups.sort((left, right) => left.componentId - right.componentId);
+  const components = orientedGroups.map((component, componentId) => ({
+    ...component, componentId,
+  }));
+  const componentByJointId = new Map();
+  components.forEach(component => component.nodeIds.forEach(jointId =>
+    componentByJointId.set(jointId, component.componentId)));
+  joints.forEach(joint => {
+    const componentId = componentByJointId.get(joint.jointId);
+    const component = components[componentId];
+    joint.parentId = component?.parentById?.[joint.jointId] ?? null;
+    joint.childrenIds = [...(component?.childrenById?.[joint.jointId] || [])];
+  });
+  return {components, componentByJointId};
+}
+
 export function orientModelRigForest(joints, edges, rootOverrides = {}) {
   const overrides = rootOverrides instanceof Map
     ? rootOverrides
@@ -1723,6 +2002,10 @@ function addAttachments(joints, sourceEdges, forest, referenceRadius,
     const edge = {
       jointA: best.jointA,
       jointB: best.jointB,
+      targetComponentId: best.targetComponentId,
+      accessoryComponentId: best.accessoryComponentId,
+      targetJointId: best.targetJointId,
+      accessoryJointId: best.accessoryJointId,
       sourceSupportCount: 0,
       sourceEdges: [],
       combinedTreeScore: best.score,
@@ -1782,20 +2065,8 @@ export function buildModelRigReconciliation(sourceRigs = [], options = {}) {
     model.joints, sourceForestEdges, sourceForest, referenceRadius,
     candidateBuild.crossEvidenceByPair);
   const finalEdges = maximumSpanningForest(model.joints, attachments.edges);
-  const initialFinalForest = orientModelForest(model.joints, finalEdges, votes);
-  const finalRootOverrides = new Map();
-  initialFinalForest.components.forEach(component => {
-    const members = new Set(component.nodeIds);
-    const attachment = finalEdges.filter(edge =>
-      edge.relationshipType === 'attachment'
-      && members.has(edge.jointA) && members.has(edge.jointB))
-      .sort((left, right) => right.attachmentScore - left.attachmentScore
-        || left.jointA - right.jointA || left.jointB - right.jointB)[0];
-    if (attachment) finalRootOverrides.set(
-      component.componentId, attachment.jointA);
-  });
-  const finalForest = orientModelForest(
-    model.joints, finalEdges, votes, finalRootOverrides);
+  const finalForest = orientModelForestWithAttachments(
+    model.joints, sourceForest, finalEdges, votes);
   const survivingAttachments = finalEdges.filter(edge =>
     edge.relationshipType === 'attachment');
   attachments.diagnostics.forEach(diagnostic => {

--- a/src/web/js/mesh/weight-rig-reconcile.js
+++ b/src/web/js/mesh/weight-rig-reconcile.js
@@ -1575,9 +1575,6 @@ function orientModelForestWithAttachments(joints, sourceForest, edges, votes) {
       });
     }
     const groupSet = new Set(groupIds);
-    const groupAttachments = attachments.filter(item =>
-      groupSet.has(item.targetComponentId)
-      && groupSet.has(item.accessoryComponentId));
     const groupRoots = groupIds.filter(id => (incomingCount.get(id) || 0) === 0)
       .map(id => componentById.get(id))
       .filter(Boolean)


### PR DESCRIPTION
## Summary
- Preserve the host component's pre-attachment inferred root and parent/child orientation when accepting cross-source attachments.
- Reroot accessory components at their attachment endpoints without changing source skinning data.
- Preserve explicit manual model roots across model-rig rebuilds using stable joint signatures, including multi-mesh shape rebaselines.
- Add regression coverage for non-root attachments, multiple accessories, attachment chains, equal-support ties, source-order invariance, and root lifecycle resets.

## Validation
- Repository pytest suite passes.
- git diff --check passes.