### PR TITLE
Add conservative residual Rig boundary bridges

### DIFF
--- a/context.md
+++ b/context.md
@@ -239,6 +239,14 @@ of documentation, comments and tests; use portable fixtures instead.
   debug projection. Shape rebaselines invalidate and lazily rebuild surface
   evidence; visibility, material, texture and per-frame paths do not rebuild
   it.
+- After a surface-evidence base forest is built, residual components may be
+  joined only by exact indexed multi-edge seams in the same normalized member.
+  Boundary triangles must be pure to one base component; matching requires two
+  boundary records, opposite geometric sides, one connected chain of at least
+  two edges, and a unique mutual-best seam bone pair. Boundary bridges remain
+  separate `mesh_boundary` evidence, are selected cycle-free, preserve the
+  existing host root, and are disabled for vertex fallback or non-indexed
+  boundary inference.
 - Infer topology only from influence overlap and weighted centers. Blend data
   supplies no names, canonical skeleton, hierarchy, bind pose or animation.
   Keep maximum-spanning relationships, weak-bridge pruning and static-boundary

--- a/context.md
+++ b/context.md
@@ -244,9 +244,10 @@ of documentation, comments and tests; use portable fixtures instead.
   Boundary triangles must be pure to one base component; matching requires two
   boundary records, opposite geometric sides, one connected chain of at least
   two edges, and a unique mutual-best seam bone pair. Boundary bridges remain
-  separate `mesh_boundary` evidence, are selected cycle-free, preserve the
-  existing host root, and are disabled for vertex fallback or non-indexed
-  boundary inference.
+  separate `mesh_boundary` evidence, are selected cycle-free, retain the
+  evidence-ranked host root (or an explicit user root), and are disabled for
+  vertex fallback or non-indexed boundary inference. Final component IDs are
+  dense ephemeral indices; bridge diagnostics retain base component IDs.
 - Infer topology only from influence overlap and weighted centers. Blend data
   supplies no names, canonical skeleton, hierarchy, bind pose or animation.
   Keep maximum-spanning relationships, weak-bridge pruning and static-boundary

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1303,6 +1303,12 @@ def test_residual_boundary_evidence_requires_exact_multi_edge_seams(module_page)
         ])}],
         influenceGraph: graph, baseForest,
       });
