### PR TITLE
Add saved humanoid-guided ModelRig build

### DIFF
--- a/src/core/geometry/draw_call.py
+++ b/src/core/geometry/draw_call.py
@@ -47,6 +47,9 @@ class AuthoredDrawCall:
     texture_provenance: dict = field(default_factory=dict)
     geometry_match: GeometryMatch | None = None
     skinning_bone_offset: int = 0
+    # Compute-resource bindings captured at the draw's execution point.  The
+    # WWMI remapper uses cs-t35 for the per-vertex full VertexVG identities.
+    skinning_remap_resources: dict[int, str | None] = field(default_factory=dict)
     slot_textures: list = field(default_factory=list)
 
 

--- a/src/core/geometry/skinning.py
+++ b/src/core/geometry/skinning.py
@@ -17,6 +17,12 @@ class SkinningSource:
     influence_count: int
     encoding: str
     bone_id_offset: int = 0
+    # WWMI can bind a per-vertex full VertexVG table to the compute remapper.
+    # When present, these IDs are authoritative and already use the model
+    # namespace; the ordinary Blend byte offset must not be applied.
+    vertex_vg_file: str | None = None
+    vertex_vg_stride: int = 16
+    bone_id_namespace: str = "model"
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,7 +66,8 @@ def normalize_skinning_source_file(value):
     return normalized
 
 
-def skinning_source_key(source_file, bone_id_offset=0):
+def skinning_source_key(source_file, bone_id_offset=0, vertex_vg_file=None,
+                        bone_id_namespace="model"):
     """Build the case-insensitive identity for one decoded skin namespace."""
     normalized = normalize_skinning_source_file(source_file)
     if normalized is None:
@@ -73,7 +80,12 @@ def skinning_source_key(source_file, bone_id_offset=0):
         return None
     if offset < 0:
         return None
-    return f"{normalized.casefold()}|offset={offset}"
+    key = f"{normalized.casefold()}|offset={offset}"
+    remap = normalize_skinning_source_file(vertex_vg_file)
+    namespace = str(bone_id_namespace or "model")
+    if remap and namespace != "model":
+        key += f"|namespace={namespace}|vertex-vg={remap.casefold()}"
+    return key
 
 
 def skinning_source_descriptor(source):
@@ -87,10 +99,18 @@ def skinning_source_descriptor(source):
         offset = int(source.bone_id_offset)
     except (TypeError, ValueError):
         return None
-    key = skinning_source_key(file, offset)
+    key = skinning_source_key(
+        file, offset, source.vertex_vg_file, source.bone_id_namespace)
     if key is None:
         return None
-    return {"key": key, "file": file, "bone_id_offset": offset}
+    descriptor = {"key": key, "file": file, "bone_id_offset": offset}
+    if source.vertex_vg_file and source.bone_id_namespace != "model":
+        descriptor.update({
+            "bone_id_namespace": source.bone_id_namespace,
+            "vertex_vg_source": normalize_skinning_source_file(
+                source.vertex_vg_file),
+        })
+    return descriptor
 
 
 def _format_supports_packed_weights(value):
@@ -99,8 +119,31 @@ def _format_supports_packed_weights(value):
             or "R8G8B8A8_UINT" in text)
 
 
+def _resolve_vertex_vg_resource(resource_name, resolve_vertex_info,
+                                influence_count):
+    """Resolve and validate the WWMI full VertexVG resource binding."""
+    if not resource_name:
+        return None, None
+    info = resolve_vertex_info(resource_name) or {}
+    filename = normalize_skinning_source_file(info.get("filename"))
+    expected_stride = influence_count * 2
+    try:
+        stride = int(info.get("stride", expected_stride))
+    except (TypeError, ValueError):
+        stride = 0
+    format_name = str(info.get("format") or "").upper()
+    valid_format = "R16_UINT" in format_name
+    if not filename or stride != expected_stride or not valid_format:
+        return None, "invalid_vertex_vg_remap"
+    return {
+        "filename": filename,
+        "stride": stride,
+        "format": info.get("format"),
+    }, None
+
+
 def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
-                            bone_id_offset=0):
+                            bone_id_offset=0, remap_resources=None):
     """Resolve one conservative Blend candidate from active ``vbN`` state.
 
     The caller supplies the resolver already used by draw-group assembly, so
@@ -145,17 +188,38 @@ def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
             unsupported.append(stride)
         if encoding is None:
             continue
+        remap_info, remap_error = (None, None)
+        if encoding.startswith("wwmi_"):
+            remap_name = (remap_resources or {}).get(35)
+            if not remap_name:
+                unsupported.append("missing_vertex_vg_remap")
+                continue
+            remap_info, remap_error = _resolve_vertex_vg_resource(
+                remap_name, resolve_vertex_info,
+                influence_count)
+            if remap_error:
+                unsupported.append(remap_error)
+                continue
         source = SkinningSource(
             file=filename, stride=stride,
             influence_count=influence_count, encoding=encoding,
-            bone_id_offset=bone_id_offset)
+            bone_id_offset=bone_id_offset,
+            vertex_vg_file=remap_info["filename"] if remap_info else None,
+            vertex_vg_stride=remap_info["stride"] if remap_info else 16,
+            bone_id_namespace=("wwmi_vertex_vg" if remap_info
+                               else "model"))
         candidates[(source.file, source.stride, source.encoding,
-                    source.bone_id_offset)] = source
+                    source.bone_id_offset, source.vertex_vg_file,
+                    source.vertex_vg_stride, source.bone_id_namespace)] = source
 
     if len(candidates) > 1:
         return None, "ambiguous_skinning_source"
     if candidates:
         return next(iter(candidates.values())), None
+    if "missing_vertex_vg_remap" in unsupported:
+        return None, "missing_vertex_vg_remap"
+    if "invalid_vertex_vg_remap" in unsupported:
+        return None, "invalid_vertex_vg_remap"
     if unsupported:
         return None, "unsupported_skinning_layout"
     return None, None
@@ -167,7 +231,7 @@ def _zero_record(indices, weights, offset, influence_count):
         struct.pack_into("<f", weights, offset + influence * 4, 0.0)
 
 
-def decode_skinning(source, raw_data, used_vertices):
+def decode_skinning(source, raw_data, used_vertices, vertex_vg_data=None):
     """Decode and compact one supported Blend stream.
 
     Malformed records are represented as safe zero-influence records and are
@@ -187,6 +251,12 @@ def decode_skinning(source, raw_data, used_vertices):
         raise ValueError(f"Unsupported skinning encoding: {source.encoding}")
 
     raw_data = bytes(raw_data)
+    if source.vertex_vg_file:
+        expected_stride = source.influence_count * 2
+        if (source.bone_id_namespace != "wwmi_vertex_vg"
+                or source.vertex_vg_stride != expected_stride):
+            raise ValueError("Invalid VertexVG remap descriptor.")
+        vertex_vg_data = bytes(vertex_vg_data or b"")
     used_vertices = tuple(used_vertices)
     count = len(used_vertices)
     item_bytes = source.influence_count * 4
@@ -196,6 +266,7 @@ def decode_skinning(source, raw_data, used_vertices):
     zero_weight = 0
     truncated = 0
     out_of_range = 0
+    vertex_vg_truncated = 0
     sums = []
     bone_ids = set()
 
@@ -233,6 +304,20 @@ def decode_skinning(source, raw_data, used_vertices):
                 "<I", raw_data, record_offset)[0],)
             values = (1.0,)
 
+        remapped_indices = None
+        if source.vertex_vg_file:
+            remap_offset = source_index * source.vertex_vg_stride
+            if (remap_offset < 0
+                    or remap_offset + source.vertex_vg_stride
+                    > len(vertex_vg_data)):
+                vertex_vg_truncated += 1
+                _zero_record(index_bytes, weight_bytes, output_offset,
+                             source.influence_count)
+                continue
+            remapped_indices = struct.unpack_from(
+                f"<{source.influence_count}H", vertex_vg_data,
+                remap_offset)
+
         if (not all(math.isfinite(value) and value >= 0 for value in values)
                 or any(value < 0 for value in decoded_indices)):
             invalid += 1
@@ -246,7 +331,9 @@ def decode_skinning(source, raw_data, used_vertices):
             zero_weight += 1
         for influence, (raw_bone, weight) in enumerate(
                 zip(decoded_indices, values)):
-            bone = int(raw_bone) + int(source.bone_id_offset)
+            bone = (int(remapped_indices[influence])
+                    if remapped_indices is not None
+                    else int(raw_bone) + int(source.bone_id_offset))
             struct.pack_into("<I", index_bytes,
                              output_offset + influence * 4, bone)
             struct.pack_into("<f", weight_bytes,
@@ -264,9 +351,15 @@ def decode_skinning(source, raw_data, used_vertices):
         "invalid_weight_vertices": invalid,
         "truncated_vertices": truncated,
         "out_of_range_vertices": out_of_range,
+        "vertex_vg_remap": bool(source.vertex_vg_file),
+        "vertex_vg_source": (normalize_skinning_source_file(
+            source.vertex_vg_file) if source.vertex_vg_file else None),
+        "vertex_vg_truncated_vertices": vertex_vg_truncated,
         "bone_id_namespace": "model",
         "bone_id_offset": int(source.bone_id_offset),
     }
+    if source.vertex_vg_file:
+        diagnostics["bone_id_namespace"] = source.bone_id_namespace
     return DecodedSkinning(
         vertex_count=count, influence_count=source.influence_count,
         indices=bytes(index_bytes), weights=bytes(weight_bytes),
@@ -282,6 +375,14 @@ def _error_for_draw(draw):
         return SkinningPreviewError(
             "unsupported_skinning_layout",
             "This Blend format is not supported by the experiment.")
+    if draw.skinning_error == "invalid_vertex_vg_remap":
+        return SkinningPreviewError(
+            "invalid_vertex_vg_remap",
+            "The WWMI VertexVG remap resource is invalid.")
+    if draw.skinning_error == "missing_vertex_vg_remap":
+        return SkinningPreviewError(
+            "skinning_remap_unavailable",
+            "The WWMI VertexVG remap binding is unavailable.")
     if draw.skinning_source is None:
         return SkinningPreviewError(
             "skinning_not_available",
@@ -304,6 +405,14 @@ def build_skinning_preview(draw, group, mod_dir, *, buffers,
         raise SkinningPreviewError(
             "skinning_not_available",
             "The skin-weight buffer could not be found.")
+    remap_path = None
+    if draw.skinning_source.vertex_vg_file:
+        remap_path = safe_resource_path(
+            mod_dir, draw.skinning_source.vertex_vg_file)
+        if not remap_path or not os.path.exists(remap_path):
+            raise SkinningPreviewError(
+                "skinning_remap_unavailable",
+                "The WWMI VertexVG remap buffer could not be found.")
     prepared = _prepare_draw_vertices(
         draw, group, mod_dir=mod_dir, default_streams=default_streams,
         default_index_size=default_index_size, buffers=buffers,
@@ -314,11 +423,17 @@ def build_skinning_preview(draw, group, mod_dir, *, buffers,
             "The rendered draw geometry could not be prepared.")
     decoded = decode_skinning(
         draw.skinning_source, buffers.raw(source_path),
-        prepared.used_vertices)
+        prepared.used_vertices,
+        (buffers.raw(remap_path) if draw.skinning_source.vertex_vg_file
+         else None))
     if decoded.diagnostics["truncated_vertices"]:
         raise SkinningPreviewError(
             "skinning_buffer_truncated",
             "The skin-weight buffer is truncated.")
+    if decoded.diagnostics["vertex_vg_truncated_vertices"]:
+        raise SkinningPreviewError(
+            "skinning_remap_truncated",
+            "The WWMI VertexVG remap buffer is truncated.")
     return decoded
 
 

--- a/src/core/ini/draw_groups.py
+++ b/src/core/ini/draw_groups.py
@@ -131,6 +131,8 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
     texture_override_index = getattr(
         section_info, "texture_override_index", TextureOverrideIndex())
     texture_override_index = texture_override_index.with_resource_files(resources)
+    global_compute_resources = dict(
+        getattr(section_info, "global_compute_resources", {}) or {})
     if not draw_sections:
         return []
 
@@ -311,9 +313,12 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                 draw.position_stride, resolve_vertex_info)
             direct_skinning_resources = dict(group_vertex_resources)
             direct_skinning_resources.update(vertex_resources)
+            remap_resources = dict(global_compute_resources)
+            remap_resources.update(authored.skinning_remap_resources)
             skinning_source, skinning_error = resolve_skinning_source(
                 direct_skinning_resources, resolve_vertex_info,
-                bone_id_offset=authored.skinning_bone_offset)
+                bone_id_offset=authored.skinning_bone_offset,
+                remap_resources=remap_resources)
             if skinning_source is None and skinning_error is None:
                 occupied_slots = (set(group_vertex_resources)
                                   | set(vertex_resources))
@@ -325,7 +330,8 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                 }
                 skinning_source, skinning_error = resolve_skinning_source(
                     blend_fallback, resolve_vertex_info,
-                    bone_id_offset=authored.skinning_bone_offset)
+                    bone_id_offset=authored.skinning_bone_offset,
+                    remap_resources=remap_resources)
             draw.skinning_source = skinning_source
             draw.skinning_error = skinning_error
             _apply_diffuse_state(draw, authored, resolve_texture_file)

--- a/src/core/ini/draw_scan.py
+++ b/src/core/ini/draw_scan.py
@@ -32,6 +32,7 @@ class _ScannedSections(dict):
     def __init__(self, *args, texture_override_index=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.texture_override_index = texture_override_index
+        self.global_compute_resources = {}
 
 
 def _run_target_name(line, section_lookup):
@@ -334,6 +335,14 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                             info, role, resource, cond_stack,
                             source=("slot" if structural_role
                                     else "legacy_slot"))
+            match = re.match(
+                r"cs-t(\d+)\s*=\s*(?:(?:ref|copy)\s+)?(\S+)",
+                line, re.I)
+            if match:
+                slot = int(match.group(1))
+                resource = match.group(2)
+                info["_cur_compute_resources"][slot] = (
+                    None if resource.lower() == "null" else resource)
             match = re.match(r"vb(\d+)\s*=\s*(?:ref\s+)?(\S+)", line, re.I)
             if match:
                 slot = int(match.group(1))
@@ -382,6 +391,8 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                     geometry_match=geometry_match(info),
                     skinning_bone_offset=info.get(
                         "_cur_skinning_bone_offset", 0),
+                    skinning_remap_resources=dict(
+                        info.get("_cur_compute_resources") or {}),
                     slot_textures=slot_snapshot(info),
                 ))
             semantic = re.match(
@@ -422,6 +433,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             "_diffuse_chain_key": None, "_diffuse_history": [],
             "_aux_maps": {}, "_texture_provenance": {},
             "_cur_vertex_resources": {}, "_cur_slot_textures": {},
+            "_cur_compute_resources": {},
             "_geometry_hash": None, "_match_first_index": None,
             "_match_index_count": None,
             "_cur_skinning_bone_offset": 0,
@@ -445,6 +457,19 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 "_diffuse_history", "_aux_maps", "_texture_provenance"):
             info.pop(key, None)
         scanned[name] = info
+    global_compute_candidates = {}
+    for name, info in scanned.items():
+        if not name.lower().startswith("commandlist"):
+            continue
+        for slot, resource in (info.get("_cur_compute_resources") or {}).items():
+            if resource is None:
+                continue
+            global_compute_candidates.setdefault(slot, set()).add(resource)
+    scanned.global_compute_resources = {
+        slot: next(iter(candidates))
+        for slot, candidates in global_compute_candidates.items()
+        if len(candidates) == 1
+    }
     return scanned
 
 

--- a/src/tests/core/geometry/test_skinning.py
+++ b/src/tests/core/geometry/test_skinning.py
@@ -50,6 +50,23 @@ def test_decode_wwmi_wide_keeps_all_eight_influences():
     assert decoded.influence_count == 8
 
 
+def test_decode_wwmi_vertex_vg_remap_keeps_colliding_raw_indices_distinct():
+    source = SkinningSource(
+        "blend.buf", 16, 8, "wwmi_u8_8", 142,
+        "remap.buf", 16, "wwmi_vertex_vg")
+    raw = bytes([3] * 8) + bytes([255, 128, 64, 32, 16, 8, 4, 2])
+    remap = struct.pack("<8H", 3, 259, 45, 257, 0, 1, 2, 3)
+
+    decoded = decode_skinning(source, raw, [0], remap)
+
+    assert unpack_values(decoded.indices, "8I") == (3, 259, 45, 257, 0, 1, 2, 3)
+    assert unpack_values(decoded.weights, "8f") == pytest.approx(
+        tuple(value / 255 for value in [255, 128, 64, 32, 16, 8, 4, 2]))
+    assert decoded.bone_ids == (0, 1, 2, 3, 45, 257, 259)
+    assert decoded.diagnostics["bone_id_namespace"] == "wwmi_vertex_vg"
+    assert decoded.diagnostics["vertex_vg_remap"] is True
+
+
 def test_decode_rigid_uses_one_implicit_weight():
     source = SkinningSource("blend.buf", 4, 1, "rigid_u32_1")
 
@@ -109,27 +126,107 @@ def test_resolver_accepts_known_blend_layouts(stride, fmt, encoding):
     resources = {"ResourceBlendBuffer": {
         "filename": "blend.buf", "stride": stride, "format": fmt,
     }}
+    remap_resources = None
+    expected_remap = None
+    if encoding.startswith("wwmi_"):
+        resources["ResourceVertexVG"] = {
+            "filename": "remap.buf", "stride": 8 if stride == 8 else 16,
+            "format": "DXGI_FORMAT_R16_UINT",
+        }
+        remap_resources = {35: "ResourceVertexVG"}
+        expected_remap = "remap.buf"
 
     source, error = resolve_skinning_source(
-        {4: "ResourceBlendBuffer"}, resources.get)
+        {4: "ResourceBlendBuffer"}, resources.get,
+        remap_resources=remap_resources)
 
     assert error is None
     assert source == SkinningSource(
         "blend.buf", stride,
-        8 if stride == 16 else (4 if stride in (8, 32) else 1), encoding)
+        8 if stride == 16 else (4 if stride in (8, 32) else 1), encoding,
+        vertex_vg_file=expected_remap,
+        vertex_vg_stride=(8 if stride == 8 else 16),
+        bone_id_namespace=("wwmi_vertex_vg" if expected_remap else "model"))
+
+
+def test_resolver_rejects_wwmi_source_without_vertex_vg_remap():
+    source, error = resolve_skinning_source(
+        {1: "ResourceBlendBuffer"},
+        {"ResourceBlendBuffer": {
+            "filename": "blend.buf", "stride": 8,
+            "format": "DXGI_FORMAT_R8_UINT",
+        }}.get)
+
+    assert source is None
+    assert error == "missing_vertex_vg_remap"
 
 
 def test_resolver_carries_the_authored_model_bone_offset():
-    resources = {"ResourceBlendBuffer": {
-        "filename": "blend.buf", "stride": 8,
-        "format": "DXGI_FORMAT_R8_UINT",
-    }}
+    resources = {
+        "ResourceBlendBuffer": {
+            "filename": "blend.buf", "stride": 8,
+            "format": "DXGI_FORMAT_R8_UINT",
+        },
+        "ResourceVertexVG": {
+            "filename": "remap.buf", "stride": 8,
+            "format": "DXGI_FORMAT_R16_UINT",
+        },
+    }
 
     source, error = resolve_skinning_source(
-        {1: "ResourceBlendBuffer"}, resources.get, bone_id_offset=12)
+        {1: "ResourceBlendBuffer"}, resources.get, bone_id_offset=12,
+        remap_resources={35: "ResourceVertexVG"})
 
     assert error is None
     assert source.bone_id_offset == 12
+
+
+def test_resolver_uses_bound_vertex_vg_resource_without_applying_offset():
+    resources = {
+        "ResourceBlendBuffer": {
+            "filename": "blend.buf", "stride": 16,
+            "format": "DXGI_FORMAT_R8_UINT",
+        },
+        "ResourceBlendRemapVertexVGBuffer": {
+            "filename": "remap.buf", "stride": 16,
+            "format": "DXGI_FORMAT_R16_UINT",
+        },
+    }
+
+    source, error = resolve_skinning_source(
+        {1: "ResourceBlendBuffer"}, resources.get, bone_id_offset=142,
+        remap_resources={35: "ResourceBlendRemapVertexVGBuffer"})
+
+    assert error is None
+    assert source == SkinningSource(
+        "blend.buf", 16, 8, "wwmi_u8_8", 142,
+        "remap.buf", 16, "wwmi_vertex_vg")
+    assert skinning_source_descriptor(source) == {
+        "key": "blend.buf|offset=142|namespace=wwmi_vertex_vg|vertex-vg=remap.buf",
+        "file": "blend.buf", "bone_id_offset": 142,
+        "bone_id_namespace": "wwmi_vertex_vg",
+        "vertex_vg_source": "remap.buf",
+    }
+
+
+def test_resolver_rejects_invalid_vertex_vg_resource():
+    resources = {
+        "ResourceBlendBuffer": {
+            "filename": "blend.buf", "stride": 16,
+            "format": "DXGI_FORMAT_R8_UINT",
+        },
+        "ResourceRemap": {
+            "filename": "remap.buf", "stride": 8,
+            "format": "DXGI_FORMAT_R16_UINT",
+        },
+    }
+
+    source, error = resolve_skinning_source(
+        {1: "ResourceBlendBuffer"}, resources.get,
+        remap_resources={35: "ResourceRemap"})
+
+    assert source is None
+    assert error == "invalid_vertex_vg_remap"
 
 
 @pytest.mark.parametrize(

--- a/src/tests/core/ini/test_draw_groups.py
+++ b/src/tests/core/ini/test_draw_groups.py
@@ -232,6 +232,7 @@ ib = ResourceBodyIB
 vb0 = ResourceBodyPosition
 vb1 = ResourceBodyBlend
 vb2 = ResourceBodyTexcoord
+cs-t35 = ref ResourceVertexVG
 drawindexed = 3, 0, 0
 
 [ResourceBodyIB]
@@ -250,6 +251,11 @@ format = DXGI_FORMAT_R8_UINT
 [ResourceBodyTexcoord]
 filename = body-texcoord.buf
 stride = 20
+
+[ResourceVertexVG]
+filename = body-vertex-vg.buf
+format = DXGI_FORMAT_R16_UINT
+stride = 8
 """)
 
     draw = build_draw_groups(
@@ -257,6 +263,7 @@ stride = 20
 
     assert draw.skinning_bone_offset == 24
     assert draw.skinning_source.bone_id_offset == 24
+    assert draw.skinning_source.vertex_vg_file == "body-vertex-vg.buf"
 
 
 @pytest.mark.parametrize(

--- a/src/tests/core/ini/test_draw_resources.py
+++ b/src/tests/core/ini/test_draw_resources.py
@@ -28,6 +28,9 @@ vb1 = ResourceBodyTexcoord
 vb4 = ResourceBlendBufferOverride
 drawindexed = 3, 0, 0
 
+[CommandListRemap]
+cs-t35 = ref ResourceBlendRemapVertexVGBuffer
+
 [ResourceBodyIB]
 filename = Meshes/Index.buf
 format = DXGI_FORMAT_R32_UINT
@@ -46,6 +49,11 @@ stride = 20
 filename = Meshes/Blend.buf
 format = DXGI_FORMAT_R8_UINT
 stride = 16
+
+[ResourceBlendRemapVertexVGBuffer]
+filename = Meshes/BlendRemapVertexVG.buf
+format = DXGI_FORMAT_R16_UINT
+stride = 16
 """)
     resources = extract_resources(sections)
     scanned = _scan_sections_for_draws(sections)