+      const rebasedPositions = new Float32Array(combinedPositions).map(
+        (value, index) => index % 3 === 0 ? value + 5 : value);
+      const rebased = boundary.buildResidualBoundaryEvidence({
+        members: [{...members[0], baselinePositions: rebasedPositions}],
+        influenceGraph: graph, baseForest,
+      });
       const merged = boundary.mergeResidualBoundaryBridges(
         baseForest, accepted.acceptedBridges, graph);
       return {
@@ -1317,7 +1323,8 @@ def test_residual_boundary_evidence_requires_exact_multi_edge_seams(module_page)
             finalComponents: merged.components.length,
             finalRoot: merged.components[0]?.rootId,
             singleRejected: single.boundaryRejectedCounts,
-        nearBridges: nearResult.acceptedBridges.length,
+            nearBridges: nearResult.acceptedBridges.length,
+            rebasedCenter: rebased.acceptedBridges[0]?.jointCenter,
       };
     }""")
     assert result["baseComponents"] == 2, result
@@ -1329,7 +1336,116 @@ def test_residual_boundary_evidence_requires_exact_multi_edge_seams(module_page)
     assert result["finalComponents"] == 1
     assert result["finalRoot"] == 0
     assert result["nearBridges"] == 0
+    assert result["rebasedCenter"] == [6, .5, 0], result
     assert result["singleRejected"]
+
+
+def test_residual_boundary_evidence_rejects_ambiguous_or_unsupported_seams(
+        module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const {buildResidualBoundaryEvidence} = await import(
+        './js/mesh/weight-rig-boundary.js');
+      const forestFor = count => ({
+        components: Array.from({length: count}, (_, componentId) => ({
+          componentId,
+        })),
+        componentByBoneId: Object.fromEntries(
+          Array.from({length: count}, (_, boneId) => [boneId, boneId])),
+      });
+      const memberFor = triangles => {
+        const positions = [];
+        const triangleIndices = [];
+        const skinIndices = [];
+        const weights = [];
+        let vertex = 0;
+        triangles.forEach(({points, bone}) => {
+          points.forEach(point => positions.push(...point));
+          triangleIndices.push(vertex, vertex + 1, vertex + 2);
+          skinIndices.push(bone, bone, bone);
+          weights.push(1, 1, 1);
+          vertex += 3;
+        });
+        return {memberKey: 'seams', positions, triangleIndices,
+          skinIndices, weights, influenceCount: 1};
+      };
+      const triangle = (x, y, side, bone, thirdX = x + .5) => ({
+        points: [[x, y, 0], [x + 1, y, 0], [thirdX, y + side, 0]], bone,
+      });
+      const pair = (x, y, sideA = 1, sideB = -1, boneA = 0, boneB = 1) => [
+        triangle(x, y, sideA, boneA, x + .25),
+        triangle(x, y, sideB, boneB, x + .75),
+      ];
+      const run = (triangles, forest = forestFor(2), options = {}) =>
+        buildResidualBoundaryEvidence({
+          members: [options.member || memberFor(triangles)],
+          influenceGraph: options.influenceGraph || {evidenceMode: 'surface'},
+          baseForest: forest,
+        });
+
+      const nonManifold = run([
+        triangle(0, 0, 1, 0, .2), triangle(0, 0, -1, 0, .5),
+        triangle(0, 0, -1, 1, .8),
+      ]);
+      const sameSide = run(pair(0, 0, 1, 1));
+      const multipleSeams = run([
+        ...pair(0, 0), ...pair(10, 0),
+      ]);
+      const cycle = run([
+        ...pair(0, 0, 1, -1, 0, 1),
+        ...pair(1, 0, 1, -1, 0, 1),
+        ...pair(0, 10, 1, -1, 1, 2),
+        ...pair(1, 10, 1, -1, 1, 2),
+        ...pair(0, 20, 1, -1, 0, 2),
+        ...pair(1, 20, 1, -1, 0, 2),
+      ], forestFor(3));
+      const connected = run([], {
+        components: [{componentId: 0}], componentByBoneId: {0: 0},
+      });
+      const vertexFallback = run(pair(0, 0), forestFor(2), {
+        influenceGraph: {evidenceMode: 'vertex'},
+      });
+      const nonIndexed = run([], forestFor(2), {
+        member: {...memberFor([triangle(0, 0, 1, 0)]),
+          triangleIndices: null},
+      });
+      return {
+        nonManifold: nonManifold.boundaryRejectedCounts,
+        sameSide: sameSide.boundaryRejectedCounts,
+        multipleSeams: multipleSeams.boundaryRejectedCounts,
+        cycle: {
+          accepted: cycle.acceptedBridges.length,
+          rejected: cycle.boundaryRejectedCounts,
+        },
+        connected: {
+          enabled: connected.boundaryEvidenceEnabled,
+          bridges: connected.acceptedBridges.length,
+          boundaryEdgeCount: connected.boundaryEdgeCount,
+        },
+        vertexFallback: {
+          enabled: vertexFallback.boundaryEvidenceEnabled,
+          reason: vertexFallback.boundaryEvidenceReason,
+        },
+        nonIndexed: {
+          enabled: nonIndexed.boundaryEvidenceEnabled,
+          reason: nonIndexed.boundaryEvidenceReason,
+        },
+      };
+    }""")
+    assert result["nonManifold"] == {"non_manifold": 1}, result
+    assert result["sameSide"] == {"non_continuing_surface": 1}, result
+    assert result["multipleSeams"] == {"multiple_seams": 1}, result
+    assert result["cycle"]["accepted"] == 2, result
+    assert result["cycle"]["rejected"] == {"cycle": 1}, result
+    assert result["connected"] == {
+        "enabled": True, "bridges": 0, "boundaryEdgeCount": 0,
+    }, result
+    assert result["vertexFallback"] == {
+        "enabled": False, "reason": "source_not_surface",
+    }, result
+    assert result["nonIndexed"] == {
+        "enabled": False, "reason": "unsupported_nonindexed_boundary",
+    }, result
 
 
 def test_residual_boundary_merge_reassigns_dense_ids_and_honors_preferred_root(

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1236,6 +1236,102 @@ def test_surface_evidence_weights_rig_nodes_relationships_and_aggregation(
         "Cannot aggregate incompatible Rig evidence modes.")
 
 
+def test_residual_boundary_evidence_requires_exact_multi_edge_seams(module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const rig = await import('./js/mesh/weight-rig.js');
+      const boundary = await import('./js/mesh/weight-rig-boundary.js');
+      const patch = (right = false) => {
+        const positions = right ? [
+          1, 0, 0, 2, 0, 0, 2, .5, 0, 2, 1, 0, 1, 1, 0, 1, .5, 0,
+        ] : [
+          0, 0, 0, 1, 0, 0, 1, .5, 0, 1, 1, 0, 0, 1, 0,
+        ];
+        const triangles = right
+          ? new Uint32Array([0, 1, 2, 0, 2, 5, 5, 2, 3, 5, 3, 4])
+          : new Uint32Array([0, 1, 2, 0, 2, 3, 0, 3, 4]);
+        const skinIndices = new Uint32Array([
+          ...(right ? [1, 1, 1, 1, 1, 1] : [0, 0, 0, 0, 0]),
+        ]);
+        const weights = new Float32Array(right ? [1, 1, 1, 1, 1, 1]
+          : [1, 1, 1, 1, 1]);
+        return {positions: new Float32Array(positions), triangles,
+          skinIndices, weights, influenceCount: 1};
+      };
+      const left = patch();
+      const right = patch(true);
+      const combinedPositions = new Float32Array([
+        ...left.positions, ...right.positions,
+      ]);
+      const combinedTriangles = new Uint32Array([
+        ...left.triangles,
+        ...[...right.triangles].map(index => index + 5),
+      ]);
+      const combinedSkinIndices = new Uint32Array([
+        ...left.skinIndices, ...right.skinIndices,
+      ]);
+      const combinedWeights = new Float32Array([
+        ...left.weights, ...right.weights,
+      ]);
+      const combinedGraph = rig.buildSurfaceInfluenceGraph(
+        combinedPositions, combinedTriangles, combinedSkinIndices,
+        combinedWeights, 1, [0, 1], 2);
+      const graph = rig.aggregateInfluenceGraphs([combinedGraph]);
+      const baseForest = rig.buildInferredRigForest(graph);
+      const members = [{memberKey: 'combined',
+        baselinePositions: combinedPositions,
+        triangleIndices: combinedTriangles,
+        skinIndices: combinedSkinIndices,
+        weights: combinedWeights, influenceCount: 1}];
+      const accepted = boundary.buildResidualBoundaryEvidence({
+        members, influenceGraph: graph, baseForest,
+      });
+      const single = boundary.buildResidualBoundaryEvidence({
+        members: [{...members[0], memberKey: 'single',
+          triangleIndices: new Uint32Array([
+            0, 1, 2, 5, 6, 7, 5, 7, 10, 10, 7, 8, 10, 8, 9,
+          ])}],
+        influenceGraph: graph, baseForest,
+      });
+      const near = {...right, positions: new Float32Array([
+        1 + 1e-6, 0, 0, 2, 0, 0, 2, .5, 0, 2, 1, 0,
+        1 + 1e-6, 1, 0, 1 + 1e-6, .5, 0,
+      ])};
+      const nearResult = boundary.buildResidualBoundaryEvidence({
+        members: [{...members[0], baselinePositions: new Float32Array([
+          ...left.positions, ...near.positions,
+        ])}],
+        influenceGraph: graph, baseForest,
+      });
+      const merged = boundary.mergeResidualBoundaryBridges(
+        baseForest, accepted.acceptedBridges, graph);
+      return {
+        baseComponents: baseForest.components.length,
+        boundaryEdgeCount: accepted.boundaryEdgeCount,
+        matched: accepted.exactMatchedEdgeCount,
+        bridges: accepted.acceptedBridges.map(edge => ({
+          boneA: edge.boneA, boneB: edge.boneB,
+          matchedEdgeCount: edge.matchedEdgeCount,
+          jointCenter: edge.jointCenter,
+        })),
+            finalComponents: merged.components.length,
+            finalRoot: merged.components[0]?.rootId,
+            singleRejected: single.boundaryRejectedCounts,
+        nearBridges: nearResult.acceptedBridges.length,
+      };
+    }""")
+    assert result["baseComponents"] == 2, result
+    assert result["bridges"] == [{
+        "boneA": 0, "boneB": 1,
+        "matchedEdgeCount": 2,
+        "jointCenter": [1, .5, 0],
+    }], result
+    assert result["finalComponents"] == 1
+    assert result["finalRoot"] == 0
+    assert result["nearBridges"] == 0
+    assert result["singleRejected"]
+
+
 def test_triangle_surface_evidence_is_invariant_for_varying_weight_tessellation(
         module_page):
     page = module_page

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1332,6 +1332,119 @@ def test_residual_boundary_evidence_requires_exact_multi_edge_seams(module_page)
     assert result["singleRejected"]
 
 
+def test_residual_boundary_merge_reassigns_dense_ids_and_honors_preferred_root(
+        module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const {mergeResidualBoundaryBridges} = await import(
+        './js/mesh/weight-rig-boundary.js');
+      const component = (componentId, rootId, nodeId) => ({
+        componentId, rootId, nodeIds: [nodeId], parentById: {[nodeId]: null},
+        childrenById: {[nodeId]: []}, depthById: {[nodeId]: 0}, edges: [],
+      });
+      const base = {
+        components: [component(0, 0, 0), component(1, 10, 10),
+          component(2, 20, 20)],
+        componentByBoneId: {0: 0, 10: 1, 20: 2},
+        edges: [], nodeIds: [0, 10, 20],
+      };
+      const graph = {nodes: [
+        {boneId: 0, totalWeight: 1, affectedMeasure: 1},
+        {boneId: 10, totalWeight: 10, affectedMeasure: 10},
+        {boneId: 20, totalWeight: 3, affectedMeasure: 3},
+      ]};
+      const bridge = {boneA: 0, boneB: 10, componentA: 0,
+        componentB: 1, evidenceType: 'mesh_boundary', matchedLength: 1,
+        jointCenter: [5, 0, 0]};
+      const merged = mergeResidualBoundaryBridges(base, [bridge], graph);
+      const reversed = mergeResidualBoundaryBridges({
+        ...base, components: [base.components[2], base.components[0],
+          base.components[1]],
+      }, [bridge], graph);
+      const preferred = mergeResidualBoundaryBridges(
+        base, [bridge], graph, {preferredRootId: 0});
+      const summary = forest => ({
+        ids: forest.components.map(component => component.componentId),
+        roots: forest.components.map(component => component.rootId),
+        lookup: [0, 10, 20].map(id => {
+          const componentId = forest.componentByBoneId[id];
+          return forest.components[componentId]?.nodeIds.includes(id) || false;
+        }),
+        baseIds: forest.components.map(component => component.baseComponentIds),
+        hostRoot: forest.components.find(component =>
+          component.nodeIds.includes(0))?.rootId,
+      });
+      return {
+        merged: summary(merged), reversed: summary(reversed),
+        preferred: summary(preferred),
+        hasPrimary: Object.prototype.hasOwnProperty.call(
+          merged, 'primaryComponentId'),
+      };
+    }""")
+    assert result["merged"] == {
+        "ids": [0, 1], "roots": [10, 20], "lookup": [True, True, True],
+        "baseIds": [[0, 1], [2]], "hostRoot": 10,
+    }, result
+    assert result["reversed"] == result["merged"]
+    assert result["preferred"]["hostRoot"] == 0
+    assert not result["hasPrimary"]
+
+
+def test_boundary_source_edge_preserves_mesh_provenance_and_pivot_weight(
+        module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const {buildModelRigReconciliation} = await import(
+        './js/mesh/weight-rig-reconcile.js');
+      const make = (boundaryOnly) => {
+        const boundary = {boneA: 0, boneB: 1, treeEdgeScore: .9,
+          evidenceType: 'mesh_boundary', jointCenter: [9, 2, 0],
+          matchedLength: 2};
+        const overlap = {boneA: 0, boneB: 1, treeEdgeScore: .01,
+          jointCenter: [1, 0, 0], jointWeightTotal: 4};
+        const nodes = [0, 1].map(boneId => ({boneId,
+          weightedCenter: [boneId, 0, 0], weightedRadius: .1,
+          totalWeight: 1, affectedVertexCount: 10}));
+        return {
+          sourceKey: boundaryOnly ? 'boundary-only' : 'weak-overlap',
+          boneIds: [0, 1], influenceGraph: {
+            nodes, relationships: boundaryOnly ? [] : [overlap],
+          },
+          centerByBoneId: new Map([[0, [0, 0, 0]], [1, [1, 0, 0]]]),
+          jointPivotByBoneId: new Map([[1, [1, 0, 0]]]),
+          restDirectionByBoneId: new Map([[0, [0, 1, 0]], [1, [0, 1, 0]]]),
+          restFrameByBoneId: new Map(),
+          restFrameEvidenceByBoneId: new Map(),
+          inferredForest: {
+            components: [{componentId: 0, rootId: 0, nodeIds: [0, 1],
+              parentById: {0: null, 1: 0}, childrenById: {0: [1], 1: []},
+              depthById: {0: 0, 1: 1}, edges: [boundary]}],
+            componentByBoneId: {0: 0, 1: 0},
+          },
+        };
+      };
+      const describe = value => value.edges
+        .find(edge => edge.relationshipType === 'source')?.sourceEdges?.[0]
+        || null;
+      const weak = describe(buildModelRigReconciliation([make(false)]));
+      const only = describe(buildModelRigReconciliation([make(true)]));
+      return {
+        weak: weak && {evidenceType: weak.evidenceType,
+          jointCenter: weak.jointCenter, pivotWeight: weak.pivotWeight,
+          jointWeightTotal: weak.jointWeightTotal},
+        only: only && {evidenceType: only.evidenceType,
+          jointCenter: only.jointCenter, pivotWeight: only.pivotWeight,
+          jointWeightTotal: only.jointWeightTotal},
+      };
+    }""")
+    expected = {
+        "evidenceType": "mesh_boundary", "jointCenter": [9, 2, 0],
+        "pivotWeight": 2, "jointWeightTotal": 0,
+    }
+    assert result["weak"] == expected, result
+    assert result["only"] == expected, result
+
+
 def test_triangle_surface_evidence_is_invariant_for_varying_weight_tessellation(
         module_page):
     page = module_page

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -2494,6 +2494,98 @@ def test_loaded_skinning_rebaselines_after_shape_change(
         context.close()
 
 
+def test_loaded_skinning_rebuilds_boundary_evidence_after_shape_rebaseline(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url,
+        {"SkinningBoundaryShape": _payload("SkinningBoundaryShape")})
+    try:
+        _open(page, "SkinningBoundaryShape")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 1")
+        result = page.evaluate("""async () => {
+          const mesh = window.modViewer.activeMeshes[0];
+          const THREE = await import('three');
+          const positions = [
+            0, 0, 0, 1, 0, 0, .25, 1, 0,
+            1, 0, 0, 2, 0, 0, 1.25, 1, 0,
+            0, 0, 0, 1, 0, 0, .75, -1, 0,
+            1, 0, 0, 2, 0, 0, 1.75, -1, 0,
+          ];
+          const geometry = new THREE.BufferGeometry();
+          geometry.setAttribute('position',
+            new THREE.Float32BufferAttribute(positions, 3));
+          geometry.setIndex([...Array(12).keys()]);
+          mesh.geometry.dispose();
+          mesh.geometry = geometry;
+          const bytes = new Uint8Array(96);
+          new Uint32Array(bytes.buffer).set([
+            0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
+          ]);
+          new Float32Array(bytes.buffer, 48).fill(1);
+          const url = URL.createObjectURL(new Blob([bytes]));
+          window.__testSkinningPreview = async () => ({
+            status: 'ok', vertex_count: 12, influence_count: 1,
+            bone_ids: [0, 1], encoding: 'test', source: {
+              key: 'test/bodyblend.buf|offset=0', file: 'Test/BodyBlend.buf',
+              bone_id_offset: 0,
+            },
+            data: {
+              url, length: 96,
+              indices: {offset: 0, length: 48, type: 'u32'},
+              weights: {offset: 48, length: 48, type: 'f32'},
+            }, diagnostics: {},
+          });
+          const experiment = await import('./js/mesh/weight-experiment.js');
+          await experiment.ensureModelWeightsLoaded();
+          await experiment.ensureModelRigLoaded();
+          const initial = experiment.getModelRigDebugState().sources[0];
+          const position = mesh.geometry.attributes.position;
+          for (let offset = 0; offset < position.array.length; offset += 3) {
+            position.array[offset] += 3;
+          }
+          position.needsUpdate = true;
+          const refreshed = experiment.refreshSkinningAfterShapeChange(mesh);
+          const invalidated = !experiment.getModelRigState().loaded;
+          await experiment.ensureModelRigLoaded();
+          const rebuilt = experiment.getModelRigDebugState().sources[0];
+          experiment.destroyModelPhysicsSession();
+          URL.revokeObjectURL(url);
+          return {
+            refreshed, invalidated,
+            initial: {
+              evidenceMode: initial.evidenceMode,
+              baseComponentCount: initial.baseComponentCount,
+              finalComponentCount: initial.finalComponentCount,
+              acceptedBoundaryBridgeCount: initial.acceptedBoundaryBridgeCount,
+              boundaryBridges: initial.boundaryBridges,
+            },
+            rebuilt: {
+              evidenceMode: rebuilt.evidenceMode,
+              baseComponentCount: rebuilt.baseComponentCount,
+              finalComponentCount: rebuilt.finalComponentCount,
+              acceptedBoundaryBridgeCount: rebuilt.acceptedBoundaryBridgeCount,
+              boundaryBridges: rebuilt.boundaryBridges,
+            },
+          };
+        }""")
+        assert result["refreshed"]
+        assert result["invalidated"]
+        assert result["initial"]["evidenceMode"] == "surface", result
+        assert result["initial"]["baseComponentCount"] == 2, result
+        assert result["initial"]["finalComponentCount"] == 1, result
+        assert result["initial"]["acceptedBoundaryBridgeCount"] == 1, result
+        assert result["initial"]["boundaryBridges"][0]["jointCenter"] == [
+            1, 0, 0]
+        assert result["rebuilt"]["evidenceMode"] == "surface", result
+        assert result["rebuilt"]["baseComponentCount"] == 2, result
+        assert result["rebuilt"]["finalComponentCount"] == 1, result
+        assert result["rebuilt"]["acceptedBoundaryBridgeCount"] == 1, result
+        assert result["rebuilt"]["boundaryBridges"][0]["jointCenter"] == [
+            4, 0, 0]
+    finally:
+        context.close()
+
+
 def _multi_mesh_skinning_shape_payload():
     payload = _payload("SkinningShapePair")
     template = next(iter(payload["meshes"].values()))

--- a/src/web/js/mesh/weight-experiment.js
+++ b/src/web/js/mesh/weight-experiment.js
@@ -1280,7 +1280,8 @@ function buildModelJointPivotByEdgeKey(rig) {
     const observations = (edge.sourceEdges || [])
       .map(sourceEdge => ({
         point: finiteVectorArray(sourceEdge.jointCenter),
-        weight: Number(sourceEdge.jointWeightTotal) || 0,
+        weight: Number(sourceEdge.pivotWeight)
+          || Number(sourceEdge.jointWeightTotal) || 0,
       }))
       .filter(observation => observation.point && observation.weight > 0);
     let pivot = observations.length
@@ -2914,7 +2915,8 @@ function setRigComponentRootForSource(sourceKey, boneId) {
     rootOverrides: overrides,
   });
   rig.inferredForest = mergeResidualBoundaryBridges(
-    rig.baseInferredForest, rig.boundaryBridges, rig.influenceGraph);
+    rig.baseInferredForest, rig.boundaryBridges, rig.influenceGraph,
+    {preferredRootId: id});
   rig.jointPivotByBoneId = jointPivotMap(
     rig.inferredForest, [...rig.influenceGraph.relationships,
       ...rig.boundaryBridges]);

--- a/src/web/js/mesh/weight-experiment.js
+++ b/src/web/js/mesh/weight-experiment.js
@@ -34,6 +34,10 @@ import {
   inspectSurfaceTopology,
   jointPivotMap,
 } from './weight-rig.js';
+import {
+  buildResidualBoundaryEvidence,
+  mergeResidualBoundaryBridges,
+} from './weight-rig-boundary.js';
 import { createWeightPickController } from '../scene/weight-pick-controller.js';
 import { raycastModelAtClientPoint } from '../scene/model-picking.js';
 import { computeModelBounds } from '../scene/model-bounds.js';
@@ -1091,15 +1095,34 @@ function aggregateSourceInfluenceGraph(members) {
     duplicateMemberKeys: normalizedMembers.duplicateMemberKeys,
     memberDiagnostics,
     partialOverlapPairs: [],
+    boundaryMembers: normalizedMembers.members.map((member, index) => ({
+      memberKey: sourceMemberKey(member, index),
+      baselinePositions: member.state.baselinePositions,
+      triangleIndices: member.surfaceIndices,
+      skinIndices: member.state.indices,
+      weights: member.state.weights,
+      influenceCount: member.state.influenceCount,
+    })),
   };
 }
 
 function createSourceSkinningRig(sourceKey, members) {
   const descriptor = modelWeightState.sourceDescriptors.get(sourceKey);
-  const influenceGraph = aggregateSourceInfluenceGraph(members);
-  const inferredForest = buildInferredRigForest(influenceGraph);
+  const aggregated = aggregateSourceInfluenceGraph(members);
+  const {boundaryMembers, ...influenceGraph} = aggregated;
+  const baseInferredForest = buildInferredRigForest(influenceGraph);
+  const boundaryStarted = performanceNow();
+  const boundaryAnalysis = buildResidualBoundaryEvidence({
+    members: boundaryMembers,
+    influenceGraph,
+    baseForest: baseInferredForest,
+  });
+  boundaryAnalysis.analysisMs = performanceNow() - boundaryStarted;
+  const inferredForest = mergeResidualBoundaryBridges(
+    baseInferredForest, boundaryAnalysis.acceptedBridges, influenceGraph);
   const jointPivotByBoneId = jointPivotMap(
-    inferredForest, influenceGraph.relationships);
+    inferredForest, [...influenceGraph.relationships,
+      ...boundaryAnalysis.acceptedBridges]);
   const rig = {
     key: sourceKey,
     sourceKey,
@@ -1107,6 +1130,9 @@ function createSourceSkinningRig(sourceKey, members) {
     boneIdOffset: descriptor?.boneIdOffset ?? 0,
     meshes: new Set(members),
     influenceGraph,
+    baseInferredForest,
+    boundaryAnalysis,
+    boundaryBridges: boundaryAnalysis.acceptedBridges,
     boneIds: (influenceGraph.nodes || []).map(node => node.boneId),
     centerByBoneId: new Map((influenceGraph.nodes || []).map(node => [
       node.boneId, node.weightedCenter])),
@@ -1159,6 +1185,9 @@ function refreshSourceSkinningRig(rig, members, {resetPose = true} = {}) {
   const refreshed = createSourceSkinningRig(rig.sourceKey, members);
   rig.meshes = refreshed.meshes;
   rig.influenceGraph = refreshed.influenceGraph;
+  rig.baseInferredForest = refreshed.baseInferredForest;
+  rig.boundaryAnalysis = refreshed.boundaryAnalysis;
+  rig.boundaryBridges = refreshed.boundaryBridges;
   rig.boneIds = refreshed.boneIds;
   rig.centerByBoneId = refreshed.centerByBoneId;
   rig.inferredForest = refreshed.inferredForest;
@@ -2874,14 +2903,21 @@ function setRigComponentRootForSource(sourceKey, boneId) {
   if (!Number.isInteger(jointId) || !modelSkinningRig) return false;
   clearModelManualPose({request: false});
   resetSourceSkinningPose(rig);
-  const overrides = new Map(rig.inferredForest.components.map(item => [
+  const baseForest = rig.baseInferredForest
+    || buildInferredRigForest(rig.influenceGraph);
+  const baseComponentId = Number(baseForest.componentByBoneId[id]);
+  const overrides = new Map(baseForest.components.map(item => [
     item.componentId, item.rootId]));
-  overrides.set(component.componentId, id);
-  rig.inferredForest = buildInferredRigForest(rig.influenceGraph, {
+  if (!Number.isInteger(baseComponentId)) return false;
+  overrides.set(baseComponentId, id);
+  rig.baseInferredForest = buildInferredRigForest(rig.influenceGraph, {
     rootOverrides: overrides,
   });
+  rig.inferredForest = mergeResidualBoundaryBridges(
+    rig.baseInferredForest, rig.boundaryBridges, rig.influenceGraph);
   rig.jointPivotByBoneId = jointPivotMap(
-    rig.inferredForest, rig.influenceGraph.relationships);
+    rig.inferredForest, [...rig.influenceGraph.relationships,
+      ...rig.boundaryBridges]);
   rebuildSourceRigRestFrames(rig);
   rig.poseRootOverrides = overrides;
   const signature = modelSkinningRig.joints[jointId]?.signature;

--- a/src/web/js/mesh/weight-rig-boundary.js
+++ b/src/web/js/mesh/weight-rig-boundary.js
@@ -1,0 +1,577 @@
+// Conservative residual surface-boundary evidence for source-local Rigs.
+//
+// This module is deliberately independent from Three.js and runtime state. It
+// only consumes normalized member arrays and the already inferred base forest.
+// Boundary evidence is a separate class from triangle-domain influence
+// overlap: it can only join components which the base forest left separate.
+
+import {collectSurfaceTriangles} from './weight-rig.js';
+
+const EPSILON = 0;
+
+function componentIdFor(forest, boneId) {
+  const value = forest?.componentByBoneId?.[boneId];
+  return value === undefined || value === null ? null : Number(value);
+}
+
+function pairKey(left, right) {
+  const a = Number(left);
+  const b = Number(right);
+  return a < b ? `${a}:${b}` : `${b}:${a}`;
+}
+
+function componentPairKey(left, right) {
+  const a = Number(left);
+  const b = Number(right);
+  return a < b ? `${a}:${b}` : `${b}:${a}`;
+}
+
+function pointKey(point) {
+  return JSON.stringify([Number(point[0]), Number(point[1]), Number(point[2])]);
+}
+
+function exactEdgeKey(first, second) {
+  const left = pointKey(first);
+  const right = pointKey(second);
+  return left < right ? `${left}|${right}` : `${right}|${left}`;
+}
+
+function topologyEdgeKey(first, second) {
+  const left = Number(first);
+  const right = Number(second);
+  return left < right ? `${left}:${right}` : `${right}:${left}`;
+}
+
+function positiveInfluences(indices, weights, influenceCount, vertex) {
+  const result = new Map();
+  if (!indices || !weights || !Number.isInteger(influenceCount)
+      || influenceCount <= 0) return result;
+  const start = vertex * influenceCount;
+  for (let offset = 0; offset < influenceCount; offset += 1) {
+    const boneId = Number(indices[start + offset]);
+    const weight = Number(weights[start + offset]);
+    if (!Number.isInteger(boneId) || boneId < 0
+        || !Number.isFinite(weight) || weight <= EPSILON) continue;
+    result.set(boneId, (result.get(boneId) || 0) + weight);
+  }
+  return result;
+}
+
+function getMemberArrays(member) {
+  return {
+    memberKey: String(member?.memberKey || member?.key || ''),
+    positions: member?.baselinePositions || member?.positions || [],
+    triangleIndices: member?.triangleIndices
+      ?? member?.surfaceIndices ?? member?.indicesBuffer ?? null,
+    skinIndices: member?.skinIndices || member?.indices || [],
+    weights: member?.weights || [],
+    influenceCount: Number(member?.influenceCount),
+  };
+}
+
+function sideVector(edgeStart, edgeEnd, third) {
+  const edge = [
+    edgeEnd[0] - edgeStart[0],
+    edgeEnd[1] - edgeStart[1],
+    edgeEnd[2] - edgeStart[2],
+  ];
+  const fromStart = [
+    third[0] - edgeStart[0],
+    third[1] - edgeStart[1],
+    third[2] - edgeStart[2],
+  ];
+  return [
+    edge[1] * fromStart[2] - edge[2] * fromStart[1],
+    edge[2] * fromStart[0] - edge[0] * fromStart[2],
+    edge[0] * fromStart[1] - edge[1] * fromStart[0],
+  ];
+}
+
+function dot(left, right) {
+  return left[0] * right[0] + left[1] * right[1] + left[2] * right[2];
+}
+
+function edgeLength(first, second) {
+  return Math.hypot(
+    second[0] - first[0], second[1] - first[1], second[2] - first[2]);
+}
+
+function weightedMean(left, right, length) {
+  return length * (left + right) / 2;
+}
+
+function edgeRecord(member, forest, triangle, edgeOffset, componentId) {
+  const [first, second, third] = [0, 1, 2].map(index => ({
+    vertex: triangle.indices[(edgeOffset + index) % 3],
+    point: triangle.points[(edgeOffset + index) % 3],
+  }));
+  const firstInfluences = positiveInfluences(
+    member.skinIndices, member.weights, member.influenceCount, first.vertex);
+  const secondInfluences = positiveInfluences(
+    member.skinIndices, member.weights, member.influenceCount, second.vertex);
+  const edgeBones = new Map();
+  for (const [boneId, value] of firstInfluences) {
+    if (componentIdFor(forest, boneId) === componentId) {
+      edgeBones.set(boneId, [value, 0]);
+    }
+  }
+  for (const [boneId, value] of secondInfluences) {
+    if (componentIdFor(forest, boneId) !== componentId) continue;
+    const values = edgeBones.get(boneId) || [0, 0];
+    values[1] = value;
+    edgeBones.set(boneId, values);
+  }
+  return {
+    memberKey: member.memberKey,
+    componentId,
+    triangleIndex: triangle.triangleIndex,
+    vertexA: first.vertex,
+    vertexB: second.vertex,
+    pointA: [...first.point],
+    pointB: [...second.point],
+    thirdPoint: [...third.point],
+    edgeKey: exactEdgeKey(first.point, second.point),
+    topologyKey: topologyEdgeKey(first.vertex, second.vertex),
+    pointKeyA: pointKey(first.point),
+    pointKeyB: pointKey(second.point),
+    length: edgeLength(first.point, second.point),
+    bones: Object.fromEntries([...edgeBones].map(([boneId, values]) => [
+      boneId, values])),
+  };
+}
+
+function collectBoundaryRecords(member, forest) {
+  const topology = collectSurfaceTriangles(
+    member.positions, member.triangleIndices, true);
+  const usage = new Map();
+  let pureTriangleCount = 0;
+  for (let triangleIndex = 0; triangleIndex < topology.triangles.length;
+      triangleIndex += 1) {
+    const triangleBase = topology.triangles[triangleIndex];
+    const triangle = {...triangleBase,
+      triangleIndex};
+    const cornerInfluences = triangle.indices.map(vertex => positiveInfluences(
+      member.skinIndices, member.weights, member.influenceCount, vertex));
+    const componentIds = new Set();
+    let pure = true;
+    for (const influences of cornerInfluences) {
+      for (const boneId of influences.keys()) {
+        const componentId = componentIdFor(forest, boneId);
+        if (componentId === null) {
+          pure = false;
+          break;
+        }
+        componentIds.add(componentId);
+      }
+      if (!pure) break;
+    }
+    if (!pure || componentIds.size !== 1) continue;
+    pureTriangleCount += 1;
+    const componentId = [...componentIds][0];
+    for (let edgeOffset = 0; edgeOffset < 3; edgeOffset += 1) {
+      const record = edgeRecord(member, forest, triangle, edgeOffset, componentId);
+      const list = usage.get(`${componentId}|${record.topologyKey}`) || [];
+      list.push(record);
+      usage.set(`${componentId}|${record.topologyKey}`, list);
+    }
+  }
+  const boundaries = [];
+  for (const records of usage.values()) {
+    if (records.length === 1) boundaries.push(records[0]);
+  }
+  return {
+    boundaries,
+    boundaryEdgeCount: boundaries.length,
+    pureTriangleCount,
+    topology,
+  };
+}
+
+function addSupport(target, record) {
+  const supports = target || new Map();
+  const length = Number(record.length) || 0;
+  Object.entries(record.bones || {})
+    .sort(([left], [right]) => Number(left) - Number(right))
+    .forEach(([boneId, values]) => {
+      const support = weightedMean(Number(values[0]) || 0,
+        Number(values[1]) || 0, length);
+      if (support > 0) supports.set(Number(boneId),
+        (supports.get(Number(boneId)) || 0) + support);
+    });
+  return supports;
+}
+
+function selectMutualBonePair(supportA, supportB) {
+  const pairSupport = {};
+  const bestForA = new Map();
+  const bestForB = new Map();
+  const valuesA = [...supportA.entries()].filter(([, value]) => value > 0);
+  const valuesB = [...supportB.entries()].filter(([, value]) => value > 0);
+  valuesA.forEach(([boneA, valueA]) => valuesB.forEach(([boneB, valueB]) => {
+    const value = valueA * valueB;
+    pairSupport[pairKey(boneA, boneB)] = value;
+    const currentA = bestForA.get(boneA);
+    if (!currentA || value > currentA.value) {
+      bestForA.set(boneA, {boneB, value, tie: false});
+    } else if (Object.is(value, currentA.value)) {
+      currentA.tie = true;
+    }
+    const currentB = bestForB.get(boneB);
+    if (!currentB || value > currentB.value) {
+      bestForB.set(boneB, {boneA, value, tie: false});
+    } else if (Object.is(value, currentB.value)) {
+      currentB.tie = true;
+    }
+  }));
+  const mutual = [];
+  bestForA.forEach((best, boneA) => {
+    const reverse = bestForB.get(best.boneB);
+    if (best.tie || reverse?.tie
+        || reverse?.boneA !== boneA) return;
+    mutual.push({boneA, boneB: best.boneB, support: best.value});
+  });
+  return {pairSupport, mutual};
+}
+
+function oppositeSides(left, right) {
+  const canonical = pointKey(left.pointA) < pointKey(left.pointB)
+    ? [left.pointA, left.pointB] : [left.pointB, left.pointA];
+  const sideA = sideVector(canonical[0], canonical[1], left.thirdPoint);
+  const sideB = sideVector(canonical[0], canonical[1], right.thirdPoint);
+  const value = dot(sideA, sideB);
+  return Number.isFinite(value) && value < 0;
+}
+
+function connectedChains(records) {
+  const adjacency = new Map();
+  const add = (from, to) => {
+    const values = adjacency.get(from) || new Set();
+    values.add(to);
+    adjacency.set(from, values);
+  };
+  records.forEach(record => {
+    add(record.pointKeyA, record.pointKeyB);
+    add(record.pointKeyB, record.pointKeyA);
+  });
+  const seen = new Set();
+  const chains = [];
+  for (const point of adjacency.keys()) {
+    if (seen.has(point)) continue;
+    const queue = [point];
+    const points = new Set();
+    while (queue.length) {
+      const current = queue.shift();
+      if (seen.has(current)) continue;
+      seen.add(current);
+      points.add(current);
+      for (const next of adjacency.get(current) || []) {
+        if (!seen.has(next)) queue.push(next);
+      }
+    }
+    chains.push(points);
+  }
+  return chains;
+}
+
+function emptyResult(reason = null, enabled = !reason) {
+  return {
+    enabled,
+    boundaryEvidenceEnabled: enabled,
+    boundaryEvidenceReason: reason,
+    boundaryEdgeCount: 0,
+    exactMatchedEdgeCount: 0,
+    validSeamSampleCount: 0,
+    boundaryComponentPairCount: 0,
+    candidates: [],
+    acceptedBridges: [],
+    boundaryRejectedCounts: {},
+  };
+}
+
+/**
+ * Extract exact indexed surface seams between residual base-forest components.
+ * Every member must already be known to use surface evidence. A missing index
+ * buffer is intentionally unsupported: inferring adjacency from positions
+ * would turn this conservative operation into implicit vertex welding.
+ */
+export function buildResidualBoundaryEvidence({
+  members = [], influenceGraph = null, baseForest = null,
+} = {}) {
+  if (influenceGraph?.evidenceMode !== 'surface') {
+    return emptyResult('source_not_surface');
+  }
+  if (!members.length) return emptyResult('no_members');
+  const normalizedMembers = members.map((member, index) => ({
+    ...getMemberArrays(member),
+    memberKey: String(member?.memberKey || member?.key || `member-${index}`),
+  }));
+  if (normalizedMembers.some(member => member.triangleIndices === null
+      || member.triangleIndices === undefined)) {
+    return emptyResult('unsupported_nonindexed_boundary');
+  }
+  if ((baseForest?.components || []).length < 2) {
+    return emptyResult(null, true);
+  }
+  const allRecords = [];
+  let boundaryEdgeCount = 0;
+  for (const member of normalizedMembers) {
+    const collected = collectBoundaryRecords(member, baseForest);
+    boundaryEdgeCount += collected.boundaryEdgeCount;
+    allRecords.push(...collected.boundaries);
+  }
+  const rejected = {};
+  const reject = reason => { rejected[reason] = (rejected[reason] || 0) + 1; };
+  const byEdge = new Map();
+  allRecords.forEach(record => {
+    const list = byEdge.get(`${record.memberKey}|${record.edgeKey}`) || [];
+    list.push(record);
+    byEdge.set(`${record.memberKey}|${record.edgeKey}`, list);
+  });
+  const matched = [];
+  let exactMatchedEdgeCount = 0;
+  for (const records of byEdge.values()) {
+    const components = new Set(records.map(record => record.componentId));
+    if (records.length !== 2 || components.size !== 2) {
+      if (records.length > 2) reject('non_manifold');
+      continue;
+    }
+    exactMatchedEdgeCount += 1;
+    if (!oppositeSides(records[0], records[1])) {
+      reject('non_continuing_surface');
+      continue;
+    }
+    matched.push(records);
+  }
+  const pairGroups = new Map();
+  matched.forEach(records => {
+    const [left, right] = records;
+    const key = `${left.memberKey}|${componentPairKey(
+      left.componentId, right.componentId)}`;
+    const group = pairGroups.get(key) || {
+      memberKey: left.memberKey,
+      componentA: Math.min(left.componentId, right.componentId),
+      componentB: Math.max(left.componentId, right.componentId),
+      segments: [],
+    };
+    group.segments.push(records);
+    pairGroups.set(key, group);
+  });
+  const candidates = [];
+  for (const group of pairGroups.values()) {
+    const segments = [...group.segments].sort((left, right) =>
+      left[0].edgeKey.localeCompare(right[0].edgeKey));
+    const matchedRecords = segments.flat();
+    const chains = connectedChains(matchedRecords);
+    if (chains.length !== 1) {
+      reject('multiple_seams');
+      continue;
+    }
+    if (segments.length < 2 || chains[0].size < 3) {
+      reject('insufficient_chain');
+      continue;
+    }
+    const supportA = new Map();
+    const supportB = new Map();
+    segments.forEach(records => {
+      const first = records.find(record => record.componentId === group.componentA);
+      const second = records.find(record => record.componentId === group.componentB);
+      addSupport(supportA, first);
+      addSupport(supportB, second);
+    });
+    const pairSelection = selectMutualBonePair(supportA, supportB);
+    if (pairSelection.mutual.length !== 1) {
+      reject('bone_pair_ambiguous');
+      continue;
+    }
+    const selectedPair = pairSelection.mutual[0];
+    const length = segments.reduce((sum, records) =>
+      sum + (Number(records[0].length) || 0), 0);
+    const center = segments.reduce((sum, records) => {
+      const edge = records[0];
+      const midpoint = [
+        (edge.pointA[0] + edge.pointB[0]) / 2,
+        (edge.pointA[1] + edge.pointB[1]) / 2,
+        (edge.pointA[2] + edge.pointB[2]) / 2,
+      ];
+      const weight = Number(edge.length) || 0;
+      return [sum[0] + midpoint[0] * weight,
+        sum[1] + midpoint[1] * weight,
+        sum[2] + midpoint[2] * weight];
+    }, [0, 0, 0]).map(value => length > 0 ? value / length : 0);
+    const bonePairSupport = pairSelection.pairSupport;
+    candidates.push({
+      boneA: selectedPair.boneA,
+      boneB: selectedPair.boneB,
+      evidenceType: 'mesh_boundary',
+      jointCenter: center,
+      matchedEdgeCount: segments.length,
+      matchedLength: length,
+      memberKey: group.memberKey,
+      componentA: group.componentA,
+      componentB: group.componentB,
+      bonePairSupport,
+      seamSupport: {
+        [selectedPair.boneA]: supportA.get(selectedPair.boneA),
+        [selectedPair.boneB]: supportB.get(selectedPair.boneB),
+      },
+      segments: segments.map(records => records.map(record => ({...record}))),
+    });
+  }
+  const ordered = candidates.sort((left, right) =>
+    right.matchedEdgeCount - left.matchedEdgeCount
+    || right.matchedLength - left.matchedLength
+    || (right.bonePairSupport[pairKey(right.boneA, right.boneB)]
+      - left.bonePairSupport[pairKey(left.boneA, left.boneB)])
+    || left.componentA - right.componentA || left.componentB - right.componentB
+    || left.boneA - right.boneA || left.boneB - right.boneB
+    || left.memberKey.localeCompare(right.memberKey));
+  const parent = new Map((baseForest?.components || [])
+    .map(component => [Number(component.componentId), Number(component.componentId)]));
+  const find = value => {
+    let current = value;
+    while (parent.has(current) && parent.get(current) !== current) {
+      current = parent.get(current);
+    }
+    return current;
+  };
+  const acceptedBridges = [];
+  ordered.forEach(candidate => {
+    const left = find(candidate.componentA);
+    const right = find(candidate.componentB);
+    if (left === right) {
+      reject('cycle');
+      return;
+    }
+    parent.set(left, right);
+    acceptedBridges.push({...candidate});
+  });
+  return {
+    enabled: true,
+    boundaryEvidenceEnabled: true,
+    boundaryEvidenceReason: null,
+    boundaryEdgeCount,
+    exactMatchedEdgeCount,
+    validSeamSampleCount: matched.length,
+    boundaryComponentPairCount: pairGroups.size,
+    candidates: ordered,
+    acceptedBridges,
+    boundaryRejectedCounts: rejected,
+  };
+}
+
+function componentEvidence(component, graph) {
+  return (component?.nodeIds || []).reduce((sum, boneId) => {
+    const node = (graph?.nodes || []).find(item => Number(item.boneId) === Number(boneId));
+    return sum + (Number(node?.totalWeight) || 0);
+  }, 0);
+}
+
+function componentMeasure(component, graph) {
+  return (component?.nodeIds || []).reduce((sum, boneId) => {
+    const node = (graph?.nodes || []).find(item => Number(item.boneId) === Number(boneId));
+    return sum + (Number(node?.affectedMeasure) || 0);
+  }, 0);
+}
+
+/** Add accepted bridges while retaining base component roots and orientation. */
+export function mergeResidualBoundaryBridges(baseForest, acceptedBridges = [], graph = null) {
+  if (!baseForest || !acceptedBridges.length) return baseForest;
+  const baseComponents = baseForest.components || [];
+  const groups = new Map();
+  const parent = new Map(baseComponents.map(component => [
+    Number(component.componentId), Number(component.componentId)]));
+  const find = value => {
+    let current = value;
+    while (parent.get(current) !== current) current = parent.get(current);
+    return current;
+  };
+  acceptedBridges.forEach(bridge => {
+    const left = find(Number(bridge.componentA));
+    const right = find(Number(bridge.componentB));
+    if (left !== right) parent.set(left, right);
+  });
+  baseComponents.forEach(component => {
+    const root = find(Number(component.componentId));
+    const group = groups.get(root) || [];
+    group.push(component);
+    groups.set(root, group);
+  });
+  const merged = [];
+  for (const components of groups.values()) {
+    const componentIds = new Set(components.map(component => Number(component.componentId)));
+    const bridges = acceptedBridges.filter(bridge => componentIds.has(Number(bridge.componentA))
+      && componentIds.has(Number(bridge.componentB)));
+    let host = components.find(component =>
+      Number(component.componentId) === Number(baseForest.primaryComponentId));
+    if (!host) host = components.find(component => component.primary);
+    if (!host) {
+      host = [...components].sort((left, right) =>
+        componentEvidence(right, graph) - componentEvidence(left, graph)
+        || componentMeasure(right, graph) - componentMeasure(left, graph)
+        || (right.nodeIds?.length || 0) - (left.nodeIds?.length || 0)
+        || Number(left.rootId) - Number(right.rootId))[0];
+    }
+    const nodeIds = components.flatMap(component => component.nodeIds || [])
+      .sort((left, right) => Number(left) - Number(right));
+    const edges = components.flatMap(component => {
+      if (component.edges?.length) return component.edges;
+      const nodeSet = new Set(component.nodeIds || []);
+      return (baseForest.edges || []).filter(edge =>
+        nodeSet.has(Number(edge.boneA)) && nodeSet.has(Number(edge.boneB)));
+    }).map(edge => ({...edge}));
+    bridges.forEach(bridge => edges.push({...bridge}));
+    const adjacency = new Map(nodeIds.map(id => [Number(id), []]));
+    edges.forEach(edge => {
+      const left = Number(edge.boneA);
+      const right = Number(edge.boneB);
+      if (!adjacency.has(left) || !adjacency.has(right)) return;
+      adjacency.get(left).push(right);
+      adjacency.get(right).push(left);
+    });
+    adjacency.forEach(values => values.sort((left, right) => left - right));
+    const rootId = Number(host.rootId);
+    const parentById = Object.fromEntries(nodeIds.map(id => [id, null]));
+    const childrenById = Object.fromEntries(nodeIds.map(id => [id, []]));
+    const depthById = Object.fromEntries(nodeIds.map(id => [id, null]));
+    const queue = [rootId];
+    depthById[rootId] = 0;
+    while (queue.length) {
+      const current = queue.shift();
+      for (const neighbor of adjacency.get(current) || []) {
+        if (depthById[neighbor] !== null) continue;
+        parentById[neighbor] = current;
+        childrenById[current].push(neighbor);
+        depthById[neighbor] = depthById[current] + 1;
+        queue.push(neighbor);
+      }
+    }
+    merged.push({
+      componentId: Math.min(...components.map(component => Number(component.componentId))),
+      nodeIds,
+      rootId,
+      parentById,
+      childrenById,
+      depthById,
+      edges,
+      edgeCount: edges.length,
+      maxDepth: Math.max(0, ...Object.values(depthById)
+        .filter(value => value !== null).map(Number)),
+      primary: components.some(component => component.primary),
+    });
+  }
+  merged.sort((left, right) => left.componentId - right.componentId);
+  const componentByBoneId = {};
+  merged.forEach(component => component.nodeIds.forEach(id => {
+    componentByBoneId[id] = component.componentId;
+  }));
+  const primary = merged.find(component => component.primary);
+  return {
+    ...baseForest,
+    primaryRootId: primary?.rootId ?? baseForest.primaryRootId,
+    primaryComponentId: primary?.componentId ?? baseForest.primaryComponentId,
+    components: merged,
+    componentByBoneId,
+    edges: merged.flatMap(component => component.edges || []),
+    nodeIds: [...(baseForest.nodeIds || [])],
+  };
+}

--- a/src/web/js/mesh/weight-rig-boundary.js
+++ b/src/web/js/mesh/weight-rig-boundary.js
@@ -406,6 +406,7 @@ export function buildResidualBoundaryEvidence({
       jointCenter: center,
       matchedEdgeCount: segments.length,
       matchedLength: length,
+      pivotWeight: length,
       memberKey: group.memberKey,
       componentA: group.componentA,
       componentB: group.componentB,
@@ -473,8 +474,13 @@ function componentMeasure(component, graph) {
   }, 0);
 }
 
-/** Add accepted bridges while retaining base component roots and orientation. */
-export function mergeResidualBoundaryBridges(baseForest, acceptedBridges = [], graph = null) {
+/**
+ * Add accepted bridges while retaining base component roots and orientation.
+ * Final component IDs are dense and ephemeral; base IDs stay on each merged
+ * component for diagnostics and for resolving bridge evidence.
+ */
+export function mergeResidualBoundaryBridges(
+    baseForest, acceptedBridges = [], graph = null, options = {}) {
   if (!baseForest || !acceptedBridges.length) return baseForest;
   const baseComponents = baseForest.components || [];
   const groups = new Map();
@@ -482,12 +488,17 @@ export function mergeResidualBoundaryBridges(baseForest, acceptedBridges = [], g
     Number(component.componentId), Number(component.componentId)]));
   const find = value => {
     let current = value;
-    while (parent.get(current) !== current) current = parent.get(current);
+    while (parent.has(current) && parent.get(current) !== current) {
+      current = parent.get(current);
+    }
     return current;
   };
   acceptedBridges.forEach(bridge => {
-    const left = find(Number(bridge.componentA));
-    const right = find(Number(bridge.componentB));
+    const leftId = Number(bridge.componentA);
+    const rightId = Number(bridge.componentB);
+    if (!parent.has(leftId) || !parent.has(rightId)) return;
+    const left = find(leftId);
+    const right = find(rightId);
     if (left !== right) parent.set(left, right);
   });
   baseComponents.forEach(component => {
@@ -496,14 +507,31 @@ export function mergeResidualBoundaryBridges(baseForest, acceptedBridges = [], g
     group.push(component);
     groups.set(root, group);
   });
+  const minNodeId = component => Math.min(...(component.nodeIds || [])
+    .map(Number).filter(Number.isFinite));
+  const groupSortKey = components => [
+    Math.min(...components.map(component => Number(component.componentId))),
+    Math.min(...components.map(minNodeId)),
+  ];
+  const groupedComponents = [...groups.values()].map(components =>
+    [...components].sort((left, right) =>
+      Number(left.componentId) - Number(right.componentId)));
+  groupedComponents.sort((left, right) => {
+    const leftKey = groupSortKey(left);
+    const rightKey = groupSortKey(right);
+    return leftKey[0] - rightKey[0] || leftKey[1] - rightKey[1];
+  });
+  const preferredRootId = Number(options.preferredRootId);
   const merged = [];
-  for (const components of groups.values()) {
-    const componentIds = new Set(components.map(component => Number(component.componentId)));
-    const bridges = acceptedBridges.filter(bridge => componentIds.has(Number(bridge.componentA))
+  for (const components of groupedComponents) {
+    const componentIds = new Set(components.map(component =>
+      Number(component.componentId)));
+    const bridges = acceptedBridges.filter(bridge =>
+      componentIds.has(Number(bridge.componentA))
       && componentIds.has(Number(bridge.componentB)));
-    let host = components.find(component =>
-      Number(component.componentId) === Number(baseForest.primaryComponentId));
-    if (!host) host = components.find(component => component.primary);
+    let host = Number.isInteger(preferredRootId)
+      ? components.find(component => (component.nodeIds || [])
+        .some(id => Number(id) === preferredRootId)) : null;
     if (!host) {
       host = [...components].sort((left, right) =>
         componentEvidence(right, graph) - componentEvidence(left, graph)
@@ -511,8 +539,8 @@ export function mergeResidualBoundaryBridges(baseForest, acceptedBridges = [], g
         || (right.nodeIds?.length || 0) - (left.nodeIds?.length || 0)
         || Number(left.rootId) - Number(right.rootId))[0];
     }
-    const nodeIds = components.flatMap(component => component.nodeIds || [])
-      .sort((left, right) => Number(left) - Number(right));
+    const nodeIds = [...new Set(components.flatMap(component =>
+      component.nodeIds || []))].sort((left, right) => Number(left) - Number(right));
     const edges = components.flatMap(component => {
       if (component.edges?.length) return component.edges;
       const nodeSet = new Set(component.nodeIds || []);
@@ -529,12 +557,14 @@ export function mergeResidualBoundaryBridges(baseForest, acceptedBridges = [], g
       adjacency.get(right).push(left);
     });
     adjacency.forEach(values => values.sort((left, right) => left - right));
-    const rootId = Number(host.rootId);
+    const preferredInHost = Number.isInteger(preferredRootId)
+      && host.nodeIds?.some(id => Number(id) === preferredRootId);
+    const rootId = preferredInHost ? preferredRootId : Number(host.rootId);
     const parentById = Object.fromEntries(nodeIds.map(id => [id, null]));
     const childrenById = Object.fromEntries(nodeIds.map(id => [id, []]));
     const depthById = Object.fromEntries(nodeIds.map(id => [id, null]));
-    const queue = [rootId];
-    depthById[rootId] = 0;
+    const queue = nodeIds.includes(rootId) ? [rootId] : [];
+    if (queue.length) depthById[rootId] = 0;
     while (queue.length) {
       const current = queue.shift();
       for (const neighbor of adjacency.get(current) || []) {
@@ -546,7 +576,7 @@ export function mergeResidualBoundaryBridges(baseForest, acceptedBridges = [], g
       }
     }
     merged.push({
-      componentId: Math.min(...components.map(component => Number(component.componentId))),
+      baseComponentIds: components.map(component => Number(component.componentId)),
       nodeIds,
       rootId,
       parentById,
@@ -556,19 +586,20 @@ export function mergeResidualBoundaryBridges(baseForest, acceptedBridges = [], g
       edgeCount: edges.length,
       maxDepth: Math.max(0, ...Object.values(depthById)
         .filter(value => value !== null).map(Number)),
-      primary: components.some(component => component.primary),
     });
   }
-  merged.sort((left, right) => left.componentId - right.componentId);
   const componentByBoneId = {};
-  merged.forEach(component => component.nodeIds.forEach(id => {
-    componentByBoneId[id] = component.componentId;
-  }));
-  const primary = merged.find(component => component.primary);
+  merged.forEach((component, componentId) => {
+    component.componentId = componentId;
+    component.nodeIds.forEach(id => {
+      componentByBoneId[id] = componentId;
+    });
+  });
+  const result = {...baseForest};
+  delete result.primaryRootId;
+  delete result.primaryComponentId;
   return {
-    ...baseForest,
-    primaryRootId: primary?.rootId ?? baseForest.primaryRootId,
-    primaryComponentId: primary?.componentId ?? baseForest.primaryComponentId,
+    ...result,
     components: merged,
     componentByBoneId,
     edges: merged.flatMap(component => component.edges || []),

--- a/src/web/js/mesh/weight-rig-boundary.js
+++ b/src/web/js/mesh/weight-rig-boundary.js
@@ -100,7 +100,8 @@ function weightedMean(left, right, length) {
   return length * (left + right) / 2;
 }
 
-function edgeRecord(member, forest, triangle, edgeOffset, componentId) {
+function edgeRecord(member, forest, triangle, edgeOffset, componentId,
+    topologyKey = null) {
   const [first, second, third] = [0, 1, 2].map(index => ({
     vertex: triangle.indices[(edgeOffset + index) % 3],
     point: triangle.points[(edgeOffset + index) % 3],
@@ -131,7 +132,7 @@ function edgeRecord(member, forest, triangle, edgeOffset, componentId) {
     pointB: [...second.point],
     thirdPoint: [...third.point],
     edgeKey: exactEdgeKey(first.point, second.point),
-    topologyKey: topologyEdgeKey(first.vertex, second.vertex),
+    topologyKey: topologyKey || topologyEdgeKey(first.vertex, second.vertex),
     pointKeyA: pointKey(first.point),
     pointKeyB: pointKey(second.point),
     length: edgeLength(first.point, second.point),
@@ -169,15 +170,21 @@ function collectBoundaryRecords(member, forest) {
     pureTriangleCount += 1;
     const componentId = [...componentIds][0];
     for (let edgeOffset = 0; edgeOffset < 3; edgeOffset += 1) {
-      const record = edgeRecord(member, forest, triangle, edgeOffset, componentId);
-      const list = usage.get(`${componentId}|${record.topologyKey}`) || [];
-      list.push(record);
-      usage.set(`${componentId}|${record.topologyKey}`, list);
+      const firstVertex = triangle.indices[edgeOffset];
+      const secondVertex = triangle.indices[(edgeOffset + 1) % 3];
+      const topologyKey = topologyEdgeKey(firstVertex, secondVertex);
+      const key = `${componentId}|${topologyKey}`;
+      const list = usage.get(key) || [];
+      list.push({triangle, edgeOffset, componentId, topologyKey});
+      usage.set(key, list);
     }
   }
   const boundaries = [];
   for (const records of usage.values()) {
-    if (records.length === 1) boundaries.push(records[0]);
+    if (records.length !== 1) continue;
+    const record = records[0];
+    boundaries.push(edgeRecord(member, forest, record.triangle,
+      record.edgeOffset, record.componentId, record.topologyKey));
   }
   return {
     boundaries,

--- a/src/web/js/mesh/weight-rig-reconcile.js
+++ b/src/web/js/mesh/weight-rig-reconcile.js
@@ -1283,7 +1283,10 @@ function sourceModelEdges(sourceRigs, keyToJoint) {
           return (a === parentBoneId && b === childBoneId)
             || (a === childBoneId && b === parentBoneId);
         });
-        const sourceRelationship = (rig.influenceGraph?.relationships || [])
+        const sourceRelationship = [
+          ...(rig.influenceGraph?.relationships || []),
+          ...(rig.boundaryBridges || []),
+        ]
           .find(candidate => {
             const a = Number(candidate.boneA);
             const b = Number(candidate.boneB);
@@ -1299,6 +1302,7 @@ function sourceModelEdges(sourceRigs, keyToJoint) {
           jointCenter: sourceRelationship?.jointCenter
             ? [...sourceRelationship.jointCenter] : null,
           jointWeightTotal: Number(sourceRelationship?.jointWeightTotal) || 0,
+          evidenceType: sourceRelationship?.evidenceType || 'triangle_overlap',
         });
         edge.combinedTreeScore += treeScore;
         edgeMap.set(key, edge);

--- a/src/web/js/mesh/weight-rig-reconcile.js
+++ b/src/web/js/mesh/weight-rig-reconcile.js
@@ -1283,16 +1283,20 @@ function sourceModelEdges(sourceRigs, keyToJoint) {
           return (a === parentBoneId && b === childBoneId)
             || (a === childBoneId && b === parentBoneId);
         });
-        const sourceRelationship = [
-          ...(rig.influenceGraph?.relationships || []),
-          ...(rig.boundaryBridges || []),
-        ]
-          .find(candidate => {
+        const sourceRelationship = (sourceEdge?.jointCenter
+          || sourceEdge?.evidenceType) ? sourceEdge
+          : (rig.influenceGraph?.relationships || []).find(candidate => {
             const a = Number(candidate.boneA);
             const b = Number(candidate.boneB);
             return (a === parentBoneId && b === childBoneId)
               || (a === childBoneId && b === parentBoneId);
           });
+        const evidenceType = sourceRelationship?.evidenceType
+          || 'triangle_overlap';
+        const pivotWeight = Number(sourceRelationship?.pivotWeight)
+          || (evidenceType === 'mesh_boundary'
+            ? Number(sourceRelationship?.matchedLength) || 0
+            : Number(sourceRelationship?.jointWeightTotal) || 0);
         const treeScore = edgeScore(sourceEdge);
         edge.sourceEdges.push({
           sourceKey: String(rig.sourceKey),
@@ -1302,7 +1306,8 @@ function sourceModelEdges(sourceRigs, keyToJoint) {
           jointCenter: sourceRelationship?.jointCenter
             ? [...sourceRelationship.jointCenter] : null,
           jointWeightTotal: Number(sourceRelationship?.jointWeightTotal) || 0,
-          evidenceType: sourceRelationship?.evidenceType || 'triangle_overlap',
+          pivotWeight,
+          evidenceType,
         });
         edge.combinedTreeScore += treeScore;
         edgeMap.set(key, edge);

--- a/src/web/js/mesh/weight-rig-snapshots.js
+++ b/src/web/js/mesh/weight-rig-snapshots.js
@@ -167,6 +167,7 @@ export function sourceRigSnapshot(rig, {
     normalizedDistance: edge.normalizedDistance,
     treeEdgeScore: edge.treeEdgeScore,
     jointWeightTotal: edge.jointWeightTotal,
+    pivotWeight: Number(edge.jointWeightTotal) || 0,
     jointCenter: edge.jointCenter ? [...edge.jointCenter] : null,
   }));
   source.boundaryBridges = (rig.boundaryBridges || []).map(edge => ({
@@ -176,6 +177,8 @@ export function sourceRigSnapshot(rig, {
     jointCenter: edge.jointCenter ? [...edge.jointCenter] : null,
     matchedEdgeCount: edge.matchedEdgeCount,
     matchedLength: edge.matchedLength,
+    pivotWeight: Number(edge.pivotWeight)
+      || Number(edge.matchedLength) || 0,
     memberKey: edge.memberKey,
     componentA: edge.componentA,
     componentB: edge.componentB,

--- a/src/web/js/mesh/weight-rig-snapshots.js
+++ b/src/web/js/mesh/weight-rig-snapshots.js
@@ -84,6 +84,21 @@ export function sourceRigSnapshot(rig, {
     zeroMeasureVertexCount: rig.influenceGraph?.zeroMeasureVertexCount || 0,
     surfaceEvidenceAvailable: rig.influenceGraph?.evidenceMode === 'surface',
     fallbackReason: rig.influenceGraph?.fallbackReason || null,
+    boundaryEvidenceEnabled: rig.boundaryAnalysis?.boundaryEvidenceEnabled === true,
+    boundaryEvidenceReason: rig.boundaryAnalysis?.boundaryEvidenceReason || null,
+    baseComponentCount: rig.baseInferredForest?.components?.length
+      ?? rig.inferredForest?.components?.length ?? 0,
+    finalComponentCount: rig.inferredForest?.components?.length || 0,
+    boundaryEdgeCount: rig.boundaryAnalysis?.boundaryEdgeCount || 0,
+    exactMatchedEdgeCount: rig.boundaryAnalysis?.exactMatchedEdgeCount || 0,
+    validSeamSampleCount: rig.boundaryAnalysis?.validSeamSampleCount || 0,
+    boundaryComponentPairCount:
+      rig.boundaryAnalysis?.boundaryComponentPairCount || 0,
+    acceptedBoundaryBridgeCount: rig.boundaryBridges?.length || 0,
+    boundaryAnalysisMs: rig.boundaryAnalysis?.analysisMs || 0,
+    boundaryRejectedCounts: {
+      ...(rig.boundaryAnalysis?.boundaryRejectedCounts || {}),
+    },
     memberCount: rig.influenceGraph?.memberCount || 0,
     uniqueMemberCount: rig.influenceGraph?.uniqueMemberCount || 0,
     duplicateMemberCount: rig.influenceGraph?.duplicateMemberCount || 0,
@@ -141,6 +156,7 @@ export function sourceRigSnapshot(rig, {
   source.relationships = (rig.influenceGraph?.relationships || []).map(edge => ({
     boneA: edge.boneA,
     boneB: edge.boneB,
+    evidenceType: 'triangle_overlap',
     sharedVertexCount: edge.sharedVertexCount,
     sharedMeasure: edge.sharedMeasure,
     minOverlap: edge.minOverlap,
@@ -152,6 +168,18 @@ export function sourceRigSnapshot(rig, {
     treeEdgeScore: edge.treeEdgeScore,
     jointWeightTotal: edge.jointWeightTotal,
     jointCenter: edge.jointCenter ? [...edge.jointCenter] : null,
+  }));
+  source.boundaryBridges = (rig.boundaryBridges || []).map(edge => ({
+    boneA: edge.boneA,
+    boneB: edge.boneB,
+    evidenceType: 'mesh_boundary',
+    jointCenter: edge.jointCenter ? [...edge.jointCenter] : null,
+    matchedEdgeCount: edge.matchedEdgeCount,
+    matchedLength: edge.matchedLength,
+    memberKey: edge.memberKey,
+    componentA: edge.componentA,
+    componentB: edge.componentB,
+    bonePairSupport: {...(edge.bonePairSupport || {})},
   }));
   return source;
 }

--- a/src/web/js/mesh/weight-rig.js
+++ b/src/web/js/mesh/weight-rig.js
@@ -17,7 +17,7 @@ function triangleArea(points) {
     ab[0] * ac[1] - ab[1] * ac[0]);
 }
 
-function collectSurfaceTriangles(
+export function collectSurfaceTriangles(
     positions, triangleIndices = null, includeTriangles = true) {
   const positionArray = positions || [];
   const positionCount = Math.floor(positionArray.length / 3);
@@ -1021,11 +1021,17 @@ export function buildInferredRigForest(graph, options = {}) {
       maxDepth: Math.max(0, ...depths),
     };
   });
+  const primaryComponentId = components.length ? 0 : null;
+  components.forEach((component, componentId) => {
+    component.primary = componentId === primaryComponentId;
+  });
   const componentByBoneId = {};
   components.forEach(component => component.nodeIds.forEach(id => {
     componentByBoneId[id] = component.componentId;
   }));
   return {
+    primaryRootId: components[primaryComponentId]?.rootId ?? null,
+    primaryComponentId,
     components,
     componentByBoneId,
     edges: tree.edges,

--- a/src/web/js/mesh/weight-rig.js
+++ b/src/web/js/mesh/weight-rig.js
@@ -1021,17 +1021,11 @@ export function buildInferredRigForest(graph, options = {}) {
       maxDepth: Math.max(0, ...depths),
     };
   });
-  const primaryComponentId = components.length ? 0 : null;
-  components.forEach((component, componentId) => {
-    component.primary = componentId === primaryComponentId;
-  });
   const componentByBoneId = {};
   components.forEach(component => component.nodeIds.forEach(id => {
     componentByBoneId[id] = component.componentId;
   }));
   return {
-    primaryRootId: components[primaryComponentId]?.rootId ?? null,
-    primaryComponentId,
     components,
     componentByBoneId,
     edges: tree.edges,


### PR DESCRIPTION
## Summary

Adds a conservative residual surface-boundary bridge stage after surface influence-graph forest inference.

- Extracts exact indexed boundary seams only from pure-component triangles.
- Uses a lightweight topology pass and materializes detailed edge records only for actual boundary edges.
- Requires opposite-side continuation, connected multi-edge evidence, unique mutual-best seam bones, and cycle-free component joins.
- Preserves base roots and keeps mesh-boundary evidence separate in Rig diagnostics and cross-source reconciliation.
- Keeps vertex fallback and non-indexed sources disabled for boundary inference.

## Validation

- `pytest -q`
- Module regressions cover non-manifold, same-side, disconnected-seam, cycle, connected-base, vertex-fallback, and non-indexed cases.
- Runtime regression covers boundary evidence rebuilding after a shape rebaseline.