@@ -61,3 +69,7 @@ stride = 16
     group = build_draw_groups(sections, resources)[0]
     assert group["draws"][0].skinning_source.file == "Meshes/Blend.buf"
     assert group["draws"][0].skinning_source.encoding == "wwmi_u8_8"
+    assert group["draws"][0].skinning_source.vertex_vg_file == \
+        "Meshes/BlendRemapVertexVG.buf"
+    assert group["draws"][0].skinning_source.bone_id_namespace == \
+        "wwmi_vertex_vg"

--- a/src/tests/integration/test_skinning_preview.py
+++ b/src/tests/integration/test_skinning_preview.py
@@ -60,6 +60,57 @@ stride = 20
     return ini
 
 
+def _write_wwmi_remap_mod(tmp_path):
+    ini = tmp_path / "wwmi.ini"
+    ini.write_text(
+        """[TextureOverrideBodyBlend]
+ib = ResourceBodyIB
+vb0 = ResourceBodyPosition
+vb1 = ResourceBodyBlend
+vb2 = ResourceBodyTexcoord
+run = CommandListRemap
+drawindexed = 3, 0, 0
+
+[CommandListRemap]
+cs-t35 = ref ResourceBlendRemapVertexVGBuffer
+
+[ResourceBodyIB]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourceBodyPosition]
+filename = body.pos
+stride = 12
+
+[ResourceBodyBlend]
+filename = body.blend
+format = DXGI_FORMAT_R8_UINT
+stride = 16
+
+[ResourceBodyTexcoord]
+filename = body.tc
+stride = 20
+
+[ResourceBlendRemapVertexVGBuffer]
+filename = body.vertex_vg
+format = DXGI_FORMAT_R16_UINT
+stride = 16
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "body.ib").write_bytes(struct.pack("<3I", 0, 1, 2))
+    (tmp_path / "body.pos").write_bytes(b"".join(
+        struct.pack("<3f", float(i), 0., 0.) for i in range(3)))
+    (tmp_path / "body.tc").write_bytes(b"\0" * 20 * 3)
+    (tmp_path / "body.blend").write_bytes(b"".join(
+        bytes([3] * 8 + [255, 128, 0, 0, 0, 0, 0, 0])
+        for _ in range(3)))
+    (tmp_path / "body.vertex_vg").write_bytes(b"".join(
+        struct.pack("<8H", 3, 259, 0, 0, 0, 0, 0, 0)
+        for _ in range(3)))
+    return ini
+
+
 def test_model_skinning_preview_matches_rendered_compaction(tmp_path, monkeypatch):
     ini = _write_mod(tmp_path)
     sections = merge_sections([str(ini)])
@@ -105,6 +156,47 @@ def test_model_skinning_preview_matches_rendered_compaction(tmp_path, monkeypatc
     assert struct.unpack_from("<4I", published["blob"], 0) == (7, 8, 9, 0)
     assert struct.unpack_from("<4f", published["blob"], 4 * 4 * 4) == pytest.approx(
         (.6, .3, .1, 0.))
+
+
+def test_model_skinning_preview_uses_wwmi_vertex_vg_identity(
+        tmp_path, monkeypatch):
+    ini = _write_wwmi_remap_mod(tmp_path)
+    sections = merge_sections([str(ini)])
+    groups = build_draw_groups(sections, extract_resources(sections))
+    geometry = GeometryBlob()
+    rendered = build_mesh_result(groups, str(tmp_path), geometry=geometry)
+    assert rendered.meshes["BodyBlend-1"]["skinning_available"] is True
+    published = {}
+
+    def publish(blob, *, replace=True):
+        published["blob"] = bytes(blob)
+        published["replace"] = replace
+        return "/geometry/wwmi-skin-test"
+
+    context = SimpleNamespace(
+        mod_dir=str(tmp_path), ini_paths=[str(ini)], docs={}, metadata={},
+        asset_folders=[])
+    preview = ModPreview(_Access())
+    monkeypatch.setattr(
+        preview, "authoritative_context",
+        lambda _path: (str(tmp_path), {}, {}, context))
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.publish_geometry", publish)
+
+    result = preview.get_model_skinning_preview(str(tmp_path))
+    entry = result["meshes"]["BodyBlend-1"]
+
+    assert result["status"] == "ok"
+    assert entry["bone_ids"] == [3, 259]
+    assert entry["diagnostics"]["bone_id_namespace"] == "wwmi_vertex_vg"
+    assert entry["diagnostics"]["vertex_vg_remap"] is True
+    assert entry["diagnostics"]["vertex_vg_source"] == "body.vertex_vg"
+    assert entry["diagnostics"]["vertex_vg_truncated_vertices"] == 0
+    assert entry["source"]["bone_id_namespace"] == "wwmi_vertex_vg"
+    assert struct.unpack_from("<8I", published["blob"], 0) == (
+        3, 259, 0, 0, 0, 0, 0, 0)
+    assert struct.unpack_from("<8f", published["blob"], 3 * 8 * 4) == pytest.approx(
+        (1., 128 / 255, 0., 0., 0., 0., 0., 0.))
 
 
 def test_get_model_skinning_preview_batches_successes_and_keeps_partial_errors(

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -4956,13 +4956,178 @@ def test_humanoid_mapped_model_joint_paths_override_heat_and_respect_graph_bound
         result["duplicateControl"]["conflictTypes"]
     assert result["mappedHandDescendants"] == {
         "bindings": [
+            {"driverId": "right_upper_arm",
+             "bindingMethod": "heat_connectivity",
+             "segmentStartControl": None, "segmentEndControl": None},
+            {"driverId": "right_upper_arm",
+             "bindingMethod": "heat_connectivity",
+             "segmentStartControl": None, "segmentEndControl": None},
             {"driverId": "left_lower_arm",
              "bindingMethod": "mapped_control_descendant",
              "segmentStartControl": None, "segmentEndControl": None},
-        ] * 3,
-        "sourceDrivers": ["left_lower_arm"] * 3,
-        "sourceMethods": ["mapped_control_descendant"] * 3,
-        "descendantCount": 3,
+        ],
+        "sourceDrivers": ["right_upper_arm", "right_upper_arm",
+                          "left_lower_arm"],
+        "sourceMethods": ["heat_connectivity", "heat_connectivity",
+                          "mapped_control_descendant"],
+        "descendantCount": 1,
+    }
+
+
+def test_complete_mapped_limb_uses_connected_descendants_before_heat(module_page):
+    result = module_page.evaluate("""async () => {
+      const THREE = await import('three');
+      const bindingModule = await import('./js/mesh/humanoid-rig-binding.js');
+      const {buildHumanoidRigBinding} = bindingModule;
+      const controls = {
+        pelvis: [0, .4, 0], chest: [0, 1.2, 0], neck: [0, 1.5, 0],
+        head: [0, 1.8, 0], leftShoulder: [-.8, 1.2, 0],
+        leftElbow: [-1.6, 1.2, 0], leftHand: [-2.4, 1.2, 0],
+        rightShoulder: [.8, 1.2, 0], rightElbow: [1.6, 1.2, 0],
+        rightHand: [2.4, 1.2, 0], leftHip: [-.45, .4, 0],
+        leftKnee: [-.45, -.4, 0], leftFoot: [-.45, -1.2, 0],
+        rightHip: [.45, .4, 0], rightKnee: [.45, -.4, 0],
+        rightFoot: [.45, -1.2, 0],
+      };
+      const positions = [[-.8, 1.2, 0], [-1.6, 1.2, 0],
+        [-2.4, 1.2, 0], [-2.8, 1.2, 0], [-1.2, .9, 0],
+        [-.7, 0, 0]];
+      const member = id => ({sourceKey: 'body', boneId: id,
+        sourceBoneKey: `body#bone=${id}`});
+      const joints = positions.map((restPivot, jointId) => ({jointId,
+        restPivot, restCenter: restPivot, restFrame: [0, 0, 0, 1],
+        members: [member(jointId)]}));
+      const modelRig = {
+        joints,
+        jointPivotByJointId: new Map(joints.map(joint =>
+          [joint.jointId, joint.restPivot])),
+        restFrameByJointId: new Map(joints.map(joint =>
+          [joint.jointId, new THREE.Quaternion()])),
+        components: [{componentId: 0, rootId: 0,
+          nodeIds: [0, 1, 2, 3, 4, 5],
+          parentById: {0: null, 1: 0, 2: 1, 3: 2, 4: null, 5: 0},
+          childrenById: {0: [1, 5], 1: [2], 2: [3], 3: [], 4: [], 5: []}}],
+        componentByJointId: new Map(joints.map(joint =>
+          [joint.jointId, 0])),
+      };
+      const controlRig = {frame: {height: 3, up: [0, 1, 0],
+        right: [1, 0, 0], forward: [0, 0, 1]}, controls:
+        Object.fromEntries(Object.entries(controls).map(([key, position]) =>
+          [key, {position}]))};
+      const heatAssignment = id => ({...member(id),
+        driverId: 'left_upper_arm', bindingMethod: 'heat_connectivity'});
+      const heatBinding = {
+        modelJointAssignments: new Map(joints.map(joint => [joint.jointId,
+          {...heatAssignment(joint.jointId), confidence: 'high'}])),
+        sourceBoneAssignments: new Map(joints.map(joint => [
+          `body#bone=${joint.jointId}`, heatAssignment(joint.jointId)])),
+      };
+      const mappings = new Map([
+        ['leftShoulder', {controlKey: 'leftShoulder', jointId: 0}],
+        ['leftElbow', {controlKey: 'leftElbow', jointId: 1}],
+        ['leftHand', {controlKey: 'leftHand', jointId: 2}],
+      ]);
+      const binding = buildHumanoidRigBinding({controlRig, modelRig,
+        heatBinding, controlMappings: mappings});
+      const descendant = binding.jointBindings.get(3);
+      return {
+        completeMappedHeatRoles: binding.diagnostics.completeMappedHeatRoles,
+        descendant: {
+          driverId: descendant?.driverId || null,
+          bindingMethod: descendant?.bindingMethod || null,
+        },
+        unclassifiedHelper: {
+          driverId: binding.jointBindings.get(5)?.driverId || null,
+          bindingMethod: binding.jointBindings.get(5)?.bindingMethod || null,
+        },
+        unrelatedBinding: binding.jointBindings.get(4)?.bindingMethod || null,
+        descendantSourceMethod: binding.sourceBoneAssignments.get(
+          'body#bone=3')?.bindingMethod || null,
+        unrelatedSourceAssignment: binding.sourceBoneAssignments.get(
+          'body#bone=4') || null,
+      };
+    }""")
+    assert result == {
+        "completeMappedHeatRoles": ["left_arm"],
+        "descendant": {"driverId": "left_lower_arm",
+                        "bindingMethod": "mapped_control_descendant"},
+        "unclassifiedHelper": {"driverId": "left_upper_arm",
+                                "bindingMethod": "mapped_control_descendant"},
+        "unrelatedBinding": None,
+        "descendantSourceMethod": "mapped_control_descendant",
+        "unrelatedSourceAssignment": None,
+    }
+
+
+def test_mapped_hip_claims_unknown_indirect_branch_before_heat(module_page):
+    result = module_page.evaluate("""async () => {
+      const THREE = await import('three');
+      const {buildHumanoidRigBinding} = await import(
+        './js/mesh/humanoid-rig-binding.js');
+      const controls = {
+        pelvis: [0, .4, 0], chest: [0, 1.2, 0], neck: [0, 1.5, 0],
+        head: [0, 1.8, 0], leftShoulder: [-.8, 1.2, 0],
+        leftElbow: [-1.6, 1.2, 0], leftHand: [-2.4, 1.2, 0],
+        rightShoulder: [.8, 1.2, 0], rightElbow: [1.6, 1.2, 0],
+        rightHand: [2.4, 1.2, 0], leftHip: [-.45, .4, 0],
+        leftKnee: [-.45, -.4, 0], leftFoot: [-.45, -1.2, 0],
+        rightHip: [.45, .4, 0], rightKnee: [.45, -.4, 0],
+        rightFoot: [.45, -1.2, 0],
+      };
+      const positions = [
+        [-.45, .4, 0], [-.45, .1, 0], [-.45, -.2, 0],
+        [-.45, -.4, 0], [-.45, -1.2, 0], [0, -.2, 0],
+      ];
+      const member = id => ({sourceKey: 'body', boneId: id,
+        sourceBoneKey: `body#bone=${id}`});
+      const joints = positions.map((restPivot, jointId) => ({jointId,
+        restPivot, restCenter: restPivot, restFrame: [0, 0, 0, 1],
+        members: [member(jointId)]}));
+      const modelRig = {
+        joints,
+        jointPivotByJointId: new Map(joints.map(joint =>
+          [joint.jointId, joint.restPivot])),
+        restFrameByJointId: new Map(joints.map(joint =>
+          [joint.jointId, new THREE.Quaternion()])),
+        components: [{componentId: 0, rootId: 0, nodeIds: [0, 1, 2, 3, 4, 5],
+          parentById: {0: null, 1: 0, 2: 1, 3: 2, 4: 3, 5: 2},
+          childrenById: {0: [1], 1: [2], 2: [3, 5], 3: [4], 4: [], 5: []}}],
+        componentByJointId: new Map(joints.map(joint =>
+          [joint.jointId, 0])),
+      };
+      const controlRig = {frame: {height: 3, up: [0, 1, 0],
+        right: [1, 0, 0], forward: [0, 0, 1]}, controls:
+        Object.fromEntries(Object.entries(controls).map(([key, position]) =>
+          [key, {position}]))};
+      const heatAssignment = id => ({...member(id),
+        driverId: 'right_upper_leg', bindingMethod: 'heat_connectivity'});
+      const heatBinding = {
+        modelJointAssignments: new Map(joints.map(joint => [joint.jointId,
+          {...heatAssignment(joint.jointId), confidence: 'high'}])),
+        sourceBoneAssignments: new Map(joints.map(joint => [
+          `body#bone=${joint.jointId}`, heatAssignment(joint.jointId)])),
+      };
+      const mappings = new Map([
+        ['leftHip', {controlKey: 'leftHip', jointId: 0}],
+        ['leftKnee', {controlKey: 'leftKnee', jointId: 3}],
+        ['leftFoot', {controlKey: 'leftFoot', jointId: 4}],
+      ]);
+      const binding = buildHumanoidRigBinding({controlRig, modelRig,
+        heatBinding, controlMappings: mappings});
+      const branch = binding.jointBindings.get(5);
+      return {
+        completeMappedHeatRoles: binding.diagnostics.completeMappedHeatRoles,
+        branch: {driverId: branch?.driverId || null,
+          bindingMethod: branch?.bindingMethod || null},
+        branchSourceMethod: binding.sourceBoneAssignments.get(
+          'body#bone=5')?.bindingMethod || null,
+      };
+    }""")
+    assert result == {
+        "completeMappedHeatRoles": ["left_leg"],
+        "branch": {"driverId": "left_upper_leg",
+                   "bindingMethod": "mapped_control_descendant"},
+        "branchSourceMethod": "mapped_control_descendant",
     }
 
 

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -852,13 +852,19 @@ def test_rig_overlay_controls_detach_for_root_but_survive_hidden_overlay(module_
     }""")
     assert result["noSelection"]["controlsCreated"] is False
     assert result["root"]["controlsAttached"] is False
+    assert result["root"]["selectedJointIndicatorVisible"] is True
+    assert result["root"]["selectedJointIndicatorPosition"] == pytest.approx(
+        [.5, .5, 0])
     assert result["rootAgain"]["controlsAttached"] is False
+    assert result["rootAgain"]["selectedJointIndicatorVisible"] is True
     assert result["nonRoot"]["controlsCreated"] is True
     assert result["nonRoot"]["controlsAttached"] is True
+    assert result["nonRoot"]["selectedJointIndicatorVisible"] is True
     assert result["nonRoot"]["helperInScene"] is True
     assert result["nonRoot"]["controlsCreateCount"] == 1
     assert result["cleared"]["proxyVisible"] is False
     assert result["cleared"]["controlsAttached"] is False
+    assert result["cleared"]["selectedJointIndicatorVisible"] is False
     assert result["cleared"]["controlsCreateCount"] == 1
     assert result["reselected"]["proxyVisible"] is True
     assert result["reselected"]["controlsAttached"] is True
@@ -885,9 +891,11 @@ def test_rig_overlay_controls_detach_for_root_but_survive_hidden_overlay(module_
     assert result["arcballActions"] == [["unset", 0], ["set", "ROTATE", 0]]
     assert result["picking"]["controlsAttached"] is False
     assert result["picking"]["staticVisible"] is True
+    assert result["picking"]["selectedJointIndicatorVisible"] is False
     assert result["picking"]["arcballEnabled"] is True
     assert result["picked"]["controlsAttached"] is True
     assert result["picked"]["staticVisible"] is False
+    assert result["picked"]["selectedJointIndicatorVisible"] is True
     assert result["picked"]["arcballEnabled"] is True
     assert result["interactionDuringGizmo"] is True
     assert result["interactionAfterGizmo"] is False
@@ -3600,6 +3608,137 @@ def test_selected_weight_topology_filters_weak_edges_and_pivots_synthetic_roots(
     }
 
 
+def test_structural_locality_filters_remote_tail_bridges_and_preserves_edges(
+        module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const rig = await import('./js/mesh/weight-rig.js');
+      const relationship = (boneA, boneB, jointCenter, options = {}) => ({
+        boneA, boneB, sharedVertexCount: 4, productOverlap: 1,
+        minOverlap: 4, containment: .4, jaccard: .2, treeEdgeScore: .4,
+        jointCenter,
+        aDominantSharedSupport: options.aDominantSharedSupport ?? 1,
+        bDominantSharedSupport: options.bDominantSharedSupport ?? 1,
+        dominanceEvidenceAvailable: true,
+      });
+      const nodesFor = (centers, radius = 1) => centers.map(([boneId, x]) => ({
+        boneId, totalWeight: 10, affectedVertexCount: 10,
+        weightedCenter: [x, 0, 0], weightedRadius: radius,
+      }));
+      const decision = (nodes, edge, options = {}) =>
+        rig.candidateRelationshipDiagnostics({
+          nodes, relationships: [edge], boundingSphereRadius: 10,
+        }, options)[0];
+      const remoteNodes = nodesFor([[1, 0], [2, 10]]);
+      const remote = decision(remoteNodes,
+        relationship(1, 2, [9, 0, 0]));
+      const longNodes = nodesFor([[1, 0], [2, 10]], 4);
+      const long = decision(longNodes,
+        relationship(1, 2, [5, 0, 0]));
+      const helperNodes = nodesFor([[1, 0], [2, .2]], 0);
+      const helper = decision(helperNodes,
+        relationship(1, 2, [.1, 0, 0]));
+
+      const chainNodes = nodesFor([
+        [396, 0], [143, 1], [145, 2], [187, 3], [294, 4],
+      ]);
+      const chainMember = (a, b, center, aSupport, bSupport) => ({
+        nodes: chainNodes,
+        boundingSphereRadius: 10,
+        relationships: [relationship(a, b, center, {
+          aDominantSharedSupport: aSupport,
+          bDominantSharedSupport: bSupport,
+        })],
+      });
+      const chainGraphs = [
+        chainMember(396, 143, [.5, 0, 0], 1, 1),
+        chainMember(143, 145, [1.5, 0, 0], 1, 1),
+        chainMember(187, 294, [3.5, 0, 0], 1, 1),
+        chainMember(145, 187, [2.5, 0, 0], 1, 1),
+        chainMember(145, 187, [2.5, 0, 0], 1, 1),
+        chainMember(145, 187, [2.5, 0, 0], 0, 1),
+        chainMember(145, 187, [2.5, 0, 0], 0, 1),
+        chainMember(145, 187, [2.5, 0, 0], 0, 1),
+      ];
+      const aggregate = rig.aggregateInfluenceGraphs(chainGraphs);
+      const decisions = rig.candidateRelationshipDiagnostics(aggregate);
+      const pair = (left, right) => {
+        const a = Math.min(left, right), b = Math.max(left, right);
+        return decisions.find(item => item.relationship.boneA === a
+          && item.relationship.boneB === b);
+      };
+      const forest = rig.buildInferredRigForest(aggregate, {
+        rootOverrides: new Map([[0, 396], [1, 294]]),
+      });
+      const selectedPairs = forest.edges.map(edge =>
+        `${Math.min(edge.boneA, edge.boneB)}:${Math.max(edge.boneA, edge.boneB)}`)
+        .sort();
+
+      const strongMemberGraphs = [
+        chainMember(396, 143, [.5, 0, 0], 10, 10),
+        chainMember(396, 143, [.5, 0, 0], 0, 1),
+        chainMember(396, 143, [.5, 0, 0], 0, 1),
+      ];
+      const strongAggregate = rig.aggregateInfluenceGraphs(strongMemberGraphs);
+      const strongDecision = rig.candidateRelationshipDiagnostics(
+        strongAggregate)[0];
+      return {
+        constants: {
+          maxJointReach: rig.MAX_JOINT_REACH,
+          maxSupportSeparation: rig.MAX_SUPPORT_SEPARATION,
+        },
+        remote: {
+          accepted: remote.accepted, reason: remote.reason,
+          maxJointReach: remote.relationship.maxJointReach,
+          supportSeparation: remote.relationship.supportSeparation,
+        },
+        long: {accepted: long.accepted, reason: long.reason,
+          structuralLocality: long.relationship.structuralLocality},
+        helper: {accepted: helper.accepted, reason: helper.reason,
+          maxJointReach: helper.relationship.maxJointReach},
+        chain: {
+          pair145187: {accepted: pair(145, 187).accepted,
+            reason: pair(145, 187).reason,
+            memberDominanceRatio: pair(145, 187).memberDominanceRatio},
+          pair396143: pair(396, 143).accepted,
+          pair143145: pair(143, 145).accepted,
+          pair187294: pair(187, 294).accepted,
+          selectedPairs,
+        },
+        strongMemberRelationship: {
+          accepted: strongDecision.accepted,
+          reason: strongDecision.reason,
+        },
+      };
+    }""")
+    assert result["remote"]["accepted"] is False
+    assert result["remote"]["reason"] == "remote_tail_bridge"
+    assert result["remote"]["maxJointReach"] > result["constants"]["maxJointReach"]
+    assert result["remote"]["supportSeparation"] > result["constants"]["maxSupportSeparation"]
+    assert result["long"] == {
+        "accepted": True,
+        "reason": None,
+        "structuralLocality": pytest.approx(4 / 9),
+    }
+    assert result["helper"]["accepted"] is True
+    assert result["helper"]["reason"] is None
+    assert result["chain"] == {
+        "pair145187": {
+            "accepted": False,
+            "reason": "weak_transition",
+            "memberDominanceRatio": pytest.approx(.4),
+        },
+        "pair396143": True,
+        "pair143145": True,
+        "pair187294": True,
+        "selectedPairs": ["143:145", "143:396", "187:294"],
+    }
+    assert result["strongMemberRelationship"] == {
+        "accepted": True,
+        "reason": None,
+    }
+
+
 def test_model_bone_stats_sum_same_ids_before_averaging(module_page):
     page = module_page
     result = page.evaluate("""async () => {
@@ -4841,6 +4980,9 @@ def test_humanoid_mapped_model_joint_paths_override_heat_and_respect_graph_bound
         controlMappings: mappingsFor([
           ['leftShoulder', 10], ['leftElbow', 14], ['leftHand', 12],
         ])});
+      const mappedHandDescendants = buildHumanoidRigBinding({
+        controlRig, modelRig: model, heatBinding: heatFor(model),
+        controlMappings: mappingsFor([['leftHand', 12]])});
       const duplicateControl = buildHumanoidRigBinding({controlRig,
         modelRig: model, heatBinding: heatFor(model),
         controlMappings: mappingsFor([
@@ -4861,6 +5003,18 @@ def test_humanoid_mapped_model_joint_paths_override_heat_and_respect_graph_bound
           pathCount: authoritative.diagnostics.mappedPathCount,
         },
         onlyStart: entry(onlyStart, 11),
+        mappedHandDescendants: {
+          bindings: [13, 14, 20].map(jointId => entry(
+            mappedHandDescendants, jointId)),
+          sourceDrivers: [13, 14, 20].map(jointId =>
+            mappedHandDescendants.sourceBoneAssignments.get(
+              `body#bone=${jointId}`)?.driverId),
+          sourceMethods: [13, 14, 20].map(jointId =>
+            mappedHandDescendants.sourceBoneAssignments.get(
+              `body#bone=${jointId}`)?.bindingMethod),
+          descendantCount: mappedHandDescendants.diagnostics
+            .mappedDescendantJointCount,
+        },
         differentComponents: {
           interior: entry(differentComponents, 11),
           pathCount: differentComponents.diagnostics.mappedPathCount,
@@ -4888,9 +5042,10 @@ def test_humanoid_mapped_model_joint_paths_override_heat_and_respect_graph_bound
     ] * 3
     assert result["authoritative"]["elbow"]["bindingMethod"] == \
         "manual_control_mapping"
-    assert result["authoritative"]["branch"]["bindingMethod"] == \
-        "heat_connectivity"
-    assert result["authoritative"]["branch"]["driverId"] == "right_upper_arm"
+    assert result["authoritative"]["branch"] == {
+        "driverId": "left_upper_arm",
+        "bindingMethod": "mapped_control_descendant",
+        "segmentStartControl": None, "segmentEndControl": None}
     assert result["authoritative"]["rightLegInterior"] == {
         "driverId": "right_lower_leg", "bindingMethod": "mapped_joint_path",
         "segmentStartControl": "rightKnee", "segmentEndControl": "rightFoot"}
@@ -4902,12 +5057,13 @@ def test_humanoid_mapped_model_joint_paths_override_heat_and_respect_graph_bound
         "left_upper_arm", "left_lower_arm", "head", "right_lower_leg"]
     assert result["authoritative"]["sourceRoles"] == ["right_leg", "torso"]
     assert result["authoritative"]["pathCount"] == 3
-    assert result["onlyStart"]["bindingMethod"] == "heat_connectivity"
+    assert result["onlyStart"]["bindingMethod"] == \
+        "mapped_control_descendant"
     assert result["differentComponents"]["interior"]["bindingMethod"] == \
-        "heat_connectivity"
+        "mapped_control_descendant"
     assert result["differentComponents"]["pathCount"] == 0
     assert result["mappedInteriorControl"]["beforeInterior"]["bindingMethod"] == \
-        "heat_connectivity"
+        "mapped_control_descendant"
     assert result["mappedInteriorControl"]["afterInterior"] == {
         "driverId": "left_lower_arm", "bindingMethod": "mapped_joint_path",
         "segmentStartControl": "leftElbow", "segmentEndControl": "leftHand"}
@@ -4917,6 +5073,16 @@ def test_humanoid_mapped_model_joint_paths_override_heat_and_respect_graph_bound
         "heat_connectivity"
     assert "conflicting_control_mappings" in \
         result["duplicateControl"]["conflictTypes"]
+    assert result["mappedHandDescendants"] == {
+        "bindings": [
+            {"driverId": "left_lower_arm",
+             "bindingMethod": "mapped_control_descendant",
+             "segmentStartControl": None, "segmentEndControl": None},
+        ] * 3,
+        "sourceDrivers": ["left_lower_arm"] * 3,
+        "sourceMethods": ["mapped_control_descendant"] * 3,
+        "descendantCount": 3,
+    }
 
 
 def test_humanoid_heat_binding_follows_overlap_chain_and_rejects_torso_leg_branches(

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -5360,3 +5360,69 @@ def test_humanoid_ik_driver_changes_a_weighted_mesh_vertex(module_page):
     assert result["solved"]
     assert result["changedVertexCount"] == 1
     assert result["output"] != pytest.approx(result["baseline"])
+
+
+def test_saved_humanoid_guide_reuses_spatial_semantics_for_source_forests(
+        module_page):
+    result = module_page.evaluate("""async () => {
+      const {classifyHumanoidPoint} = await import(
+        './js/mesh/humanoid-rig-binding.js');
+      const {buildHumanoidGuidedSourceForest} = await import(
+        './js/mesh/humanoid-guided-rig.js');
+      const controls = {
+        pelvis: [0, 0, 0], chest: [0, 4, 0], neck: [0, 6, 0], head: [0, 8, 0],
+        leftShoulder: [-2, 5.5, 0], leftElbow: [-3.5, 5, 0],
+        leftHand: [-5, 4.5, 0], rightShoulder: [2, 5.5, 0],
+        rightElbow: [3.5, 5, 0], rightHand: [5, 4.5, 0],
+        leftHip: [-1, 0, 0], leftKnee: [-1, -3, 0], leftFoot: [-1, -6, 0],
+        rightHip: [1, 0, 0], rightKnee: [1, -3, 0], rightFoot: [1, -6, 0],
+      };
+      const controlRig = {
+        accepted: true, frame: {height: 8, right: [1, 0, 0],
+          forward: [0, 0, 1]},
+        controls: Object.fromEntries(Object.entries(controls).map(
+          ([key, position]) => [key, {position}])),
+      };
+      const graph = {
+        evidenceMode: 'vertex',
+        nodes: [
+          {boneId: 0, weightedCenter: [-1.8, 5.35, 0]},
+          {boneId: 1, weightedCenter: [-2.2, 5.43, 0]},
+          {boneId: 2, weightedCenter: [2, 5.5, 0]},
+        ],
+        relationships: [
+          {boneA: 0, boneB: 1, sharedVertexCount: 4,
+            containment: .4, jaccard: .2},
+          {boneA: 1, boneB: 2, sharedVertexCount: 4,
+            containment: .4, jaccard: .2},
+        ],
+      };
+      const classified = classifyHumanoidPoint([-2.75, 5.25, 0], controlRig);
+      const result = buildHumanoidGuidedSourceForest(
+        {sourceKey: 'body', influenceGraph: graph}, controlRig);
+      return {
+        classification: {
+          driverId: classified.driverId,
+          confidence: classified.confidence,
+          classified: classified.classified,
+        },
+        diagnostics: result.diagnostics,
+        roots: result.forest.components.map(component => ({
+          rootId: component.rootId, nodeIds: component.nodeIds,
+        })),
+      };
+    }""")
+    assert result["classification"] == {
+        "driverId": "left_upper_arm",
+        "confidence": "high",
+        "classified": True,
+    }
+    assert result["diagnostics"]["candidateEdges"] == 2
+    assert result["diagnostics"]["guidedEdges"] == 1
+    assert result["diagnostics"]["rejectedEdges"] == 1
+    assert result["diagnostics"]["adjacentArticulationEdges"] == 1
+    assert {tuple(item["nodeIds"]) for item in result["roots"]} == {
+        (0, 1), (2,),
+    }
+    assert next(item["rootId"] for item in result["roots"]
+                if item["nodeIds"] == [0, 1]) == 0

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -3608,137 +3608,6 @@ def test_selected_weight_topology_filters_weak_edges_and_pivots_synthetic_roots(
     }
 
 
-def test_structural_locality_filters_remote_tail_bridges_and_preserves_edges(
-        module_page):
-    page = module_page
-    result = page.evaluate("""async () => {
-      const rig = await import('./js/mesh/weight-rig.js');
-      const relationship = (boneA, boneB, jointCenter, options = {}) => ({
-        boneA, boneB, sharedVertexCount: 4, productOverlap: 1,
-        minOverlap: 4, containment: .4, jaccard: .2, treeEdgeScore: .4,
-        jointCenter,
-        aDominantSharedSupport: options.aDominantSharedSupport ?? 1,
-        bDominantSharedSupport: options.bDominantSharedSupport ?? 1,
-        dominanceEvidenceAvailable: true,
-      });
-      const nodesFor = (centers, radius = 1) => centers.map(([boneId, x]) => ({
-        boneId, totalWeight: 10, affectedVertexCount: 10,
-        weightedCenter: [x, 0, 0], weightedRadius: radius,
-      }));
-      const decision = (nodes, edge, options = {}) =>
-        rig.candidateRelationshipDiagnostics({
-          nodes, relationships: [edge], boundingSphereRadius: 10,
-        }, options)[0];
-      const remoteNodes = nodesFor([[1, 0], [2, 10]]);
-      const remote = decision(remoteNodes,
-        relationship(1, 2, [9, 0, 0]));
-      const longNodes = nodesFor([[1, 0], [2, 10]], 4);
-      const long = decision(longNodes,
-        relationship(1, 2, [5, 0, 0]));
-      const helperNodes = nodesFor([[1, 0], [2, .2]], 0);
-      const helper = decision(helperNodes,
-        relationship(1, 2, [.1, 0, 0]));
-
-      const chainNodes = nodesFor([
-        [396, 0], [143, 1], [145, 2], [187, 3], [294, 4],
-      ]);
-      const chainMember = (a, b, center, aSupport, bSupport) => ({
-        nodes: chainNodes,
-        boundingSphereRadius: 10,
-        relationships: [relationship(a, b, center, {
-          aDominantSharedSupport: aSupport,
-          bDominantSharedSupport: bSupport,
-        })],
-      });
-      const chainGraphs = [
-        chainMember(396, 143, [.5, 0, 0], 1, 1),
-        chainMember(143, 145, [1.5, 0, 0], 1, 1),
-        chainMember(187, 294, [3.5, 0, 0], 1, 1),
-        chainMember(145, 187, [2.5, 0, 0], 1, 1),
-        chainMember(145, 187, [2.5, 0, 0], 1, 1),
-        chainMember(145, 187, [2.5, 0, 0], 0, 1),
-        chainMember(145, 187, [2.5, 0, 0], 0, 1),
-        chainMember(145, 187, [2.5, 0, 0], 0, 1),
-      ];
-      const aggregate = rig.aggregateInfluenceGraphs(chainGraphs);
-      const decisions = rig.candidateRelationshipDiagnostics(aggregate);
-      const pair = (left, right) => {
-        const a = Math.min(left, right), b = Math.max(left, right);
-        return decisions.find(item => item.relationship.boneA === a
-          && item.relationship.boneB === b);
-      };
-      const forest = rig.buildInferredRigForest(aggregate, {
-        rootOverrides: new Map([[0, 396], [1, 294]]),
-      });
-      const selectedPairs = forest.edges.map(edge =>
-        `${Math.min(edge.boneA, edge.boneB)}:${Math.max(edge.boneA, edge.boneB)}`)
-        .sort();
-
-      const strongMemberGraphs = [
-        chainMember(396, 143, [.5, 0, 0], 10, 10),
-        chainMember(396, 143, [.5, 0, 0], 0, 1),
-        chainMember(396, 143, [.5, 0, 0], 0, 1),
-      ];
-      const strongAggregate = rig.aggregateInfluenceGraphs(strongMemberGraphs);
-      const strongDecision = rig.candidateRelationshipDiagnostics(
-        strongAggregate)[0];
-      return {
-        constants: {
-          maxJointReach: rig.MAX_JOINT_REACH,
-          maxSupportSeparation: rig.MAX_SUPPORT_SEPARATION,
-        },
-        remote: {
-          accepted: remote.accepted, reason: remote.reason,
-          maxJointReach: remote.relationship.maxJointReach,
-          supportSeparation: remote.relationship.supportSeparation,
-        },
-        long: {accepted: long.accepted, reason: long.reason,
-          structuralLocality: long.relationship.structuralLocality},
-        helper: {accepted: helper.accepted, reason: helper.reason,
-          maxJointReach: helper.relationship.maxJointReach},
-        chain: {
-          pair145187: {accepted: pair(145, 187).accepted,
-            reason: pair(145, 187).reason,
-            memberDominanceRatio: pair(145, 187).memberDominanceRatio},
-          pair396143: pair(396, 143).accepted,
-          pair143145: pair(143, 145).accepted,
-          pair187294: pair(187, 294).accepted,
-          selectedPairs,
-        },
-        strongMemberRelationship: {
-          accepted: strongDecision.accepted,
-          reason: strongDecision.reason,
-        },
-      };
-    }""")
-    assert result["remote"]["accepted"] is False
-    assert result["remote"]["reason"] == "remote_tail_bridge"
-    assert result["remote"]["maxJointReach"] > result["constants"]["maxJointReach"]
-    assert result["remote"]["supportSeparation"] > result["constants"]["maxSupportSeparation"]
-    assert result["long"] == {
-        "accepted": True,
-        "reason": None,
-        "structuralLocality": pytest.approx(4 / 9),
-    }
-    assert result["helper"]["accepted"] is True
-    assert result["helper"]["reason"] is None
-    assert result["chain"] == {
-        "pair145187": {
-            "accepted": False,
-            "reason": "weak_transition",
-            "memberDominanceRatio": pytest.approx(.4),
-        },
-        "pair396143": True,
-        "pair143145": True,
-        "pair187294": True,
-        "selectedPairs": ["143:145", "143:396", "187:294"],
-    }
-    assert result["strongMemberRelationship"] == {
-        "accepted": True,
-        "reason": None,
-    }
-
-
 def test_model_bone_stats_sum_same_ids_before_averaging(module_page):
     page = module_page
     result = page.evaluate("""async () => {
@@ -4101,6 +3970,15 @@ def test_humanoid_edit_session_snapping_uses_hysteresis_and_releases(module_page
       const initial = session.snapshot();
       const rootsAfterBegin = [...modelRigState.explicitRootSignatures];
       const poseAfterBegin = {...modelRigState.humanoidPose};
+      session.beginCarry('head');
+      const notificationsBeforeSilentUpdate = notifications;
+      const silentUpdated = session.updateDraft('head', [.3, .4, .5], {
+        candidateJointId: null, candidateDistance: Infinity,
+        notifyState: false, request: false,
+      });
+      const silentNotificationDelta =
+        notifications - notificationsBeforeSilentUpdate;
+      session.finishCarry();
       const allCarryResults = control.HUMANOID_CONTROL_KEYS.map((key, index) => {
         const target = [.1 * (index + 1), .2 * (index + 1),
           .03 * (index + 1)];
@@ -4125,13 +4003,16 @@ def test_humanoid_edit_session_snapping_uses_hysteresis_and_releases(module_page
       const saved = await session.save();
       const expectedSemantic = control.humanoidControlPositionToSemantic(
         [1, 1, 1], rig.humanoidControlRig);
-      return {initial, rootsAfterBegin, poseAfterBegin, allCarryResults,
+      return {initial, rootsAfterBegin, poseAfterBegin, silentUpdated,
+        silentNotificationDelta, allCarryResults,
         snapped, sticky, free, saved, persisted, expectedSemantic,
         notifications, resets};
     }""")
     assert result["initial"]["controls"]["leftShoulder"]["position"] == [0, 0, 0]
     assert result["rootsAfterBegin"] == ["custom-root"]
     assert result["poseAfterBegin"] == {}
+    assert result["silentUpdated"] is True
+    assert result["silentNotificationDelta"] == 0
     assert len(result["allCarryResults"]) == 16
     assert all(item["began"] and item["updated"] and item["finished"]
                and item["position"] != [0, 0, 0]
@@ -5592,3 +5473,130 @@ def test_saved_humanoid_guide_reuses_spatial_semantics_for_source_forests(
     }
     assert next(item["rootId"] for item in result["roots"]
                 if item["nodeIds"] == [0, 1]) == 0
+
+
+def test_saved_humanoid_guide_handles_pelvis_adjacency_and_central_roots(
+        module_page):
+    result = module_page.evaluate("""async () => {
+      const {buildHumanoidGuidedSourceForest} = await import(
+        './js/mesh/humanoid-guided-rig.js');
+      const controls = {
+        pelvis: [0, 0, 0], chest: [0, 4, 0], neck: [0, 6, 0], head: [0, 8, 0],
+        leftShoulder: [-1, 5.5, 0], leftElbow: [-2, 5, 0],
+        leftHand: [-3, 4.5, 0], rightShoulder: [1, 5.5, 0],
+        rightElbow: [2, 5, 0], rightHand: [3, 4.5, 0],
+        leftHip: [-6.25, 0, 0], leftKnee: [-6.25, -3, 0],
+        leftFoot: [-6.25, -6, 0], rightHip: [6.25, 0, 0],
+        rightKnee: [6.25, -3, 0], rightFoot: [6.25, -6, 0],
+      };
+      const controlRig = {
+        accepted: true, frame: {height: 8, right: [1, 0, 0],
+          forward: [0, 0, 1]},
+        controls: Object.fromEntries(Object.entries(controls).map(
+          ([key, position]) => [key, {position}]))
+      };
+      const guide = nodes => buildHumanoidGuidedSourceForest({
+        sourceKey: 'body', influenceGraph: {
+          evidenceMode: 'vertex', nodes,
+          relationships: [{boneA: nodes[0].boneId, boneB: nodes[1].boneId,
+            sharedVertexCount: 4, containment: .4, jaccard: .2}],
+        },
+      }, controlRig);
+      const central = guide([
+        {boneId: 10, weightedCenter: [0, .2, 0]},
+        {boneId: 2, weightedCenter: [0, 3.8, 0]},
+      ]);
+      const pelvis = guide([
+        {boneId: 30, weightedCenter: [0, .2, 0]},
+        {boneId: 40, weightedCenter: [-1.25, 0, 0]},
+      ]);
+      return {
+        centralRoot: central.forest.components[0].rootId,
+        centralDiagnostics: central.diagnostics,
+        pelvisDiagnostics: pelvis.diagnostics,
+      };
+    }""")
+    assert result["centralRoot"] == 10
+    assert result["centralDiagnostics"]["rootOverrideCount"] == 1
+    assert result["pelvisDiagnostics"]["guidedEdges"] == 1
+    assert result["pelvisDiagnostics"]["rejectedEdges"] == 0
+    assert result["pelvisDiagnostics"]["adjacentArticulationEdges"] == 1
+
+
+def test_mapped_control_descendants_stop_at_attachment_edges(module_page):
+    result = module_page.evaluate("""async () => {
+      const THREE = await import('three');
+      const {buildHumanoidRigBinding} = await import(
+        './js/mesh/humanoid-rig-binding.js');
+      const controls = {
+        pelvis: [0, .4, 0], chest: [0, 1.2, 0], neck: [0, 1.5, 0],
+        head: [0, 1.8, 0], leftShoulder: [-.8, 1.2, 0],
+        leftElbow: [-2, 1.2, 0], leftHand: [-3, 1.2, 0],
+        rightShoulder: [.8, 1.2, 0], rightElbow: [2, 1.2, 0],
+        rightHand: [3, 1.2, 0], leftHip: [-.45, .4, 0],
+        leftKnee: [-.45, -.4, 0], leftFoot: [-.45, -1.2, 0],
+        rightHip: [.45, .4, 0], rightKnee: [.45, -.4, 0],
+        rightFoot: [.45, -1.2, 0],
+      };
+      const member = id => ({sourceKey: 'body', boneId: id,
+        sourceBoneKey: `body#bone=${id}`});
+      const joints = [1, 2].map((jointId, index) => ({
+        jointId, restPivot: [-3 - index * .5, 1.2, 0],
+        restCenter: [-3 - index * .5, 1.2, 0],
+        restFrame: [0, 0, 0, 1], members: [member(jointId)],
+      }));
+      const modelRig = {
+        joints,
+        jointPivotByJointId: new Map(joints.map(joint =>
+          [joint.jointId, joint.restPivot])),
+        restFrameByJointId: new Map(joints.map(joint =>
+          [joint.jointId, new THREE.Quaternion()])),
+        components: [{componentId: 0, rootId: 1, nodeIds: [1, 2],
+          parentById: {1: null, 2: 1}, childrenById: {1: [2], 2: []},
+          edges: [{jointA: 1, jointB: 2, relationshipType: 'Attachment'}]}],
+        componentByJointId: new Map([[1, 0], [2, 0]]),
+      };
+      const controlRig = {frame: {height: 3, right: [1, 0, 0],
+        forward: [0, 0, 1]}, controls: Object.fromEntries(
+        Object.entries(controls).map(([key, position]) => [key, {position}]))};
+      const binding = buildHumanoidRigBinding({controlRig, modelRig,
+        heatBinding: {modelJointAssignments: new Map(),
+          sourceBoneAssignments: new Map()},
+        controlMappings: new Map([['leftHand', {
+          controlKey: 'leftHand', jointId: 1, sourceMembers: [member(1)],
+        }]])});
+      return {
+        root: binding.jointBindings.get(1)?.bindingMethod || null,
+        accessory: binding.jointBindings.get(2)?.bindingMethod || null,
+        unbound: binding.unboundJointIds,
+      };
+    }""")
+    assert result == {
+        "root": "manual_control_mapping",
+        "accessory": None,
+        "unbound": [2],
+    }
+
+
+def test_guided_forest_pivots_follow_changed_parent_edges(module_page):
+    result = module_page.evaluate("""async () => {
+      const {buildInferredRigForest, jointPivotMap} = await import(
+        './js/mesh/weight-rig.js');
+      const nodes = [1, 2, 3].map(boneId => ({boneId}));
+      const edges = [
+        {boneA: 1, boneB: 2, treeEdgeScore: .9, jointCenter: [1, 0, 0]},
+        {boneA: 2, boneB: 3, treeEdgeScore: .8, jointCenter: [2, 0, 0]},
+        {boneA: 1, boneB: 3, treeEdgeScore: .7, jointCenter: [3, 0, 0]},
+      ];
+      const legacy = buildInferredRigForest({nodes, relationships: edges}, {
+        edges: edges.slice(0, 2), rootOverrides: new Map([[0, 1]]),
+      });
+      const guided = buildInferredRigForest({nodes, relationships: edges}, {
+        edges: [edges[1], edges[2]], rootOverrides: new Map([[0, 1]]),
+      });
+      const pivots = forest => Object.fromEntries(
+        [...jointPivotMap(forest, edges)].map(([id, point]) => [id, point]));
+      return {legacy: pivots(legacy), guided: pivots(guided)};
+    }""")
+    assert result["legacy"]["2"] == [1, 0, 0]
+    assert result["guided"]["2"] == [2, 0, 0]

--- a/src/web/js/main.js
+++ b/src/web/js/main.js
@@ -30,6 +30,7 @@ import {
   setRigJointRotation, solveRigIkTarget,
   selectHumanoidControl,
   setRigPoseControlStatus,
+  getHumanoidRigEditSnapshot,
   beginHumanoidControlCarry, updateHumanoidControlDraft,
   finishHumanoidControlCarry, cancelHumanoidControlCarry,
 } from './mesh/weight-rig-runtime.js';
@@ -259,6 +260,7 @@ rendererReady.then(ready => {
     arcballControls: controls,
     getMeshes: () => activeMeshes,
     getRigState: getModelRigState,
+    getHumanoidRigEditSnapshot,
     getRigJointPoseFrame,
     setRigJointRotation,
     solveRigIkTarget,

--- a/src/web/js/mesh/humanoid-guided-rig.js
+++ b/src/web/js/mesh/humanoid-guided-rig.js
@@ -67,7 +67,13 @@ function adjacentSegments(left, right) {
   const rightToLeft = rightSegment.end === leftSegment.start
     && right.projection >= 1 - ADJACENT_PROJECTION_MARGIN
     && left.projection <= ADJACENT_PROJECTION_MARGIN;
-  return leftToRight || rightToLeft;
+  const sharedStart = leftSegment.start === rightSegment.start
+    && left.projection <= ADJACENT_PROJECTION_MARGIN
+    && right.projection <= ADJACENT_PROJECTION_MARGIN;
+  const sharedEnd = leftSegment.end === rightSegment.end
+    && left.projection >= 1 - ADJACENT_PROJECTION_MARGIN
+    && right.projection >= 1 - ADJACENT_PROJECTION_MARGIN;
+  return leftToRight || rightToLeft || sharedStart || sharedEnd;
 }
 
 function semanticRelationship(left, right) {
@@ -149,7 +155,8 @@ function rootOverrideForComponent(component, classifications, controlRig) {
     const pelvis = controlRig?.controls?.pelvis?.position
       || controlRig?.controls?.pelvis;
     return central.sort((left, right) =>
-      distance(left.position, pelvis) - distance(right.position, pelvis)
+      distance(left.classification.position, pelvis)
+        - distance(right.classification.position, pelvis)
       || left.boneId - right.boneId)[0].boneId;
   }
   if (roles.size !== 1) return null;

--- a/src/web/js/mesh/humanoid-guided-rig.js
+++ b/src/web/js/mesh/humanoid-guided-rig.js
@@ -1,0 +1,273 @@
+// Optional semantic guidance for the viewer-owned ModelRig build.
+//
+// This module only changes the source-local relationship forest when a saved
+// Humanoid Control Rig is present.  It does not change influence weights,
+// source graphs, or the legacy relationship classifier.
+
+import {
+  buildInferredRigForest,
+  candidateRelationshipEdges,
+} from './weight-rig.js';
+import {
+  classifyHumanoidPoint,
+  HUMANOID_DRIVER_SEGMENTS,
+} from './humanoid-rig-binding.js';
+
+const CONFIDENT_LEVELS = new Set(['high', 'medium']);
+const CENTRAL_ROLES = new Set(['torso']);
+const ADJACENT_PROJECTION_MARGIN = 0.2;
+
+function number(value, fallback = 0) {
+  const result = Number(value);
+  return Number.isFinite(result) ? result : fallback;
+}
+
+function vector(value) {
+  const values = Array.isArray(value) || ArrayBuffer.isView(value)
+    ? value : [value?.x, value?.y, value?.z];
+  const result = [0, 1, 2].map(index => Number(values?.[index]));
+  return result.every(Number.isFinite) ? result : null;
+}
+
+function distance(left, right) {
+  const a = vector(left);
+  const b = vector(right);
+  if (!a || !b) return Infinity;
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+function sourceBoneKey(sourceKey, boneId) {
+  return `${String(sourceKey)}#bone=${Number(boneId)}`;
+}
+
+const SEGMENTS_BY_ID = new Map(HUMANOID_DRIVER_SEGMENTS.map(segment => [
+  segment.id, segment,
+]));
+const SEGMENT_ORDER = new Map(HUMANOID_DRIVER_SEGMENTS.map((segment, index) => [
+  segment.id, index,
+]));
+
+function classificationFor(classifications, boneId) {
+  return classifications.get(Number(boneId)) || null;
+}
+
+function isConfident(classification) {
+  return !!classification?.classified
+    && CONFIDENT_LEVELS.has(classification.confidence);
+}
+
+function adjacentSegments(left, right) {
+  const leftSegment = SEGMENTS_BY_ID.get(left?.driverId);
+  const rightSegment = SEGMENTS_BY_ID.get(right?.driverId);
+  if (!leftSegment || !rightSegment
+      || leftSegment.id === rightSegment.id) return false;
+  const leftToRight = leftSegment.end === rightSegment.start
+    && left.projection >= 1 - ADJACENT_PROJECTION_MARGIN
+    && right.projection <= ADJACENT_PROJECTION_MARGIN;
+  const rightToLeft = rightSegment.end === leftSegment.start
+    && right.projection >= 1 - ADJACENT_PROJECTION_MARGIN
+    && left.projection <= ADJACENT_PROJECTION_MARGIN;
+  return leftToRight || rightToLeft;
+}
+
+function semanticRelationship(left, right) {
+  if (!isConfident(left) || !isConfident(right)) {
+    return {kind: 'unclassified', score: 0, reject: false};
+  }
+  if (left.driverId === right.driverId) {
+    return {kind: 'same_segment', score: 0.35, reject: false};
+  }
+  if (adjacentSegments(left, right)) {
+    return {kind: 'adjacent_articulation', score: 0.24, reject: false};
+  }
+  if (left.role && left.role === right.role) {
+    return {kind: 'same_region', score: 0.06, reject: false};
+  }
+  // A confident torso-to-limb or left-to-right correspondence is a strong
+  // semantic contradiction.  The edge is rejected only when both endpoints
+  // have a confident classification; accessory/unclassified branches keep
+  // their ordinary weight-derived score.
+  return {kind: 'semantic_mismatch', score: 0, reject: true};
+}
+
+function edgeBaseScore(edge) {
+  return number(edge?.treeEdgeScore ?? edge?.score
+    ?? edge?.containment ?? edge?.jaccard, 0);
+}
+
+function guidedEdges(graph, classifications) {
+  const metrics = {
+    candidateEdges: 0,
+    guidedEdges: 0,
+    rejectedEdges: 0,
+    sameSegmentEdges: 0,
+    adjacentArticulationEdges: 0,
+    sameRegionEdges: 0,
+    semanticMismatchEdges: 0,
+  };
+  const edges = candidateRelationshipEdges(graph).map(edge => {
+    metrics.candidateEdges += 1;
+    const left = classificationFor(classifications, edge.boneA);
+    const right = classificationFor(classifications, edge.boneB);
+    const semantic = semanticRelationship(left, right);
+    if (semantic.reject) {
+      metrics.rejectedEdges += 1;
+      metrics.semanticMismatchEdges += 1;
+      return null;
+    }
+    if (semantic.kind === 'same_segment') metrics.sameSegmentEdges += 1;
+    if (semantic.kind === 'adjacent_articulation') {
+      metrics.adjacentArticulationEdges += 1;
+    }
+    if (semantic.kind === 'same_region') metrics.sameRegionEdges += 1;
+    metrics.guidedEdges += 1;
+    return {
+      ...edge,
+      treeEdgeScore: edgeBaseScore(edge) + semantic.score,
+      humanoidSemantic: {
+        kind: semantic.kind,
+        leftDriverId: left?.driverId || null,
+        rightDriverId: right?.driverId || null,
+        leftConfidence: left?.confidence || null,
+        rightConfidence: right?.confidence || null,
+      },
+    };
+  }).filter(Boolean);
+  return {edges, metrics};
+}
+
+function rootOverrideForComponent(component, classifications, controlRig) {
+  const entries = (component?.nodeIds || []).map(boneId => ({
+    boneId: Number(boneId),
+    classification: classificationFor(classifications, boneId),
+  })).filter(entry => isConfident(entry.classification));
+  if (entries.length < 2) return null;
+  const roles = new Set(entries.map(entry => entry.classification.role));
+  const central = entries.filter(entry =>
+    CENTRAL_ROLES.has(entry.classification.role));
+  if (central.length) {
+    const pelvis = controlRig?.controls?.pelvis?.position
+      || controlRig?.controls?.pelvis;
+    return central.sort((left, right) =>
+      distance(left.position, pelvis) - distance(right.position, pelvis)
+      || left.boneId - right.boneId)[0].boneId;
+  }
+  if (roles.size !== 1) return null;
+  // For an isolated limb source, orient the component from the proximal end
+  // of the semantic chain.  This affects only components with at least two
+  // confident, same-region points; unrelated accessory components retain the
+  // legacy root choice.
+  return entries.sort((left, right) =>
+    (SEGMENT_ORDER.get(left.classification.driverId)
+      ?? HUMANOID_DRIVER_SEGMENTS.length)
+      + number(left.classification.projection)
+      - ((SEGMENT_ORDER.get(right.classification.driverId)
+        ?? HUMANOID_DRIVER_SEGMENTS.length)
+        + number(right.classification.projection))
+    || left.boneId - right.boneId)[0].boneId;
+}
+
+function rootOverridesForForest(forest, classifications, controlRig) {
+  const overrides = new Map();
+  (forest?.components || []).forEach(component => {
+    const root = rootOverrideForComponent(component, classifications, controlRig);
+    if (Number.isFinite(root)) overrides.set(Number(component.componentId), root);
+  });
+  return overrides;
+}
+
+export function classifyHumanoidSourceBones(rig, controlRig, options = {}) {
+  const byBoneId = new Map();
+  const bySourceBoneKey = new Map();
+  const counts = {
+    total: 0, classified: 0, confident: 0, high: 0, medium: 0,
+    low: 0, unclassified: 0,
+  };
+  (rig?.influenceGraph?.nodes || []).forEach(node => {
+    const boneId = Number(node?.boneId);
+    if (!Number.isFinite(boneId)) return;
+    const classification = classifyHumanoidPoint(
+      node.weightedCenter, controlRig, options);
+    const entry = {
+      boneId, position: vector(node.weightedCenter), ...classification,
+    };
+    byBoneId.set(boneId, entry);
+    bySourceBoneKey.set(sourceBoneKey(rig.sourceKey, boneId), entry);
+    counts.total += 1;
+    if (classification.classified) counts.classified += 1;
+    else counts.unclassified += 1;
+    if (classification.confident) counts.confident += 1;
+    if (classification.confidence === 'high') counts.high += 1;
+    if (classification.confidence === 'medium') counts.medium += 1;
+    if (classification.confidence === 'low') counts.low += 1;
+  });
+  return {byBoneId, bySourceBoneKey, counts};
+}
+
+export function buildHumanoidGuidedSourceForest(rig, controlRig, options = {}) {
+  if (!rig?.influenceGraph || !controlRig?.accepted) return null;
+  const classifications = classifyHumanoidSourceBones(rig, controlRig, options);
+  const guided = guidedEdges(rig.influenceGraph, classifications.byBoneId);
+  const firstForest = buildInferredRigForest(rig.influenceGraph, {
+    edges: guided.edges,
+  });
+  const rootOverrides = rootOverridesForForest(
+    firstForest, classifications.byBoneId, controlRig);
+  const forest = rootOverrides.size
+    ? buildInferredRigForest(rig.influenceGraph, {
+      edges: guided.edges, rootOverrides,
+    }) : firstForest;
+  return {
+    forest,
+    classifications,
+    diagnostics: {
+      ...guided.metrics,
+      ...classifications.counts,
+      rootOverrideCount: rootOverrides.size,
+      componentCount: forest.components.length,
+    },
+  };
+}
+
+export function buildHumanoidJointGuide(sourceRigs, controlRig, options = {}) {
+  const sourceResults = new Map();
+  const sourceBoneClassifications = new Map();
+  const diagnostics = {
+    sourceCount: 0,
+    total: 0,
+    classified: 0,
+    confident: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    unclassified: 0,
+    candidateEdges: 0,
+    guidedEdges: 0,
+    rejectedEdges: 0,
+    sameSegmentEdges: 0,
+    adjacentArticulationEdges: 0,
+    sameRegionEdges: 0,
+    semanticMismatchEdges: 0,
+    rootOverrideCount: 0,
+  };
+  for (const rig of sourceRigs || []) {
+    const result = buildHumanoidGuidedSourceForest(rig, controlRig, options);
+    if (!result) continue;
+    const key = String(rig.sourceKey);
+    sourceResults.set(key, result);
+    result.classifications.bySourceBoneKey.forEach((entry, boneKey) =>
+      sourceBoneClassifications.set(boneKey, entry));
+    diagnostics.sourceCount += 1;
+    Object.keys(result.diagnostics).forEach(field => {
+      if (field === 'componentCount') return;
+      diagnostics[field] = (diagnostics[field] || 0)
+        + (Number(result.diagnostics[field]) || 0);
+    });
+  }
+  return {
+    controlRig,
+    sourceResults,
+    sourceBoneClassifications,
+    diagnostics,
+  };
+}

--- a/src/web/js/mesh/humanoid-rig-binding.js
+++ b/src/web/js/mesh/humanoid-rig-binding.js
@@ -500,7 +500,8 @@ function sourceChildIds(modelRig, jointId) {
   const edges = component?.edges;
   if (!Array.isArray(edges) || !edges.length) return children;
   const sourcePairs = new Set(edges.filter(edge =>
-    edge?.relationshipType !== 'attachment').map(edge => {
+    String(edge?.relationshipType || '').toLowerCase() !== 'attachment')
+    .map(edge => {
     const left = numberId(edge?.jointA ?? edge?.boneA);
     const right = numberId(edge?.jointB ?? edge?.boneB);
     return left === null || right === null ? null

--- a/src/web/js/mesh/humanoid-rig-binding.js
+++ b/src/web/js/mesh/humanoid-rig-binding.js
@@ -259,6 +259,50 @@ function isExactArticulationTie(candidates, best) {
       && candidate.projection > .95);
 }
 
+/**
+ * Classify a rest-space point against the fitted humanoid driver corridors.
+ *
+ * The binding path intentionally keeps this classifier private because it
+ * also applies binding-specific distance gates.  The optional guided ModelRig
+ * builder uses the same spatial semantics, but does not need a ModelJoint or
+ * a heat-binding result yet.  Returning the candidate list makes ambiguity a
+ * visible, conservative outcome instead of silently forcing a classification.
+ */
+export function classifyHumanoidPoint(pointValue, controlRig, options = {}) {
+  const point = vector(pointValue);
+  const height = Math.max(Number(controlRig?.frame?.height) || 0, EPSILON);
+  const drivers = buildHumanoidDriverFrames(controlRig);
+  const candidates = sortedCandidates(point, drivers, height, controlRig);
+  const best = articulationPreferredCandidate(candidates);
+  const maximumDistanceRatio = Number.isFinite(
+    Number(options.maximumDistanceRatio))
+    ? Number(options.maximumDistanceRatio) : DEFAULT_SECONDARY_DISTANCE_RATIO;
+  const ambiguityMargin = Number.isFinite(Number(options.ambiguityMarginRatio))
+    ? Number(options.ambiguityMarginRatio) : DEFAULT_AMBIGUITY_MARGIN_RATIO;
+  if (!best) {
+    return {
+      classified: false, confident: false, confidence: 'low',
+      reason: 'no_semantic_candidate', candidates: [],
+    };
+  }
+  const ambiguous = isAmbiguous(candidates, ambiguityMargin)
+    && !isExactArticulationTie(candidates, best);
+  const withinDistance = best.distanceRatio <= maximumDistanceRatio;
+  const confidence = confidenceForDistance(best.distanceRatio);
+  const classified = withinDistance && !ambiguous;
+  return {
+    ...best,
+    role: HUMANOID_DRIVER_SEGMENTS.find(segment =>
+      segment.id === best.driverId)?.role || null,
+    confidence,
+    classified,
+    confident: classified && confidence !== 'low',
+    reason: !withinDistance ? 'outside_semantic_corridor'
+      : ambiguous ? 'ambiguous_semantic_candidate' : null,
+    candidates: candidates.slice(0, 4).map(candidate => ({...candidate})),
+  };
+}
+
 function directBindingFor(modelRig, jointId, candidate, driverMap, metadata = {}) {
   const restJointWorld = restJointWorldMatrix(modelRig, jointId);
   const driver = driverMap.get(candidate.driverId);

--- a/src/web/js/mesh/humanoid-rig-binding.js
+++ b/src/web/js/mesh/humanoid-rig-binding.js
@@ -39,6 +39,18 @@ const DEFAULT_SECONDARY_DISTANCE_RATIO = 0.24;
 const DEFAULT_AMBIGUITY_MARGIN_RATIO = 0.025;
 const TERMINAL_EXTENSION_RATIO = 0.15;
 const CENTRAL_DRIVER_IDS = new Set(['torso', 'neck', 'head']);
+const COMPLETE_MAPPED_HEAT_CONTROLS = Object.freeze({
+  left_arm: Object.freeze(['leftShoulder', 'leftElbow', 'leftHand']),
+  right_arm: Object.freeze(['rightShoulder', 'rightElbow', 'rightHand']),
+  left_leg: Object.freeze(['leftHip', 'leftKnee', 'leftFoot']),
+  right_leg: Object.freeze(['rightHip', 'rightKnee', 'rightFoot']),
+});
+const HEAT_DRIVER_ROLES = Object.freeze({
+  left_upper_arm: 'left_arm', left_lower_arm: 'left_arm',
+  right_upper_arm: 'right_arm', right_lower_arm: 'right_arm',
+  left_upper_leg: 'left_leg', left_lower_leg: 'left_leg',
+  right_upper_leg: 'right_leg', right_lower_leg: 'right_leg',
+});
 
 function numberId(value) {
   const result = Number(value);
@@ -370,6 +382,23 @@ function mappedControlEntries(controlMappings) {
   };
 }
 
+function completeMappedHeatRoles(entries) {
+  const mappedControls = new Set(entries.map(entry => entry.controlKey));
+  return new Set(Object.entries(COMPLETE_MAPPED_HEAT_CONTROLS)
+    .filter(([, controls]) => controls.every(controlKey =>
+      mappedControls.has(controlKey)))
+    .map(([role]) => role));
+}
+
+function heatRoleForAssignment(assignment) {
+  return assignment?.limbRole || HEAT_DRIVER_ROLES[assignment?.driverId]
+    || null;
+}
+
+function heatAssignmentSuppressed(assignment, suppressedRoles) {
+  return suppressedRoles.has(heatRoleForAssignment(assignment));
+}
+
 function mappedPathCandidates(modelRig, controlMappings) {
   const mapped = mappedControlEntries(controlMappings);
   const byControl = new Map(mapped.entries.map(entry =>
@@ -511,8 +540,35 @@ function sourceChildIds(modelRig, jointId) {
     `${Math.min(Number(jointId), child)}:${Math.max(Number(jointId), child)}`));
 }
 
+function mappedDescendantOwnership(modelRig, jointId, driverId, drivers,
+    controlRig, height, secondaryLimit, ambiguityMargin) {
+  const point = pointForJoint(modelRig, jointId);
+  const driver = drivers.get(driverId);
+  if (!point || !driver) return 'unknown';
+
+  // A mapped ancestor must retain unclassified helper/cloth descendants. Only
+  // stop when another driver is a clear, unambiguous semantic owner.
+  const candidates = sortedCandidates(point, drivers, height, controlRig);
+  const best = articulationPreferredCandidate(candidates);
+  const ambiguous = isAmbiguous(candidates, ambiguityMargin)
+    && !isExactArticulationTie(candidates, best);
+  const confidentlyDifferent = !ambiguous
+    && best && best.driverId !== driverId
+    && best.distanceRatio <= secondaryLimit
+    && confidenceForDistance(best.distanceRatio) !== 'low';
+  if (confidentlyDifferent) return 'different';
+
+  const ownCandidate = candidateForPoint(point, driver, height);
+  if (semanticCandidateAllowed(point, driver, ownCandidate, controlRig, height)
+      && ownCandidate.distanceRatio <= secondaryLimit) {
+    return 'same';
+  }
+  return 'unknown';
+}
+
 function mappedDescendantJointIds(modelRig, rootId, mappedJointIds,
-    jointBindings, driverId) {
+    jointBindings, driverId, drivers, controlRig, height, secondaryLimit,
+    ambiguityMargin) {
   const descendants = [];
   const visited = new Set([Number(rootId)]);
   const queue = sourceChildIds(modelRig, rootId);
@@ -525,6 +581,9 @@ function mappedDescendantJointIds(modelRig, rootId, mappedJointIds,
     if (mappedJointIds.has(jointId)) continue;
     const existing = jointBindings.get(jointId);
     if (existing?.driverId && existing.driverId !== driverId) continue;
+    const ownership = mappedDescendantOwnership(modelRig, jointId, driverId,
+      drivers, controlRig, height, secondaryLimit, ambiguityMargin);
+    if (ownership === 'different') continue;
     if (!existing) descendants.push(jointId);
     sourceChildIds(modelRig, jointId).forEach(child => {
       if (!visited.has(child)) queue.push(child);
@@ -614,16 +673,24 @@ export function buildHumanoidRigBinding({controlRig, modelRig, heatBinding,
   const candidatesByJointId = new Map();
   let ambiguousBindingCount = 0;
   const mapped = mappedControlEntries(controlMappings);
+  const completeMappedRoles = completeMappedHeatRoles(mapped.entries);
   const mappedPaths = mappedPathCandidates(modelRig, controlMappings);
   const mappedJointIds = new Set(mapped.entries.map(entry => entry.jointId));
   const sourceBoneAssignments = new Map();
   let mappedDescendantJointCount = 0;
   if (heatBinding?.sourceBoneAssignments instanceof Map) {
-    heatBinding.sourceBoneAssignments.forEach((assignment, sourceKey) =>
-      sourceBoneAssignments.set(sourceKey, assignment));
+    heatBinding.sourceBoneAssignments.forEach((assignment, sourceKey) => {
+      if (!heatAssignmentSuppressed(assignment, completeMappedRoles)) {
+        sourceBoneAssignments.set(sourceKey, assignment);
+      }
+    });
   } else {
     Object.entries(heatBinding?.sourceBoneAssignments || {}).forEach(
-      ([sourceKey, assignment]) => sourceBoneAssignments.set(sourceKey, assignment));
+      ([sourceKey, assignment]) => {
+        if (!heatAssignmentSuppressed(assignment, completeMappedRoles)) {
+          sourceBoneAssignments.set(sourceKey, assignment);
+        }
+      });
   }
 
   // A manually snapped control owns its resolved ModelJoint before either
@@ -694,7 +761,8 @@ export function buildHumanoidRigBinding({controlRig, modelRig, heatBinding,
     const driver = drivers.get(driverId);
     if (!driver || jointId === null) return;
     const descendants = mappedDescendantJointIds(modelRig, jointId,
-      mappedJointIds, jointBindings, driverId);
+      mappedJointIds, jointBindings, driverId, drivers, controlRig, height,
+      secondaryLimit, ambiguityMargin);
     descendants.forEach(descendantId => {
       if (jointBindings.has(descendantId)) return;
       const restJointWorld = restJointWorldMatrix(modelRig, descendantId);
@@ -725,13 +793,16 @@ export function buildHumanoidRigBinding({controlRig, modelRig, heatBinding,
     });
   });
 
-  // Heat ownership is authoritative for all eight limb drivers. It is
-  // automatic inference only; explicit mappings and mapped graph paths have
-  // already claimed their endpoints/interiors above.
+  // Heat ownership is the fallback for limb drivers that do not have a
+  // complete mapped control chain. Explicit mappings and mapped graph paths
+  // have already claimed their endpoints/interiors; a complete mapped chain
+  // also disables heat for that limb so unrelated nearby source bones cannot
+  // pull the mapped limb into the torso.
   allJointIds(modelRig).forEach(jointId => {
     if (jointBindings.has(jointId)) return;
     const assignment = valueFor(heatBinding?.modelJointAssignments, jointId);
     if (!assignment?.driverId || !drivers.has(assignment.driverId)) return;
+    if (heatAssignmentSuppressed(assignment, completeMappedRoles)) return;
     const point = pointForJoint(modelRig, jointId);
     const driver = drivers.get(assignment.driverId);
     const restJointWorld = restJointWorldMatrix(modelRig, jointId);
@@ -847,6 +918,7 @@ export function buildHumanoidRigBinding({controlRig, modelRig, heatBinding,
       directDistanceRatio: directLimit,
       secondaryDistanceRatio: secondaryLimit,
       ambiguityMarginRatio: ambiguityMargin,
+      completeMappedHeatRoles: [...completeMappedRoles].sort(),
       candidateCount: candidatesByJointId.size,
       mappedPathCount: mappedPaths.candidates.length,
       mappedPathJointCount: mappedPaths.candidates.reduce((sum, candidate) =>

--- a/src/web/js/mesh/humanoid-rig-binding.js
+++ b/src/web/js/mesh/humanoid-rig-binding.js
@@ -1,9 +1,10 @@
 import * as THREE from 'three';
 import {HUMANOID_CONTROL_DRIVER_IDS} from './humanoid-control-rig.js';
 
-// The control rig owns the semantic topology. ModelJoint edges are consulted
-// only when two explicitly mapped controls can claim the corresponding model
-// graph path; automatic heat/geometric inference remains the fallback.
+// The control rig owns the semantic topology. Explicitly mapped ModelJoints
+// own their source-connected descendants until another mapped control or a
+// mapped path takes ownership; automatic heat/geometric inference remains the
+// fallback for everything else.
 export const HUMANOID_DRIVER_SEGMENTS = Object.freeze([
   {id: 'torso', role: 'torso', start: 'pelvis', end: 'chest'},
   {id: 'neck', role: 'torso', start: 'chest', end: 'neck'},
@@ -491,6 +492,46 @@ function componentChildren(modelRig, jointId) {
     .map(numberId).filter(Number.isInteger).sort((left, right) => left - right);
 }
 
+function sourceChildIds(modelRig, jointId) {
+  const children = componentChildren(modelRig, jointId);
+  const componentId = modelRig?.componentByJointId?.get?.(Number(jointId));
+  const component = Number.isInteger(Number(componentId))
+    ? modelRig?.components?.[Number(componentId)] : null;
+  const edges = component?.edges;
+  if (!Array.isArray(edges) || !edges.length) return children;
+  const sourcePairs = new Set(edges.filter(edge =>
+    edge?.relationshipType !== 'attachment').map(edge => {
+    const left = numberId(edge?.jointA ?? edge?.boneA);
+    const right = numberId(edge?.jointB ?? edge?.boneB);
+    return left === null || right === null ? null
+      : `${Math.min(left, right)}:${Math.max(left, right)}`;
+  }).filter(Boolean));
+  return children.filter(child => sourcePairs.has(
+    `${Math.min(Number(jointId), child)}:${Math.max(Number(jointId), child)}`));
+}
+
+function mappedDescendantJointIds(modelRig, rootId, mappedJointIds,
+    jointBindings, driverId) {
+  const descendants = [];
+  const visited = new Set([Number(rootId)]);
+  const queue = sourceChildIds(modelRig, rootId);
+  while (queue.length) {
+    const jointId = queue.shift();
+    if (visited.has(jointId)) continue;
+    visited.add(jointId);
+    // An explicitly mapped control is a boundary. Its own mapping will walk
+    // its descendants with the correct, more specific driver.
+    if (mappedJointIds.has(jointId)) continue;
+    const existing = jointBindings.get(jointId);
+    if (existing?.driverId && existing.driverId !== driverId) continue;
+    if (!existing) descendants.push(jointId);
+    sourceChildIds(modelRig, jointId).forEach(child => {
+      if (!visited.has(child)) queue.push(child);
+    });
+  }
+  return descendants;
+}
+
 function unboundSubtree(modelRig, rootId, directIds) {
   const result = [];
   const queue = [rootId];
@@ -573,7 +614,9 @@ export function buildHumanoidRigBinding({controlRig, modelRig, heatBinding,
   let ambiguousBindingCount = 0;
   const mapped = mappedControlEntries(controlMappings);
   const mappedPaths = mappedPathCandidates(modelRig, controlMappings);
+  const mappedJointIds = new Set(mapped.entries.map(entry => entry.jointId));
   const sourceBoneAssignments = new Map();
+  let mappedDescendantJointCount = 0;
   if (heatBinding?.sourceBoneAssignments instanceof Map) {
     heatBinding.sourceBoneAssignments.forEach((assignment, sourceKey) =>
       sourceBoneAssignments.set(sourceKey, assignment));
@@ -637,6 +680,47 @@ export function buildHumanoidRigBinding({controlRig, modelRig, heatBinding,
             segmentEndControl: segment.end,
             bindingMethod: 'mapped_joint_path',
           })));
+    });
+  });
+
+  // A mapped control is an authoritative anchor for its source-connected
+  // descendants. Walk through same-driver mapped path joints, but stop at a
+  // different mapped control so each explicit control remains a boundary.
+  // Attachment edges are excluded by sourceChildIds; accessories retain the
+  // existing conservative binding behavior.
+  mapped.entries.forEach(({controlKey, jointId}) => {
+    const driverId = HUMANOID_CONTROL_DRIVER_IDS[controlKey];
+    const driver = drivers.get(driverId);
+    if (!driver || jointId === null) return;
+    const descendants = mappedDescendantJointIds(modelRig, jointId,
+      mappedJointIds, jointBindings, driverId);
+    descendants.forEach(descendantId => {
+      if (jointBindings.has(descendantId)) return;
+      const restJointWorld = restJointWorldMatrix(modelRig, descendantId);
+      if (!restJointWorld) return;
+      const sourceMembers = sourceMembersForJoint(modelRig, descendantId);
+      const localMatrix = driver.matrix.clone().invert().multiply(restJointWorld);
+      jointBindings.set(descendantId, {
+        type: 'driver', driverId, localMatrix, restJointWorld,
+        distance: 0, distanceRatio: 0, rawProjection: 0, projection: 0,
+        endpointDistanceRatio: 0, score: 0, confidence: 'high',
+        bindingMethod: 'mapped_control_descendant',
+        controlKey,
+        mappedRootJointId: jointId,
+        sourceBoneKeys: sourceMembers.map(member => member.sourceBoneKey).sort(),
+      });
+      sourceMembers.forEach(member => sourceBoneAssignments.set(
+        member.sourceBoneKey, sourceAssignmentForMember(member, driverId, {
+          limbRole: sourceRoleForControl(controlKey),
+          progress: sourceProgress(controlKey),
+          segmentIndex: /Elbow|Knee|Hand|Foot/.test(controlKey) ? 1 : 0,
+          bindingMethod: 'mapped_control_descendant',
+          controlKey,
+          mappedRootJointId: jointId,
+          pathMember: false,
+          branchMember: true,
+        })));
+      mappedDescendantJointCount += 1;
     });
   });
 
@@ -766,6 +850,7 @@ export function buildHumanoidRigBinding({controlRig, modelRig, heatBinding,
       mappedPathCount: mappedPaths.candidates.length,
       mappedPathJointCount: mappedPaths.candidates.reduce((sum, candidate) =>
         sum + Math.max(0, candidate.path.length - 2), 0),
+      mappedDescendantJointCount,
       mappedPathConflicts: mappedPaths.conflicts,
       heatBinding: heatBinding?.diagnostics || null,
       heatConflicts: [...(heatBinding?.conflicts || [])],

--- a/src/web/js/mesh/humanoid-rig-edit-session.js
+++ b/src/web/js/mesh/humanoid-rig-edit-session.js
@@ -183,12 +183,14 @@ function createSession({modelRigState, getModelRig, getAutomaticRig,
   function updateDraft(controlKey, position, {
     candidateJointId = null, candidateDistance = Infinity,
     mappedDistance = Infinity,
+    notifyState = true, request = true,
   } = {}) {
     if (!state.editing || state.carryingControlKey !== controlKey) return false;
     const freePosition = finitePosition(position);
     if (!freePosition) {
       state.error = 'The draft control position is invalid.';
-      notify();
+      if (notifyState) notify();
+      if (request) requestRender?.();
       return false;
     }
     const modelRig = getModelRig?.();
@@ -243,8 +245,8 @@ function createSession({modelRigState, getModelRig, getAutomaticRig,
     rebuildHumanoidControlPaths(state.draftRig);
     state.error = null;
     updateDirty();
-    notify();
-    requestRender?.();
+    if (notifyState) notify();
+    if (request) requestRender?.();
     return true;
   }
 

--- a/src/web/js/mesh/weight-rig-core.js
+++ b/src/web/js/mesh/weight-rig-core.js
@@ -786,11 +786,11 @@ function applyHumanoidJointGuide(sourceRigs, guide) {
       ? guide.sourceResults.get(String(sourceRig.sourceKey)) : null;
     if (result) {
       sourceRig.inferredForest = cloneSourceForest(result.forest);
-      // Keep the established weight-derived pivots for this first guided
-      // pass.  Only the relationship orientation is semantically guided.
-      sourceRig.jointPivotByBoneId = new Map(
-        [...(sourceRig.defaultJointPivotByBoneId || [])]
-          .map(([boneId, pivot]) => [boneId, [...pivot]]));
+      // Pivots belong to the selected undirected parent/child relationship.
+      // Guidance can replace that relationship, so the legacy pivot map is
+      // stale whenever the guided forest changes an edge.
+      sourceRig.jointPivotByBoneId = jointPivotMap(
+        sourceRig.inferredForest, sourceRig.influenceGraph?.relationships);
       sourceRig.humanoidJointGuideMode = 'humanoid_guided';
       rebuildSourceRigRestFrames(sourceRig);
       return;

--- a/src/web/js/mesh/weight-rig-core.js
+++ b/src/web/js/mesh/weight-rig-core.js
@@ -85,6 +85,7 @@ import {buildHumanoidHeatBinding} from './humanoid-heat-binding.js';
 import {
   initializeHumanoidRigEditSession, resetHumanoidRigEditSession,
 } from './humanoid-rig-edit-session.js';
+import {buildHumanoidJointGuide} from './humanoid-guided-rig.js';
 
 const weightRuntime = createWeightRuntimeState();
 const {states, knownMeshes, modelWeightState, stateFor} = weightRuntime;
@@ -282,7 +283,8 @@ humanoidRigEditSession = initializeHumanoidRigEditSession({
   cancelRigPicking: cancelRigJointPicking,
   rebuildActiveRig: async () => {
     if (!modelSkinningRig) return;
-    buildPrimaryHumanoidRig(modelSkinningRig);
+    const sourceRigs = buildAllSourceSkinningRigs();
+    buildModelSkinningRig(sourceRigs);
     // Edit mode starts from rest and does not carry a virtual pose into the
     // rebuilt control rig.
     modelRigState.humanoidPose = {};
@@ -424,7 +426,11 @@ function modelRigSnapshotForState() {
     quaternionIsIdentity,
     matrixIsIdentity,
   });
-  if (snapshot) snapshot.humanoidControlRig = humanoidControlRigSnapshot();
+  if (snapshot) {
+    snapshot.humanoidControlRig = humanoidControlRigSnapshot();
+    snapshot.jointBuild = modelSkinningRig?.jointBuildDiagnostics
+      ? {...modelSkinningRig.jointBuildDiagnostics} : null;
+  }
   return snapshot;
 }
 
@@ -727,6 +733,73 @@ function restoreDefaultSourceRigOrientations() {
     .map(restoreDefaultSourceRigOrientation).some(Boolean);
 }
 
+function hasSavedHumanoidMainRig(savedOverrides) {
+  return !!(savedOverrides?.controls
+    && Object.keys(savedOverrides.controls).length);
+}
+
+function buildSavedHumanoidJointGuide(savedOverrides) {
+  if (!hasSavedHumanoidMainRig(savedOverrides)) return null;
+  try {
+    const orientationState = getModelTransformState?.();
+    const automaticRig = buildHumanoidControlRig({
+      meshes: [...knownMeshes],
+      axes: humanoidSemanticAxes(),
+      orientationState,
+    });
+    if (!automaticRig?.accepted) {
+      return {automaticRig, controlRig: null,
+        fallbackReason: automaticRig?.diagnostics?.reason
+          || 'automatic_humanoid_rig_unavailable'};
+    }
+    // The saved metadata is a geometry guide at this stage.  ModelJoint
+    // signatures are resolved only after the guided ModelRig exists.
+    const controlRig = applyHumanoidControlRigOverrides({
+      automaticRig,
+      savedOverrides,
+      modelRig: null,
+      resolvedMappings: new Map(),
+    });
+    if (!controlRig?.accepted) {
+      return {automaticRig, controlRig: null,
+        fallbackReason: 'guided_humanoid_rig_unavailable'};
+    }
+    return {automaticRig, controlRig, fallbackReason: null};
+  } catch (error) {
+    return {
+      automaticRig: null,
+      controlRig: null,
+      fallbackReason: error instanceof Error ? error.message
+        : 'guided_humanoid_rig_failed',
+    };
+  }
+}
+
+function applyHumanoidJointGuide(sourceRigs, guide) {
+  const guided = !!guide?.sourceResults;
+  sourceRigs.forEach(sourceRig => {
+    if (!guided && sourceRig.humanoidJointGuideMode !== 'humanoid_guided') {
+      sourceRig.humanoidJointGuideMode = 'legacy';
+      return;
+    }
+    const result = guided
+      ? guide.sourceResults.get(String(sourceRig.sourceKey)) : null;
+    if (result) {
+      sourceRig.inferredForest = cloneSourceForest(result.forest);
+      // Keep the established weight-derived pivots for this first guided
+      // pass.  Only the relationship orientation is semantically guided.
+      sourceRig.jointPivotByBoneId = new Map(
+        [...(sourceRig.defaultJointPivotByBoneId || [])]
+          .map(([boneId, pivot]) => [boneId, [...pivot]]));
+      sourceRig.humanoidJointGuideMode = 'humanoid_guided';
+      rebuildSourceRigRestFrames(sourceRig);
+      return;
+    }
+    restoreDefaultSourceRigOrientation(sourceRig);
+    sourceRig.humanoidJointGuideMode = 'legacy';
+  });
+}
+
 function defaultRootOverrides(rig) {
   return new Map((rig.defaultComponents || []).map(component => [
     Number(component.componentId), Number(component.rootId),
@@ -812,7 +885,26 @@ function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
   const previousRootSignatures = new Set(
     modelRigState.explicitRootSignatures);
   if (modelSkinningRig) resetModelPose({request: false});
-  const reconciliation = buildModelRigReconciliation(sourceRigs);
+  const savedOverrides = humanoidRigEditSession?.getSavedOverrides?.();
+  const savedMainRig = hasSavedHumanoidMainRig(savedOverrides);
+  const savedGuide = buildSavedHumanoidJointGuide(savedOverrides);
+  let humanoidGuide = null;
+  let guideFallbackReason = savedGuide?.fallbackReason || null;
+  if (savedGuide?.controlRig) {
+    try {
+      humanoidGuide = buildHumanoidJointGuide(
+        sourceRigs, savedGuide.controlRig);
+    } catch (error) {
+      guideFallbackReason = error instanceof Error ? error.message
+        : 'guided_humanoid_rig_failed';
+    }
+  }
+  applyHumanoidJointGuide(sourceRigs, humanoidGuide);
+  const reconciliation = buildModelRigReconciliation(sourceRigs,
+    humanoidGuide ? {
+      semanticBySourceBoneKey: humanoidGuide.sourceBoneClassifications,
+      humanoidGuidanceDiagnostics: humanoidGuide.diagnostics,
+    } : undefined);
   const joints = reconciliation.joints || [];
   const rig = {
     key: 'model-rig',
@@ -854,6 +946,29 @@ function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
     poseSourceBoneIdsByMesh: new Map(),
     poseRevision: 0,
     structureRevision: ++rigRuntime.structureRevision,
+    humanoidGuidedAutomaticRig: humanoidGuide
+      ? savedGuide.automaticRig : null,
+    jointBuildDiagnostics: {
+      mode: humanoidGuide ? 'humanoid_guided' : 'legacy',
+      savedMainRig,
+      classifiedCount: humanoidGuide?.diagnostics?.classified || 0,
+      unclassifiedCount: humanoidGuide?.diagnostics?.unclassified
+        || (reconciliation.reconciliation?.sourceBoneCount
+          || reconciliation.sourceBoneEvidence?.length || 0)
+          - (humanoidGuide?.diagnostics?.classified || 0),
+      guidedEdgeCount: humanoidGuide?.diagnostics?.guidedEdges || 0,
+      rejectedEdgeCount: humanoidGuide?.diagnostics?.rejectedEdges || 0,
+      sameSegmentEdgeCount: humanoidGuide?.diagnostics?.sameSegmentEdges || 0,
+      adjacentArticulationEdgeCount:
+        humanoidGuide?.diagnostics?.adjacentArticulationEdges || 0,
+      rootOverrideCount: humanoidGuide?.diagnostics?.rootOverrideCount || 0,
+      mergeCount: reconciliation.reconciliation?.equivalenceClusterCount || 0,
+      semanticMergeCount: (reconciliation.reconciliation?.acceptedEquivalences
+        || []).filter(item => ['same_segment', 'same_region'].includes(
+          item.semanticKind)).length,
+      fallbackReason: savedMainRig && !humanoidGuide
+        ? guideFallbackReason || 'guided_humanoid_rig_failed' : null,
+    },
   };
   // Install provenance-derived edge pivots before capturing the default
   // orientation. Reset Pose must restore the same pivots used on first load.
@@ -912,11 +1027,12 @@ function buildPrimaryHumanoidRig(rig) {
   humanoidControlRigCacheKey = '';
   humanoidControlRigSnapshotCache = null;
   const orientationState = getModelTransformState?.();
-  const automaticRig = buildHumanoidControlRig({
-    meshes: [...knownMeshes],
-    axes: humanoidSemanticAxes(),
-    orientationState,
-  });
+  const automaticRig = rig.humanoidGuidedAutomaticRig
+    || buildHumanoidControlRig({
+      meshes: [...knownMeshes],
+      axes: humanoidSemanticAxes(),
+      orientationState,
+    });
   const savedOverrides = humanoidRigEditSession?.getSavedOverrides?.();
   const resolvedMappings = automaticRig?.accepted
     ? resolveHumanoidControlMappings({
@@ -934,6 +1050,7 @@ function buildPrimaryHumanoidRig(rig) {
     ? buildHumanoidRigBinding({controlRig, modelRig: rig, heatBinding,
       controlMappings: resolvedMappings}) : null;
   rig.humanoidAutomaticControlRig = automaticRig;
+  delete rig.humanoidGuidedAutomaticRig;
   rig.humanoidControlRig = controlRig;
   rig.humanoidHeatBinding = heatBinding;
   rig.humanoidBinding = binding;

--- a/src/web/js/mesh/weight-rig-reconcile.js
+++ b/src/web/js/mesh/weight-rig-reconcile.js
@@ -397,6 +397,22 @@ export function crossSourceWeightEvidence(
   return evidence;
 }
 
+function semanticRelationshipFor(left, right, semanticBySourceBoneKey) {
+  if (!(semanticBySourceBoneKey instanceof Map)) return null;
+  const leftSemantic = semanticBySourceBoneKey.get(left.sourceBoneKey);
+  const rightSemantic = semanticBySourceBoneKey.get(right.sourceBoneKey);
+  if (!leftSemantic?.confident || !rightSemantic?.confident) {
+    return {kind: 'unclassified', score: 0};
+  }
+  if (leftSemantic.driverId === rightSemantic.driverId) {
+    return {kind: 'same_segment', score: 0.08};
+  }
+  if (leftSemantic.role && leftSemantic.role === rightSemantic.role) {
+    return {kind: 'same_region', score: 0.04};
+  }
+  return {kind: 'semantic_mismatch', score: -0.12};
+}
+
 function candidateFor(left, right, allEvidence, crossEvidenceByPair, gate) {
   // Equivalence compares like-for-like neutral regions. The parent joint pivot
   // is a structural anchor, not a replacement for a source bone's region.
@@ -442,6 +458,11 @@ function candidateFor(left, right, allEvidence, crossEvidenceByPair, gate) {
   // and a one-vertex coincidence cannot become a seed by itself.
   const combinedConfidence = 1 - (1 - geometryConfidence)
     * (1 - crossConfidence);
+  const semantic = semanticRelationshipFor(left, right,
+    gate.semanticBySourceBoneKey);
+  const semanticScore = semantic?.score || 0;
+  const semanticallyAdjustedConfidence = clamp(
+    combinedConfidence + semanticScore);
   const strongCrossEvidence = !!crossEvidence
     && crossEvidence.matchedVertexCount >= CROSS_SOURCE_STRONG_VERTEX_COUNT
     && crossEvidence.weightedMatchStrength
@@ -474,7 +495,10 @@ function candidateFor(left, right, allEvidence, crossEvidenceByPair, gate) {
     weightedMatchStrength: crossEvidence?.weightedMatchStrength || 0,
     geometryConfidence,
     crossConfidence,
-    combinedConfidence,
+    combinedConfidence: semanticallyAdjustedConfidence,
+    baseCombinedConfidence: combinedConfidence,
+    semanticKind: semantic?.kind || null,
+    semanticScore,
     strongCrossEvidence,
     geometrySeed,
     confidenceClass,
@@ -671,6 +695,10 @@ function diagnosticCandidate(candidate, decision, rejectionReason = null) {
     crossJaccard: candidate.crossEvidence?.crossJaccard ?? null,
     strongCrossEvidence: !!candidate.strongCrossEvidence,
     geometrySeed: !!candidate.geometrySeed,
+    ...(candidate.semanticKind ? {
+      semanticKind: candidate.semanticKind,
+      semanticScore: candidate.semanticScore || 0,
+    } : {}),
     confidenceClass: candidate.confidenceClass || 0,
     rootConflict: !!candidate.topology?.rootConflict,
     score: candidate.combinedConfidence ?? candidate.score,
@@ -699,7 +727,8 @@ function buildCrossSourceWeightEvidence(sourceRigs, referenceRadius) {
   return evidence;
 }
 
-function buildCandidates(evidenceByKey, referenceRadius, sourceRigs = []) {
+function buildCandidates(evidenceByKey, referenceRadius, sourceRigs = [],
+    options = {}) {
   const crossEvidenceByPair = buildCrossSourceWeightEvidence(
     sourceRigs, referenceRadius);
   const bySource = new Map();
@@ -719,6 +748,7 @@ function buildCandidates(evidenceByKey, referenceRadius, sourceRigs = []) {
           const candidate = candidateFor(left, right, evidenceByKey,
             crossEvidenceByPair, {
             referenceRadius,
+            semanticBySourceBoneKey: options.semanticBySourceBoneKey,
           });
           if (candidate) candidates.push(candidate);
         }
@@ -2047,7 +2077,7 @@ export function buildModelRigReconciliation(sourceRigs = [], options = {}) {
   const referenceRadius = Math.max(EPSILON, number(options.modelReferenceRadius,
     modelReferenceRadius(evidenceByKey)));
   const candidateBuild = buildCandidates(
-    evidenceByKey, referenceRadius, rigs);
+    evidenceByKey, referenceRadius, rigs, options);
   const candidates = candidateBuild.candidates;
   const unionFind = new GuardedUnionFind([...evidenceByKey.keys()]);
   const equivalence = runEquivalencePasses(
@@ -2115,6 +2145,9 @@ export function buildModelRigReconciliation(sourceRigs = [], options = {}) {
       sum + component.nodeIds.length, 0),
     unresolvedSourceKeys,
     modelReferenceRadius: referenceRadius,
+    ...(options.humanoidGuidanceDiagnostics ? {
+      semanticGuidance: {...options.humanoidGuidanceDiagnostics},
+    } : {}),
     joints: model.joints,
     acceptedEquivalences,
     acceptedAttachments: survivingAttachments,

--- a/src/web/js/mesh/weight-rig.js
+++ b/src/web/js/mesh/weight-rig.js
@@ -6,10 +6,6 @@
 
 export const CANDIDATE_CONTAINMENT_THRESHOLD = 0.02;
 export const CANDIDATE_JACCARD_THRESHOLD = 0.01;
-export const MIN_BONE_RADIUS_RATIO = 0.005;
-export const MAX_JOINT_REACH = 2.5;
-export const MAX_SUPPORT_SEPARATION = 2.5;
-export const MIN_DOMINANCE_BALANCE = 0.5;
 
 function triangleArea(points) {
   const [a, b, c] = points;
@@ -281,20 +277,6 @@ function integrateMinimumLinearWeight(
     + integratePolygonLinearWeight(rightRegion, 'rightWeight');
 }
 
-function integrateDominantLinearWeight(
-    points, leftWeights, rightWeights, area, dominantSide) {
-  const vertices = points.map((position, index) => ({
-    position,
-    leftWeight: leftWeights[index],
-    rightWeight: rightWeights[index],
-    d: leftWeights[index] - rightWeights[index],
-  }));
-  const leftDominant = dominantSide === 'left';
-  const region = clipLinearWeightPolygon(vertices, !leftDominant);
-  return integratePolygonLinearWeight(region,
-    leftDominant ? 'leftWeight' : 'rightWeight');
-}
-
 function surfaceInfluenceWeights(
     indices, weights, influenceCount, vertexIndex, requested) {
   const values = positiveInfluencesForVertex(
@@ -378,8 +360,6 @@ export function buildSurfaceInfluenceGraph(
           sharedMeasure: 0,
           minOverlap: 0,
           productOverlap: 0,
-          aDominantSharedSupport: 0,
-          bDominantSharedSupport: 0,
           jointWeightTotal: 0,
           jointX: 0,
           jointY: 0,
@@ -391,10 +371,6 @@ export function buildSurfaceInfluenceGraph(
         relationship.sharedMeasure += triangle.area;
         relationship.minOverlap += integrateMinimumLinearWeight(
           triangle.points, weightsA, weightsB, triangle.area);
-        relationship.aDominantSharedSupport += integrateDominantLinearWeight(
-          triangle.points, weightsA, weightsB, triangle.area, 'left');
-        relationship.bDominantSharedSupport += integrateDominantLinearWeight(
-          triangle.points, weightsA, weightsB, triangle.area, 'right');
         relationship.productOverlap += productOverlap;
         relationship.jointWeightTotal += productOverlap;
         relationship.jointX += jointMoment[0];
@@ -434,8 +410,6 @@ export function buildSurfaceInfluenceGraph(
   const sourceRadius = nodes.length ? Math.max(...nodes.map(node =>
     (centerDistance(node.weightedCenter, sourceCenter) || 0)
       + (Number(node.weightedRadius) || 0))) : null;
-  const graphRadius = Number.isFinite(radius) && radius > 0
-    ? radius : sourceRadius;
   const relationships = [...relationshipEntries.values()].map(relationship => {
     const nodeA = nodeById.get(relationship.boneA);
     const nodeB = nodeById.get(relationship.boneB);
@@ -445,11 +419,11 @@ export function buildSurfaceInfluenceGraph(
     const jaccardDenominator = supportA + supportB - relationship.minOverlap;
     const distance = centerDistance(nodeA?.weightedCenter, nodeB?.weightedCenter);
     const normalizedDistance = distance !== null
-      && Number.isFinite(graphRadius) && graphRadius > 0
-      ? distance / graphRadius : null;
+      && Number.isFinite(radius) && radius > 0
+      ? distance / radius : null;
     const distancePenalty = Number.isFinite(normalizedDistance)
       ? 1 / (1 + Math.max(0, normalizedDistance)) : 1;
-    const finalized = {
+    return {
       ...relationship,
       jointCenter: relationship.jointWeightTotal > 0
         ? [relationship.jointX / relationship.jointWeightTotal,
@@ -463,11 +437,6 @@ export function buildSurfaceInfluenceGraph(
       normalizedDistance,
       treeEdgeScore: (denominator > 0
         ? relationship.minOverlap / denominator : 0) * distancePenalty,
-    };
-    return {
-      ...finalized,
-      ...relationshipSpatialEvidence(finalized, nodeA, nodeB, graphRadius),
-      ...relationshipDominanceEvidence(finalized),
     };
   });
   return {
@@ -577,177 +546,6 @@ function centerDistance(centerA, centerB) {
     Number(centerA[2]) - Number(centerB[2]));
 }
 
-function inferredSourceRadius(nodes) {
-  const weightedNodes = (nodes || []).filter(node =>
-    Number(node?.totalWeight) > 0 && node?.weightedCenter?.length >= 3);
-  const totalWeight = weightedNodes.reduce((sum, node) =>
-    sum + Number(node.totalWeight), 0);
-  if (!weightedNodes.length || totalWeight <= 0) return null;
-  const center = weightedNodes.reduce((sum, node) => {
-    const weight = Number(node.totalWeight) || 0;
-    return [
-      sum[0] + Number(node.weightedCenter[0]) * weight,
-      sum[1] + Number(node.weightedCenter[1]) * weight,
-      sum[2] + Number(node.weightedCenter[2]) * weight,
-    ];
-  }, [0, 0, 0]).map(value => value / totalWeight);
-  return Math.max(...weightedNodes.map(node =>
-    (centerDistance(node.weightedCenter, center) || 0)
-      + (Number(node.weightedRadius) || 0)));
-}
-
-function effectiveBoneRadius(node, sourceRadius) {
-  const weightedRadius = Number(node?.weightedRadius);
-  const radius = Number(sourceRadius);
-  const floor = Number.isFinite(radius) && radius > 0
-    ? radius * MIN_BONE_RADIUS_RATIO : 0;
-  return Math.max(
-    Number.isFinite(weightedRadius) && weightedRadius > 0
-      ? weightedRadius : 0,
-    floor, Number.EPSILON);
-}
-
-/** Calculate locality of an overlap region relative to both bone supports. */
-export function relationshipSpatialEvidence(
-    relationship, nodeA, nodeB, sourceRadius = null) {
-  const jointCenter = relationship?.jointCenter;
-  const radius = Number(sourceRadius);
-  const reachA = centerDistance(nodeA?.weightedCenter, jointCenter);
-  const reachB = centerDistance(nodeB?.weightedCenter, jointCenter);
-  const effectiveRadiusA = effectiveBoneRadius(nodeA, radius);
-  const effectiveRadiusB = effectiveBoneRadius(nodeB, radius);
-  const jointReachA = reachA === null ? null : reachA / effectiveRadiusA;
-  const jointReachB = reachB === null ? null : reachB / effectiveRadiusB;
-  const maxJointReach = jointReachA === null || jointReachB === null
-    ? null : Math.max(jointReachA, jointReachB);
-  const centerDistanceValue = centerDistance(
-    nodeA?.weightedCenter, nodeB?.weightedCenter);
-  const supportSeparation = centerDistanceValue === null
-    ? null : centerDistanceValue / (effectiveRadiusA + effectiveRadiusB);
-  const reachFactor = maxJointReach === null
-    ? 1 : 1 / (1 + Math.max(0, maxJointReach));
-  const separationFactor = supportSeparation === null
-    ? 1 : 1 / (1 + Math.max(0, supportSeparation));
-  return {
-    jointReachA,
-    jointReachB,
-    maxJointReach,
-    supportSeparation,
-    structuralLocality: Math.max(0, Math.min(1,
-      Math.sqrt(reachFactor * separationFactor))),
-  };
-}
-
-/** Calculate whether shared support contains a meaningful dominance transition. */
-export function relationshipDominanceEvidence(relationship) {
-  const available = relationship?.dominanceEvidenceAvailable !== undefined
-    ? relationship.dominanceEvidenceAvailable === true
-    : Object.hasOwn(relationship || {}, 'aDominantSharedSupport')
-      && Object.hasOwn(relationship || {}, 'bDominantSharedSupport');
-  if (!available) {
-    return {
-      dominanceBalance: null,
-      hasBidirectionalDominance: null,
-      dominanceEvidenceAvailable: false,
-    };
-  }
-  const aSupport = Number(relationship?.aDominantSharedSupport);
-  const bSupport = Number(relationship?.bDominantSharedSupport);
-  if (![aSupport, bSupport].every(Number.isFinite)) {
-    return {
-      dominanceBalance: null,
-      hasBidirectionalDominance: null,
-      dominanceEvidenceAvailable: false,
-    };
-  }
-  const total = Math.max(0, aSupport) + Math.max(0, bSupport);
-  const maximum = Math.max(Math.max(0, aSupport), Math.max(0, bSupport));
-  return {
-    dominanceBalance: maximum > 0
-      ? Math.min(Math.max(0, aSupport), Math.max(0, bSupport)) / maximum
-      : 0,
-    hasBidirectionalDominance: aSupport > 0 && bSupport > 0 && total > 0,
-    dominanceEvidenceAvailable: true,
-  };
-}
-
-function relationshipEvidence(relationship, nodeById, sourceRadius) {
-  const nodeA = nodeById.get(Number(relationship?.boneA));
-  const nodeB = nodeById.get(Number(relationship?.boneB));
-  return {
-    ...relationship,
-    ...relationshipSpatialEvidence(relationship, nodeA, nodeB, sourceRadius),
-    ...relationshipDominanceEvidence(relationship),
-  };
-}
-
-/** Evaluate spatial eligibility separately from overlap eligibility. */
-export function evaluateStructuralRelationship(relationship, options = {}) {
-  const structuralEvidenceAvailable = options.structuralEvidenceAvailable
-    !== false;
-  const maxJointReach = Number(options.maxJointReach
-    ?? MAX_JOINT_REACH);
-  const maxSupportSeparation = Number(options.maxSupportSeparation
-    ?? MAX_SUPPORT_SEPARATION);
-  const minDominanceBalance = Number(options.minDominanceBalance
-    ?? MIN_DOMINANCE_BALANCE);
-  const reach = Number(relationship?.maxJointReach);
-  const separation = Number(relationship?.supportSeparation);
-  const remoteTail = structuralEvidenceAvailable
-    && Number.isFinite(reach) && reach > maxJointReach;
-  const separatedSupports = structuralEvidenceAvailable
-    && Number.isFinite(separation)
-    && separation > maxSupportSeparation;
-  const dominanceBalance = Number(relationship?.dominanceBalance);
-  const weakDominance = structuralEvidenceAvailable
-    && Number.isFinite(dominanceBalance)
-    && dominanceBalance < minDominanceBalance;
-  const memberEvidence = Array.isArray(relationship?.memberEvidence)
-    ? relationship.memberEvidence : [];
-  const bidirectionalMemberCount = memberEvidence.filter(item =>
-    item.hasBidirectionalDominance === true).length;
-  const memberDominanceRatio = memberEvidence.length
-    ? bidirectionalMemberCount / memberEvidence.length : null;
-  const localMemberEvidence = structuralEvidenceAvailable
-    && memberEvidence.some(item =>
-    item.hasBidirectionalDominance === true
-      && Number(item.structuralLocality) >= .5);
-  // A low aggregate balance can be caused by unrelated members contaminating
-  // a real transition. Reject only when that contamination is consistent
-  // across the aggregate evidence and no local member supports the edge.
-  const weakMemberTransition = structuralEvidenceAvailable
-    && memberEvidence.length >= 3
-    && relationship?.dominanceEvidenceAvailable === true
-    && memberDominanceRatio < .5
-    && weakDominance;
-  const remoteTailBridge = (remoteTail && separatedSupports
-    && !localMemberEvidence) || weakMemberTransition;
-  const baseScore = Number(relationship?.treeEdgeScore
-    ?? relationship?.containment ?? relationship?.jaccard);
-  const locality = Number(relationship?.structuralLocality);
-  const memberLocality = Number(relationship?.maxMemberStructuralLocality);
-  const localityValues = [locality, memberLocality]
-    .filter(Number.isFinite);
-  const effectiveLocality = localMemberEvidence && localityValues.length
-    ? Math.max(...localityValues) : locality;
-  const structuralLocality = Number.isFinite(effectiveLocality)
-    ? Math.max(0, Math.min(1, effectiveLocality)) : 1;
-  return {
-    accepted: !remoteTailBridge,
-    reason: remoteTailBridge
-      ? (weakMemberTransition ? 'weak_transition' : 'remote_tail_bridge')
-      : null,
-    remoteTail,
-    separatedSupports,
-    weakDominance,
-    memberDominanceRatio,
-    localMemberEvidence,
-    weakMemberTransition,
-    treeEdgeScore: Number.isFinite(baseScore)
-      ? baseScore * structuralLocality : baseScore,
-  };
-}
-
 /** Build overlap evidence and an overlap-derived pivot for every bone pair. */
 export function buildInfluenceRelationships(
     baselinePositions, indices, weights, influenceCount, nodes,
@@ -779,10 +577,8 @@ export function buildInfluenceRelationships(
       for (let right = left + 1; right < ids.length; right += 1) {
         const [boneA, boneB] = pairIds(ids[left], ids[right]);
         const key = pairKey(boneA, boneB);
-        const weightLeft = mergedWeights[left];
-        const weightRight = mergedWeights[right];
-        const weightA = ids[left] === boneA ? weightLeft : weightRight;
-        const weightB = ids[left] === boneA ? weightRight : weightLeft;
+        const weightA = mergedWeights[left];
+        const weightB = mergedWeights[right];
         const jointWeight = weightA * weightB;
         const relationship = relationships.get(key) || {
           boneA,
@@ -791,8 +587,6 @@ export function buildInfluenceRelationships(
           sharedMeasure: null,
           minOverlap: 0,
           productOverlap: 0,
-          aDominantSharedSupport: 0,
-          bDominantSharedSupport: 0,
           jointWeightTotal: 0,
           jointX: 0,
           jointY: 0,
@@ -801,11 +595,6 @@ export function buildInfluenceRelationships(
         relationship.sharedVertexCount += 1;
         relationship.minOverlap += Math.min(weightA, weightB);
         relationship.productOverlap += jointWeight;
-        if (weightA > weightB) {
-          relationship.aDominantSharedSupport += weightA;
-        } else if (weightB > weightA) {
-          relationship.bDominantSharedSupport += weightB;
-        }
         if (baselinePositions && baselinePositions.length >= vertex * 3 + 3
             && Number.isFinite(jointWeight) && jointWeight > 0) {
           const offset = vertex * 3;
@@ -825,8 +614,6 @@ export function buildInfluenceRelationships(
   }
 
   const radius = Number(boundingSphereRadius);
-  const graphRadius = Number.isFinite(radius) && radius > 0
-    ? radius : inferredSourceRadius(nodes);
   return [...relationships.values()].map(relationship => {
     const nodeA = nodeById.get(relationship.boneA);
     const nodeB = nodeById.get(relationship.boneB);
@@ -842,7 +629,7 @@ export function buildInfluenceRelationships(
         relationship.jointY / relationship.jointWeightTotal,
         relationship.jointZ / relationship.jointWeightTotal]
       : null;
-    const finalized = {
+    return {
       ...relationship,
       jointCenter,
       containment: containmentDenominator > 0
@@ -850,13 +637,8 @@ export function buildInfluenceRelationships(
       jaccard: jaccardDenominator > 0
         ? relationship.minOverlap / jaccardDenominator : 0,
       centerDistance: distance,
-      normalizedDistance: distance !== null && graphRadius > 0
-        ? distance / graphRadius : null,
-    };
-    return {
-      ...finalized,
-      ...relationshipSpatialEvidence(finalized, nodeA, nodeB, graphRadius),
-      ...relationshipDominanceEvidence(finalized),
+      normalizedDistance: distance !== null && radius > 0
+        ? distance / radius : null,
     };
   });
 }
@@ -880,64 +662,29 @@ function treeEdgeCompare(a, b) {
 }
 
 export function candidateRelationshipEdges(graph, options = {}) {
-  return candidateRelationshipDiagnostics(graph, options)
-    .filter(result => result.accepted)
-    .map(result => result.relationship)
-    .sort(relationshipSort);
-}
-
-/** Return candidate decisions, including reasons for rejected relationships. */
-export function candidateRelationshipDiagnostics(graph, options = {}) {
   const minSharedVertexCount = Number(options.minSharedVertexCount ?? 1);
   const containmentThreshold = Number(
     options.containmentThreshold ?? CANDIDATE_CONTAINMENT_THRESHOLD);
   const jaccardThreshold = Number(
     options.jaccardThreshold ?? CANDIDATE_JACCARD_THRESHOLD);
   const surfaceEvidence = graph?.evidenceMode === 'surface';
-  const nodeById = new Map((graph?.nodes || []).map(node => [
-    Number(node.boneId), node]));
-  const suppliedRadius = Number(graph?.boundingSphereRadius);
-  const sourceRadius = Number.isFinite(suppliedRadius) && suppliedRadius > 0
-    ? suppliedRadius : inferredSourceRadius(graph?.nodes);
-  const hasExplicitSpatialEvidence = (graph?.relationships || []).some(
-    relationship => ['jointReachA', 'jointReachB', 'maxJointReach',
-      'supportSeparation', 'structuralLocality'].some(field =>
-      Object.hasOwn(relationship, field)));
-  const structuralEvidenceAvailable = Number.isFinite(suppliedRadius)
-    && suppliedRadius > 0 || hasExplicitSpatialEvidence;
-  return (graph?.relationships || []).map(relationship => {
-    const overlapEligible = (surfaceEvidence
+  return (graph?.relationships || [])
+    .filter(relationship => (surfaceEvidence
       ? Number(relationship.productOverlap) > 0
       : relationship.sharedVertexCount >= minSharedVertexCount)
       && (relationship.containment >= containmentThreshold
-        || relationship.jaccard >= jaccardThreshold);
-    const normalizedDistance = Number(relationship.normalizedDistance);
-    const distancePenalty = Number.isFinite(normalizedDistance)
-      ? 1 / (1 + Math.max(0, normalizedDistance)) : 1;
-    const baseRelationship = {
-      ...relationship,
-      treeEdgeScore: relationship.treeEdgeScore
-        ?? (relationship.containment * distancePenalty),
-    };
-    const enriched = relationshipEvidence(
-      baseRelationship, nodeById, sourceRadius);
-    const structural = evaluateStructuralRelationship(enriched, {
-      ...options,
-      structuralEvidenceAvailable,
-    });
-    const reason = !overlapEligible
-      ? 'below_overlap_threshold' : structural.reason;
-    return {
-      relationship: {
-        ...enriched,
-        treeEdgeScore: structural.treeEdgeScore,
-      },
-      ...structural,
-      accepted: overlapEligible && structural.accepted,
-      reason: reason || null,
-      overlapEligible,
-    };
-  });
+        || relationship.jaccard >= jaccardThreshold))
+    .map(relationship => {
+      const normalizedDistance = Number(relationship.normalizedDistance);
+      const distancePenalty = Number.isFinite(normalizedDistance)
+        ? 1 / (1 + Math.max(0, normalizedDistance)) : 1;
+      return {
+        ...relationship,
+        treeEdgeScore: relationship.treeEdgeScore
+          ?? (relationship.containment * distancePenalty),
+      };
+    })
+    .sort(relationshipSort);
 }
 
 export function buildMaximumSpanningTree(nodes, edges) {
@@ -1301,9 +1048,7 @@ export function aggregateInfluenceGraphs(graphs) {
     .map(graph => graph?.fallbackReason).filter(Boolean))];
   const nodeTotals = new Map();
   const relationshipTotals = new Map();
-  inputGraphs.forEach((graph, memberIndex) => {
-    const memberNodeById = new Map((graph?.nodes || []).map(node => [
-      Number(node.boneId), node]));
+  for (const graph of inputGraphs) {
     for (const node of graph?.nodes || []) {
       const boneId = Number(node.boneId);
       const totalWeight = Number(node.totalWeight) || 0;
@@ -1340,10 +1085,7 @@ export function aggregateInfluenceGraphs(graphs) {
         boneA: Math.min(boneA, boneB), boneB: Math.max(boneA, boneB),
         sharedVertexCount: 0, sharedMeasure: 0,
         minOverlap: 0, productOverlap: 0,
-        aDominantSharedSupport: 0, bDominantSharedSupport: 0,
-        dominanceEvidenceAvailable: false,
         jointWeightTotal: 0, jointX: 0, jointY: 0, jointZ: 0,
-        memberEvidence: [],
       };
       entry.sharedVertexCount += Number(relationship.sharedVertexCount) || 0;
       if (evidenceMode === 'surface') {
@@ -1351,10 +1093,6 @@ export function aggregateInfluenceGraphs(graphs) {
       }
       entry.minOverlap += Number(relationship.minOverlap) || 0;
       entry.productOverlap += Number(relationship.productOverlap) || 0;
-      entry.aDominantSharedSupport += Number(
-        relationship.aDominantSharedSupport) || 0;
-      entry.bDominantSharedSupport += Number(
-        relationship.bDominantSharedSupport) || 0;
       const jointWeightTotal = Number(relationship.jointWeightTotal) || 0;
       const jointCenter = relationship.jointCenter;
       if (jointWeightTotal > 0 && jointCenter?.length >= 3) {
@@ -1363,24 +1101,9 @@ export function aggregateInfluenceGraphs(graphs) {
         entry.jointY += Number(jointCenter[1]) * jointWeightTotal;
         entry.jointZ += Number(jointCenter[2]) * jointWeightTotal;
       }
-      const memberNodeA = memberNodeById.get(boneA);
-      const memberNodeB = memberNodeById.get(boneB);
-      const memberSpatial = relationshipSpatialEvidence(
-        relationship, memberNodeA, memberNodeB,
-        graph?.boundingSphereRadius);
-      const memberDominance = relationshipDominanceEvidence(relationship);
-      entry.dominanceEvidenceAvailable = entry.dominanceEvidenceAvailable
-        || memberDominance.dominanceEvidenceAvailable;
-      entry.memberEvidence.push({
-        memberIndex,
-        containment: Number(relationship.containment) || 0,
-        jaccard: Number(relationship.jaccard) || 0,
-        ...memberSpatial,
-        ...memberDominance,
-      });
       relationshipTotals.set(key, entry);
     }
-  });
+  }
   const nodes = [...nodeTotals.values()].map(entry => {
     const center = entry.totalWeight > 0 ? [
       entry.weightedX / entry.totalWeight,
@@ -1424,16 +1147,7 @@ export function aggregateInfluenceGraphs(graphs) {
       ? distance / radius : null;
     const distancePenalty = Number.isFinite(normalizedDistance)
       ? 1 / (1 + Math.max(0, normalizedDistance)) : 1;
-    const memberEvidence = relationship.memberEvidence || [];
-    const memberReaches = memberEvidence.map(item =>
-      Number(item.maxJointReach)).filter(Number.isFinite);
-    const memberLocalities = memberEvidence.map(item =>
-      Number(item.structuralLocality)).filter(Number.isFinite);
-    const memberContainments = memberEvidence.map(item =>
-      Number(item.containment)).filter(Number.isFinite);
-    const memberJaccards = memberEvidence.map(item =>
-      Number(item.jaccard)).filter(Number.isFinite);
-    const finalized = {
+    return {
       ...relationship,
       sharedMeasure: evidenceMode === 'surface'
         ? relationship.sharedMeasure : null,
@@ -1449,27 +1163,6 @@ export function aggregateInfluenceGraphs(graphs) {
       normalizedDistance,
       treeEdgeScore: (denominator > 0
         ? relationship.minOverlap / denominator : 0) * distancePenalty,
-    };
-    const spatial = relationshipSpatialEvidence(
-      finalized, nodeA, nodeB, radius);
-    const dominance = relationshipDominanceEvidence(finalized);
-    return {
-      ...finalized,
-      ...spatial,
-      ...dominance,
-      memberEvidence,
-      memberEvidenceCount: memberEvidence.length,
-      qualifyingMemberCount: memberEvidence.filter(item =>
-        item.containment >= CANDIDATE_CONTAINMENT_THRESHOLD
-          || item.jaccard >= CANDIDATE_JACCARD_THRESHOLD).length,
-      maxMemberContainment: memberContainments.length
-        ? Math.max(...memberContainments) : null,
-      maxMemberJaccard: memberJaccards.length
-        ? Math.max(...memberJaccards) : null,
-      minMemberJointReach: memberReaches.length
-        ? Math.min(...memberReaches) : null,
-      maxMemberStructuralLocality: memberLocalities.length
-        ? Math.max(...memberLocalities) : null,
     };
   });
   return {

--- a/src/web/js/mesh/weight-rig.js
+++ b/src/web/js/mesh/weight-rig.js
@@ -6,6 +6,10 @@
 
 export const CANDIDATE_CONTAINMENT_THRESHOLD = 0.02;
 export const CANDIDATE_JACCARD_THRESHOLD = 0.01;
+export const MIN_BONE_RADIUS_RATIO = 0.005;
+export const MAX_JOINT_REACH = 2.5;
+export const MAX_SUPPORT_SEPARATION = 2.5;
+export const MIN_DOMINANCE_BALANCE = 0.5;
 
 function triangleArea(points) {
   const [a, b, c] = points;
@@ -277,6 +281,20 @@ function integrateMinimumLinearWeight(
     + integratePolygonLinearWeight(rightRegion, 'rightWeight');
 }
 
+function integrateDominantLinearWeight(
+    points, leftWeights, rightWeights, area, dominantSide) {
+  const vertices = points.map((position, index) => ({
+    position,
+    leftWeight: leftWeights[index],
+    rightWeight: rightWeights[index],
+    d: leftWeights[index] - rightWeights[index],
+  }));
+  const leftDominant = dominantSide === 'left';
+  const region = clipLinearWeightPolygon(vertices, !leftDominant);
+  return integratePolygonLinearWeight(region,
+    leftDominant ? 'leftWeight' : 'rightWeight');
+}
+
 function surfaceInfluenceWeights(
     indices, weights, influenceCount, vertexIndex, requested) {
   const values = positiveInfluencesForVertex(
@@ -360,6 +378,8 @@ export function buildSurfaceInfluenceGraph(
           sharedMeasure: 0,
           minOverlap: 0,
           productOverlap: 0,
+          aDominantSharedSupport: 0,
+          bDominantSharedSupport: 0,
           jointWeightTotal: 0,
           jointX: 0,
           jointY: 0,
@@ -371,6 +391,10 @@ export function buildSurfaceInfluenceGraph(
         relationship.sharedMeasure += triangle.area;
         relationship.minOverlap += integrateMinimumLinearWeight(
           triangle.points, weightsA, weightsB, triangle.area);
+        relationship.aDominantSharedSupport += integrateDominantLinearWeight(
+          triangle.points, weightsA, weightsB, triangle.area, 'left');
+        relationship.bDominantSharedSupport += integrateDominantLinearWeight(
+          triangle.points, weightsA, weightsB, triangle.area, 'right');
         relationship.productOverlap += productOverlap;
         relationship.jointWeightTotal += productOverlap;
         relationship.jointX += jointMoment[0];
@@ -410,6 +434,8 @@ export function buildSurfaceInfluenceGraph(
   const sourceRadius = nodes.length ? Math.max(...nodes.map(node =>
     (centerDistance(node.weightedCenter, sourceCenter) || 0)
       + (Number(node.weightedRadius) || 0))) : null;
+  const graphRadius = Number.isFinite(radius) && radius > 0
+    ? radius : sourceRadius;
   const relationships = [...relationshipEntries.values()].map(relationship => {
     const nodeA = nodeById.get(relationship.boneA);
     const nodeB = nodeById.get(relationship.boneB);
@@ -419,11 +445,11 @@ export function buildSurfaceInfluenceGraph(
     const jaccardDenominator = supportA + supportB - relationship.minOverlap;
     const distance = centerDistance(nodeA?.weightedCenter, nodeB?.weightedCenter);
     const normalizedDistance = distance !== null
-      && Number.isFinite(radius) && radius > 0
-      ? distance / radius : null;
+      && Number.isFinite(graphRadius) && graphRadius > 0
+      ? distance / graphRadius : null;
     const distancePenalty = Number.isFinite(normalizedDistance)
       ? 1 / (1 + Math.max(0, normalizedDistance)) : 1;
-    return {
+    const finalized = {
       ...relationship,
       jointCenter: relationship.jointWeightTotal > 0
         ? [relationship.jointX / relationship.jointWeightTotal,
@@ -437,6 +463,11 @@ export function buildSurfaceInfluenceGraph(
       normalizedDistance,
       treeEdgeScore: (denominator > 0
         ? relationship.minOverlap / denominator : 0) * distancePenalty,
+    };
+    return {
+      ...finalized,
+      ...relationshipSpatialEvidence(finalized, nodeA, nodeB, graphRadius),
+      ...relationshipDominanceEvidence(finalized),
     };
   });
   return {
@@ -546,6 +577,177 @@ function centerDistance(centerA, centerB) {
     Number(centerA[2]) - Number(centerB[2]));
 }
 
+function inferredSourceRadius(nodes) {
+  const weightedNodes = (nodes || []).filter(node =>
+    Number(node?.totalWeight) > 0 && node?.weightedCenter?.length >= 3);
+  const totalWeight = weightedNodes.reduce((sum, node) =>
+    sum + Number(node.totalWeight), 0);
+  if (!weightedNodes.length || totalWeight <= 0) return null;
+  const center = weightedNodes.reduce((sum, node) => {
+    const weight = Number(node.totalWeight) || 0;
+    return [
+      sum[0] + Number(node.weightedCenter[0]) * weight,
+      sum[1] + Number(node.weightedCenter[1]) * weight,
+      sum[2] + Number(node.weightedCenter[2]) * weight,
+    ];
+  }, [0, 0, 0]).map(value => value / totalWeight);
+  return Math.max(...weightedNodes.map(node =>
+    (centerDistance(node.weightedCenter, center) || 0)
+      + (Number(node.weightedRadius) || 0)));
+}
+
+function effectiveBoneRadius(node, sourceRadius) {
+  const weightedRadius = Number(node?.weightedRadius);
+  const radius = Number(sourceRadius);
+  const floor = Number.isFinite(radius) && radius > 0
+    ? radius * MIN_BONE_RADIUS_RATIO : 0;
+  return Math.max(
+    Number.isFinite(weightedRadius) && weightedRadius > 0
+      ? weightedRadius : 0,
+    floor, Number.EPSILON);
+}
+
+/** Calculate locality of an overlap region relative to both bone supports. */
+export function relationshipSpatialEvidence(
+    relationship, nodeA, nodeB, sourceRadius = null) {
+  const jointCenter = relationship?.jointCenter;
+  const radius = Number(sourceRadius);
+  const reachA = centerDistance(nodeA?.weightedCenter, jointCenter);
+  const reachB = centerDistance(nodeB?.weightedCenter, jointCenter);
+  const effectiveRadiusA = effectiveBoneRadius(nodeA, radius);
+  const effectiveRadiusB = effectiveBoneRadius(nodeB, radius);
+  const jointReachA = reachA === null ? null : reachA / effectiveRadiusA;
+  const jointReachB = reachB === null ? null : reachB / effectiveRadiusB;
+  const maxJointReach = jointReachA === null || jointReachB === null
+    ? null : Math.max(jointReachA, jointReachB);
+  const centerDistanceValue = centerDistance(
+    nodeA?.weightedCenter, nodeB?.weightedCenter);
+  const supportSeparation = centerDistanceValue === null
+    ? null : centerDistanceValue / (effectiveRadiusA + effectiveRadiusB);
+  const reachFactor = maxJointReach === null
+    ? 1 : 1 / (1 + Math.max(0, maxJointReach));
+  const separationFactor = supportSeparation === null
+    ? 1 : 1 / (1 + Math.max(0, supportSeparation));
+  return {
+    jointReachA,
+    jointReachB,
+    maxJointReach,
+    supportSeparation,
+    structuralLocality: Math.max(0, Math.min(1,
+      Math.sqrt(reachFactor * separationFactor))),
+  };
+}
+
+/** Calculate whether shared support contains a meaningful dominance transition. */
+export function relationshipDominanceEvidence(relationship) {
+  const available = relationship?.dominanceEvidenceAvailable !== undefined
+    ? relationship.dominanceEvidenceAvailable === true
+    : Object.hasOwn(relationship || {}, 'aDominantSharedSupport')
+      && Object.hasOwn(relationship || {}, 'bDominantSharedSupport');
+  if (!available) {
+    return {
+      dominanceBalance: null,
+      hasBidirectionalDominance: null,
+      dominanceEvidenceAvailable: false,
+    };
+  }
+  const aSupport = Number(relationship?.aDominantSharedSupport);
+  const bSupport = Number(relationship?.bDominantSharedSupport);
+  if (![aSupport, bSupport].every(Number.isFinite)) {
+    return {
+      dominanceBalance: null,
+      hasBidirectionalDominance: null,
+      dominanceEvidenceAvailable: false,
+    };
+  }
+  const total = Math.max(0, aSupport) + Math.max(0, bSupport);
+  const maximum = Math.max(Math.max(0, aSupport), Math.max(0, bSupport));
+  return {
+    dominanceBalance: maximum > 0
+      ? Math.min(Math.max(0, aSupport), Math.max(0, bSupport)) / maximum
+      : 0,
+    hasBidirectionalDominance: aSupport > 0 && bSupport > 0 && total > 0,
+    dominanceEvidenceAvailable: true,
+  };
+}
+
+function relationshipEvidence(relationship, nodeById, sourceRadius) {
+  const nodeA = nodeById.get(Number(relationship?.boneA));
+  const nodeB = nodeById.get(Number(relationship?.boneB));
+  return {
+    ...relationship,
+    ...relationshipSpatialEvidence(relationship, nodeA, nodeB, sourceRadius),
+    ...relationshipDominanceEvidence(relationship),
+  };
+}
+
+/** Evaluate spatial eligibility separately from overlap eligibility. */
+export function evaluateStructuralRelationship(relationship, options = {}) {
+  const structuralEvidenceAvailable = options.structuralEvidenceAvailable
+    !== false;
+  const maxJointReach = Number(options.maxJointReach
+    ?? MAX_JOINT_REACH);
+  const maxSupportSeparation = Number(options.maxSupportSeparation
+    ?? MAX_SUPPORT_SEPARATION);
+  const minDominanceBalance = Number(options.minDominanceBalance
+    ?? MIN_DOMINANCE_BALANCE);
+  const reach = Number(relationship?.maxJointReach);
+  const separation = Number(relationship?.supportSeparation);
+  const remoteTail = structuralEvidenceAvailable
+    && Number.isFinite(reach) && reach > maxJointReach;
+  const separatedSupports = structuralEvidenceAvailable
+    && Number.isFinite(separation)
+    && separation > maxSupportSeparation;
+  const dominanceBalance = Number(relationship?.dominanceBalance);
+  const weakDominance = structuralEvidenceAvailable
+    && Number.isFinite(dominanceBalance)
+    && dominanceBalance < minDominanceBalance;
+  const memberEvidence = Array.isArray(relationship?.memberEvidence)
+    ? relationship.memberEvidence : [];
+  const bidirectionalMemberCount = memberEvidence.filter(item =>
+    item.hasBidirectionalDominance === true).length;
+  const memberDominanceRatio = memberEvidence.length
+    ? bidirectionalMemberCount / memberEvidence.length : null;
+  const localMemberEvidence = structuralEvidenceAvailable
+    && memberEvidence.some(item =>
+    item.hasBidirectionalDominance === true
+      && Number(item.structuralLocality) >= .5);
+  // A low aggregate balance can be caused by unrelated members contaminating
+  // a real transition. Reject only when that contamination is consistent
+  // across the aggregate evidence and no local member supports the edge.
+  const weakMemberTransition = structuralEvidenceAvailable
+    && memberEvidence.length >= 3
+    && relationship?.dominanceEvidenceAvailable === true
+    && memberDominanceRatio < .5
+    && weakDominance;
+  const remoteTailBridge = (remoteTail && separatedSupports
+    && !localMemberEvidence) || weakMemberTransition;
+  const baseScore = Number(relationship?.treeEdgeScore
+    ?? relationship?.containment ?? relationship?.jaccard);
+  const locality = Number(relationship?.structuralLocality);
+  const memberLocality = Number(relationship?.maxMemberStructuralLocality);
+  const localityValues = [locality, memberLocality]
+    .filter(Number.isFinite);
+  const effectiveLocality = localMemberEvidence && localityValues.length
+    ? Math.max(...localityValues) : locality;
+  const structuralLocality = Number.isFinite(effectiveLocality)
+    ? Math.max(0, Math.min(1, effectiveLocality)) : 1;
+  return {
+    accepted: !remoteTailBridge,
+    reason: remoteTailBridge
+      ? (weakMemberTransition ? 'weak_transition' : 'remote_tail_bridge')
+      : null,
+    remoteTail,
+    separatedSupports,
+    weakDominance,
+    memberDominanceRatio,
+    localMemberEvidence,
+    weakMemberTransition,
+    treeEdgeScore: Number.isFinite(baseScore)
+      ? baseScore * structuralLocality : baseScore,
+  };
+}
+
 /** Build overlap evidence and an overlap-derived pivot for every bone pair. */
 export function buildInfluenceRelationships(
     baselinePositions, indices, weights, influenceCount, nodes,
@@ -577,8 +779,10 @@ export function buildInfluenceRelationships(
       for (let right = left + 1; right < ids.length; right += 1) {
         const [boneA, boneB] = pairIds(ids[left], ids[right]);
         const key = pairKey(boneA, boneB);
-        const weightA = mergedWeights[left];
-        const weightB = mergedWeights[right];
+        const weightLeft = mergedWeights[left];
+        const weightRight = mergedWeights[right];
+        const weightA = ids[left] === boneA ? weightLeft : weightRight;
+        const weightB = ids[left] === boneA ? weightRight : weightLeft;
         const jointWeight = weightA * weightB;
         const relationship = relationships.get(key) || {
           boneA,
@@ -587,6 +791,8 @@ export function buildInfluenceRelationships(
           sharedMeasure: null,
           minOverlap: 0,
           productOverlap: 0,
+          aDominantSharedSupport: 0,
+          bDominantSharedSupport: 0,
           jointWeightTotal: 0,
           jointX: 0,
           jointY: 0,
@@ -595,6 +801,11 @@ export function buildInfluenceRelationships(
         relationship.sharedVertexCount += 1;
         relationship.minOverlap += Math.min(weightA, weightB);
         relationship.productOverlap += jointWeight;
+        if (weightA > weightB) {
+          relationship.aDominantSharedSupport += weightA;
+        } else if (weightB > weightA) {
+          relationship.bDominantSharedSupport += weightB;
+        }
         if (baselinePositions && baselinePositions.length >= vertex * 3 + 3
             && Number.isFinite(jointWeight) && jointWeight > 0) {
           const offset = vertex * 3;
@@ -614,6 +825,8 @@ export function buildInfluenceRelationships(
   }
 
   const radius = Number(boundingSphereRadius);
+  const graphRadius = Number.isFinite(radius) && radius > 0
+    ? radius : inferredSourceRadius(nodes);
   return [...relationships.values()].map(relationship => {
     const nodeA = nodeById.get(relationship.boneA);
     const nodeB = nodeById.get(relationship.boneB);
@@ -629,7 +842,7 @@ export function buildInfluenceRelationships(
         relationship.jointY / relationship.jointWeightTotal,
         relationship.jointZ / relationship.jointWeightTotal]
       : null;
-    return {
+    const finalized = {
       ...relationship,
       jointCenter,
       containment: containmentDenominator > 0
@@ -637,8 +850,13 @@ export function buildInfluenceRelationships(
       jaccard: jaccardDenominator > 0
         ? relationship.minOverlap / jaccardDenominator : 0,
       centerDistance: distance,
-      normalizedDistance: distance !== null && radius > 0
-        ? distance / radius : null,
+      normalizedDistance: distance !== null && graphRadius > 0
+        ? distance / graphRadius : null,
+    };
+    return {
+      ...finalized,
+      ...relationshipSpatialEvidence(finalized, nodeA, nodeB, graphRadius),
+      ...relationshipDominanceEvidence(finalized),
     };
   });
 }
@@ -662,29 +880,64 @@ function treeEdgeCompare(a, b) {
 }
 
 export function candidateRelationshipEdges(graph, options = {}) {
+  return candidateRelationshipDiagnostics(graph, options)
+    .filter(result => result.accepted)
+    .map(result => result.relationship)
+    .sort(relationshipSort);
+}
+
+/** Return candidate decisions, including reasons for rejected relationships. */
+export function candidateRelationshipDiagnostics(graph, options = {}) {
   const minSharedVertexCount = Number(options.minSharedVertexCount ?? 1);
   const containmentThreshold = Number(
     options.containmentThreshold ?? CANDIDATE_CONTAINMENT_THRESHOLD);
   const jaccardThreshold = Number(
     options.jaccardThreshold ?? CANDIDATE_JACCARD_THRESHOLD);
   const surfaceEvidence = graph?.evidenceMode === 'surface';
-  return (graph?.relationships || [])
-    .filter(relationship => (surfaceEvidence
+  const nodeById = new Map((graph?.nodes || []).map(node => [
+    Number(node.boneId), node]));
+  const suppliedRadius = Number(graph?.boundingSphereRadius);
+  const sourceRadius = Number.isFinite(suppliedRadius) && suppliedRadius > 0
+    ? suppliedRadius : inferredSourceRadius(graph?.nodes);
+  const hasExplicitSpatialEvidence = (graph?.relationships || []).some(
+    relationship => ['jointReachA', 'jointReachB', 'maxJointReach',
+      'supportSeparation', 'structuralLocality'].some(field =>
+      Object.hasOwn(relationship, field)));
+  const structuralEvidenceAvailable = Number.isFinite(suppliedRadius)
+    && suppliedRadius > 0 || hasExplicitSpatialEvidence;
+  return (graph?.relationships || []).map(relationship => {
+    const overlapEligible = (surfaceEvidence
       ? Number(relationship.productOverlap) > 0
       : relationship.sharedVertexCount >= minSharedVertexCount)
       && (relationship.containment >= containmentThreshold
-        || relationship.jaccard >= jaccardThreshold))
-    .map(relationship => {
-      const normalizedDistance = Number(relationship.normalizedDistance);
-      const distancePenalty = Number.isFinite(normalizedDistance)
-        ? 1 / (1 + Math.max(0, normalizedDistance)) : 1;
-      return {
-        ...relationship,
-        treeEdgeScore: relationship.treeEdgeScore
-          ?? (relationship.containment * distancePenalty),
-      };
-    })
-    .sort(relationshipSort);
+        || relationship.jaccard >= jaccardThreshold);
+    const normalizedDistance = Number(relationship.normalizedDistance);
+    const distancePenalty = Number.isFinite(normalizedDistance)
+      ? 1 / (1 + Math.max(0, normalizedDistance)) : 1;
+    const baseRelationship = {
+      ...relationship,
+      treeEdgeScore: relationship.treeEdgeScore
+        ?? (relationship.containment * distancePenalty),
+    };
+    const enriched = relationshipEvidence(
+      baseRelationship, nodeById, sourceRadius);
+    const structural = evaluateStructuralRelationship(enriched, {
+      ...options,
+      structuralEvidenceAvailable,
+    });
+    const reason = !overlapEligible
+      ? 'below_overlap_threshold' : structural.reason;
+    return {
+      relationship: {
+        ...enriched,
+        treeEdgeScore: structural.treeEdgeScore,
+      },
+      ...structural,
+      accepted: overlapEligible && structural.accepted,
+      reason: reason || null,
+      overlapEligible,
+    };
+  });
 }
 
 export function buildMaximumSpanningTree(nodes, edges) {
@@ -1048,7 +1301,9 @@ export function aggregateInfluenceGraphs(graphs) {
     .map(graph => graph?.fallbackReason).filter(Boolean))];
   const nodeTotals = new Map();
   const relationshipTotals = new Map();
-  for (const graph of inputGraphs) {
+  inputGraphs.forEach((graph, memberIndex) => {
+    const memberNodeById = new Map((graph?.nodes || []).map(node => [
+      Number(node.boneId), node]));
     for (const node of graph?.nodes || []) {
       const boneId = Number(node.boneId);
       const totalWeight = Number(node.totalWeight) || 0;
@@ -1085,7 +1340,10 @@ export function aggregateInfluenceGraphs(graphs) {
         boneA: Math.min(boneA, boneB), boneB: Math.max(boneA, boneB),
         sharedVertexCount: 0, sharedMeasure: 0,
         minOverlap: 0, productOverlap: 0,
+        aDominantSharedSupport: 0, bDominantSharedSupport: 0,
+        dominanceEvidenceAvailable: false,
         jointWeightTotal: 0, jointX: 0, jointY: 0, jointZ: 0,
+        memberEvidence: [],
       };
       entry.sharedVertexCount += Number(relationship.sharedVertexCount) || 0;
       if (evidenceMode === 'surface') {
@@ -1093,6 +1351,10 @@ export function aggregateInfluenceGraphs(graphs) {
       }
       entry.minOverlap += Number(relationship.minOverlap) || 0;
       entry.productOverlap += Number(relationship.productOverlap) || 0;
+      entry.aDominantSharedSupport += Number(
+        relationship.aDominantSharedSupport) || 0;
+      entry.bDominantSharedSupport += Number(
+        relationship.bDominantSharedSupport) || 0;
       const jointWeightTotal = Number(relationship.jointWeightTotal) || 0;
       const jointCenter = relationship.jointCenter;
       if (jointWeightTotal > 0 && jointCenter?.length >= 3) {
@@ -1101,9 +1363,24 @@ export function aggregateInfluenceGraphs(graphs) {
         entry.jointY += Number(jointCenter[1]) * jointWeightTotal;
         entry.jointZ += Number(jointCenter[2]) * jointWeightTotal;
       }
+      const memberNodeA = memberNodeById.get(boneA);
+      const memberNodeB = memberNodeById.get(boneB);
+      const memberSpatial = relationshipSpatialEvidence(
+        relationship, memberNodeA, memberNodeB,
+        graph?.boundingSphereRadius);
+      const memberDominance = relationshipDominanceEvidence(relationship);
+      entry.dominanceEvidenceAvailable = entry.dominanceEvidenceAvailable
+        || memberDominance.dominanceEvidenceAvailable;
+      entry.memberEvidence.push({
+        memberIndex,
+        containment: Number(relationship.containment) || 0,
+        jaccard: Number(relationship.jaccard) || 0,
+        ...memberSpatial,
+        ...memberDominance,
+      });
       relationshipTotals.set(key, entry);
     }
-  }
+  });
   const nodes = [...nodeTotals.values()].map(entry => {
     const center = entry.totalWeight > 0 ? [
       entry.weightedX / entry.totalWeight,
@@ -1147,7 +1424,16 @@ export function aggregateInfluenceGraphs(graphs) {
       ? distance / radius : null;
     const distancePenalty = Number.isFinite(normalizedDistance)
       ? 1 / (1 + Math.max(0, normalizedDistance)) : 1;
-    return {
+    const memberEvidence = relationship.memberEvidence || [];
+    const memberReaches = memberEvidence.map(item =>
+      Number(item.maxJointReach)).filter(Number.isFinite);
+    const memberLocalities = memberEvidence.map(item =>
+      Number(item.structuralLocality)).filter(Number.isFinite);
+    const memberContainments = memberEvidence.map(item =>
+      Number(item.containment)).filter(Number.isFinite);
+    const memberJaccards = memberEvidence.map(item =>
+      Number(item.jaccard)).filter(Number.isFinite);
+    const finalized = {
       ...relationship,
       sharedMeasure: evidenceMode === 'surface'
         ? relationship.sharedMeasure : null,
@@ -1163,6 +1449,27 @@ export function aggregateInfluenceGraphs(graphs) {
       normalizedDistance,
       treeEdgeScore: (denominator > 0
         ? relationship.minOverlap / denominator : 0) * distancePenalty,
+    };
+    const spatial = relationshipSpatialEvidence(
+      finalized, nodeA, nodeB, radius);
+    const dominance = relationshipDominanceEvidence(finalized);
+    return {
+      ...finalized,
+      ...spatial,
+      ...dominance,
+      memberEvidence,
+      memberEvidenceCount: memberEvidence.length,
+      qualifyingMemberCount: memberEvidence.filter(item =>
+        item.containment >= CANDIDATE_CONTAINMENT_THRESHOLD
+          || item.jaccard >= CANDIDATE_JACCARD_THRESHOLD).length,
+      maxMemberContainment: memberContainments.length
+        ? Math.max(...memberContainments) : null,
+      maxMemberJaccard: memberJaccards.length
+        ? Math.max(...memberJaccards) : null,
+      minMemberJointReach: memberReaches.length
+        ? Math.min(...memberReaches) : null,
+      maxMemberStructuralLocality: memberLocalities.length
+        ? Math.max(...memberLocalities) : null,
     };
   });
   return {

--- a/src/web/js/scene/rig-overlay-controller.js
+++ b/src/web/js/scene/rig-overlay-controller.js
@@ -21,6 +21,7 @@ const HUMANOID_HALO_SIZE_PX = 26;
 const HUMANOID_CANDIDATE_SIZE_PX = 30;
 const MODEL_JOINT_MARKER_SIZE_PX = 5;
 const MODEL_JOINT_CANDIDATE_SIZE_PX = 9;
+const SELECTED_JOINT_INDICATOR_SIZE_PX = 16;
 
 function vector(value) {
   if (value?.isVector3) return value.clone();
@@ -328,6 +329,18 @@ export function createRigOverlayController({
   modelJointMarkerMesh.frustumCulled = false;
   modelJointMarkerMesh.raycast = () => {};
   modelJointMarkerMesh.instanceMatrix.setUsage?.(THREE.DynamicDrawUsage);
+  const selectedJointIndicatorMaterial = new THREE.SpriteMaterial({
+    color: 0xfacc15, map: modelJointMarkerTexture,
+    depthTest: false, depthWrite: false, transparent: true,
+    opacity: .95, alphaTest: .1,
+  });
+  const selectedJointIndicator = new THREE.Sprite(
+    selectedJointIndicatorMaterial);
+  selectedJointIndicator.name = 'viewer-inferred-rig-selected-joint-indicator';
+  selectedJointIndicator.renderOrder = 13;
+  selectedJointIndicator.frustumCulled = false;
+  selectedJointIndicator.raycast = () => {};
+  selectedJointIndicator.visible = false;
   const hoverMaterial = new THREE.PointsMaterial({
     color: 0xfacc15, size: 0.06, sizeAttenuation: false,
     depthTest: false, depthWrite: false,
@@ -358,6 +371,7 @@ export function createRigOverlayController({
   staticGroup.add(lineSegments, centerPoints, jointPoints,
     modelJointMarkerMesh, hoverPoint);
   group.add(staticGroup);
+  group.add(selectedJointIndicator);
 
   // Geometry fitting is intentionally a separate semantic group. It draws
   // virtual controls and medial paths; the inferred ModelJoint Rig remains
@@ -745,6 +759,55 @@ export function createRigOverlayController({
     if (modelJointMarkerMesh.instanceColor) {
       modelJointMarkerMesh.instanceColor.needsUpdate = true;
     }
+  }
+
+  function updateSelectedJointIndicator(source = currentSource) {
+    if (!selectedJointIndicator) return;
+    const jointId = selectedJointId;
+    const hiddenByEditing = currentSnapshot?.humanoidRigEdit?.editing === true;
+    const hiddenByPicking = !!currentSnapshot?.jointPickIntent;
+    if (!source || !Number.isInteger(jointId)
+        || hiddenByEditing || hiddenByPicking) {
+      selectedJointIndicator.visible = false;
+      return;
+    }
+    const frame = getRigJointPoseFrame?.(jointId);
+    const point = frame?.pivot || pivotFor(source, jointId);
+    if (!point) {
+      selectedJointIndicator.visible = false;
+      return;
+    }
+
+    const localPoint = vector(point);
+    selectedJointIndicator.position.copy(localPoint);
+    group.updateMatrixWorld?.(true);
+    camera?.updateMatrixWorld?.();
+    const rect = canvasRect(canvas);
+    const canvasHeight = Number(rect?.height) || 1;
+    const worldScale = new THREE.Vector3();
+    group.getWorldScale?.(worldScale);
+    const localScale = Math.max(.0001,
+      (Math.abs(worldScale.x) + Math.abs(worldScale.y)
+        + Math.abs(worldScale.z)) / 3 || 1);
+    const worldPoint = localPoint.clone().applyMatrix4(group.matrixWorld);
+    const viewPoint = worldPoint.applyMatrix4(camera?.matrixWorldInverse
+      || new THREE.Matrix4());
+    let worldPerPixel = .05;
+    if (camera?.isPerspectiveCamera) {
+      const depth = -viewPoint.z;
+      if (depth > 0) {
+        const fov = THREE.MathUtils.degToRad(camera.fov || 50);
+        worldPerPixel = (2 * depth * Math.tan(fov / 2))
+          / (canvasHeight * (Number(camera.zoom) || 1));
+      }
+    } else if (camera?.isOrthographicCamera) {
+      worldPerPixel = (camera.top - camera.bottom)
+        / (canvasHeight * (Number(camera.zoom) || 1));
+    }
+    const size = Math.max(.001,
+      worldPerPixel * SELECTED_JOINT_INDICATOR_SIZE_PX / localScale);
+    selectedJointIndicator.scale.set(size, size, 1);
+    selectedJointIndicator.visible = true;
   }
 
   function createHumanoidSprite({name, color, opacity, renderOrder}) {
@@ -1179,7 +1242,10 @@ export function createRigOverlayController({
   }
 
   function updatePosedOverlay(source = currentSource) {
-    if (!source) return;
+    if (!source) {
+      updateSelectedJointIndicator(source);
+      return;
+    }
     const centers = new Map();
     const pivots = new Map();
     const centerAttribute = centerPoints.geometry.getAttribute('position');
@@ -1218,6 +1284,7 @@ export function createRigOverlayController({
     });
     if (jointAttribute) jointAttribute.needsUpdate = true;
     updateModelJointMarkers(source);
+    updateSelectedJointIndicator(source);
     updateHumanoidPosedOverlay(source);
     posedOverlayUpdateCount += 1;
   }
@@ -1631,6 +1698,7 @@ export function createRigOverlayController({
       proxy.visible = false;
       ikTargetProxy.visible = false;
     }
+    updateSelectedJointIndicator(currentSource);
   }
 
   async function ensureTransformControls() {
@@ -1843,11 +1911,13 @@ export function createRigOverlayController({
   const onArcballChanged = () => {
     updateHumanoidSpriteSizes();
     updateModelJointMarkers(currentSource);
+    updateSelectedJointIndicator(currentSource);
     requestRender?.();
   };
   const onModelTransformChanged = () => {
     updateModelFrame();
     updateModelJointMarkers(currentSource);
+    updateSelectedJointIndicator(currentSource);
     if (currentSnapshot?.jointPickIntent && lastPickClientPoint) {
       updatePickHoverAt(lastPickClientPoint.x, lastPickClientPoint.y);
     }
@@ -1884,6 +1954,9 @@ export function createRigOverlayController({
         modelJointMarkerInstanced: modelJointMarkerMesh.isInstancedMesh === true,
         modelJointMarkerSizePx: MODEL_JOINT_MARKER_SIZE_PX,
         modelJointCandidateSizePx: MODEL_JOINT_CANDIDATE_SIZE_PX,
+        selectedJointIndicatorVisible: selectedJointIndicator.visible,
+        selectedJointIndicatorPosition: selectedJointIndicator.position.toArray(),
+        selectedJointIndicatorSizePx: SELECTED_JOINT_INDICATOR_SIZE_PX,
         edgeCount: lineSegments.geometry.getAttribute('position')?.count / 2 || 0,
         humanoidOverlayVisible: humanoidGroup.visible,
         humanoidSegmentCount: humanoidLinePairs.length,
@@ -1960,6 +2033,7 @@ export function createRigOverlayController({
       humanoidPointMaterial.dispose();
       humanoidCandidateMaterial.dispose();
       humanoidCandidateSprite.material.dispose();
+      selectedJointIndicatorMaterial.dispose();
       clearHumanoidSprites(humanoidPointSprites);
       clearHumanoidSprites(humanoidHaloSprites);
       humanoidMarkerTexture?.dispose?.();

--- a/src/web/js/scene/rig-overlay-controller.js
+++ b/src/web/js/scene/rig-overlay-controller.js
@@ -65,7 +65,8 @@ function overlayPresentationKey(source) {
 }
 
 function pivotFor(source, boneId) {
-  const joint = source?.joints?.find(item => item.jointId === Number(boneId));
+  const id = Number(boneId);
+  const joint = source?.joints?.find(item => Number(item?.jointId) === id);
   return joint?.restPivot || joint?.restCenter || null;
 }
 
@@ -277,6 +278,7 @@ const CONTROL_KEYS_FOR_OVERLAY = Object.freeze(HUMANOID_CONTROL_KEYS.map(key => 
 
 export function createRigOverlayController({
   scene, camera, canvas, getMeshes, getRigState,
+  getHumanoidRigEditSnapshot,
   getRigJointPoseFrame, arcballControls, setRigJointRotation,
   solveRigIkTarget, finishRigJointPose, onTransformControlsUnavailable,
   onRigJointPicked, onRigSurfacePickRequested, onRigJointPickCancelled,
@@ -492,6 +494,7 @@ export function createRigOverlayController({
   let hoveredControlKey = null;
   let humanoidCarryPlane = null;
   let humanoidCarryOffset = new THREE.Vector3();
+  let humanoidJointCandidates = null;
   let humanoidCarryControlKey = null;
   let humanoidCarryPointerId = null;
   let humanoidNavigationGesture = false;
@@ -1031,23 +1034,41 @@ export function createRigOverlayController({
       .map(([, jointId]) => Number(jointId)));
   }
 
+  function invalidateHumanoidJointCandidates() {
+    humanoidJointCandidates = null;
+  }
+
+  function buildHumanoidJointCandidates() {
+    if (!currentSource) {
+      humanoidJointCandidates = [];
+      return humanoidJointCandidates;
+    }
+    group.updateMatrixWorld?.(true);
+    humanoidJointCandidates = (currentSource.joints || []).flatMap(joint => {
+      const jointId = Number(joint?.jointId);
+      if (!Number.isInteger(jointId)) return [];
+      const frame = getRigJointPoseFrame?.(jointId);
+      const pivot = frame?.pivot || joint.restPivot || joint.restCenter;
+      const screen = projectRigPointToClient({
+        point: pivot, camera, canvas, worldMatrix: group.matrixWorld,
+      });
+      return screen && pivot ? [{jointId, pivot, screen}] : [];
+    });
+    return humanoidJointCandidates;
+  }
+
   function nearestMagneticJoint(clientX, clientY, controlKey) {
     const excluded = mappedJointIdsExcept(controlKey);
     const mappedJointId = Number(currentSnapshot?.humanoidRigEdit
       ?.mappedJointIdByControl?.[controlKey]);
     let mappedDistance = Infinity;
-    const candidates = (currentSource?.joints || []).flatMap(joint => {
-      const jointId = Number(joint.jointId);
-      if (!Number.isInteger(jointId) || excluded.has(jointId)) return [];
-      const pivot = getRigJointPoseFrame?.(jointId)?.pivot
-        || joint.restPivot || joint.restCenter;
-      const screen = projectRigPointToClient({
-        point: pivot, camera, canvas, worldMatrix: group.matrixWorld,
-      });
-      if (!screen) return [];
-      const distance = Math.hypot(screen.x - clientX, screen.y - clientY);
-      if (jointId === mappedJointId) mappedDistance = distance;
-      return [{jointId, pivot, screen, distance}];
+    const candidates = (humanoidJointCandidates
+      || buildHumanoidJointCandidates()).filter(candidate =>
+      !excluded.has(candidate.jointId)).map(candidate => {
+      const distance = Math.hypot(
+        candidate.screen.x - clientX, candidate.screen.y - clientY);
+      if (candidate.jointId === mappedJointId) mappedDistance = distance;
+      return {...candidate, distance};
     }).sort((left, right) => left.distance - right.distance
       || left.jointId - right.jointId);
     return candidates[0] ? {...candidates[0], mappedDistance} : null;
@@ -1074,15 +1095,20 @@ export function createRigOverlayController({
     return world.applyMatrix4(group.matrixWorld.clone().invert()).toArray();
   }
 
-  function syncAfterEditCallback() {
-    const snapshot = getRigState?.();
+  function syncAfterEditCallback({refreshState = false} = {}) {
+    const snapshot = refreshState ? getRigState?.() : null;
     if (snapshot) {
       currentSnapshot = snapshot;
       currentSource = sourceFor(snapshot);
-      updateHumanoidPosedOverlay(currentSource);
-      updateHumanoidCandidateMarker();
-      updateHumanoidVisibility();
+    } else {
+      const edit = getHumanoidRigEditSnapshot?.();
+      if (edit && currentSnapshot) {
+        currentSnapshot = {...currentSnapshot, humanoidRigEdit: edit};
+      }
     }
+    updateHumanoidPosedOverlay(currentSource);
+    updateHumanoidCandidateMarker();
+    updateHumanoidVisibility();
     requestRender?.();
   }
 
@@ -1119,6 +1145,8 @@ export function createRigOverlayController({
     humanoidCarryPointerId = pointerId;
     humanoidNavigationGesture = false;
     hoveredControlKey = nearest.key;
+    invalidateHumanoidJointCandidates();
+    buildHumanoidJointCandidates();
     setArcballHumanoidCarryState(true);
     syncAfterEditCallback();
     return true;
@@ -1135,6 +1163,8 @@ export function createRigOverlayController({
       candidateJointId: candidate?.jointId ?? null,
       candidateDistance: candidate?.distance ?? Infinity,
       mappedDistance: candidate?.mappedDistance ?? Infinity,
+      notifyState: false,
+      request: false,
     });
     humanoidCandidateJointId = candidate && candidate.distance
       <= JOINT_ATTRACTION_RADIUS_PX ? candidate.jointId : null;
@@ -1153,6 +1183,7 @@ export function createRigOverlayController({
     humanoidNavigationGesture = false;
     humanoidCandidateJointId = null;
     humanoidCandidateScreen = null;
+    invalidateHumanoidJointCandidates();
     setArcballHumanoidCarryState(false);
     setPickCursor('');
     syncAfterEditCallback();
@@ -1169,6 +1200,7 @@ export function createRigOverlayController({
     humanoidNavigationGesture = false;
     humanoidCandidateJointId = null;
     humanoidCandidateScreen = null;
+    invalidateHumanoidJointCandidates();
     setArcballHumanoidCarryState(false);
     setPickCursor('');
     syncAfterEditCallback();
@@ -1837,6 +1869,7 @@ export function createRigOverlayController({
     const wasHumanoidEditing = currentSnapshot?.humanoidRigEdit?.editing === true;
     currentSnapshot = snapshot || {};
     currentSource = sourceFor(currentSnapshot);
+    invalidateHumanoidJointCandidates();
     rigJointPickingActive = !!currentSnapshot.jointPickIntent;
     const humanoidEditing = currentSnapshot?.humanoidRigEdit?.editing === true;
     if (humanoidEditing
@@ -1909,12 +1942,14 @@ export function createRigOverlayController({
   const onRigChanged = event => refresh(event.detail || getRigState?.());
   const onPoseChanged = event => updatePoseFromEvent(event.detail);
   const onArcballChanged = () => {
+    invalidateHumanoidJointCandidates();
     updateHumanoidSpriteSizes();
     updateModelJointMarkers(currentSource);
     updateSelectedJointIndicator(currentSource);
     requestRender?.();
   };
   const onModelTransformChanged = () => {
+    invalidateHumanoidJointCandidates();
     updateModelFrame();
     updateModelJointMarkers(currentSource);
     updateSelectedJointIndicator(currentSource);


### PR DESCRIPTION
## Summary
- add an optional saved-Main-Rig guided source-forest build
- reuse humanoid spatial classification for semantic edge guidance and cross-source scoring
- rebuild the ModelRig on Main Rig Save and Reset, with legacy fallback and diagnostics

## Tests
- python -m pytest -q