### PR TITLE
Reuse model vertex mapping for Weight preview

### DIFF
--- a/src/app/bridge/api.py
+++ b/src/app/bridge/api.py
@@ -121,6 +121,7 @@ class ModViewerAPI:
     # -- Asset preview and fill --------------------------------------------
 
     def load_asset(self, folder_path):
+        self._mod_preview.clear_loaded_model()
         return self._asset_preview.load_asset(folder_path)
 
     def pick_asset_texture_file(self, folder_path, texture_role=None):

--- a/src/app/bridge/api.py
+++ b/src/app/bridge/api.py
@@ -191,6 +191,9 @@ class ModViewerAPI:
     def get_model_skinning_preview(self, folder_path):
         return self._mod_preview.get_model_skinning_preview(folder_path)
 
+    def get_memory_diagnostics(self):
+        return self._mod_preview.get_memory_diagnostics()
+
     def get_diagnostics(self, folder_path):
         return self._mod_preview.get_diagnostics(folder_path)
 

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -78,13 +78,15 @@ class ModPreview:
         traceback.print_exc()
         return {"error": "Unexpected backend error. See the application log for details."}
 
-    def load_mod(self, folder_path, disabled_ini=False):
-        previous_folder = self._current_model_folder
-        if previous_folder is not None:
-            self._skinning_manifests.pop(previous_folder, None)
-            self._active_mesh_keys.pop(previous_folder, None)
-            self._last_skinning_diagnostics.pop(previous_folder, None)
+    def clear_loaded_model(self):
+        """Release private state for the model currently shown in the scene."""
         self._current_model_folder = None
+        self._active_mesh_keys.clear()
+        self._skinning_manifests.clear()
+        self._last_skinning_diagnostics.clear()
+
+    def load_mod(self, folder_path, disabled_ini=False):
+        self.clear_loaded_model()
         folder_path, overrides, pending_new_sections, context = \
             self.authoritative_context(folder_path, disabled_ini=disabled_ini)
         geometry = GeometryBlob()

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -3,6 +3,8 @@
 import os
 import time
 import traceback
+import threading
+from collections import OrderedDict
 
 import webview
 
@@ -14,7 +16,7 @@ from core.geometry.skinning import (
     skinning_source_descriptor,
 )
 from core.resource_paths import safe_resource_path
-from core.textures import encode_texture_file
+from core.textures import encode_texture_file, texture_cache_stats
 from core.mod_discovery import discover_ini_paths
 from core.ini.health import analyze_mod
 from app.mods.analysis import resolved_draws
@@ -29,13 +31,19 @@ from app.session import edit as edit_session
 
 
 class ModPreview:
+    _DDS_CLASSIFICATION_CACHE_FOLDER_LIMIT = 24
+
     def __init__(self, access):
         self._access = access
         self._active_mesh_keys = {}
         self._skinning_manifests = {}
         self._current_model_folder = None
         self._last_skinning_diagnostics = {}
-        self._dds_classification_caches = {}
+        self._last_weight_blob_bytes = 0
+        self._model_generation = 0
+        self._pending_skinning_geometry_urls = set()
+        self._model_state_lock = threading.RLock()
+        self._dds_classification_caches = OrderedDict()
 
     @staticmethod
     def _active_texture_source(folder_path, validate=False):
@@ -63,8 +71,15 @@ class ModPreview:
             folder_path, ini_paths, edit_session.documents_for(folder_path),
             metadata.load(folder_path))
         cache_key = os.path.normcase(os.path.abspath(folder_path))
-        context.dds_classification_cache = \
-            self._dds_classification_caches.setdefault(cache_key, {})
+        with self._model_state_lock:
+            cache = self._dds_classification_caches.pop(cache_key, None)
+            if cache is None:
+                cache = {}
+            self._dds_classification_caches[cache_key] = cache
+            while (len(self._dds_classification_caches)
+                   > self._DDS_CLASSIFICATION_CACHE_FOLDER_LIMIT):
+                self._dds_classification_caches.popitem(last=False)
+        context.dds_classification_cache = cache
         try:
             context.asset_folders = asset_folders.load_registry()
         except asset_folders.AssetFolderError:
@@ -80,10 +95,43 @@ class ModPreview:
 
     def clear_loaded_model(self):
         """Release private state for the model currently shown in the scene."""
-        self._current_model_folder = None
-        self._active_mesh_keys.clear()
-        self._skinning_manifests.clear()
-        self._last_skinning_diagnostics.clear()
+        with self._model_state_lock:
+            self._model_generation += 1
+            pending = self._pending_skinning_geometry_urls
+            self._pending_skinning_geometry_urls = set()
+            self._current_model_folder = None
+            self._active_mesh_keys.clear()
+            self._skinning_manifests.clear()
+            self._last_skinning_diagnostics.clear()
+            self._last_weight_blob_bytes = 0
+        for url in pending:
+            server.release_geometry(url)
+
+    @staticmethod
+    def _stale_skinning_preview():
+        return {
+            "status": "stale",
+            "format_version": 1,
+            "saved_bones": [],
+            "meshes": {},
+        }
+
+    def _skinning_request_is_current(self, generation):
+        with self._model_state_lock:
+            return generation == self._model_generation
+
+    def _publish_skinning_geometry(self, blob, generation):
+        """Publish one Weight blob only while its model session is current."""
+        url = server.publish_geometry(blob, replace=False)
+        with self._model_state_lock:
+            current = generation == self._model_generation
+            if current:
+                self._pending_skinning_geometry_urls.add(url)
+                self._last_weight_blob_bytes = len(blob)
+        if not current:
+            server.release_geometry(url)
+            return None
+        return url
 
     def load_mod(self, folder_path, disabled_ini=False):
         self.clear_loaded_model()
@@ -132,7 +180,8 @@ class ModPreview:
             self._active_mesh_keys[folder_path] = set(result.get("meshes", {}))
             self._skinning_manifests[folder_path] = dict(
                 getattr(context, "skinning_manifest", {}) or {})
-            self._current_model_folder = folder_path
+            with self._model_state_lock:
+                self._current_model_folder = folder_path
             return result
         except Exception:
             publication.discard()
@@ -258,6 +307,8 @@ class ModPreview:
 
     def get_model_skinning_preview(self, folder_path):
         """Decode all active skin streams for the currently loaded model."""
+        with self._model_state_lock:
+            request_generation = self._model_generation
         request_started = time.perf_counter()
         timing = {
             "resolve_draws_seconds": 0.0,
@@ -312,6 +363,8 @@ class ModPreview:
             convention = (geometry_convention_for(parsed.game.game)
                           if parsed is not None else None)
             for mesh_key in sorted(selected_items):
+                if not self._skinning_request_is_current(request_generation):
+                    return self._stale_skinning_preview()
                 selected = selected_items[mesh_key]
                 draw = selected[0] if manifest is None else None
                 try:
@@ -357,7 +410,9 @@ class ModPreview:
                 }
             blob_started = time.perf_counter()
             blob = b"".join(pieces)
-            url = server.publish_geometry(blob, replace=False)
+            url = self._publish_skinning_geometry(blob, request_generation)
+            if url is None:
+                return self._stale_skinning_preview()
             timing["build_blob_seconds"] = time.perf_counter() - blob_started
             timing["weight_blob_bytes"] = len(blob)
             return {
@@ -375,7 +430,30 @@ class ModPreview:
             timing["total_seconds"] = time.perf_counter() - request_started
             timing["mapping_source"] = mapping_source if "mapping_source" in locals() \
                 else "unavailable"
-            self._last_skinning_diagnostics[folder_path] = timing
+            with self._model_state_lock:
+                if request_generation == self._model_generation:
+                    self._last_skinning_diagnostics[folder_path] = timing
+
+    def get_memory_diagnostics(self):
+        """Return lightweight process-local resource retention metrics."""
+        with self._model_state_lock:
+            dds_folder_count = len(self._dds_classification_caches)
+            dds_entry_count = sum(
+                len(cache) for cache in self._dds_classification_caches.values())
+            pending_weight_count = len(self._pending_skinning_geometry_urls)
+            last_weight_bytes = self._last_weight_blob_bytes
+        return {
+            "geometry": server.geometry_stats(),
+            "weight": {
+                "pending_skinning_publication_count": pending_weight_count,
+                "last_weight_blob_bytes": last_weight_bytes,
+            },
+            "dds": {
+                "cached_folder_count": dds_folder_count,
+                "classification_entry_count": dds_entry_count,
+            },
+            "texture": texture_cache_stats(),
+        }
 
     @staticmethod
     def _decode_skinning_manifest_entry(entry, mod_dir, buffers, timing):

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -250,6 +250,10 @@ class ModPreview:
                 },
             },
             "diagnostics": dict(decoded.diagnostics),
+            "weight_stats": {
+                str(bone_id): dict(stats)
+                for bone_id, stats in getattr(decoded, "bone_stats", {}).items()
+            },
         }, blob)
 
     def get_model_skinning_preview(self, folder_path):

--- a/src/app/bridge/mod_preview.py
+++ b/src/app/bridge/mod_preview.py
@@ -1,6 +1,7 @@
 """Mod preview orchestration behind the JavaScript bridge facade."""
 
 import os
+import time
 import traceback
 
 import webview
@@ -9,7 +10,8 @@ from core.geometry.buffers import BufferStore
 from core.geometry.conventions import geometry_convention_for
 from core.geometry.mesh_builder import GeometryBlob
 from core.geometry.skinning import (
-    SkinningPreviewError, build_skinning_preview, skinning_source_descriptor,
+    SkinningPreviewError, build_skinning_preview, decode_skinning,
+    skinning_source_descriptor,
 )
 from core.resource_paths import safe_resource_path
 from core.textures import encode_texture_file
@@ -30,6 +32,9 @@ class ModPreview:
     def __init__(self, access):
         self._access = access
         self._active_mesh_keys = {}
+        self._skinning_manifests = {}
+        self._current_model_folder = None
+        self._last_skinning_diagnostics = {}
         self._dds_classification_caches = {}
 
     @staticmethod
@@ -74,6 +79,12 @@ class ModPreview:
         return {"error": "Unexpected backend error. See the application log for details."}
 
     def load_mod(self, folder_path, disabled_ini=False):
+        previous_folder = self._current_model_folder
+        if previous_folder is not None:
+            self._skinning_manifests.pop(previous_folder, None)
+            self._active_mesh_keys.pop(previous_folder, None)
+            self._last_skinning_diagnostics.pop(previous_folder, None)
+        self._current_model_folder = None
         folder_path, overrides, pending_new_sections, context = \
             self.authoritative_context(folder_path, disabled_ini=disabled_ini)
         geometry = GeometryBlob()
@@ -91,6 +102,8 @@ class ModPreview:
             if not isinstance(result, dict) or result.get("error"):
                 publication.discard()
                 self._active_mesh_keys.pop(folder_path, None)
+                self._skinning_manifests.pop(folder_path, None)
+                self._last_skinning_diagnostics.pop(folder_path, None)
                 return result
 
             saved_metadata = context.metadata
@@ -115,10 +128,15 @@ class ModPreview:
             server.publish_payload_geometry(result, geometry)
             publication.commit()
             self._active_mesh_keys[folder_path] = set(result.get("meshes", {}))
+            self._skinning_manifests[folder_path] = dict(
+                getattr(context, "skinning_manifest", {}) or {})
+            self._current_model_folder = folder_path
             return result
         except Exception:
             publication.discard()
             self._active_mesh_keys.pop(folder_path, None)
+            self._skinning_manifests.pop(folder_path, None)
+            self._last_skinning_diagnostics.pop(folder_path, None)
             raise
 
     def get_present_state(self, folder_path):
@@ -180,7 +198,7 @@ class ModPreview:
 
     @staticmethod
     def _decode_skinning_draw(draw, group, mod_dir, buffers,
-                              geometry_convention):
+                              geometry_convention, timing=None):
         paths = [
             safe_resource_path(mod_dir, group["position_file"]),
             safe_resource_path(mod_dir, group["texcoord_file"]),
@@ -198,14 +216,16 @@ class ModPreview:
             draw, group, mod_dir, buffers=buffers,
             default_streams=default_streams,
             default_index_size=group.get("index_size", 4),
-            geometry_convention=geometry_convention)
+            geometry_convention=geometry_convention, timing=timing)
 
     @staticmethod
-    def _skinning_source_descriptor(draw):
-        return skinning_source_descriptor(draw.skinning_source)
+    def _skinning_source_descriptor(draw_or_source):
+        source = getattr(draw_or_source, "skinning_source", draw_or_source)
+        return skinning_source_descriptor(source)
 
     @staticmethod
-    def _skin_entry(decoded, draw, offset):
+    def _skin_entry(decoded, draw_or_source, offset):
+        source = getattr(draw_or_source, "skinning_source", draw_or_source)
         indices_length = len(decoded.indices)
         blob = decoded.indices + decoded.weights
         return ({
@@ -213,8 +233,8 @@ class ModPreview:
             "vertex_count": decoded.vertex_count,
             "influence_count": decoded.influence_count,
             "bone_ids": list(decoded.bone_ids),
-            "encoding": draw.skinning_source.encoding,
-            "source": ModPreview._skinning_source_descriptor(draw),
+            "encoding": source.encoding,
+            "source": ModPreview._skinning_source_descriptor(source),
             "data": {
                 "indices": {
                     "offset": offset,
@@ -231,35 +251,75 @@ class ModPreview:
         }, blob)
 
     def get_model_skinning_preview(self, folder_path):
-        """Decode all active skinned draws through one analyzed model context."""
+        """Decode all active skin streams for the currently loaded model."""
+        request_started = time.perf_counter()
+        timing = {
+            "resolve_draws_seconds": 0.0,
+            "prepare_draw_vertices_seconds": 0.0,
+            "decode_skinning_seconds": 0.0,
+            "build_blob_seconds": 0.0,
+            "resolve_draw_count": 0,
+            "prepare_draw_vertices_calls": 0,
+            "decoded_mesh_count": 0,
+            "compact_vertex_count": 0,
+            "weight_blob_bytes": 0,
+        }
         try:
             folder_path, overrides, _pending, context = \
                 self.authoritative_context(folder_path)
             saved_bones = metadata.weight_selected_bones(
                 data=context.metadata)
-            parsed, draws = self._skinning_draws(context, overrides)
             active_mesh_keys = self._active_mesh_keys.get(folder_path)
-            eligible_draws = {
-                key: selected for key, selected in draws.items()
-                if selected[0].skinning_source is not None
-            }
-            requested = (set(active_mesh_keys) if active_mesh_keys is not None
-                         else set(eligible_draws))
-            requested &= set(eligible_draws)
+            manifest = self._skinning_manifests.get(folder_path)
+            mapping_source = "loaded_model_manifest" if manifest is not None \
+                else "legacy_rebuild"
+            if manifest is not None:
+                requested = (set(active_mesh_keys)
+                             if active_mesh_keys is not None
+                             else set(manifest))
+                requested &= set(manifest)
+                selected_items = {
+                    key: manifest[key] for key in requested
+                }
+                parsed = None
+            else:
+                resolve_started = time.perf_counter()
+                parsed, draws = self._skinning_draws(context, overrides)
+                timing["resolve_draws_seconds"] = (
+                    time.perf_counter() - resolve_started)
+                timing["resolve_draw_count"] = len(draws)
+                eligible_draws = {
+                    key: selected for key, selected in draws.items()
+                    if selected[0].skinning_source is not None
+                }
+                requested = (set(active_mesh_keys)
+                             if active_mesh_keys is not None
+                             else set(eligible_draws))
+                requested &= set(eligible_draws)
+                selected_items = {
+                    key: eligible_draws[key] for key in requested
+                }
             meshes = {}
             pieces = []
             offset = 0
             buffers = BufferStore()
-            convention = geometry_convention_for(parsed.game.game)
-            for mesh_key in sorted(requested):
-                selected = eligible_draws.get(mesh_key)
-                if selected is None:
-                    continue
-                draw, group = selected
+            convention = (geometry_convention_for(parsed.game.game)
+                          if parsed is not None else None)
+            for mesh_key in sorted(selected_items):
+                selected = selected_items[mesh_key]
+                draw = selected[0] if manifest is None else None
                 try:
-                    decoded = self._decode_skinning_draw(
-                        draw, group, context.mod_dir, buffers, convention)
-                    entry, blob = self._skin_entry(decoded, draw, offset)
+                    if manifest is not None:
+                        decoded = self._decode_skinning_manifest_entry(
+                            selected, context.mod_dir, buffers, timing)
+                        entry, blob = self._skin_entry(
+                            decoded, selected.skinning_source, offset)
+                    else:
+                        draw, group = selected
+                        decoded = self._decode_skinning_draw(
+                            draw, group, context.mod_dir, buffers, convention,
+                            timing=timing)
+                        entry, blob = self._skin_entry(decoded, draw, offset)
                 except SkinningPreviewError as error:
                     meshes[mesh_key] = {
                         "status": "error",
@@ -278,6 +338,8 @@ class ModPreview:
                 meshes[mesh_key] = entry
                 pieces.append(blob)
                 offset += len(blob)
+                timing["decoded_mesh_count"] += 1
+                timing["compact_vertex_count"] += decoded.vertex_count
 
             if not pieces:
                 return {
@@ -287,8 +349,11 @@ class ModPreview:
                     "meshes": meshes,
                     "error": "No active mesh has usable skin weights.",
                 }
+            blob_started = time.perf_counter()
             blob = b"".join(pieces)
             url = server.publish_geometry(blob, replace=False)
+            timing["build_blob_seconds"] = time.perf_counter() - blob_started
+            timing["weight_blob_bytes"] = len(blob)
             return {
                 "status": "ok" if all(
                     entry.get("status") == "ok" for entry in meshes.values())
@@ -300,6 +365,46 @@ class ModPreview:
             }
         except Exception:
             return self._semantic_read_error()
+        finally:
+            timing["total_seconds"] = time.perf_counter() - request_started
+            timing["mapping_source"] = mapping_source if "mapping_source" in locals() \
+                else "unavailable"
+            self._last_skinning_diagnostics[folder_path] = timing
+
+    @staticmethod
+    def _decode_skinning_manifest_entry(entry, mod_dir, buffers, timing):
+        source = entry.skinning_source
+        source_path = safe_resource_path(mod_dir, source.file)
+        if not source_path or not os.path.exists(source_path):
+            raise SkinningPreviewError(
+                "skinning_not_available",
+                "The skin-weight buffer could not be found.")
+        remap_path = None
+        if source.vertex_vg_file:
+            remap_path = safe_resource_path(mod_dir, source.vertex_vg_file)
+            if not remap_path or not os.path.exists(remap_path):
+                raise SkinningPreviewError(
+                    "skinning_remap_unavailable",
+                    "The WWMI VertexVG remap buffer could not be found.")
+        decode_started = time.perf_counter()
+        decoded = decode_skinning(
+            source, buffers.raw(source_path), entry.used_vertices,
+            buffers.raw(remap_path) if remap_path else None)
+        timing["decode_skinning_seconds"] += (
+            time.perf_counter() - decode_started)
+        if decoded.vertex_count != entry.vertex_count:
+            raise SkinningPreviewError(
+                "skinning_preview_failed",
+                "The retained skinning mapping is inconsistent.")
+        if decoded.diagnostics["truncated_vertices"]:
+            raise SkinningPreviewError(
+                "skinning_buffer_truncated",
+                "The skin-weight buffer is truncated.")
+        if decoded.diagnostics["vertex_vg_truncated_vertices"]:
+            raise SkinningPreviewError(
+                "skinning_remap_truncated",
+                "The WWMI VertexVG remap buffer is truncated.")
+        return decoded
 
     def get_diagnostics(self, folder_path):
         """Return the read-only health scan for the current edit revision."""

--- a/src/app/mods/loader.py
+++ b/src/app/mods/loader.py
@@ -51,6 +51,8 @@ class ModLoadContext:
     metadata: dict = field(default_factory=dict)
     asset_folders: list = field(default_factory=list)
     dds_classification_cache: dict = field(default_factory=dict)
+    # Private state retained by the bridge for the exact loaded model.
+    skinning_manifest: dict = field(default_factory=dict)
 
 
 def _resolve_context(folder_path, ini_paths=None, documents=None, context=None):
@@ -155,6 +157,7 @@ def load_mod(folder_path=None, overrides=None, pending_new_sections=None, *,
     """
     context = _resolve_context(
         folder_path, ini_paths=ini_paths, documents=documents, context=context)
+    context.skinning_manifest = {}
     overrides = overrides or {}
     if not context.ini_paths:
         health = _failure_health(context, overrides)
@@ -180,11 +183,15 @@ def load_mod(folder_path=None, overrides=None, pending_new_sections=None, *,
             game_profile=parsed.game.game)
         mesh_payload = built.meshes
         if not mesh_payload:
+            context.skinning_manifest = {}
             health = _failure_health(context, overrides)
             return _structured_payload(
                 health=health,
                 error="No mesh data could be extracted (buffer files missing?).",
                 game=parsed.game)
+
+        context.skinning_manifest = getattr(
+            built, "skinning_manifest", None) or {}
 
         # Viewer-only material choices are hydrated into the same evidence
         # field used by the classifier. This never edits the source INI.
@@ -203,6 +210,7 @@ def load_mod(folder_path=None, overrides=None, pending_new_sections=None, *,
             game=parsed.game, material_profiles=material_profiles,
             asset_resolution=asset_resolution)
     except Exception:
+        context.skinning_manifest = {}
         traceback.print_exc()
         health = _failure_health(context, overrides)
         return _structured_payload(

--- a/src/app/mods/metadata.py
+++ b/src/app/mods/metadata.py
@@ -270,10 +270,15 @@ def _normalized_weight_bones(value):
             continue
         source = normalize_skinning_source_file(item.get("source"))
         offset = item.get("bone_id_offset")
+        source_key = item.get("source_key")
         if (source is None or isinstance(offset, bool)
                 or not isinstance(offset, int) or offset < 0):
             continue
-        key = skinning_source_key(source, offset)
+        if not isinstance(source_key, str) or not source_key.strip():
+            source_key = skinning_source_key(source, offset)
+        else:
+            source_key = source_key.strip().replace("\\", "/").casefold()
+        key = source_key
         if key is None:
             continue
         bone_ids = {
@@ -285,6 +290,7 @@ def _normalized_weight_bones(value):
             continue
         entry = merged.setdefault(key, {
             "source": source,
+            "source_key": source_key,
             "bone_id_offset": offset,
             "bone_ids": set(),
         })
@@ -292,6 +298,7 @@ def _normalized_weight_bones(value):
     return [
         {
             "source": entry["source"],
+            "source_key": entry["source_key"],
             "bone_id_offset": entry["bone_id_offset"],
             "bone_ids": sorted(entry["bone_ids"]),
         }

--- a/src/app/runtime/server.py
+++ b/src/app/runtime/server.py
@@ -317,6 +317,16 @@ def release_geometry(url):
         return _geometry_blobs.pop(token, None) is not None
 
 
+def geometry_stats():
+    """Return the currently retained geometry publication footprint."""
+    with _geometry_lock:
+        return {
+            "pending_blob_count": len(_geometry_blobs),
+            "pending_blob_bytes": sum(
+                len(blob) for blob in _geometry_blobs.values()),
+        }
+
+
 class _Handler(http.server.SimpleHTTPRequestHandler):
     """Serves web/ with two extras: a /vendor/ mount and a rendered index.html."""
 

--- a/src/core/geometry/draw_call.py
+++ b/src/core/geometry/draw_call.py
@@ -129,6 +129,7 @@ class DrawCall(MutableMapping):
     skinning_bone_offset: int = 0
     skinning_source: SkinningSource | None = None
     skinning_error: str | None = None
+    skinning_resolution: dict = field(default_factory=dict)
 
     _ALWAYS_PRESENT: ClassVar[frozenset[str]] = frozenset({
         "count", "start", "base", "conditions", "sources",
@@ -145,7 +146,7 @@ class DrawCall(MutableMapping):
         "slot_textures", "asset_binding", "texture_provenance",
         "asset_slot_evidence", "texture_hashes",
         "skinning_bone_offset",
-        "skinning_source", "skinning_error",
+        "skinning_source", "skinning_error", "skinning_resolution",
     })
     _RENDER_IDENTITY_FIELDS: ClassVar[tuple[str, ...]] = (
         "count", "start", "base",

--- a/src/core/geometry/mesh_builder.py
+++ b/src/core/geometry/mesh_builder.py
@@ -19,6 +19,7 @@ from .texture_bindings import (
 )
 from .transport import GeometryBlob
 from .identity import mesh_identity_for_draw
+from .skinning import SkinningManifestEntry
 from ..resource_paths import safe_resource_path
 
 
@@ -28,12 +29,14 @@ class MeshBuildResult:
 
     ``meshes`` contains only draw entries and ``textures`` is the shared
     texture registry. ``geometry`` records the optional caller-owned blob
-    writer used to produce offset/length references.
+    writer used to produce offset/length references. ``skinning_manifest`` is
+    private backend state and is never included in the public payload.
     """
 
     meshes: dict
     textures: dict
     geometry: GeometryBlob | None = None
+    skinning_manifest: dict[str, SkinningManifestEntry] | None = None
 
 
 def _geometry_ref(raw, geometry):
@@ -59,6 +62,7 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
     buffers = BufferStore()
     sparse_shape_cache = {}
     result = {}
+    skinning_manifest = {}
 
     for group in groups:
         pos_path = safe_resource_path(mod_dir, group["position_file"])
@@ -93,6 +97,12 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
             )
             if packed is None:
                 continue
+
+            if draw.skinning_source is not None:
+                skinning_manifest[draw.label] = \
+                    SkinningManifestEntry.from_vertices(
+                        draw.label, draw.skinning_source,
+                        packed.used_vertices)
 
             entry: dict = {
                 "pos": _geometry_ref(packed.positions, geometry),
@@ -150,6 +160,7 @@ def build_mesh_result(groups, mod_dir, max_draws=0, geometry=None,
         meshes=result,
         textures=registry.sources,
         geometry=geometry,
+        skinning_manifest=skinning_manifest,
     )
 
 

--- a/src/core/geometry/packing.py
+++ b/src/core/geometry/packing.py
@@ -27,6 +27,9 @@ class PackedDrawGeometry:
     texcoords: bytes | None
     normals: bytes | None
     shape_targets: list[PackedShapeTarget]
+    # Backend-only source mapping retained by the model builder for Weight.
+    # This is deliberately not part of the application payload.
+    used_vertices: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -318,6 +321,7 @@ def pack_draw_geometry(
         texcoords=bytes(uv_bytes) if uv_bytes is not None else None,
         normals=bytes(normal_bytes) if normal_bytes is not None else None,
         shape_targets=shape_targets,
+        used_vertices=tuple(used),
     )
 
 

--- a/src/core/geometry/skinning.py
+++ b/src/core/geometry/skinning.py
@@ -161,7 +161,8 @@ def _resolve_vertex_vg_resource(resource_name, resolve_vertex_info,
 
 
 def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
-                            bone_id_offset=0, remap_resources=None):
+                            bone_id_offset=0, remap_resources=None,
+                            allow_unlabeled=False):
     """Resolve one conservative Blend candidate from active ``vbN`` state.
 
     The caller supplies the resolver already used by draw-group assembly, so
@@ -184,7 +185,8 @@ def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
         if not filename:
             continue
         evidence = f"{resource_name} {filename}".lower()
-        if "blend" not in evidence:
+        labeled_blend = "blend" in evidence
+        if not allow_unlabeled and not labeled_blend:
             continue
         try:
             stride = int(info.get("stride"))
@@ -203,21 +205,20 @@ def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
         elif stride == 4:
             encoding, influence_count = "rigid_u32_1", 1
         else:
-            unsupported.append(stride)
+            if labeled_blend or not allow_unlabeled:
+                unsupported.append(stride)
         if encoding is None:
             continue
         remap_info, remap_error = (None, None)
         if encoding.startswith("wwmi_"):
             remap_name = (remap_resources or {}).get(35)
-            if not remap_name:
-                unsupported.append("missing_vertex_vg_remap")
-                continue
-            remap_info, remap_error = _resolve_vertex_vg_resource(
-                remap_name, resolve_vertex_info,
-                influence_count)
-            if remap_error:
-                unsupported.append(remap_error)
-                continue
+            if remap_name:
+                remap_info, remap_error = _resolve_vertex_vg_resource(
+                    remap_name, resolve_vertex_info,
+                    influence_count)
+                if remap_error:
+                    unsupported.append(remap_error)
+                    continue
         source = SkinningSource(
             file=filename, stride=stride,
             influence_count=influence_count, encoding=encoding,

--- a/src/core/geometry/skinning.py
+++ b/src/core/geometry/skinning.py
@@ -161,8 +161,7 @@ def _resolve_vertex_vg_resource(resource_name, resolve_vertex_info,
 
 
 def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
-                            bone_id_offset=0, remap_resources=None,
-                            provenance_slots=None):
+                            bone_id_offset=0, remap_resources=None):
     """Resolve one conservative Blend candidate from active ``vbN`` state.
 
     The caller supplies the resolver already used by draw-group assembly, so
@@ -176,10 +175,6 @@ def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
         bone_id_offset = 0
     candidates = {}
     unsupported = []
-    provenance_slots = {
-        int(slot) for slot in (provenance_slots or ())
-        if isinstance(slot, int) and slot >= 2
-    }
     for _slot, resource_name in sorted(
             (effective_vertex_resources or {}).items()):
         if not resource_name:
@@ -190,7 +185,7 @@ def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
             continue
         evidence = f"{resource_name} {filename}".lower()
         labeled_blend = "blend" in evidence
-        if not labeled_blend and _slot not in provenance_slots:
+        if not labeled_blend:
             continue
         try:
             stride = int(info.get("stride"))

--- a/src/core/geometry/skinning.py
+++ b/src/core/geometry/skinning.py
@@ -5,6 +5,8 @@ import ntpath
 import os
 import posixpath
 import struct
+import time
+from array import array
 from dataclasses import dataclass
 
 
@@ -23,6 +25,21 @@ class SkinningSource:
     vertex_vg_file: str | None = None
     vertex_vg_stride: int = 16
     bone_id_namespace: str = "model"
+
+
+@dataclass(frozen=True, slots=True)
+class SkinningManifestEntry:
+    """Private mapping from one rendered mesh to authored skin vertices."""
+
+    mesh_key: str
+    skinning_source: SkinningSource
+    used_vertices: array
+    vertex_count: int
+
+    @classmethod
+    def from_vertices(cls, mesh_key, skinning_source, used_vertices):
+        compact = array("I", used_vertices)
+        return cls(mesh_key, skinning_source, compact, len(compact))
 
 
 @dataclass(frozen=True, slots=True)
@@ -392,7 +409,7 @@ def _error_for_draw(draw):
 
 def build_skinning_preview(draw, group, mod_dir, *, buffers,
                            default_streams, default_index_size,
-                           geometry_convention):
+                           geometry_convention, timing=None):
     """Prepare the selected draw, decode its source, and return canonical data."""
     from .packing import _prepare_draw_vertices
     from ..resource_paths import safe_resource_path
@@ -413,19 +430,28 @@ def build_skinning_preview(draw, group, mod_dir, *, buffers,
             raise SkinningPreviewError(
                 "skinning_remap_unavailable",
                 "The WWMI VertexVG remap buffer could not be found.")
+    prepare_started = time.perf_counter() if timing is not None else None
     prepared = _prepare_draw_vertices(
         draw, group, mod_dir=mod_dir, default_streams=default_streams,
         default_index_size=default_index_size, buffers=buffers,
         geometry_convention=geometry_convention)
+    if timing is not None:
+        timing["prepare_draw_vertices_seconds"] += (
+            time.perf_counter() - prepare_started)
+        timing["prepare_draw_vertices_calls"] += 1
     if prepared is None:
         raise SkinningPreviewError(
             "geometry_not_available",
             "The rendered draw geometry could not be prepared.")
+    decode_started = time.perf_counter() if timing is not None else None
     decoded = decode_skinning(
         draw.skinning_source, buffers.raw(source_path),
         prepared.used_vertices,
         (buffers.raw(remap_path) if draw.skinning_source.vertex_vg_file
          else None))
+    if timing is not None:
+        timing["decode_skinning_seconds"] += (
+            time.perf_counter() - decode_started)
     if decoded.diagnostics["truncated_vertices"]:
         raise SkinningPreviewError(
             "skinning_buffer_truncated",
@@ -438,7 +464,8 @@ def build_skinning_preview(draw, group, mod_dir, *, buffers,
 
 
 __all__ = [
-    "SkinningSource", "DecodedSkinning", "SkinningPreviewError",
+    "SkinningSource", "SkinningManifestEntry", "DecodedSkinning",
+    "SkinningPreviewError",
     "normalize_skinning_source_file", "skinning_source_key",
     "skinning_source_descriptor", "resolve_skinning_source",
     "decode_skinning", "build_skinning_preview",

--- a/src/core/geometry/skinning.py
+++ b/src/core/geometry/skinning.py
@@ -6,7 +6,6 @@ import os
 import posixpath
 import struct
 import time
-from array import array
 from dataclasses import dataclass, field
 
 
@@ -33,12 +32,13 @@ class SkinningManifestEntry:
 
     mesh_key: str
     skinning_source: SkinningSource
-    used_vertices: array
+    used_vertices: tuple[int, ...]
     vertex_count: int
 
     @classmethod
     def from_vertices(cls, mesh_key, skinning_source, used_vertices):
-        compact = array("I", used_vertices)
+        compact = (used_vertices if isinstance(used_vertices, tuple)
+                   else tuple(used_vertices))
         return cls(mesh_key, skinning_source, compact, len(compact))
 
 
@@ -275,7 +275,6 @@ def decode_skinning(source, raw_data, used_vertices, vertex_vg_data=None):
                 or source.vertex_vg_stride != expected_stride):
             raise ValueError("Invalid VertexVG remap descriptor.")
         vertex_vg_data = bytes(vertex_vg_data or b"")
-    used_vertices = tuple(used_vertices)
     count = len(used_vertices)
     item_bytes = source.influence_count * 4
     index_bytes = bytearray(count * item_bytes)
@@ -289,7 +288,10 @@ def decode_skinning(source, raw_data, used_vertices, vertex_vg_data=None):
     bone_ids = set()
     bone_stats_accum = {}
 
-    for compact_index, source_index in enumerate(used_vertices):
+    # Consume the retained compact sequence directly.  Indexing avoids a
+    # decoder-side tuple materialization for backend manifest mappings.
+    for compact_index in range(count):
+        source_index = used_vertices[compact_index]
         output_offset = compact_index * item_bytes
         try:
             source_index = int(source_index)

--- a/src/core/geometry/skinning.py
+++ b/src/core/geometry/skinning.py
@@ -162,7 +162,7 @@ def _resolve_vertex_vg_resource(resource_name, resolve_vertex_info,
 
 def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
                             bone_id_offset=0, remap_resources=None,
-                            allow_unlabeled=False):
+                            provenance_slots=None):
     """Resolve one conservative Blend candidate from active ``vbN`` state.
 
     The caller supplies the resolver already used by draw-group assembly, so
@@ -176,6 +176,10 @@ def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
         bone_id_offset = 0
     candidates = {}
     unsupported = []
+    provenance_slots = {
+        int(slot) for slot in (provenance_slots or ())
+        if isinstance(slot, int) and slot >= 2
+    }
     for _slot, resource_name in sorted(
             (effective_vertex_resources or {}).items()):
         if not resource_name:
@@ -186,7 +190,7 @@ def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
             continue
         evidence = f"{resource_name} {filename}".lower()
         labeled_blend = "blend" in evidence
-        if not allow_unlabeled and not labeled_blend:
+        if not labeled_blend and _slot not in provenance_slots:
             continue
         try:
             stride = int(info.get("stride"))
@@ -205,8 +209,7 @@ def resolve_skinning_source(effective_vertex_resources, resolve_vertex_info, *,
         elif stride == 4:
             encoding, influence_count = "rigid_u32_1", 1
         else:
-            if labeled_blend or not allow_unlabeled:
-                unsupported.append(stride)
+            unsupported.append(stride)
         if encoding is None:
             continue
         remap_info, remap_error = (None, None)

--- a/src/core/geometry/skinning.py
+++ b/src/core/geometry/skinning.py
@@ -7,7 +7,7 @@ import posixpath
 import struct
 import time
 from array import array
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,6 +52,7 @@ class DecodedSkinning:
     weights: bytes
     bone_ids: tuple[int, ...]
     diagnostics: dict
+    bone_stats: dict[int, dict[str, float | int]] = field(default_factory=dict)
 
 
 class SkinningPreviewError(ValueError):
@@ -286,6 +287,7 @@ def decode_skinning(source, raw_data, used_vertices, vertex_vg_data=None):
     vertex_vg_truncated = 0
     sums = []
     bone_ids = set()
+    bone_stats_accum = {}
 
     for compact_index, source_index in enumerate(used_vertices):
         output_offset = compact_index * item_bytes
@@ -357,6 +359,15 @@ def decode_skinning(source, raw_data, used_vertices, vertex_vg_data=None):
                              output_offset + influence * 4, weight)
             if weight > 0:
                 bone_ids.add(bone)
+                stats = bone_stats_accum.get(bone)
+                if stats is None:
+                    bone_stats_accum[bone] = [compact_index, 1, weight]
+                elif stats[0] != compact_index:
+                    stats[0] = compact_index
+                    stats[1] += 1
+                    stats[2] += weight
+                else:
+                    stats[2] += weight
 
     diagnostics = {
         "vertex_count": count,
@@ -377,10 +388,18 @@ def decode_skinning(source, raw_data, used_vertices, vertex_vg_data=None):
     }
     if source.vertex_vg_file:
         diagnostics["bone_id_namespace"] = source.bone_id_namespace
+    bone_stats = {
+        bone: {
+            "affected_vertex_count": stats[1],
+            "total_weight": stats[2],
+        }
+        for bone, stats in bone_stats_accum.items()
+    }
     return DecodedSkinning(
         vertex_count=count, influence_count=source.influence_count,
         indices=bytes(index_bytes), weights=bytes(weight_bytes),
-        bone_ids=tuple(sorted(bone_ids)), diagnostics=diagnostics)
+        bone_ids=tuple(sorted(bone_ids)), diagnostics=diagnostics,
+        bone_stats=bone_stats)
 
 
 def _error_for_draw(draw):

--- a/src/core/ini/draw_groups.py
+++ b/src/core/ini/draw_groups.py
@@ -114,8 +114,9 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
     section_info = _scan_sections_for_draws(sections, var_prefix, gating_vars)
     resource_copy_sources = _collect_resource_copy_sources(sections, resources)
     resolved_buffers = _resolve_component_buffers(
-        section_info, resources, resource_copy_sources)
+        section_info, resources, resource_copy_sources, sections=sections)
     resolve_vertex_info = resolved_buffers["resolve_vertex_info"]
+    vertex_binding_index = resolved_buffers["vertex_binding_index"]
     component_buffers = resolved_buffers["component_buffers"]
     component_positions = resolved_buffers["component_positions"]
     component_texcoords = resolved_buffers["component_texcoords"]
@@ -174,6 +175,12 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
 
         ib_resource = info["ib"] or global_ib
         component = _ib_res_to_component(ib_resource)
+        group_vertex_resources = {
+            slot: resource
+            for slot, resource in (
+                info.get("vertex_resources_at_end") or {}).items()
+            if resource
+        }
         buffers = lookup_component_buffers(component)
         if not buffers:
             position = (info["vb0"] or _lookup_component_value(
@@ -212,10 +219,6 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
         texcoord_stride = texcoord_info.get("stride", 20)
         position_stride = position_info.get("stride", POSITION_STRIDE)
         index_size = _ib_index_size(ib_info.get("format"))
-        group_vertex_resources = {
-            slot: info[f"vb{slot}"]
-            for slot in (0, 1, 2) if info[f"vb{slot}"]
-        }
         group_normal_source = _resolve_normal_source(
             group_vertex_resources, resources, position_file, position_stride,
             resolve_vertex_info)
@@ -259,6 +262,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
 
             draw_buffers = lookup_component_buffers(
                 _ib_res_to_component(effective_ib))
+            effective_position_resource = buffers["position"]
             if draw_buffers and draw_buffers != buffers:
                 position, stride = resolve_vertex_resource(
                     draw_buffers["position"])
@@ -267,6 +271,7 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                 if position:
                     draw.position_file = position
                     draw.position_stride = stride or POSITION_STRIDE
+                    effective_position_resource = draw_buffers["position"]
                 if texcoord:
                     draw.texcoord_file = texcoord
                     draw.texcoord_stride = texcoord_stride_for_draw or 20
@@ -277,11 +282,13 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                 if position_resource is None:
                     draw.position_file = None
                     draw.position_stride = None
+                    effective_position_resource = None
                 else:
                     position, stride = resolve_vertex_resource(position_resource)
                     if position:
                         draw.position_file = position
                         draw.position_stride = stride or POSITION_STRIDE
+                        effective_position_resource = position_resource
 
             authored_texcoords = {
                 slot: vertex_resources[slot]
@@ -311,29 +318,76 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             draw.normal_source = _resolve_normal_source(
                 effective_vertex_resources, resources, draw.position_file,
                 draw.position_stride, resolve_vertex_info)
-            direct_skinning_resources = dict(group_vertex_resources)
-            direct_skinning_resources.update(vertex_resources)
+            # AuthoredDrawCall.vertex_resources is the complete effective
+            # state captured at this draw, including CommandList bindings and
+            # explicit nulls.  Do not merge a section-end snapshot here: a
+            # later vbN assignment must not leak backward to an earlier draw.
+            direct_skinning_resources = {
+                slot: resource
+                for slot, resource in vertex_resources.items()
+                if resource
+            }
             remap_resources = dict(global_compute_resources)
             remap_resources.update(authored.skinning_remap_resources)
+            skinning_resolution = {
+                "direct_candidate_count": sum(
+                    1 for resource in direct_skinning_resources.values()
+                    if resource),
+                "position_resource": effective_position_resource,
+                "provenance_section_count": 0,
+                "provenance_candidate_count": 0,
+                "legacy_component_candidate_count": 0,
+                "resolution_source": None,
+            }
             skinning_source, skinning_error = resolve_skinning_source(
                 direct_skinning_resources, resolve_vertex_info,
                 bone_id_offset=authored.skinning_bone_offset,
                 remap_resources=remap_resources)
+            if skinning_source is not None:
+                skinning_resolution["resolution_source"] = "direct"
             if skinning_source is None and skinning_error is None:
-                occupied_slots = (set(group_vertex_resources)
-                                  | set(vertex_resources))
+                provenance_resources, provenance_sections = \
+                    vertex_binding_index.provenance_for_position(
+                        effective_position_resource,
+                        root_section=section_name,
+                        current_bindings=vertex_resources)
+                skinning_resolution.update({
+                    "provenance_section_count": len(provenance_sections),
+                    "provenance_candidate_count": len(provenance_resources),
+                })
+                provenance_bindings = {
+                    slot: resource
+                    for slot, resource in enumerate(sorted(
+                        provenance_resources, key=str.casefold))
+                }
+                skinning_source, skinning_error = resolve_skinning_source(
+                    provenance_bindings, resolve_vertex_info,
+                    bone_id_offset=authored.skinning_bone_offset,
+                    remap_resources=remap_resources,
+                    allow_unlabeled=True)
+                if skinning_source is not None:
+                    skinning_resolution["resolution_source"] = \
+                        "position_provenance"
+            if skinning_source is None and skinning_error is None:
+                occupied_slots = set(vertex_resources)
                 blend_fallback = {
                     slot: resource
                     for slot, resource in lookup_component_blend_vertex_resources(
                         _ib_res_to_component(effective_ib)).items()
                     if slot not in occupied_slots
                 }
+                skinning_resolution[
+                    "legacy_component_candidate_count"] = len(blend_fallback)
                 skinning_source, skinning_error = resolve_skinning_source(
                     blend_fallback, resolve_vertex_info,
                     bone_id_offset=authored.skinning_bone_offset,
                     remap_resources=remap_resources)
+                if skinning_source is not None:
+                    skinning_resolution["resolution_source"] = \
+                        "legacy_component"
             draw.skinning_source = skinning_source
             draw.skinning_error = skinning_error
+            draw.skinning_resolution = skinning_resolution
             _apply_diffuse_state(draw, authored, resolve_texture_file)
             _apply_auxiliary_map_state(draw, authored, resolve_texture_file)
             draw.texture_provenance = {

--- a/src/core/ini/draw_groups.py
+++ b/src/core/ini/draw_groups.py
@@ -346,25 +346,31 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
             if skinning_source is not None:
                 skinning_resolution["resolution_source"] = "direct"
             if skinning_source is None and skinning_error is None:
-                provenance_resources, provenance_sections = \
-                    vertex_binding_index.provenance_for_position(
+                provenance_bindings, provenance_sections = \
+                    vertex_binding_index.provenance_bindings_for_position(
                         effective_position_resource,
                         root_section=section_name,
                         current_bindings=vertex_resources)
+                provenance_resources = {
+                    resource for _slot, resource in provenance_bindings
+                }
                 skinning_resolution.update({
                     "provenance_section_count": len(provenance_sections),
                     "provenance_candidate_count": len(provenance_resources),
                 })
-                provenance_bindings = {
-                    slot: resource
-                    for slot, resource in enumerate(sorted(
-                        provenance_resources, key=str.casefold))
-                }
+                provenance_candidates = provenance_bindings
+                provenance_bindings = {}
+                provenance_slots = set()
+                for slot, resource in provenance_candidates:
+                    synthetic_slot = len(provenance_bindings) + 2
+                    provenance_bindings[synthetic_slot] = resource
+                    if slot >= 2:
+                        provenance_slots.add(synthetic_slot)
                 skinning_source, skinning_error = resolve_skinning_source(
                     provenance_bindings, resolve_vertex_info,
                     bone_id_offset=authored.skinning_bone_offset,
                     remap_resources=remap_resources,
-                    allow_unlabeled=True)
+                    provenance_slots=provenance_slots)
                 if skinning_source is not None:
                     skinning_resolution["resolution_source"] = \
                         "position_provenance"

--- a/src/core/ini/draw_groups.py
+++ b/src/core/ini/draw_groups.py
@@ -351,6 +351,12 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                         effective_position_resource,
                         root_section=section_name,
                         current_bindings=vertex_resources)
+                provenance_bindings = [
+                    (slot, resource)
+                    for slot, resource in provenance_bindings
+                    if slot not in vertex_resources
+                ]
+                provenance_candidates = provenance_bindings
                 provenance_resources = {
                     resource for _slot, resource in provenance_bindings
                 }
@@ -358,19 +364,14 @@ def build_draw_groups(sections, resources, var_prefix=None, source=None, seen=No
                     "provenance_section_count": len(provenance_sections),
                     "provenance_candidate_count": len(provenance_resources),
                 })
-                provenance_candidates = provenance_bindings
                 provenance_bindings = {}
-                provenance_slots = set()
-                for slot, resource in provenance_candidates:
+                for _slot, resource in provenance_candidates:
                     synthetic_slot = len(provenance_bindings) + 2
                     provenance_bindings[synthetic_slot] = resource
-                    if slot >= 2:
-                        provenance_slots.add(synthetic_slot)
                 skinning_source, skinning_error = resolve_skinning_source(
                     provenance_bindings, resolve_vertex_info,
                     bone_id_offset=authored.skinning_bone_offset,
-                    remap_resources=remap_resources,
-                    provenance_slots=provenance_slots)
+                    remap_resources=remap_resources)
                 if skinning_source is not None:
                     skinning_resolution["resolution_source"] = \
                         "position_provenance"

--- a/src/core/ini/draw_resources.py
+++ b/src/core/ini/draw_resources.py
@@ -1,9 +1,87 @@
 """Resolution of authored geometry resources into file-backed buffers."""
 
+from dataclasses import dataclass
 import re
 
 from ..geometry.buffers import POSITION_STRIDE, _res_get
 from ..geometry.vertex_attributes import VertexAttributeSource
+from .draw_scan import (_reachable_execution_sections, _run_target_name)
+
+
+@dataclass
+class VertexBindingIndex:
+    """Reverse references between authored vertex bindings and INI scopes.
+
+    This is deliberately smaller than an execution graph.  The draw scanner
+    already captures effective per-draw state; this index only retains enough
+    authored scope information to answer which vertex resources were bound
+    alongside a resolved Position resource.
+    """
+
+    sections: dict
+    section_lookup: dict
+    section_bindings: dict
+    section_draw_bindings: dict
+    section_runs: dict
+    resource_consumers: dict
+    resource_copy_sources: dict
+
+    def _resource_reaches(self, start, target):
+        """Return whether an authored resource copy chain reaches target."""
+        if not start or not target:
+            return False
+        target_key = str(target).casefold()
+        pending = [str(start)]
+        visited = set()
+        while pending:
+            current = pending.pop()
+            current_key = current.casefold()
+            if current_key in visited:
+                continue
+            visited.add(current_key)
+            if current_key == target_key:
+                return True
+            pending.extend(self.resource_copy_sources.get(current_key, ()))
+        return False
+
+    def _scope_sections(self, root):
+        if root not in self.sections:
+            return (root,)
+        return _reachable_execution_sections(
+            self.sections, root, self.section_lookup)
+
+    def provenance_for_position(self, position_resource, *, root_section=None,
+                                current_bindings=None):
+        """Return co-bound resources and their authored provenance sections."""
+        if not position_resource:
+            return set(), set()
+
+        roots = set()
+        for bound_resource, consumers in self.resource_consumers.items():
+            if self._resource_reaches(bound_resource, position_resource):
+                roots.update(consumers)
+
+        candidates = set()
+        provenance_sections = set()
+        for root in roots:
+            for section_name in self._scope_sections(root):
+                if (section_name == root
+                        and section_name in self.section_draw_bindings):
+                    if section_name == root_section and current_bindings is not None:
+                        scopes = (current_bindings,)
+                    else:
+                        scopes = self.section_draw_bindings[section_name]
+                else:
+                    scopes = (self.section_bindings.get(section_name, {}),)
+                for bindings in scopes:
+                    for resource in bindings.values():
+                        if not resource:
+                            continue
+                        if self._resource_reaches(resource, position_resource):
+                            continue
+                        candidates.add(resource)
+                        provenance_sections.add(section_name)
+        return candidates, provenance_sections
 
 
 def _ib_res_to_component(ib_res):
@@ -102,6 +180,52 @@ def _resolve_normal_source(effective_vertex_resources, resources,
     return None
 
 
+def _build_vertex_binding_index(section_info, sections,
+                                resource_copy_sources):
+    """Build the small reverse index used by skinning provenance lookup."""
+    section_lookup = {str(name).lower(): name for name in sections}
+    section_bindings = {}
+    section_draw_bindings = {}
+    section_runs = {}
+    resource_consumers = {}
+
+    for name, info in section_info.items():
+        bindings = dict(info.get("vertex_resources_at_end") or {})
+        section_bindings[name] = bindings
+        draw_bindings = [
+            dict(draw.vertex_resources)
+            for draw in info.get("draws", ())
+        ]
+        if draw_bindings:
+            section_draw_bindings[name] = draw_bindings
+        for resource in bindings.values():
+            if resource:
+                resource_consumers.setdefault(
+                    str(resource).casefold(), set()).add(name)
+        for snapshot in draw_bindings:
+            for resource in snapshot.values():
+                if resource:
+                    resource_consumers.setdefault(
+                        str(resource).casefold(), set()).add(name)
+
+        runs = []
+        for raw in sections.get(name, ()):
+            target_name = _run_target_name(raw, section_lookup)
+            if target_name and target_name not in runs:
+                runs.append(target_name)
+        section_runs[name] = tuple(runs)
+
+    return VertexBindingIndex(
+        sections=sections,
+        section_lookup=section_lookup,
+        section_bindings=section_bindings,
+        section_draw_bindings=section_draw_bindings,
+        section_runs=section_runs,
+        resource_consumers=resource_consumers,
+        resource_copy_sources=resource_copy_sources,
+    )
+
+
 def _select_draw_sections(section_info, global_ib):
     """Select TextureOverride sections that can produce viewer geometry."""
     return [(name, info) for name, info in section_info.items()
@@ -110,7 +234,8 @@ def _select_draw_sections(section_info, global_ib):
             and (info["draws"] or (info["ib"] and not info["handling_skip"]))]
 
 
-def _resolve_component_buffers(section_info, resources, resource_copy_sources):
+def _resolve_component_buffers(section_info, resources, resource_copy_sources,
+                               sections=None):
     """Resolve component, hash, and WWMI global buffer bindings."""
     vertex_info_cache = {}
 
@@ -245,6 +370,9 @@ def _resolve_component_buffers(section_info, resources, resource_copy_sources):
 
     return {
         "resolve_vertex_info": resolve_vertex_info,
+        "vertex_binding_index": _build_vertex_binding_index(
+            section_info, sections or {},
+            resource_copy_sources),
         "component_buffers": component_buffers,
         "component_positions": component_positions,
         "component_texcoords": component_texcoords,
@@ -262,4 +390,5 @@ __all__ = [
     "_ib_res_to_component", "_ib_index_size", "_extract_hash",
     "_collect_resource_copy_sources", "_resolve_normal_source",
     "_resolve_component_buffers", "_select_draw_sections",
+    "VertexBindingIndex",
 ]

--- a/src/core/ini/draw_resources.py
+++ b/src/core/ini/draw_resources.py
@@ -21,6 +21,7 @@ class VertexBindingIndex:
     sections: dict
     section_lookup: dict
     section_bindings: dict
+    section_binding_conditionals: dict
     section_draw_bindings: dict
     section_runs: dict
     resource_consumers: dict
@@ -93,6 +94,11 @@ class VertexBindingIndex:
         candidates = []
         provenance_sections = set()
         for root in roots:
+            if root != root_section and root in self.section_draw_bindings:
+                # A different draw root has its own execution state. Its
+                # command-list closure must not leak into this draw's
+                # provenance candidates.
+                continue
             for section_name in self._scope_sections(root):
                 # A draw-producing root contains multiple execution snapshots.
                 # Unless it is the exact target draw, those snapshots are not
@@ -100,6 +106,8 @@ class VertexBindingIndex:
                 # may not match the target draw.
                 if (section_name != root_section
                         and section_name in self.section_draw_bindings):
+                    continue
+                if self.section_binding_conditionals.get(section_name, False):
                     continue
                 if (section_name == root
                         and section_name in self.section_draw_bindings):
@@ -221,6 +229,7 @@ def _build_vertex_binding_index(section_info, sections,
     """Build the small reverse index used by skinning provenance lookup."""
     section_lookup = {str(name).lower(): name for name in sections}
     section_bindings = {}
+    section_binding_conditionals = {}
     section_draw_bindings = {}
     section_runs = {}
     resource_consumers = {}
@@ -237,6 +246,8 @@ def _build_vertex_binding_index(section_info, sections,
     for name, info in section_info.items():
         bindings = dict(info.get("vertex_resources_at_end") or {})
         section_bindings[name] = bindings
+        section_binding_conditionals[name] = bool(
+            info.get("vertex_bindings_conditional"))
         draw_bindings = [
             dict(draw.vertex_resources)
             for draw in info.get("draws", ())
@@ -264,6 +275,7 @@ def _build_vertex_binding_index(section_info, sections,
         sections=sections,
         section_lookup=section_lookup,
         section_bindings=section_bindings,
+        section_binding_conditionals=section_binding_conditionals,
         section_draw_bindings=section_draw_bindings,
         section_runs=section_runs,
         resource_consumers=resource_consumers,

--- a/src/core/ini/draw_resources.py
+++ b/src/core/ini/draw_resources.py
@@ -1,6 +1,6 @@
 """Resolution of authored geometry resources into file-backed buffers."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import re
 
 from ..geometry.buffers import POSITION_STRIDE, _res_get
@@ -25,9 +25,14 @@ class VertexBindingIndex:
     section_runs: dict
     resource_consumers: dict
     resource_copy_sources: dict
+    resource_copy_neighbors: dict
+    _position_roots_cache: dict = field(default_factory=dict, init=False,
+                                        repr=False)
+    _scope_sections_cache: dict = field(default_factory=dict, init=False,
+                                        repr=False)
 
-    def _resource_reaches(self, start, target):
-        """Return whether an authored resource copy chain reaches target."""
+    def _resource_connected(self, start, target):
+        """Return whether explicit authored resource edges connect two names."""
         if not start or not target:
             return False
         target_key = str(target).casefold()
@@ -41,30 +46,61 @@ class VertexBindingIndex:
             visited.add(current_key)
             if current_key == target_key:
                 return True
-            pending.extend(self.resource_copy_sources.get(current_key, ()))
+            pending.extend(self.resource_copy_neighbors.get(current_key, ()))
         return False
 
     def _scope_sections(self, root):
+        cached = self._scope_sections_cache.get(root)
+        if cached is not None:
+            return cached
         if root not in self.sections:
-            return (root,)
-        return _reachable_execution_sections(
-            self.sections, root, self.section_lookup)
+            result = (root,)
+        else:
+            result = _reachable_execution_sections(
+                self.sections, root, self.section_lookup)
+        self._scope_sections_cache[root] = result
+        return result
+
+    def _position_roots(self, position_resource):
+        key = str(position_resource).casefold()
+        cached = self._position_roots_cache.get(key)
+        if cached is not None:
+            return cached
+        roots = set()
+        for bound_resource, consumers in self.resource_consumers.items():
+            if self._resource_connected(bound_resource, position_resource):
+                roots.update(consumers)
+        self._position_roots_cache[key] = roots
+        return roots
 
     def provenance_for_position(self, position_resource, *, root_section=None,
                                 current_bindings=None):
         """Return co-bound resources and their authored provenance sections."""
+        bindings, provenance_sections = self.provenance_bindings_for_position(
+            position_resource, root_section=root_section,
+            current_bindings=current_bindings)
+        return {resource for _slot, resource in bindings}, provenance_sections
+
+    def provenance_bindings_for_position(
+            self, position_resource, *, root_section=None,
+            current_bindings=None):
+        """Return co-bound ``(slot, resource)`` pairs with provenance."""
         if not position_resource:
-            return set(), set()
+            return [], set()
 
-        roots = set()
-        for bound_resource, consumers in self.resource_consumers.items():
-            if self._resource_reaches(bound_resource, position_resource):
-                roots.update(consumers)
+        roots = self._position_roots(position_resource)
 
-        candidates = set()
+        candidates = []
         provenance_sections = set()
         for root in roots:
             for section_name in self._scope_sections(root):
+                # A draw-producing root contains multiple execution snapshots.
+                # Unless it is the exact target draw, those snapshots are not
+                # safe provenance evidence because their conditions and order
+                # may not match the target draw.
+                if (section_name != root_section
+                        and section_name in self.section_draw_bindings):
+                    continue
                 if (section_name == root
                         and section_name in self.section_draw_bindings):
                     if section_name == root_section and current_bindings is not None:
@@ -74,12 +110,12 @@ class VertexBindingIndex:
                 else:
                     scopes = (self.section_bindings.get(section_name, {}),)
                 for bindings in scopes:
-                    for resource in bindings.values():
+                    for slot, resource in bindings.items():
                         if not resource:
                             continue
-                        if self._resource_reaches(resource, position_resource):
+                        if self._resource_connected(resource, position_resource):
                             continue
-                        candidates.add(resource)
+                        candidates.append((slot, resource))
                         provenance_sections.add(section_name)
         return candidates, provenance_sections
 
@@ -188,6 +224,15 @@ def _build_vertex_binding_index(section_info, sections,
     section_draw_bindings = {}
     section_runs = {}
     resource_consumers = {}
+    resource_copy_neighbors = {}
+    for destination, sources in resource_copy_sources.items():
+        destination_key = str(destination).casefold()
+        for source in sources:
+            source_key = str(source).casefold()
+            resource_copy_neighbors.setdefault(destination_key, set()).add(
+                source)
+            resource_copy_neighbors.setdefault(source_key, set()).add(
+                destination)
 
     for name, info in section_info.items():
         bindings = dict(info.get("vertex_resources_at_end") or {})
@@ -223,6 +268,7 @@ def _build_vertex_binding_index(section_info, sections,
         section_runs=section_runs,
         resource_consumers=resource_consumers,
         resource_copy_sources=resource_copy_sources,
+        resource_copy_neighbors=resource_copy_neighbors,
     )
 
 

--- a/src/core/ini/draw_resources.py
+++ b/src/core/ini/draw_resources.py
@@ -70,7 +70,9 @@ class VertexBindingIndex:
         roots = set()
         for bound_resource, consumers in self.resource_consumers.items():
             if self._resource_connected(bound_resource, position_resource):
-                roots.update(consumers)
+                roots.update(
+                    consumer for consumer in consumers
+                    if str(consumer).lower().startswith("textureoverride"))
         self._position_roots_cache[key] = roots
         return roots
 
@@ -94,6 +96,11 @@ class VertexBindingIndex:
         candidates = []
         provenance_sections = set()
         for root in roots:
+            if self.section_binding_conditionals.get(root, False):
+                # A conditional binding anywhere in a TextureOverride's
+                # execution closure makes the complete root unsafe as static
+                # provenance evidence.
+                continue
             if root != root_section and root in self.section_draw_bindings:
                 # A different draw root has its own execution state. Its
                 # command-list closure must not leak into this draw's

--- a/src/core/ini/draw_scan.py
+++ b/src/core/ini/draw_scan.py
@@ -348,6 +348,8 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
                 slot = int(match.group(1))
                 resource = match.group(2)
                 value = None if resource.lower() == "null" else resource
+                if cond_stack:
+                    info["vertex_bindings_conditional"] = True
                 if slot <= 2 and value and not info[f"vb{slot}"]:
                     info[f"vb{slot}"] = value
                 info["_cur_vertex_resources"][slot] = value
@@ -433,6 +435,7 @@ def _scan_sections_for_draws(sections, var_prefix=None, gating_vars=None):
             "_diffuse_chain_key": None, "_diffuse_history": [],
             "_aux_maps": {}, "_texture_provenance": {},
             "_cur_vertex_resources": {}, "_cur_slot_textures": {},
+            "vertex_bindings_conditional": False,
             "_cur_compute_resources": {},
             "_geometry_hash": None, "_match_first_index": None,
             "_match_index_count": None,

--- a/src/core/textures/__init__.py
+++ b/src/core/textures/__init__.py
@@ -15,6 +15,7 @@ from .pipeline import (
     reset_texture_cache,
     set_texture_profile_hook,
     split_texture_key,
+    texture_cache_stats,
     texture_key,
     texture_key_for_role,
 )
@@ -44,6 +45,7 @@ __all__ = [
     "reset_texture_cache",
     "set_texture_profile_hook",
     "split_texture_key",
+    "texture_cache_stats",
     "texture_key",
     "texture_key_for_role",
     "UVCoverage",

--- a/src/core/textures/pipeline.py
+++ b/src/core/textures/pipeline.py
@@ -121,6 +121,15 @@ def reset_texture_cache():
         _texture_cache_mod = None
 
 
+def texture_cache_stats():
+    """Return the process-local rendered-PNG cache footprint."""
+    with _texture_cache_lock:
+        return {
+            "rendered_png_cache_entry_count": len(_texture_cache),
+            "rendered_png_cache_bytes": _texture_cache_bytes,
+        }
+
+
 def _cache_texture(key, png):
     global _texture_cache_bytes
     size = len(png)

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -172,6 +172,21 @@ def test_load_mod_forwards_disabled_ini_flag(monkeypatch):
     assert calls == [("mod", True)]
 
 
+def test_load_asset_clears_loaded_mod_state_before_transition(monkeypatch):
+    api = ModViewerAPI()
+    calls = []
+    monkeypatch.setattr(
+        api._mod_preview, "clear_loaded_model",
+        lambda: calls.append("clear"))
+    monkeypatch.setattr(
+        api._asset_preview, "load_asset",
+        lambda path: calls.append(("asset", path)) or {"ok": True},
+    )
+
+    assert api.load_asset("asset") == {"ok": True}
+    assert calls == ["clear", ("asset", "asset")]
+
+
 def test_texture_save_forwards_targets_and_usage(monkeypatch):
     api = ModViewerAPI()
     calls = []

--- a/src/tests/app/bridge/test_api.py
+++ b/src/tests/app/bridge/test_api.py
@@ -29,6 +29,7 @@ EXPECTED_API_METHODS = {
     "get_asset_folders",
     "get_control_state",
     "get_diagnostics",
+    "get_memory_diagnostics",
     "get_ini_text",
     "get_mesh_semantics",
     "save_texture_color",

--- a/src/tests/app/bridge/test_mod_preview.py
+++ b/src/tests/app/bridge/test_mod_preview.py
@@ -106,6 +106,7 @@ def test_model_skinning_preview_includes_validated_saved_bones(monkeypatch):
     assert result["status"] == "error"
     assert result["saved_bones"] == [{
         "source": "Hair/HairBlend.buf", "bone_id_offset": 0,
+        "source_key": "hair/hairblend.buf|offset=0",
         "bone_ids": [7, 9],
     }]
 
@@ -273,6 +274,113 @@ def test_clear_loaded_model_releases_all_model_private_state():
     assert preview._active_mesh_keys == {}
     assert preview._skinning_manifests == {}
     assert preview._last_skinning_diagnostics == {}
+
+
+def test_skinning_publications_follow_model_generation_and_fetch_lifecycle(
+        monkeypatch):
+    preview = ModPreview(_Access())
+    blobs = {}
+    released = []
+    published = 0
+
+    def publish(blob, *, replace=True):
+        nonlocal published
+        published += 1
+        url = f"/geometry/test-{published}"
+        blobs[url] = bytes(blob)
+        return url
+
+    def release(url):
+        released.append(url)
+        return blobs.pop(url, None) is not None
+
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.publish_geometry", publish)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.release_geometry", release)
+
+    generation = preview._model_generation
+    first = preview._publish_skinning_geometry(b"old-model", generation)
+    assert first in blobs
+    preview.clear_loaded_model()
+    assert first in released
+    assert blobs == {}
+
+    stale = preview._publish_skinning_geometry(b"stale-model", generation)
+    assert stale is None
+    assert stale not in blobs
+
+    current = preview._publish_skinning_geometry(
+        b"current-model", preview._model_generation)
+    assert current in blobs
+    blobs.pop(current)
+    preview.clear_loaded_model()
+
+    assert released == [first, "/geometry/test-2", current]
+    assert blobs == {}
+    assert preview._pending_skinning_geometry_urls == set()
+
+
+def test_stale_skinning_publications_do_not_accumulate_under_repeated_reload(
+        monkeypatch):
+    preview = ModPreview(_Access())
+    blobs = {}
+    released = []
+
+    def publish(blob, *, replace=True):
+        url = f"/geometry/test-{len(blobs)}-{len(released)}"
+        blobs[url] = bytes(blob)
+        return url
+
+    def release(url):
+        released.append(url)
+        blobs.pop(url, None)
+        return True
+
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.publish_geometry", publish)
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.release_geometry", release)
+
+    generation = preview._model_generation
+    preview.clear_loaded_model()
+    for _ in range(32):
+        assert preview._publish_skinning_geometry(
+            b"stale-model", generation) is None
+
+    assert blobs == {}
+    assert len(released) == 32
+    assert preview._pending_skinning_geometry_urls == set()
+
+
+def test_memory_diagnostics_report_resource_retention(monkeypatch):
+    preview = ModPreview(_Access())
+    preview._dds_classification_caches["mod"] = {"one": object()}
+    preview._pending_skinning_geometry_urls.add("/geometry/weight")
+    preview._last_weight_blob_bytes = 17
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.server.geometry_stats",
+        lambda: {"pending_blob_count": 2, "pending_blob_bytes": 23})
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.texture_cache_stats",
+        lambda: {"rendered_png_cache_entry_count": 3,
+                 "rendered_png_cache_bytes": 29})
+
+    assert preview.get_memory_diagnostics() == {
+        "geometry": {"pending_blob_count": 2, "pending_blob_bytes": 23},
+        "weight": {
+            "pending_skinning_publication_count": 1,
+            "last_weight_blob_bytes": 17,
+        },
+        "dds": {
+            "cached_folder_count": 1,
+            "classification_entry_count": 1,
+        },
+        "texture": {
+            "rendered_png_cache_entry_count": 3,
+            "rendered_png_cache_bytes": 29,
+        },
+    }
 
 
 def test_semantic_control_read_reuses_active_mesh_keys(monkeypatch):

--- a/src/tests/app/bridge/test_mod_preview.py
+++ b/src/tests/app/bridge/test_mod_preview.py
@@ -132,19 +132,24 @@ def test_load_commits_texture_publication_after_geometry(monkeypatch):
     events = []
     publication = _Publication(events)
     preview = ModPreview(_Access())
+    context = _context()
+    manifest = {"Body-1": object()}
     monkeypatch.setattr(
         preview, "authoritative_context",
-        lambda _folder, **_kwargs: ("mod", {}, {}, _context()))
+        lambda _folder, **_kwargs: ("mod", {}, {}, context))
     monkeypatch.setattr(
         "app.bridge.mod_preview.server.begin_texture_publication",
         lambda _folder: publication)
-    monkeypatch.setattr(
-        "app.bridge.mod_preview.mod_loader.load_mod",
-        lambda **_kwargs: {
+    def load_model(**kwargs):
+        kwargs["context"].skinning_manifest = manifest
+        return {
             "meshes": {"Body-1": {}},
             "metadata": {"game": {"id": "genshin"}},
             "controls": {"present": {}},
-        })
+        }
+
+    monkeypatch.setattr(
+        "app.bridge.mod_preview.mod_loader.load_mod", load_model)
     monkeypatch.setattr(
         "app.bridge.mod_preview.metadata.hydrate_textures",
         lambda *_args, **_kwargs: None)
@@ -161,6 +166,7 @@ def test_load_commits_texture_publication_after_geometry(monkeypatch):
     assert result["meshes"] == {"Body-1": {}}
     assert [event[0] for event in events] == ["profile", "publish", "commit"]
     assert preview._active_mesh_keys == {"mod": {"Body-1"}}
+    assert preview._skinning_manifests == {"mod": manifest}
 
 
 def test_load_forwards_disabled_mode_to_authoritative_context(monkeypatch):
@@ -234,6 +240,7 @@ def test_failed_load_discards_publication_and_clears_active_meshes(monkeypatch):
     publication = _Publication(events)
     preview = ModPreview(_Access())
     preview._active_mesh_keys["mod"] = {"old"}
+    preview._skinning_manifests["mod"] = {"old": object()}
     monkeypatch.setattr(
         preview, "authoritative_context",
         lambda _folder, **_kwargs: ("mod", {}, {}, _context()))
@@ -250,6 +257,7 @@ def test_failed_load_discards_publication_and_clears_active_meshes(monkeypatch):
 
     assert events == [("discard",)]
     assert "mod" not in preview._active_mesh_keys
+    assert "mod" not in preview._skinning_manifests
 
 
 def test_semantic_control_read_reuses_active_mesh_keys(monkeypatch):

--- a/src/tests/app/bridge/test_mod_preview.py
+++ b/src/tests/app/bridge/test_mod_preview.py
@@ -260,6 +260,21 @@ def test_failed_load_discards_publication_and_clears_active_meshes(monkeypatch):
     assert "mod" not in preview._skinning_manifests
 
 
+def test_clear_loaded_model_releases_all_model_private_state():
+    preview = ModPreview(_Access())
+    preview._current_model_folder = "mod"
+    preview._active_mesh_keys["mod"] = {"Body-1"}
+    preview._skinning_manifests["mod"] = {"Body-1": object()}
+    preview._last_skinning_diagnostics["mod"] = {"total_seconds": 1}
+
+    preview.clear_loaded_model()
+
+    assert preview._current_model_folder is None
+    assert preview._active_mesh_keys == {}
+    assert preview._skinning_manifests == {}
+    assert preview._last_skinning_diagnostics == {}
+
+
 def test_semantic_control_read_reuses_active_mesh_keys(monkeypatch):
     preview = ModPreview(_Access())
     preview._active_mesh_keys["mod"] = {"Body-1"}

--- a/src/tests/app/mods/test_metadata.py
+++ b/src/tests/app/mods/test_metadata.py
@@ -14,6 +14,7 @@ from app.mods import metadata
         ([{"source": "Hair\\HairBlend.buf", "bone_id_offset": 0,
            "bone_ids": [49, 45, True, -1, 47.0, 45, 53]}], [
              {"source": "Hair/HairBlend.buf", "bone_id_offset": 0,
+              "source_key": "hair/hairblend.buf|offset=0",
               "bone_ids": [45, 49, 53]},
          ]),
         ([
@@ -27,12 +28,24 @@ from app.mods import metadata
              "bone_ids": [99]},
         ], [
             {"source": "Hair/HairBlend.buf", "bone_id_offset": 0,
+             "source_key": "hair/hairblend.buf|offset=0",
              "bone_ids": [45, 49]},
             {"source": "Hair/HairBlend.buf", "bone_id_offset": 24,
+             "source_key": "hair/hairblend.buf|offset=24",
              "bone_ids": [1]},
             {"source": "HairBlend.buf", "bone_id_offset": 0,
+             "source_key": "hairblend.buf|offset=0",
              "bone_ids": [99]},
         ]),
+        ([{"source": "Meshes/Blend.buf", "source_key":
+           "meshes/blend.buf|offset=142|namespace=wwmi_vertex_vg|"
+           "vertex-vg=meshes/blendremapvertexvg.buf",
+           "bone_id_offset": 142, "bone_ids": [318, 319]}], [
+             {"source": "Meshes/Blend.buf", "source_key":
+              "meshes/blend.buf|offset=142|namespace=wwmi_vertex_vg|"
+              "vertex-vg=meshes/blendremapvertexvg.buf",
+              "bone_id_offset": 142, "bone_ids": [318, 319]},
+         ]),
     ],
 )
 def test_weight_selected_bones_validates_persisted_values(stored, expected):
@@ -57,6 +70,7 @@ def test_save_weight_selected_bones_preserves_unrelated_metadata(tmp_path):
     assert result["saved"] is True
     assert result["selected_bones"] == [{
         "source": "Hair/HairBlend.buf", "bone_id_offset": 0,
+        "source_key": "hair/hairblend.buf|offset=0",
         "bone_ids": [45, 49, 53],
     }]
     assert json.loads(path.read_text(encoding="utf-8")) == {
@@ -65,6 +79,7 @@ def test_save_weight_selected_bones_preserves_unrelated_metadata(tmp_path):
             "future_option": "preserve",
             "selected_bones": [{
                 "source": "Hair/HairBlend.buf", "bone_id_offset": 0,
+                "source_key": "hair/hairblend.buf|offset=0",
                 "bone_ids": [45, 49, 53],
             }],
         },

--- a/src/tests/core/geometry/test_packing.py
+++ b/src/tests/core/geometry/test_packing.py
@@ -67,6 +67,7 @@ def test_repeated_vertices_keep_exact_packed_positions_uvs_and_indices(
 
     assert _unpack_f32(packed.positions) == (
         2., 0., 0., 4., 0., 0., 5., 0., 0.)
+    assert packed.used_vertices == (2, 4, 5)
     assert _unpack_f32(packed.texcoords) == (
         2., .75, 4., .5, 5., .25)
     assert _unpack_indices(packed.indices) == (2, 0, 2, 1, 2, 0)
@@ -80,6 +81,7 @@ def test_base_vertex_location_is_applied_before_packing(tmp_path):
     assert _unpack_f32(packed.positions) == (
         3., 0., 0., 4., 0., 0., 5., 0., 0.)
     assert _unpack_indices(packed.indices) == (0, 1, 2)
+    assert packed.used_vertices == (3, 4, 5)
 
 
 def test_negative_effective_index_rejects_the_draw(tmp_path):
@@ -98,6 +100,7 @@ def test_truncated_position_removes_only_the_affected_triangle(tmp_path):
         uvs=[(0., 0.)] * 5)
 
     assert _unpack_indices(packed.indices) == (0, 1, 2)
+    assert packed.used_vertices == (0, 1, 2)
 
 
 def test_invalid_vertex_decode_is_cached_across_triangles(tmp_path):
@@ -179,6 +182,7 @@ def test_reverse_winding_preserves_compact_vertex_order_and_output_shape(
     assert reverse.positions == forward.positions
     assert reverse.texcoords == forward.texcoords
     assert reverse.indices == forward.indices
+    assert reverse.used_vertices == forward.used_vertices
 
 
 @pytest.mark.parametrize("trailing", [(0,), (0, 1)])
@@ -240,6 +244,7 @@ def test_shared_vertices_preserve_prepared_identity_and_decode_once(tmp_path):
     prepared, = prepared_results
     assert prepared.raw_indices == [5, 4, 2, 4, 5, 2]
     assert prepared.used_vertices == [2, 4, 5]
+    assert packed.used_vertices == (2, 4, 5)
     assert prepared.remap == {2: 0, 4: 1, 5: 2}
     assert prepared.decoded_vertices == {
         i: (float(i), 0., 0., None, None) for i in (2, 4, 5)}

--- a/src/tests/core/geometry/test_skinning.py
+++ b/src/tests/core/geometry/test_skinning.py
@@ -194,7 +194,7 @@ def test_resolver_accepts_known_blend_layouts(stride, fmt, encoding):
         bone_id_namespace=("wwmi_vertex_vg" if expected_remap else "model"))
 
 
-def test_resolver_rejects_wwmi_source_without_vertex_vg_remap():
+def test_resolver_accepts_wwmi_source_without_vertex_vg_remap():
     source, error = resolve_skinning_source(
         {1: "ResourceBlendBuffer"},
         {"ResourceBlendBuffer": {
@@ -202,8 +202,13 @@ def test_resolver_rejects_wwmi_source_without_vertex_vg_remap():
             "format": "DXGI_FORMAT_R8_UINT",
         }}.get)
 
-    assert source is None
-    assert error == "missing_vertex_vg_remap"
+    assert error is None
+    assert source == SkinningSource(
+        "blend.buf", 8, 4, "wwmi_u8_4", bone_id_namespace="model")
+    decoded = decode_skinning(
+        source, bytes([3, 4, 5, 6, 255, 128, 64, 32]), [0])
+    assert decoded.bone_ids == (3, 4, 5, 6)
+    assert decoded.diagnostics["vertex_vg_remap"] is False
 
 
 def test_resolver_carries_the_authored_model_bone_offset():

--- a/src/tests/core/geometry/test_skinning.py
+++ b/src/tests/core/geometry/test_skinning.py
@@ -26,6 +26,11 @@ def test_decode_gimi_four_influences_to_canonical_bytes():
     assert unpack_values(decoded.weights, "4f") == pytest.approx((.6, .3, .1, 0.))
     assert decoded.bone_ids == (7, 8, 9)
     assert decoded.diagnostics["invalid_weight_vertices"] == 0
+    assert decoded.bone_stats == {
+        7: {"affected_vertex_count": 1, "total_weight": pytest.approx(.6)},
+        8: {"affected_vertex_count": 1, "total_weight": pytest.approx(.3)},
+        9: {"affected_vertex_count": 1, "total_weight": pytest.approx(.1)},
+    }
 
 
 def test_decode_wwmi_four_influences_divides_bytes_by_255():
@@ -63,8 +68,23 @@ def test_decode_wwmi_vertex_vg_remap_keeps_colliding_raw_indices_distinct():
     assert unpack_values(decoded.weights, "8f") == pytest.approx(
         tuple(value / 255 for value in [255, 128, 64, 32, 16, 8, 4, 2]))
     assert decoded.bone_ids == (0, 1, 2, 3, 45, 257, 259)
+    assert decoded.bone_stats[259] == {
+        "affected_vertex_count": 1, "total_weight": pytest.approx(128 / 255),
+    }
     assert decoded.diagnostics["bone_id_namespace"] == "wwmi_vertex_vg"
     assert decoded.diagnostics["vertex_vg_remap"] is True
+
+
+def test_decode_bone_stats_count_each_vertex_once_and_sum_duplicate_slots():
+    source = SkinningSource("blend.buf", 8, 4, "wwmi_u8_4")
+    raw = bytes([2, 2, 3, 0, 128, 64, 32, 0])
+
+    decoded = decode_skinning(source, raw, [0])
+
+    assert decoded.bone_stats == {
+        2: {"affected_vertex_count": 1, "total_weight": pytest.approx(192 / 255)},
+        3: {"affected_vertex_count": 1, "total_weight": pytest.approx(32 / 255)},
+    }
 
 
 def test_decode_rigid_uses_one_implicit_weight():

--- a/src/tests/core/geometry/test_skinning.py
+++ b/src/tests/core/geometry/test_skinning.py
@@ -325,10 +325,11 @@ def test_skinning_source_descriptor_excludes_decoder_details():
     }
 
 
-def test_resolver_does_not_infer_blend_from_stride_alone():
+@pytest.mark.parametrize("stride", [4, 8, 16, 32])
+def test_resolver_does_not_infer_blend_from_stride_alone(stride):
     source, error = resolve_skinning_source(
         {1: "ResourceSomething"},
-        lambda _name: {"filename": "stream.buf", "stride": 8},
+        lambda _name: {"filename": "stream.buf", "stride": stride},
     )
 
     assert source is None

--- a/src/tests/core/geometry/test_skinning.py
+++ b/src/tests/core/geometry/test_skinning.py
@@ -16,6 +16,31 @@ def unpack_values(raw, fmt):
     return struct.unpack(f"<{fmt}", raw)
 
 
+class IndexedMapping:
+    """Sequence fixture that exposes accidental decoder iteration/copying."""
+
+    def __init__(self, values):
+        self.values = list(values)
+
+    def __len__(self):
+        return len(self.values)
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+    def __iter__(self):
+        raise AssertionError("decoder should consume the retained mapping")
+
+
+def test_decode_consumes_retained_vertex_mapping_without_materializing_tuple():
+    source = SkinningSource("blend.buf", 4, 1, "rigid_u32_1")
+
+    decoded = decode_skinning(
+        source, struct.pack("<2I", 7, 11), IndexedMapping([0, 1]))
+
+    assert unpack_values(decoded.indices, "2I") == (7, 11)
+
+
 def test_decode_gimi_four_influences_to_canonical_bytes():
     source = SkinningSource("blend.buf", 32, 4, "gimi_f32_u32_4")
     raw = struct.pack("<4f4I", .6, .3, .1, 0., 7, 8, 9, 0)

--- a/src/tests/core/ini/test_draw_groups.py
+++ b/src/tests/core/ini/test_draw_groups.py
@@ -310,3 +310,211 @@ stride = 20
         assert draw.skinning_source.file == "body-blend.buf"
     else:
         assert draw.skinning_source is None
+
+
+def test_draw_groups_resolve_blend_from_position_provenance_without_hashes():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverridePotato]
+hash = 11111111
+vb0 = ResourceAlpha
+vb7 = ResourceSkinData
+
+[TextureOverrideBanana]
+hash = 22222222
+ib = ResourceIndex
+vb0 = ResourceAlpha
+vb1 = ResourceTexcoord
+drawindexed = 3, 0, 0
+
+[ResourceIndex]
+filename = index.buf
+format = DXGI_FORMAT_R32_UINT
+
+[ResourceAlpha]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceSkinData]
+filename = skin-data.bin
+stride = 32
+""")
+
+    draw = build_draw_groups(
+        sections, extract_resources(sections))[0]["draws"][0]
+
+    assert draw.skinning_error is None
+    assert draw.skinning_source.file == "skin-data.bin"
+    assert draw.skinning_resolution["resolution_source"] == \
+        "position_provenance"
+
+
+def test_draw_groups_position_provenance_reports_ambiguity():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverridePositionA]
+vb0 = ResourcePosition
+vb2 = ResourceBlendA
+
+[TextureOverridePositionB]
+vb0 = ResourcePosition
+vb2 = ResourceBlendB
+
+[TextureOverrideBody]
+ib = ResourceIndex
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+drawindexed = 3, 0, 0
+
+[ResourceIndex]
+filename = index.buf
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceBlendA]
+filename = a.bin
+stride = 32
+
+[ResourceBlendB]
+filename = b.bin
+stride = 32
+""")
+
+    draw = build_draw_groups(
+        sections, extract_resources(sections))[0]["draws"][0]
+
+    assert draw.skinning_source is None
+    assert draw.skinning_error == "ambiguous_skinning_source"
+
+
+def test_draw_groups_direct_binding_beats_position_provenance():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverridePosition]
+vb0 = ResourcePosition
+vb4 = ResourceFallbackBlend
+
+[TextureOverrideBody]
+ib = ResourceIndex
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+vb4 = ResourceDirectBlend
+drawindexed = 3, 0, 0
+
+[ResourceIndex]
+filename = index.buf
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceFallbackBlend]
+filename = fallback.bin
+stride = 32
+
+[ResourceDirectBlend]
+filename = direct.bin
+stride = 32
+""")
+
+    draw = build_draw_groups(
+        sections, extract_resources(sections))[0]["draws"][0]
+
+    assert draw.skinning_error is None
+    assert draw.skinning_source.file == "direct.bin"
+    assert draw.skinning_resolution["resolution_source"] == "direct"
+
+
+def test_draw_groups_keep_draw_time_vertex_state_ordered():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverridePosition]
+vb0 = ResourcePosition
+vb4 = ResourceFallbackBlend
+
+[TextureOverrideBody]
+ib = ResourceIndex
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+drawindexed = 3, 0, 0
+vb4 = ResourceDirectBlend
+drawindexed = 3, 3, 0
+
+[ResourceIndex]
+filename = index.buf
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceFallbackBlend]
+filename = fallback.bin
+stride = 32
+
+[ResourceDirectBlend]
+filename = direct.bin
+stride = 32
+""")
+
+    draws = build_draw_groups(
+        sections, extract_resources(sections))[0]["draws"]
+
+    assert draws[0].skinning_source.file == "fallback.bin"
+    assert draws[0].skinning_resolution["resolution_source"] == \
+        "position_provenance"
+    assert draws[1].skinning_source.file == "direct.bin"
+    assert draws[1].skinning_resolution["resolution_source"] == "direct"
+
+
+def test_draw_groups_command_list_bindings_are_direct_draw_state():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverrideBody]
+ib = ResourceIndex
+run = CommandListShared
+drawindexed = 3, 0, 0
+
+[CommandListShared]
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+vb4 = ResourceBlendBuffer
+
+[ResourceIndex]
+filename = index.buf
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceBlendBuffer]
+filename = blend.buf
+stride = 32
+""")
+
+    draw = build_draw_groups(
+        sections, extract_resources(sections))[0]["draws"][0]
+
+    assert draw.skinning_error is None
+    assert draw.skinning_source.file == "blend.buf"
+    assert draw.skinning_resolution["resolution_source"] == "direct"

--- a/src/tests/core/ini/test_draw_groups.py
+++ b/src/tests/core/ini/test_draw_groups.py
@@ -317,7 +317,7 @@ def test_draw_groups_resolve_blend_from_position_provenance_without_hashes():
 [TextureOverridePotato]
 hash = 11111111
 vb0 = ResourceAlpha
-vb7 = ResourceSkinData
+vb7 = ResourceAuthoredBlendStream
 
 [TextureOverrideBanana]
 hash = 22222222
@@ -338,6 +338,96 @@ stride = 40
 filename = texcoord.buf
 stride = 20
 
+[ResourceAuthoredBlendStream]
+filename = skin-data.bin
+stride = 32
+""")
+
+    draw = build_draw_groups(
+        sections, extract_resources(sections))[0]["draws"][0]
+
+    assert draw.skinning_error is None
+    assert draw.skinning_source.file == "skin-data.bin"
+    assert draw.skinning_resolution["resolution_source"] == \
+        "position_provenance"
+
+
+def test_draw_groups_position_provenance_does_not_merge_draw_snapshots():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverrideSource]
+ib = ResourceSourceIndex
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+vb4 = ResourceSourceBlend
+drawindexed = 3, 0, 0
+vb4 = ResourceOtherBlend
+drawindexed = 3, 3, 0
+
+[TextureOverrideBody]
+ib = ResourceBodyIndex
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+drawindexed = 3, 0, 0
+
+[ResourceSourceIndex]
+filename = source.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourceBodyIndex]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceSourceBlend]
+filename = source-a.blend
+stride = 32
+
+[ResourceOtherBlend]
+filename = source-b.blend
+stride = 32
+""")
+
+    groups = build_draw_groups(
+        sections, extract_resources(sections))
+    body_draw = next(
+        draw for group in groups if group["name"] == "Body"
+        for draw in group["draws"])
+
+    assert body_draw.skinning_source is None
+    assert body_draw.skinning_error is None
+
+
+def test_draw_groups_accepts_unlabeled_authored_weight_provenance():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverridePosition]
+vb0 = ResourcePosition
+vb7 = ResourceSkinData
+
+[TextureOverrideBody]
+ib = ResourceBodyIndex
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+drawindexed = 3, 0, 0
+
+[ResourceBodyIndex]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
 [ResourceSkinData]
 filename = skin-data.bin
 stride = 32
@@ -348,6 +438,49 @@ stride = 32
 
     assert draw.skinning_error is None
     assert draw.skinning_source.file == "skin-data.bin"
+    assert draw.skinning_resolution["resolution_source"] == \
+        "position_provenance"
+
+
+def test_draw_groups_position_provenance_follows_reverse_explicit_copy():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverridePosition]
+vb0 = ResourcePosition
+vb4 = ResourceAuthoredBlend
+
+[TextureOverrideBody]
+ib = ResourceBodyIndex
+vb0 = ResourcePositionAlias
+vb1 = ResourceTexcoord
+drawindexed = 3, 0, 0
+
+[Present]
+ResourcePositionAlias = copy ResourcePosition
+
+[ResourceBodyIndex]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourcePositionAlias]
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceAuthoredBlend]
+filename = blend.buf
+stride = 32
+""")
+
+    draw = build_draw_groups(
+        sections, extract_resources(sections))[0]["draws"][0]
+
+    assert draw.skinning_error is None
+    assert draw.skinning_source.file == "blend.buf"
     assert draw.skinning_resolution["resolution_source"] == \
         "position_provenance"
 

--- a/src/tests/core/ini/test_draw_groups.py
+++ b/src/tests/core/ini/test_draw_groups.py
@@ -574,6 +574,48 @@ stride = 32
     assert draw.skinning_error is None
 
 
+def test_draw_groups_position_provenance_rejects_conditional_commandlist_root():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverridePosition]
+vb0 = ResourcePosition
+if $mode
+    run = CommandListConditional
+endif
+
+[CommandListConditional]
+vb0 = ResourcePosition
+vb4 = ResourceConditionalBlend
+
+[TextureOverrideBody]
+ib = ResourceBodyIndex
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+drawindexed = 3, 0, 0
+
+[ResourceBodyIndex]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceConditionalBlend]
+filename = conditional.blend
+stride = 32
+""")
+
+    draw = build_draw_groups(
+        sections, extract_resources(sections))[0]["draws"][0]
+
+    assert draw.skinning_source is None
+    assert draw.skinning_error is None
+
+
 def test_draw_groups_position_provenance_follows_reverse_explicit_copy():
     sections = parse_sections("sample.ini", text="""
 [TextureOverridePosition]

--- a/src/tests/core/ini/test_draw_groups.py
+++ b/src/tests/core/ini/test_draw_groups.py
@@ -404,11 +404,11 @@ stride = 32
     assert body_draw.skinning_error is None
 
 
-def test_draw_groups_accepts_unlabeled_authored_weight_provenance():
+def test_draw_groups_rejects_unlabeled_authored_weight_provenance():
     sections = parse_sections("sample.ini", text="""
 [TextureOverridePosition]
 vb0 = ResourcePosition
-vb7 = ResourceSkinData
+vb7 = ResourceColorData
 
 [TextureOverrideBody]
 ib = ResourceBodyIndex
@@ -428,8 +428,8 @@ stride = 40
 filename = texcoord.buf
 stride = 20
 
-[ResourceSkinData]
-filename = skin-data.bin
+[ResourceColorData]
+filename = color.bin
 stride = 32
 """)
 
@@ -437,9 +437,141 @@ stride = 32
         sections, extract_resources(sections))[0]["draws"][0]
 
     assert draw.skinning_error is None
-    assert draw.skinning_source.file == "skin-data.bin"
-    assert draw.skinning_resolution["resolution_source"] == \
-        "position_provenance"
+    assert draw.skinning_source is None
+    assert draw.skinning_resolution["resolution_source"] is None
+
+
+def test_draw_groups_position_provenance_respects_actual_draw_slots():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverridePosition]
+vb0 = ResourcePosition
+vb2 = ResourceFallbackBlend
+
+[TextureOverrideBody]
+ib = ResourceBodyIndex
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+vb2 = ResourceOtherStream
+drawindexed = 3, 0, 0
+
+[ResourceBodyIndex]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceFallbackBlend]
+filename = fallback.blend
+stride = 32
+
+[ResourceOtherStream]
+filename = color.bin
+stride = 32
+""")
+
+    draw = build_draw_groups(
+        sections, extract_resources(sections))[0]["draws"][0]
+
+    assert draw.skinning_source is None
+    assert draw.skinning_error is None
+
+
+def test_draw_groups_position_provenance_rejects_unrelated_draw_scope():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverrideOtherDraw]
+ib = ResourceOtherIndex
+vb0 = ResourcePosition
+run = CommandListOther
+drawindexed = 3, 0, 0
+
+[CommandListOther]
+vb4 = ResourceOtherBlend
+
+[TextureOverrideBody]
+ib = ResourceBodyIndex
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+drawindexed = 3, 0, 0
+
+[ResourceOtherIndex]
+filename = other.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourceBodyIndex]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceOtherBlend]
+filename = other.blend
+stride = 32
+""")
+
+    groups = build_draw_groups(
+        sections, extract_resources(sections))
+    body_draw = next(
+        draw for group in groups if group["name"] == "Body"
+        for draw in group["draws"])
+
+    assert body_draw.skinning_source is None
+    assert body_draw.skinning_error is None
+
+
+def test_draw_groups_position_provenance_rejects_conditional_bindings():
+    sections = parse_sections("sample.ini", text="""
+[TextureOverridePosition]
+vb0 = ResourcePosition
+if $mode
+    vb2 = ResourceBlendA
+else
+    vb2 = ResourceBlendB
+endif
+
+[TextureOverrideBody]
+ib = ResourceBodyIndex
+vb0 = ResourcePosition
+vb1 = ResourceTexcoord
+drawindexed = 3, 0, 0
+
+[ResourceBodyIndex]
+filename = body.ib
+format = DXGI_FORMAT_R32_UINT
+
+[ResourcePosition]
+filename = position.buf
+stride = 40
+
+[ResourceTexcoord]
+filename = texcoord.buf
+stride = 20
+
+[ResourceBlendA]
+filename = a.blend
+stride = 32
+
+[ResourceBlendB]
+filename = b.blend
+stride = 32
+""")
+
+    draw = build_draw_groups(
+        sections, extract_resources(sections))[0]["draws"][0]
+
+    assert draw.skinning_source is None
+    assert draw.skinning_error is None
 
 
 def test_draw_groups_position_provenance_follows_reverse_explicit_copy():

--- a/src/tests/integration/test_skinning_preview.py
+++ b/src/tests/integration/test_skinning_preview.py
@@ -130,15 +130,22 @@ def test_model_skinning_preview_matches_rendered_compaction(tmp_path, monkeypatc
         mod_dir=str(tmp_path), ini_paths=[str(ini)], docs={}, metadata={},
         asset_folders=[])
     preview = ModPreview(_Access())
+    preview._active_mesh_keys[str(tmp_path)] = set(rendered.meshes)
+    preview._skinning_manifests[str(tmp_path)] = rendered.skinning_manifest
     monkeypatch.setattr(
         preview, "authoritative_context",
         lambda _path: (str(tmp_path), {}, {}, context))
     monkeypatch.setattr(
         "app.bridge.mod_preview.server.publish_geometry", publish)
     monkeypatch.setattr(
-        "app.bridge.mod_preview.mod_loader.load_mod",
-        lambda **_kwargs: (_ for _ in ()).throw(
-            AssertionError("preview must not load the model")),
+        preview, "_skinning_draws",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("loaded-model Weight must not resolve draws")),
+    )
+    monkeypatch.setattr(
+        "core.geometry.packing._prepare_draw_vertices",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("loaded-model Weight must not prepare geometry")),
     )
 
     result = preview.get_model_skinning_preview(str(tmp_path))
@@ -156,6 +163,15 @@ def test_model_skinning_preview_matches_rendered_compaction(tmp_path, monkeypatc
     assert struct.unpack_from("<4I", published["blob"], 0) == (7, 8, 9, 0)
     assert struct.unpack_from("<4f", published["blob"], 4 * 4 * 4) == pytest.approx(
         (.6, .3, .1, 0.))
+    assert list(rendered.skinning_manifest["BodyBlend-1"].used_vertices) == [
+        0, 1, 2, 3]
+    assert result_entry["source"]["file"] == "body.blend"
+    assert preview._last_skinning_diagnostics[str(tmp_path)][
+        "mapping_source"] == "loaded_model_manifest"
+    assert preview._last_skinning_diagnostics[str(tmp_path)][
+        "resolve_draw_count"] == 0
+    assert preview._last_skinning_diagnostics[str(tmp_path)][
+        "prepare_draw_vertices_calls"] == 0
 
 
 def test_model_skinning_preview_uses_wwmi_vertex_vg_identity(
@@ -177,11 +193,18 @@ def test_model_skinning_preview_uses_wwmi_vertex_vg_identity(
         mod_dir=str(tmp_path), ini_paths=[str(ini)], docs={}, metadata={},
         asset_folders=[])
     preview = ModPreview(_Access())
+    preview._active_mesh_keys[str(tmp_path)] = set(rendered.meshes)
+    preview._skinning_manifests[str(tmp_path)] = rendered.skinning_manifest
     monkeypatch.setattr(
         preview, "authoritative_context",
         lambda _path: (str(tmp_path), {}, {}, context))
     monkeypatch.setattr(
         "app.bridge.mod_preview.server.publish_geometry", publish)
+    monkeypatch.setattr(
+        preview, "_skinning_draws",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("loaded-model Weight must not resolve draws")),
+    )
 
     result = preview.get_model_skinning_preview(str(tmp_path))
     entry = result["meshes"]["BodyBlend-1"]
@@ -193,6 +216,11 @@ def test_model_skinning_preview_uses_wwmi_vertex_vg_identity(
     assert entry["diagnostics"]["vertex_vg_source"] == "body.vertex_vg"
     assert entry["diagnostics"]["vertex_vg_truncated_vertices"] == 0
     assert entry["source"]["bone_id_namespace"] == "wwmi_vertex_vg"
+    manifest_source = rendered.skinning_manifest[
+        "BodyBlend-1"].skinning_source
+    assert manifest_source.vertex_vg_file == "body.vertex_vg"
+    assert manifest_source.vertex_vg_stride == 16
+    assert manifest_source.bone_id_namespace == "wwmi_vertex_vg"
     assert struct.unpack_from("<8I", published["blob"], 0) == (
         3, 259, 0, 0, 0, 0, 0, 0)
     assert struct.unpack_from("<8f", published["blob"], 3 * 8 * 4) == pytest.approx(

--- a/src/tests/integration/test_skinning_preview.py
+++ b/src/tests/integration/test_skinning_preview.py
@@ -156,6 +156,11 @@ def test_model_skinning_preview_matches_rendered_compaction(tmp_path, monkeypatc
     assert result_entry["vertex_count"] == position_length // 12
     assert result_entry["encoding"] == "gimi_f32_u32_4"
     assert result_entry["bone_ids"] == [7, 8, 9]
+    assert result_entry["weight_stats"] == {
+        "7": {"affected_vertex_count": 4, "total_weight": pytest.approx(2.4)},
+        "8": {"affected_vertex_count": 4, "total_weight": pytest.approx(1.2)},
+        "9": {"affected_vertex_count": 4, "total_weight": pytest.approx(.4)},
+    }
     assert result_entry["data"]["indices"]["offset"] == 0
     assert result_entry["data"]["weights"]["offset"] == 4 * 4 * 4
     assert result["data"]["length"] == len(published["blob"])
@@ -211,6 +216,10 @@ def test_model_skinning_preview_uses_wwmi_vertex_vg_identity(
 
     assert result["status"] == "ok"
     assert entry["bone_ids"] == [3, 259]
+    assert entry["weight_stats"]["259"] == {
+        "affected_vertex_count": 3,
+        "total_weight": pytest.approx(3 * 128 / 255),
+    }
     assert entry["diagnostics"]["bone_id_namespace"] == "wwmi_vertex_vg"
     assert entry["diagnostics"]["vertex_vg_remap"] is True
     assert entry["diagnostics"]["vertex_vg_source"] == "body.vertex_vg"

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1917,6 +1917,8 @@ def test_rig_source_session_deduplicates_exact_evidence_and_falls_back_source_wi
       };
       const first = makeMesh('first', true);
       const duplicate = makeMesh('duplicate', true, 2);
+      // Provenance may differ even when the retained Rig evidence is equal.
+      duplicate.userData.identity.geometry_state.ib_file = 'other-indices.buf';
       const invalid = makeMesh('invalid', false, 1);
       const graphFor = (mesh, state, evidenceMode, surfaceEvidence) => {
         graphCalls.push({mesh: mesh.userData.semanticKey, evidenceMode,

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1440,6 +1440,45 @@ def test_surface_evidence_weights_rig_nodes_relationships_and_aggregation(
         "Cannot aggregate incompatible Rig evidence modes.")
 
 
+def test_cooperative_surface_evidence_matches_sync_and_supports_cancellation(
+        module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const rig = await import('./js/mesh/weight-rig.js');
+      const positions = new Float32Array([
+        0, 0, 0, 2, 0, 0, 0, 2, 0,
+        1, 0, 0, 1, 1, 0, 0, 1, 0,
+      ]);
+      const triangles = new Uint32Array([
+        0, 1, 2, 1, 3, 2,
+      ]);
+      const indices = new Uint32Array([
+        0, 1, 0, 1, 0, 1,
+        0, 1, 0, 1, 0, 1,
+      ]);
+      const weights = new Float32Array([
+        0, 1, .5, .5, 1, 0,
+        0, 1, .5, .5, 1, 0,
+      ]);
+      const args = [positions, triangles, indices, weights, 2, [0, 1], 4];
+      const synchronous = rig.buildSurfaceInfluenceGraph(...args);
+      const cooperative = await rig.buildSurfaceInfluenceGraphCooperative(
+        ...args, {triangleBatch: 1, budgetMs: .01});
+      let checks = 0;
+      const cancelled = await rig.buildSurfaceInfluenceGraphCooperative(
+        ...args, {triangleBatch: 1, budgetMs: .01,
+          isCurrent: () => checks++ < 2});
+      return {
+        same: JSON.stringify(cooperative) === JSON.stringify(synchronous),
+        cancelled: cancelled === null,
+        cooperative,
+      };
+    }""")
+    assert result["same"]
+    assert result["cooperative"]["evidenceMode"] == "surface"
+    assert result["cooperative"]["validTriangleCount"] == 2
+
+
 def test_triangle_surface_evidence_is_invariant_for_varying_weight_tessellation(
         module_page):
     page = module_page
@@ -2106,7 +2145,8 @@ def test_inferred_rig_rest_frames_are_deterministic_and_transport_axes(module_pa
 def test_cross_source_reconciliation_uses_geometry_and_guards_clusters(module_page):
     page = module_page
     result = page.evaluate("""async () => {
-      const {buildModelRigReconciliation} = await import(
+      const {buildModelRigReconciliation,
+        buildModelRigReconciliationCooperative} = await import(
         './js/mesh/weight-rig-reconcile.js');
       const rig = (sourceKey, entries, edges = []) => {
         const nodeIds = entries.map(item => item[0]);
@@ -2157,6 +2197,8 @@ def test_cross_source_reconciliation_uses_geometry_and_guards_clusters(module_pa
       ], [[4, 43, .8]]);
       const far = rig('far', [[0, [10, 0, 0]]]);
       const result = buildModelRigReconciliation([body, legs, far]);
+      const cooperative = await buildModelRigReconciliationCooperative(
+        [body, legs, far]);
       const bodyJoint = result.sourceBoneToModelJointId['body#bone=0'];
       const legsJoint = result.sourceBoneToModelJointId['legs#bone=4'];
       const bodyChild = result.sourceBoneToModelJointId['body#bone=1'];
@@ -2178,6 +2220,17 @@ def test_cross_source_reconciliation_uses_geometry_and_guards_clusters(module_pa
           .map(item => item.rejectionReason).filter(Boolean),
         sourceEdgeSupport: result.edges.filter(edge =>
           edge.relationshipType === 'source').map(edge => edge.sourceSupportCount),
+        cooperativeSame: JSON.stringify({
+          joints: cooperative.joints,
+          edges: cooperative.edges,
+          components: cooperative.components,
+          sourceBoneToModelJointId: cooperative.sourceBoneToModelJointId,
+        }) === JSON.stringify({
+          joints: result.joints,
+          edges: result.edges,
+          components: result.components,
+          sourceBoneToModelJointId: result.sourceBoneToModelJointId,
+        }),
       };
     }""")
     assert result["sameRoot"]
@@ -2186,6 +2239,7 @@ def test_cross_source_reconciliation_uses_geometry_and_guards_clusters(module_pa
     assert sorted(result["clusterSizes"], reverse=True)[:2] == [2, 2]
     assert "topology_conflict" in result["rejected"] or "not_mutual" in result["rejected"]
     assert 2 in result["sourceEdgeSupport"]
+    assert result["cooperativeSame"]
     assert all(signature == expected
                for signature, expected in result["jointSignatures"])
 
@@ -2194,7 +2248,8 @@ def test_cross_source_neutral_sampling_uses_radius_and_true_mutual_nearest(
         module_page):
     page = module_page
     result = page.evaluate("""async () => {
-      const {crossSourceWeightEvidence} = await import(
+      const {crossSourceWeightEvidence,
+        crossSourceWeightEvidenceCooperative} = await import(
         './js/mesh/weight-rig-reconcile.js');
       const make = (sourceKey, positions, ids) => ({
         sourceKey,
@@ -2212,17 +2267,27 @@ def test_cross_source_neutral_sampling_uses_radius_and_true_mutual_nearest(
       const mutual = crossSourceWeightEvidence(
         make('mutual-left', [0, 0, 0, 0, .018, 0], [10, 11]),
         make('mutual-right', [-.018, 0, 0, 0, .0095, 0], [20, 21]), 1);
+      const cooperative = await crossSourceWeightEvidenceCooperative(
+        make('coop-left', [0, 0, 0, 0, .018, 0], [10, 11]),
+        make('coop-right', [-.018, 0, 0, 0, .0095, 0], [20, 21]), 1);
       return {
         spatialMatches: spatial.get('left#bone=0|right#bone=1')
           ?.matchedVertexCount || 0,
         mutualPairs: [...mutual.values()].map(item => [
           item.leftSourceBoneKey, item.rightSourceBoneKey,
         ]).sort(),
+        cooperativePairs: [...cooperative.values()].map(item => [
+          item.leftSourceBoneKey, item.rightSourceBoneKey,
+          item.matchedVertexCount, item.weightedMatchStrength,
+        ]).sort(),
       };
     }""")
     assert result["spatialMatches"] == 1
     assert result["mutualPairs"] == [[
         "mutual-left#bone=11", "mutual-right#bone=21"]]
+    assert result["cooperativePairs"] == [[
+        "coop-left#bone=11", "coop-right#bone=21", 1,
+        pytest.approx(.575)]]
 
 
 def test_cross_source_reconciliation_preserves_host_root_and_reroots_accessory(

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1244,6 +1244,130 @@ def test_inferred_rig_pivots_aggregate_and_keep_disconnected_components(module_p
     assert result["nonZeroRootPivotKeys"] == [0, 2]
 
 
+def test_barycentric_third_moment_matches_reference_for_all_index_triples(
+        module_page):
+    result = module_page.evaluate("""async () => {
+      const {barycentricThirdMoment} = await import(
+        './js/mesh/weight-rig.js');
+      const reference = (first, second, third, area) => {
+        const counts = [first, second, third].reduce((map, index) => {
+          map.set(index, (map.get(index) || 0) + 1);
+          return map;
+        }, new Map());
+        const multiplicities = [...counts.values()];
+        if (multiplicities.length === 1) return area / 10;
+        if (multiplicities.length === 2) return area / 30;
+        return area / 60;
+      };
+      const areas = [0, 1, .5, .123456789, 1234.56789, 1e-12];
+      const mismatches = [];
+      let caseCount = 0;
+      for (let first = 0; first < 3; first += 1) {
+        for (let second = 0; second < 3; second += 1) {
+          for (let third = 0; third < 3; third += 1) {
+            for (const area of areas) {
+              caseCount += 1;
+              const actual = barycentricThirdMoment(
+                first, second, third, area);
+              const expected = reference(first, second, third, area);
+              if (!Object.is(actual, expected)) {
+                mismatches.push({first, second, third, area, actual, expected});
+              }
+            }
+          }
+        }
+      }
+      return {caseCount, mismatches};
+    }""")
+    assert result == {"caseCount": 162, "mismatches": []}
+
+
+def test_surface_integrators_match_reference_third_moment_order(module_page):
+    result = module_page.evaluate("""async () => {
+      const {integrateLinearSecondMoment, integratePositionProduct} =
+        await import('./js/mesh/weight-rig.js');
+      const referenceThirdMoment = (first, second, third, area) => {
+        const counts = [first, second, third].reduce((map, index) => {
+          map.set(index, (map.get(index) || 0) + 1);
+          return map;
+        }, new Map());
+        const multiplicities = [...counts.values()];
+        if (multiplicities.length === 1) return area / 10;
+        if (multiplicities.length === 2) return area / 30;
+        return area / 60;
+      };
+      const dot3 = (left, right) => left[0] * right[0]
+        + left[1] * right[1] + left[2] * right[2];
+      const referenceSecondMoment = (points, weights, area) => {
+        let result = 0;
+        for (let left = 0; left < 3; left += 1) {
+          for (let right = 0; right < 3; right += 1) {
+            for (let weight = 0; weight < 3; weight += 1) {
+              result += dot3(points[left], points[right])
+                * weights[weight]
+                * referenceThirdMoment(left, right, weight, area);
+            }
+          }
+        }
+        return result;
+      };
+      const referencePositionProduct = (
+          points, leftWeights, rightWeights, area) => {
+        const result = [0, 0, 0];
+        for (let point = 0; point < 3; point += 1) {
+          for (let left = 0; left < 3; left += 1) {
+            for (let right = 0; right < 3; right += 1) {
+              const contribution = leftWeights[left] * rightWeights[right]
+                * referenceThirdMoment(point, left, right, area);
+              result[0] += points[point][0] * contribution;
+              result[1] += points[point][1] * contribution;
+              result[2] += points[point][2] * contribution;
+            }
+          }
+        }
+        return result;
+      };
+      const cases = [
+        {
+          points: [[0, 0, 0], [2, 0, 0], [0, 2, 0]],
+          weights: [.25, .5, .75],
+          left: [.2, .3, .5], right: [.8, .1, .4], area: 2,
+        },
+        {
+          points: [[1, -2, .5], [-.25, 3, 1.75], [2.5, .25, -1]],
+          weights: [1, 0, 0],
+          left: [1, 0, 0], right: [0, 0, 1], area: .123456789,
+        },
+        {
+          points: [[-.7, .2, 1.1], [1.3, -1.4, .6], [2.2, .9, -2.5]],
+          weights: [1 / 3, 2 / 3, 1 / 7],
+          left: [.25, .5, .25], right: [.6, .2, .2], area: 1e-12,
+        },
+      ];
+      return cases.map(item => {
+        const actualSecond = integrateLinearSecondMoment(
+          item.points, item.weights, item.area);
+        const expectedSecond = referenceSecondMoment(
+          item.points, item.weights, item.area);
+        const actualPosition = integratePositionProduct(
+          item.points, item.left, item.right, item.area);
+        const expectedPosition = referencePositionProduct(
+          item.points, item.left, item.right, item.area);
+        return {
+          secondEqual: Object.is(actualSecond, expectedSecond),
+          positionEqual: actualPosition.every((value, index) =>
+            Object.is(value, expectedPosition[index])),
+          actualSecond, expectedSecond, actualPosition, expectedPosition,
+        };
+      });
+    }""")
+    assert all(item["secondEqual"] and item["positionEqual"]
+               for item in result)
+    for item in result:
+        assert item["actualSecond"] == item["expectedSecond"]
+        assert item["actualPosition"] == item["expectedPosition"]
+
+
 def test_surface_evidence_weights_rig_nodes_relationships_and_aggregation(
         module_page):
     page = module_page
@@ -1623,6 +1747,248 @@ def test_surface_topology_diagnostics_reject_bad_triangles_without_nan(
         "measuredVertexCount": 0,
         "zeroMeasureVertexCount": 3,
         "surfaceEvidenceAvailable": False,
+    }
+
+
+def test_surface_eligibility_probe_matches_topology_diagnostics(module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const rig = await import('./js/mesh/weight-rig.js');
+      const cases = [
+        {
+          name: 'indexed',
+          positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+          indices: [0, 1, 2],
+        },
+        {
+          name: 'nonIndexed',
+          positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+        },
+        {
+          name: 'laterValidTriangle',
+          positions: [0, 0, 0, 1, 0, 0, 0, 1, 0, NaN, 0, 0],
+          indices: [0, 1, 3, 0, 1, 2],
+        },
+        {
+          name: 'degenerate',
+          positions: [0, 0, 0, 1, 0, 0, 2, 0, 0],
+          indices: [0, 1, 2],
+        },
+        {
+          name: 'invalidIndex',
+          positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+          indices: [0, 1, 9],
+        },
+        {
+          name: 'empty',
+          positions: [],
+        },
+      ];
+      return cases.map(item => {
+        const positions = new Float32Array(item.positions);
+        const indices = item.indices === undefined
+          ? null : new Uint32Array(item.indices);
+        const diagnostics = rig.inspectSurfaceTopology(positions, indices);
+        return {
+          name: item.name,
+          usable: rig.hasUsableSurfaceTopology(positions, indices),
+          diagnosed: diagnostics.surfaceEvidenceAvailable,
+          validTriangleCount: diagnostics.validTriangleCount,
+        };
+      });
+    }""")
+    assert result == [
+        {"name": "indexed", "usable": True, "diagnosed": True,
+         "validTriangleCount": 1},
+        {"name": "nonIndexed", "usable": True, "diagnosed": True,
+         "validTriangleCount": 1},
+        {"name": "laterValidTriangle", "usable": True, "diagnosed": True,
+         "validTriangleCount": 1},
+        {"name": "degenerate", "usable": False, "diagnosed": False,
+         "validTriangleCount": 0},
+        {"name": "invalidIndex", "usable": False, "diagnosed": False,
+         "validTriangleCount": 0},
+        {"name": "empty", "usable": False, "diagnosed": False,
+         "validTriangleCount": 0},
+    ]
+
+
+def test_rig_member_structural_identity_ignores_ui_and_provenance(module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const {memberStructuralEvidenceKey} = await import(
+        './js/mesh/rig-model-session.js');
+      const makeMember = (changes = {}) => ({
+        state: {
+          skinningSourceKey: 'source', influenceCount: 4,
+          encoding: 'compact', ...changes.state,
+        },
+        mesh: {
+          userData: {
+            semanticKey: 'semantic-a', component: 'Body', occurrence: 1,
+            material: 'material-a', texture: 'texture-a', visible: true,
+            identity: {
+              draw: {count: 6, start: 0, base: 0},
+              geometry_state: {
+                ib_file: 'indices.buf', index_size: 2,
+                position_file: 'positions.buf', position_stride: 12,
+                texcoord_file: 'uv.buf', texcoord_stride: 8,
+              },
+              ...changes.identity,
+            },
+          },
+          geometry: {
+            attributes: {position: {count: 3}},
+            index: {count: 3},
+            ...changes.geometry,
+          },
+        },
+      });
+      const base = makeMember();
+      const uiOnly = makeMember({
+        state: {semanticKey: 'ignored-state-field'},
+        identity: {component: 'Legs', material: 'material-b',
+          texture: 'texture-b'},
+      });
+      const different = field => memberStructuralEvidenceKey(
+        makeMember(field));
+      const baseKey = memberStructuralEvidenceKey(base);
+      return {
+        uiOnlyMatches: baseKey === memberStructuralEvidenceKey(uiOnly),
+        changedKeys: [
+          different({state: {skinningSourceKey: 'other'}}),
+          different({state: {influenceCount: 8}}),
+          different({state: {encoding: 'expanded'}}),
+          different({identity: {draw: {count: 7, start: 0, base: 0}}}),
+          different({identity: {draw: {count: 6, start: 1, base: 0}}}),
+          different({identity: {draw: {count: 6, start: 0, base: 1}}}),
+          different({identity: {geometry_state: {ib_file: 'other'}}}),
+          different({identity: {geometry_state: {index_size: 4}}}),
+          different({identity: {geometry_state: {position_file: 'other'}}}),
+          different({identity: {geometry_state: {position_stride: 16}}}),
+          different({identity: {geometry_state: {texcoord_file: 'other'}}}),
+          different({identity: {geometry_state: {texcoord_stride: 16}}}),
+          different({geometry: {attributes: {position: {count: 4}}}}),
+          different({geometry: {index: {count: 6}}}),
+        ].map(key => key !== baseKey),
+      };
+    }""")
+    assert result == {
+        "uiOnlyMatches": True,
+        "changedKeys": [True] * 14,
+    }
+
+
+def test_rig_source_session_deduplicates_exact_evidence_and_falls_back_source_wide(
+        module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const {initializeRigSourceSession} = await import(
+        './js/mesh/rig-model-session.js');
+      const states = new Map();
+      const knownMeshes = new Set();
+      const sourceSkinningRigs = new Map();
+      const graphCalls = [];
+      const makeMesh = (name, valid, drawStart = 0) => {
+        const mesh = {
+          userData: {semanticKey: name, identity: {
+            draw: {count: 3, start: drawStart, base: 0},
+            geometry_state: {ib_file: 'indices.buf', index_size: 2,
+              position_file: 'positions.buf', position_stride: 12,
+              texcoord_file: 'uv.buf', texcoord_stride: 8},
+          }},
+          geometry: {
+            attributes: {position: {count: 3}},
+            index: {array: new Uint32Array([0, 1, 2]), count: 3},
+          },
+        };
+        states.set(mesh, {
+          loaded: true, skinningSourceKey: 'source', influenceCount: 1,
+          encoding: 'compact',
+          baselinePositions: new Float32Array(valid
+            ? [0, 0, 0, 1, 0, 0, 0, 1, 0]
+            : [0, 0, 0, 1, 0, 0, 2, 0, 0]),
+          indices: new Uint32Array([0, 1, 2]),
+          weights: new Float32Array([1, 1, 1]),
+          boneIds: new Uint16Array([1, 1, 1]),
+        });
+        knownMeshes.add(mesh);
+        return mesh;
+      };
+      const first = makeMesh('first', true);
+      const duplicate = makeMesh('duplicate', true, 2);
+      const invalid = makeMesh('invalid', false, 1);
+      const graphFor = (mesh, state, evidenceMode, surfaceEvidence) => {
+        graphCalls.push({mesh: mesh.userData.semanticKey, evidenceMode,
+          surfaceAvailable: surfaceEvidence?.surfaceEvidenceAvailable ?? null});
+        return {
+          nodes: [{boneId: 1, totalWeight: 1, affectedVertexCount: 3,
+            affectedMeasure: evidenceMode === 'surface' ? 1 : null,
+            maxVertexWeight: 1, weightedCenter: [0, 0, 0],
+            weightedRadius: 0}], relationships: [], evidenceMode,
+          triangleCount: evidenceMode === 'surface' ? 1 : 0,
+          validTriangleCount: evidenceMode === 'surface' ? 1 : 0,
+        };
+      };
+      const session = initializeRigSourceSession({
+        states, knownMeshes, modelWeightState: {
+          sourceDescriptors: new Map([['source', {
+            sourceFile: 'weights.buf', boneIdOffset: 0,
+          }]]),
+        }, sourceSkinningRigs,
+        ensureRigMeshPrepared: () => true,
+        ensureInfluenceGraph: graphFor,
+        rebuildRestFrames: () => {},
+        cloneForest: forest => forest,
+      });
+      const fallbackRig = session.ensure('source',
+        [first, duplicate, invalid]);
+      const fallback = {
+        memberCount: fallbackRig.influenceGraph.memberCount,
+        uniqueMemberCount: fallbackRig.influenceGraph.uniqueMemberCount,
+        evidenceMode: fallbackRig.influenceGraph.evidenceMode,
+        graphCalls: [...graphCalls],
+      };
+      graphCalls.length = 0;
+      const surfaceRig = session.ensure('source', [first, duplicate]);
+      return {
+        fallback,
+        surface: {
+          memberCount: surfaceRig.influenceGraph.memberCount,
+          uniqueMemberCount: surfaceRig.influenceGraph.uniqueMemberCount,
+          evidenceMode: surfaceRig.influenceGraph.evidenceMode,
+          graphCalls,
+        },
+        exactOutput: {
+          nodes: surfaceRig.influenceGraph.nodes,
+          relationships: surfaceRig.influenceGraph.relationships,
+        },
+      };
+    }""")
+    assert result["fallback"] == {
+        "memberCount": 3,
+        "uniqueMemberCount": 2,
+        "evidenceMode": "vertex",
+        "graphCalls": [
+            {"mesh": "first", "evidenceMode": "vertex",
+             "surfaceAvailable": True},
+            {"mesh": "invalid", "evidenceMode": "vertex",
+             "surfaceAvailable": False},
+        ],
+    }
+    assert result["surface"] == {
+        "memberCount": 2,
+        "uniqueMemberCount": 1,
+        "evidenceMode": "surface",
+        "graphCalls": [{"mesh": "first", "evidenceMode": "surface",
+                         "surfaceAvailable": True}],
+    }
+    assert result["exactOutput"] == {
+        "nodes": [{"boneId": 1, "totalWeight": 1,
+                    "affectedVertexCount": 3, "affectedMeasure": 1,
+                    "maxVertexWeight": 1,
+                    "weightedCenter": [0, 0, 0], "weightedRadius": 0}],
+        "relationships": [],
     }
 
 

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1475,6 +1475,7 @@ def test_cooperative_surface_evidence_matches_sync_and_supports_cancellation(
       };
     }""")
     assert result["same"]
+    assert result["cancelled"]
     assert result["cooperative"]["evidenceMode"] == "surface"
     assert result["cooperative"]["validTriangleCount"] == 2
 

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1908,8 +1908,8 @@ def test_weight_panel_preserves_picker_and_slider_dom_during_state_changes(
             meshes: {[key]: {
               status: 'ok', vertex_count: 3, influence_count: 2,
               bone_ids: [0, 1, 2], encoding: 'test', source: {
-                key: 'test/bodyblend.buf|offset=0', file: 'Test/BodyBlend.buf',
-                bone_id_offset: 0,
+                key: 'test/bodyblend.buf|offset=0',
+                file: 'Test/BodyBlend.buf', bone_id_offset: 0,
               },
               data: {
                 indices: {offset: 0, length: 24, type: 'u32'},
@@ -2019,20 +2019,23 @@ def test_weight_saved_selection_applies_once_and_controls_physics(
           window.__savedSelections = [];
           window.pywebview.api.get_model_skinning_preview = async () => ({
             status: 'ok', format_version: 1,
-            saved_bones: [{source: 'Test/BodyBlend.buf', bone_id_offset: 0,
+            saved_bones: [{source: 'Test/BodyBlend.buf',
+              source_key: 'test/bodyblend.buf|offset=0|namespace=wwmi_vertex_vg|'
+                + 'vertex-vg=test/bodyremap.buf', bone_id_offset: 0,
               bone_ids: [99, 1]}],
             data: {url, length: 48},
             meshes: {[key]: {
               status: 'ok', vertex_count: 3, influence_count: 2,
               bone_ids: [0, 1, 2], encoding: 'test', source: {
-                key: 'test/bodyblend.buf|offset=0', file: 'Test/BodyBlend.buf',
+                key: 'test/bodyblend.buf|offset=0|namespace=wwmi_vertex_vg|vertex-vg=test/bodyremap.buf',
+                file: 'Test/BodyBlend.buf',
                 bone_id_offset: 0,
               },
               data: {
                 indices: {offset: 0, length: 24, type: 'u32'},
                 weights: {offset: 24, length: 24, type: 'f32'},
               }, diagnostics: {}, source: {
-                key: 'test/bodyblend.buf|offset=0',
+                key: 'test/bodyblend.buf|offset=0|namespace=wwmi_vertex_vg|vertex-vg=test/bodyremap.buf',
                 file: 'Test/BodyBlend.buf', bone_id_offset: 0,
               },
             }},
@@ -2102,6 +2105,7 @@ def test_weight_saved_selection_applies_once_and_controls_physics(
         page.wait_for_function("window.__savedSelections.length === 1")
         assert page.evaluate("window.__savedSelections") == [[{
             'source': 'Test/BodyBlend.buf', 'bone_id_offset': 0,
+            'source_key': 'test/bodyblend.buf|offset=0|namespace=wwmi_vertex_vg|vertex-vg=test/bodyremap.buf',
             'bone_ids': [1],
         }]]
         page.evaluate("""() => {

--- a/src/tests/web/test_rendering.py
+++ b/src/tests/web/test_rendering.py
@@ -1061,6 +1061,115 @@ def test_rig_panel_loads_lazily_and_keeps_weight_selection_separate(
     finally:
         context.close()
 
+
+def test_rig_panel_does_not_start_rig_for_model_without_weights(
+        edge_browser, frontend_url):
+    payload = _payload("NoWeights")
+    payload["meshes"]["Body-NoWeights-0"]["skinning_available"] = False
+    context, page = _page(
+        edge_browser, frontend_url, {"NoWeights": payload})
+    try:
+        _open(page, "NoWeights")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 1")
+        page.locator("#weight-rig-tab").click()
+        page.wait_for_function("""() => {
+          const weight = window.__testWeightRigRuntime.getModelWeightState();
+          return weight.loaded && weight.noWeights;
+        }""")
+        page.wait_for_timeout(100)
+        result = page.evaluate("""() => ({
+          weight: window.__testWeightRigRuntime.getModelWeightState(),
+          rig: window.__testWeightRigRuntime.getModelRigState(),
+        })""")
+        assert result["weight"]["loaded"]
+        assert result["weight"]["noWeights"]
+        assert not result["weight"]["error"]
+        assert not result["rig"]["loading"]
+        assert not result["rig"]["loaded"]
+    finally:
+        context.close()
+
+
+def test_weight_ready_state_has_no_eager_rig_preparation(
+        edge_browser, frontend_url):
+    context, page = _page(
+        edge_browser, frontend_url, {"WeightFirst": _payload("WeightFirst")})
+    try:
+        _open(page, "WeightFirst")
+        page.wait_for_function("window.modViewer.activeMeshes.length === 1")
+        result = page.evaluate("""async () => {
+          const runtime = window.__testWeightRigRuntime;
+          const mesh = window.modViewer.activeMeshes[0];
+          const bytes = new Uint8Array(48);
+          new Uint32Array(bytes.buffer).set([0, 1, 1, 2, 0, 2]);
+          new Float32Array(bytes.buffer, 24).set([.8, .2, .7, .3, .6, .4]);
+          const url = URL.createObjectURL(new Blob([bytes]));
+          let releasePreview;
+          const pending = new Promise(resolve => { releasePreview = resolve; });
+          window.__testSkinningPreview = async () => pending;
+          const weightPromise = runtime.ensureModelWeightsLoaded();
+          await new Promise(resolve => setTimeout(resolve, 0));
+          const loading = {
+            weight: runtime.getModelWeightState(),
+            rig: runtime.getModelRigState(),
+          };
+          releasePreview({
+            status: 'ok', vertex_count: 3, influence_count: 2,
+            bone_ids: [0, 1, 2], encoding: 'test', source: {
+              key: 'test/bodyblend.buf|offset=0',
+              file: 'Test/BodyBlend.buf', bone_id_offset: 0,
+            },
+            weight_stats: {
+              '1': {affected_vertex_count: 2, total_weight: 1.1},
+              '2': {affected_vertex_count: 2, total_weight: .7},
+            },
+            data: {
+              url, length: 48,
+              indices: {offset: 0, length: 24, type: 'u32'},
+              weights: {offset: 24, length: 24, type: 'f32'},
+            }, diagnostics: {},
+          });
+          const weight = await weightPromise;
+          const stateAfterWeight = runtime.getModelWeightState();
+          const skinRuntime = await import('./js/mesh/skinning-runtime.js');
+          const skinAfterWeight = skinRuntime.getSkinningState(mesh);
+          const weightBaselineWasNull = skinAfterWeight.baselinePositions === null;
+          const weightNodesWereNull = skinAfterWeight.influenceNodes === null;
+          const rig = await runtime.ensureModelRigLoaded();
+          const skinAfterRig = skinRuntime.getSkinningState(mesh);
+          URL.revokeObjectURL(url);
+          return {
+            loadingWeight: loading.weight.loading,
+            loadingRig: loading.rig.loading,
+            loadingRigLoaded: loading.rig.loaded,
+            weightLoaded: weight.loaded,
+            stats: stateAfterWeight.sources[0].boneStats,
+            weightBaselineWasNull,
+            weightNodesWereNull,
+            rigLoaded: rig.loaded,
+            rigBaselineLength: skinAfterRig.baselinePositions?.length || 0,
+            rigNodeCount: skinAfterRig.influenceNodes?.length || 0,
+          };
+        }""")
+        assert result["loadingWeight"]
+        assert not result["loadingRig"]
+        assert not result["loadingRigLoaded"]
+        assert result["weightLoaded"]
+        assert result["stats"] == {
+            "1": {"affectedVertexCount": 2,
+                  "averageInfluence": pytest.approx(.55)},
+            "2": {"affectedVertexCount": 2,
+                  "averageInfluence": pytest.approx(.35)},
+        }
+        assert result["weightBaselineWasNull"]
+        assert result["weightNodesWereNull"]
+        assert result["rigLoaded"]
+        assert result["rigBaselineLength"] == 9
+        assert result["rigNodeCount"] == 3
+    finally:
+        context.close()
+
+
 def test_model_rig_pose_deforms_equivalent_source_meshes_together(
         edge_browser, frontend_url):
     payload = _payload("CrossSourceRig")
@@ -1934,6 +2043,25 @@ def test_weight_saved_selection_applies_once_and_controls_physics(
               return {saved: true, selected_bones: bones};
             };
         }""")
+        readiness = page.evaluate("""async () => {
+          const runtime = window.__testWeightRigRuntime;
+          let physicsAtWeightReady = null;
+          const onWeightChanged = event => {
+            if (event.detail?.loaded && physicsAtWeightReady === null) {
+              physicsAtWeightReady = runtime.getModelPhysicsState().enabled;
+            }
+          };
+          window.addEventListener('mod-viewer-model-weight-changed',
+            onWeightChanged);
+          await runtime.ensureModelWeightsLoaded();
+          window.removeEventListener('mod-viewer-model-weight-changed',
+            onWeightChanged);
+          return {
+            selectedBoneCount: runtime.getModelWeightState().selectedBoneCount,
+            physicsAtWeightReady,
+          };
+        }""")
+        assert readiness == {"selectedBoneCount": 1, "physicsAtWeightReady": False}
         page.locator("#weight-rig-tab").click()
         page.wait_for_function("""() =>
           window.__testWeightRigRuntime.getModelWeightState().selectedBoneCount === 1""")
@@ -2126,7 +2254,8 @@ def test_weight_selection_is_scoped_to_the_decoded_blend_source(
           const [hair, coat] = window.modViewer.activeMeshes.map(getSkinningState);
           return {
             selected: window.__testWeightRigRuntime.getModelWeightState().selectedBones,
-            masks: [hair.selectedWeightMask[0], coat.selectedWeightMask[0]],
+            masks: [hair.selectedWeightMask?.[0] ?? null,
+                    coat.selectedWeightMask?.[0] ?? null],
             physics: window.__testWeightRigRuntime.getModelPhysicsState(),
             participants: [hair.physicsEnabled, coat.physicsEnabled],
           };
@@ -2136,7 +2265,7 @@ def test_weight_selection_is_scoped_to_the_decoded_blend_source(
             "sourceFile": "Hair/HairBlend.buf", "boneIdOffset": 0,
             "boneIds": [1],
         }]
-        assert result["masks"] == pytest.approx([.8, 0])
+        assert result["masks"] == [pytest.approx(.8), None]
         assert result["participants"] == [True, False]
         assert result["physics"]["participantCount"] == 1
 
@@ -2168,6 +2297,26 @@ def test_weight_selection_is_scoped_to_the_decoded_blend_source(
         assert distinct["physics"]["participantCount"] == 2
         assert distinct["physics"]["participatingMeshCount"] == 2
         assert distinct["independentSources"]
+        cleared = page.evaluate("""async () => {
+          const runtime = await import('./js/mesh/weight-rig-runtime.js');
+          const {getSkinningState} = await import('./js/mesh/skinning-runtime.js');
+          runtime.clearSelectedBones();
+          return window.modViewer.activeMeshes.map(mesh => {
+            const state = getSkinningState(mesh);
+            return {
+              selectedMask: state.selectedWeightMask,
+              heatmapMode: state.heatmapMode,
+              materialRestored: state.originalMaterial === mesh.material,
+              hasColor: !!mesh.geometry.getAttribute('color'),
+            };
+          });
+        }""")
+        assert cleared == [
+            {"selectedMask": None, "heatmapMode": None,
+             "materialRestored": True, "hasColor": False},
+            {"selectedMask": None, "heatmapMode": None,
+             "materialRestored": True, "hasColor": False},
+        ]
     finally:
         context.close()
 

--- a/src/web/js/mesh/cooperative-scheduler.js
+++ b/src/web/js/mesh/cooperative-scheduler.js
@@ -1,0 +1,44 @@
+// Small scheduling primitives shared by the Weight, Rig, and physics loaders.
+// The time budget keeps progress predictable while giving the browser regular
+// opportunities to paint and process input.
+
+const DEFAULT_BUDGET_MS = 8;
+
+function now() {
+  return typeof globalThis.performance?.now === 'function'
+    ? globalThis.performance.now() : Date.now();
+}
+
+export async function yieldToBrowser() {
+  if (typeof globalThis.scheduler?.yield === 'function') {
+    await globalThis.scheduler.yield();
+    return;
+  }
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+export function createWorkBudget({budgetMs = DEFAULT_BUDGET_MS,
+    onYield = null} = {}) {
+  const limit = Number.isFinite(Number(budgetMs)) && Number(budgetMs) > 0
+    ? Number(budgetMs) : DEFAULT_BUDGET_MS;
+  let startedAt = now();
+  let largestChunkMs = 0;
+  let yieldCount = 0;
+
+  return {
+    async checkpoint() {
+      const elapsed = now() - startedAt;
+      largestChunkMs = Math.max(largestChunkMs, elapsed);
+      if (elapsed < limit) return;
+      yieldCount += 1;
+      if (typeof onYield === 'function') onYield(elapsed);
+      await yieldToBrowser();
+      startedAt = now();
+    },
+    getStats() {
+      return {largestChunkMs, yieldCount};
+    },
+  };
+}
+
+export const COOPERATIVE_BUDGET_MS = DEFAULT_BUDGET_MS;

--- a/src/web/js/mesh/rig-model-session.js
+++ b/src/web/js/mesh/rig-model-session.js
@@ -10,6 +10,7 @@ import {
   inspectSurfaceTopology,
   jointPivotMap,
 } from './weight-rig.js';
+import {createWorkBudget} from './cooperative-scheduler.js';
 
 let activeSession = null;
 
@@ -43,13 +44,16 @@ export function memberStructuralEvidenceKey(member = {}) {
   return JSON.stringify(memberStructuralEvidenceFields(member));
 }
 
-function memberCompatibilityEvidenceKey(member = {}) {
-  // Some authored draw records share identical Rig evidence while their
-  // provenance-only draw start differs. Keep that broader key as a candidate
-  // only; memberEvidenceEqual remains the final identity decision.
-  const fields = memberStructuralEvidenceFields(member);
-  fields.splice(4, 1);
-  return JSON.stringify(fields);
+function memberEvidenceShapeKey(member = {}) {
+  const state = member.state || {};
+  return JSON.stringify([
+    state.influenceCount ?? null,
+    state.baselinePositions?.length ?? null,
+    state.indices?.length ?? null,
+    state.weights?.length ?? null,
+    state.boneIds?.length ?? null,
+    member.surfaceIndices?.length ?? null,
+  ]);
 }
 
 function createSourceSession({states, knownMeshes, modelWeightState,
@@ -95,24 +99,19 @@ function createSourceSession({states, knownMeshes, modelWeightState,
   }
 
   function normalizeMembers(members) {
-    const structuralBuckets = new Map();
-    const compatibilityBuckets = new Map();
+    const evidenceBuckets = new Map();
     const uniqueMembers = [];
     for (const member of members) {
-      const structuralKey = memberStructuralEvidenceKey(member);
-      const bucket = structuralBuckets.get(structuralKey) || [];
+      // Provenance identifies a draw, but it is not part of Rig evidence
+      // equality.  Bucket only by cheap evidence shape, then retain the
+      // exact array comparison as the authoritative duplicate check.
+      const key = memberEvidenceShapeKey(member);
+      const bucket = evidenceBuckets.get(key) || [];
       if (bucket.some(candidate => memberEvidenceEqual(candidate, member))) {
         continue;
       }
-      const compatibilityKey = memberCompatibilityEvidenceKey(member);
-      const compatibilityBucket = compatibilityBuckets.get(compatibilityKey)
-        || [];
-      if (compatibilityBucket.some(candidate =>
-          memberEvidenceEqual(candidate, member))) continue;
       bucket.push(member);
-      structuralBuckets.set(structuralKey, bucket);
-      compatibilityBucket.push(member);
-      compatibilityBuckets.set(compatibilityKey, compatibilityBucket);
+      evidenceBuckets.set(key, bucket);
       uniqueMembers.push(member);
     }
     return uniqueMembers;
@@ -148,10 +147,9 @@ function createSourceSession({states, knownMeshes, modelWeightState,
     };
   }
 
-  function createSourceSkinningRig(sourceKey, members) {
+  function assembleSourceSkinningRig(sourceKey, members, influenceGraph,
+      inferredForest, {finalize = true} = {}) {
     const descriptor = modelWeightState.sourceDescriptors.get(sourceKey);
-    const influenceGraph = aggregateInfluenceGraph(members);
-    const inferredForest = buildInferredRigForest(influenceGraph);
     const jointPivotByBoneId = jointPivotMap(
       inferredForest, influenceGraph.relationships);
     const rig = {
@@ -189,6 +187,31 @@ function createSourceSession({states, knownMeshes, modelWeightState,
       poseRootOverrides: new Map(),
       physicsRig: null,
     };
+    if (finalize) {
+      rebuildRestFrames(rig);
+      rig.defaultInferredForest = cloneForest(rig.inferredForest);
+      rig.defaultJointPivotByBoneId = new Map([...rig.jointPivotByBoneId]
+        .map(([boneId, pivot]) => [boneId, [...pivot]]));
+    }
+    return rig;
+  }
+
+  function createSourceSkinningRig(sourceKey, members) {
+    const influenceGraph = aggregateInfluenceGraph(members);
+    const inferredForest = buildInferredRigForest(influenceGraph);
+    return assembleSourceSkinningRig(
+      sourceKey, members, influenceGraph, inferredForest);
+  }
+
+  async function createSourceSkinningRigCooperative(sourceKey, members,
+      budget) {
+    const influenceGraph = aggregateInfluenceGraph(members);
+    await budget.checkpoint();
+    const inferredForest = buildInferredRigForest(influenceGraph);
+    await budget.checkpoint();
+    const rig = assembleSourceSkinningRig(
+      sourceKey, members, influenceGraph, inferredForest, {finalize: false});
+    await budget.checkpoint();
     rebuildRestFrames(rig);
     rig.defaultInferredForest = cloneForest(rig.inferredForest);
     rig.defaultJointPivotByBoneId = new Map([...rig.jointPivotByBoneId]
@@ -244,6 +267,39 @@ function createSourceSession({states, knownMeshes, modelWeightState,
     return rig;
   }
 
+  const inFlight = new Map();
+
+  async function ensureCooperative(sourceKey, members, {
+      generation = null, isCurrent = () => true,
+  } = {}) {
+    const current = () => generation === null
+      || generation === undefined || isCurrent();
+    if (!current()) return null;
+    const existing = sourceSkinningRigs.get(sourceKey);
+    if (existing && sameMeshSet(existing.meshes, members)) return existing;
+    if (inFlight.has(sourceKey)) {
+      const pending = await inFlight.get(sourceKey);
+      if (!current()) return null;
+      if (pending && sameMeshSet(pending.meshes, members)) return pending;
+    }
+    const budget = createWorkBudget();
+    const promise = (async () => {
+      await budget.checkpoint();
+      if (!current()) return null;
+      const rig = await createSourceSkinningRigCooperative(
+        sourceKey, members, budget);
+      if (!current()) return null;
+      sourceSkinningRigs.set(sourceKey, rig);
+      return rig;
+    })();
+    inFlight.set(sourceKey, promise);
+    try {
+      return await promise;
+    } finally {
+      if (inFlight.get(sourceKey) === promise) inFlight.delete(sourceKey);
+    }
+  }
+
   function buildAll() {
     const groups = new Map();
     for (const mesh of knownMeshes) {
@@ -260,7 +316,31 @@ function createSourceSession({states, knownMeshes, modelWeightState,
     return [...sourceSkinningRigs.values()];
   }
 
-  return {ensure, buildAll, resetPose};
+  async function buildAllCooperative({generation = null,
+      isCurrent = () => true} = {}) {
+    const groups = new Map();
+    for (const mesh of knownMeshes) {
+      const state = states.get(mesh);
+      if (!state?.loaded || !state.skinningSourceKey) continue;
+      const members = groups.get(state.skinningSourceKey) || [];
+      members.push(mesh);
+      groups.set(state.skinningSourceKey, members);
+    }
+    const budget = createWorkBudget();
+    for (const [sourceKey, members] of groups) {
+      if (generation !== null && !isCurrent()) return null;
+      await ensureCooperative(sourceKey, members, {generation, isCurrent});
+      await budget.checkpoint();
+    }
+    if (generation !== null && !isCurrent()) return null;
+    for (const sourceKey of [...sourceSkinningRigs.keys()]) {
+      if (!groups.has(sourceKey)) sourceSkinningRigs.delete(sourceKey);
+    }
+    return [...sourceSkinningRigs.values()];
+  }
+
+  return {ensure, ensureCooperative, buildAll, buildAllCooperative, resetPose,
+    reset() { inFlight.clear(); }};
 }
 
 export function initializeRigSourceSession(options) {
@@ -268,7 +348,9 @@ export function initializeRigSourceSession(options) {
 }
 
 function createSession({state, modelWeightState, getGeneration,
-    ensureModelWeightsLoaded, buildAllSourceSkinningRigs, buildModelSkinningRig,
+    ensureModelWeightsLoaded, buildAllSourceSkinningRigs,
+    buildAllSourceSkinningRigsCooperatively = buildAllSourceSkinningRigs,
+    buildModelSkinningRig,
     getSnapshot, notifyChanged, requestRender, cancelWeightPicking,
     pickFromSurface, getModelJointId, rotationSnapValues} = {}) {
   let loadToken = null;
@@ -329,13 +411,24 @@ function createSession({state, modelWeightState, getGeneration,
     state.pickStatus = '';
     notifyChanged();
     const promise = ensureModelWeightsLoaded()
-      .then(() => {
+      .then(async () => {
         if (generation !== getGeneration() || loadToken !== token) {
           return getSnapshot();
         }
         if (modelWeightState.error) throw new Error(modelWeightState.error);
-        const sourceRigs = buildAllSourceSkinningRigs();
-        buildModelSkinningRig(sourceRigs);
+        const sourceRigs = await buildAllSourceSkinningRigsCooperatively({
+          generation,
+          isCurrent: () => generation === getGeneration() && loadToken === token,
+        });
+        if (!sourceRigs || generation !== getGeneration()
+            || loadToken !== token) return getSnapshot();
+        const built = await buildModelSkinningRig(sourceRigs, {
+          generation,
+          isCurrent: () => generation === getGeneration() && loadToken === token,
+        });
+        if (!built || generation !== getGeneration() || loadToken !== token) {
+          return getSnapshot();
+        }
         state.loaded = true;
         return getSnapshot();
       })

--- a/src/web/js/mesh/rig-model-session.js
+++ b/src/web/js/mesh/rig-model-session.js
@@ -8,9 +8,15 @@ import {
   buildInferredRigForest,
   hasUsableSurfaceTopology,
   inspectSurfaceTopology,
+  inspectSurfaceTopologyCooperative,
   jointPivotMap,
 } from './weight-rig.js';
 import {createWorkBudget} from './cooperative-scheduler.js';
+
+function clockNow() {
+  return typeof globalThis.performance?.now === 'function'
+    ? globalThis.performance.now() : Date.now();
+}
 
 let activeSession = null;
 
@@ -57,7 +63,9 @@ function memberEvidenceShapeKey(member = {}) {
 }
 
 function createSourceSession({states, knownMeshes, modelWeightState,
-    sourceSkinningRigs, ensureRigMeshPrepared, ensureInfluenceGraph,
+    sourceSkinningRigs, ensureRigMeshPrepared,
+    ensureRigMeshPreparedCooperative = ensureRigMeshPrepared,
+    ensureInfluenceGraph, ensureInfluenceGraphCooperative = ensureInfluenceGraph,
     rebuildRestFrames,
     cloneForest} = {}) {
   function memberArraysEqual(left, right) {
@@ -147,6 +155,160 @@ function createSourceSession({states, knownMeshes, modelWeightState,
     };
   }
 
+  async function memberArraysEqualCooperative(left, right, budget, isCurrent) {
+    if (left === right) return true;
+    if (!left || !right || left.length !== right.length) return false;
+    for (let index = 0; index < left.length; index += 1) {
+      if (!Object.is(left[index], right[index])) return false;
+      if ((index & 2047) === 0) {
+        if (!isCurrent()) return null;
+        await budget.checkpoint();
+        if (!isCurrent()) return null;
+      }
+    }
+    return true;
+  }
+
+  async function memberEvidenceEqualCooperative(left, right, budget,
+      isCurrent) {
+    const leftState = left.state;
+    const rightState = right.state;
+    if (leftState.influenceCount !== rightState.influenceCount) return false;
+    const leftLengths = [
+      leftState.baselinePositions,
+      leftState.indices,
+      leftState.weights,
+      leftState.boneIds,
+      left.surfaceIndices,
+    ].map(values => values?.length ?? null);
+    const rightLengths = [
+      rightState.baselinePositions,
+      rightState.indices,
+      rightState.weights,
+      rightState.boneIds,
+      right.surfaceIndices,
+    ].map(values => values?.length ?? null);
+    if (leftLengths.some((length, index) => length !== rightLengths[index])) {
+      return false;
+    }
+    for (const [leftValues, rightValues] of [
+      [leftState.boneIds, rightState.boneIds],
+      [left.surfaceIndices, right.surfaceIndices],
+      [leftState.indices, rightState.indices],
+      [leftState.weights, rightState.weights],
+      [leftState.baselinePositions, rightState.baselinePositions],
+    ]) {
+      const equal = await memberArraysEqualCooperative(
+        leftValues, rightValues, budget, isCurrent);
+      if (equal === null) return null;
+      if (!equal) return false;
+    }
+    return isCurrent() ? true : null;
+  }
+
+  async function normalizeMembersCooperative(members, budget, isCurrent) {
+    const evidenceBuckets = new Map();
+    const uniqueMembers = [];
+    for (const member of members) {
+      if (!isCurrent()) return null;
+      const key = memberEvidenceShapeKey(member);
+      const bucket = evidenceBuckets.get(key) || [];
+      let duplicate = false;
+      for (const candidate of bucket) {
+        const equal = await memberEvidenceEqualCooperative(
+          candidate, member, budget, isCurrent);
+        if (equal === null) return null;
+        if (equal) {
+          duplicate = true;
+          break;
+        }
+      }
+      if (!duplicate) {
+        bucket.push(member);
+        evidenceBuckets.set(key, bucket);
+        uniqueMembers.push(member);
+      }
+      await budget.checkpoint();
+    }
+    return uniqueMembers;
+  }
+
+  async function aggregateInfluenceGraphCooperative(members, {
+      budget, isCurrent = () => true,
+  }) {
+    const timings = {
+      sourceKey: String(states.get(members[0])?.skinningSourceKey || ''),
+      meshCount: 0,
+      vertexCount: 0,
+      triangleCount: 0,
+      meshPreparationMs: 0,
+      topologyMs: 0,
+      surfaceGraphMs: 0,
+      vertexGraphMs: 0,
+    };
+    const loadedMembers = [];
+    for (const mesh of members) {
+      if (!isCurrent()) return null;
+      const state = states.get(mesh);
+      if (!state?.loaded) continue;
+      const preparationStartedAt = clockNow();
+      if (!(await ensureRigMeshPreparedCooperative(mesh, state,
+        {budget, isCurrent}))) return null;
+      timings.meshPreparationMs += clockNow() - preparationStartedAt;
+      loadedMembers.push({
+        mesh,
+        state,
+        surfaceIndices: mesh.geometry?.index?.array || null,
+      });
+      await budget.checkpoint();
+    }
+    const uniqueMembers = await normalizeMembersCooperative(
+      loadedMembers, budget, isCurrent);
+    if (!uniqueMembers) return null;
+    timings.meshCount = loadedMembers.length;
+    timings.vertexCount = uniqueMembers.reduce((sum, member) => sum +
+      Math.floor((member.state.baselinePositions?.length || 0) / 3), 0);
+    const surfaceEvidenceByMesh = new Map();
+    let surfaceEligible = true;
+    for (const member of uniqueMembers) {
+      const topologyStartedAt = clockNow();
+      const measure = await inspectSurfaceTopologyCooperative(
+        member.state.baselinePositions, member.surfaceIndices,
+        {budget, isCurrent});
+      if (!measure) return null;
+      timings.topologyMs += clockNow() - topologyStartedAt;
+      surfaceEvidenceByMesh.set(member.mesh, measure);
+      timings.triangleCount += measure.triangleCount;
+      surfaceEligible = surfaceEligible && measure.surfaceEvidenceAvailable;
+    }
+    const evidenceMode = surfaceEligible ? 'surface' : 'vertex';
+    const graphs = [];
+    for (const member of uniqueMembers) {
+      if (!isCurrent()) return null;
+      const surfaceEvidence = surfaceEvidenceByMesh.get(member.mesh);
+      const graphStartedAt = clockNow();
+      const graph = await ensureInfluenceGraphCooperative(
+        member.mesh, member.state, evidenceMode,
+        evidenceMode === 'surface' ? surfaceEvidence : surfaceEvidence,
+        {budget, isCurrent});
+      if (!graph) return null;
+      if (evidenceMode === 'surface') {
+        timings.surfaceGraphMs += clockNow() - graphStartedAt;
+      } else {
+        timings.vertexGraphMs += clockNow() - graphStartedAt;
+      }
+      graphs.push(graph);
+      await budget.checkpoint();
+    }
+    const graph = aggregateInfluenceGraphs(graphs);
+    return {
+      ...graph,
+      memberCount: loadedMembers.length,
+      uniqueMemberCount: uniqueMembers.length,
+      __cooperativeTimings: timings,
+    };
+  }
+
   function assembleSourceSkinningRig(sourceKey, members, influenceGraph,
       inferredForest, {finalize = true} = {}) {
     const descriptor = modelWeightState.sourceDescriptors.get(sourceKey);
@@ -198,24 +360,47 @@ function createSourceSession({states, knownMeshes, modelWeightState,
 
   function createSourceSkinningRig(sourceKey, members) {
     const influenceGraph = aggregateInfluenceGraph(members);
+    const forestStartedAt = clockNow();
     const inferredForest = buildInferredRigForest(influenceGraph);
+    if (influenceGraph.__cooperativeTimings) {
+      influenceGraph.__cooperativeTimings.inferredForestMs =
+        clockNow() - forestStartedAt;
+    }
     return assembleSourceSkinningRig(
       sourceKey, members, influenceGraph, inferredForest);
   }
 
   async function createSourceSkinningRigCooperative(sourceKey, members,
-      budget) {
-    const influenceGraph = aggregateInfluenceGraph(members);
-    await budget.checkpoint();
+      budget, isCurrent = () => true) {
+    const influenceGraph = await aggregateInfluenceGraphCooperative(members, {
+      budget, isCurrent,
+    });
+    if (!influenceGraph || !isCurrent()) return null;
+    const forestStartedAt = clockNow();
     const inferredForest = buildInferredRigForest(influenceGraph);
+    if (influenceGraph.__cooperativeTimings) {
+      influenceGraph.__cooperativeTimings.inferredForestMs =
+        clockNow() - forestStartedAt;
+    }
     await budget.checkpoint();
+    if (!isCurrent()) return null;
     const rig = assembleSourceSkinningRig(
       sourceKey, members, influenceGraph, inferredForest, {finalize: false});
     await budget.checkpoint();
+    if (!isCurrent()) return null;
+    const restFrameStartedAt = clockNow();
     rebuildRestFrames(rig);
+    if (influenceGraph.__cooperativeTimings) {
+      influenceGraph.__cooperativeTimings.restFrameMs =
+        clockNow() - restFrameStartedAt;
+    }
+    await budget.checkpoint();
+    if (!isCurrent()) return null;
     rig.defaultInferredForest = cloneForest(rig.inferredForest);
     rig.defaultJointPivotByBoneId = new Map([...rig.jointPivotByBoneId]
       .map(([boneId, pivot]) => [boneId, [...pivot]]));
+    rig.__cooperativeStats = budget.getStats();
+    rig.__cooperativeTimings = influenceGraph.__cooperativeTimings || null;
     return rig;
   }
 
@@ -287,7 +472,7 @@ function createSourceSession({states, knownMeshes, modelWeightState,
       await budget.checkpoint();
       if (!current()) return null;
       const rig = await createSourceSkinningRigCooperative(
-        sourceKey, members, budget);
+        sourceKey, members, budget, current);
       if (!current()) return null;
       sourceSkinningRigs.set(sourceKey, rig);
       return rig;

--- a/src/web/js/mesh/rig-model-session.js
+++ b/src/web/js/mesh/rig-model-session.js
@@ -6,29 +6,56 @@ import {sourceBoneKey} from './weight-rig-reconcile.js';
 import {
   aggregateInfluenceGraphs,
   buildInferredRigForest,
+  hasUsableSurfaceTopology,
   inspectSurfaceTopology,
   jointPivotMap,
 } from './weight-rig.js';
 
 let activeSession = null;
 
-function createSourceSession({states, knownMeshes, modelWeightState,
-    sourceSkinningRigs, ensureInfluenceGraph, rebuildRestFrames,
-    cloneForest} = {}) {
-  function memberArrayFingerprint(values) {
-    if (!values) return 'none';
-    const bytes = ArrayBuffer.isView(values)
-      ? new Uint8Array(values.buffer, values.byteOffset, values.byteLength)
-      : null;
-    if (!bytes) return `array:${values.length}:${[...values].join(',')}`;
-    let hash = 2166136261;
-    for (const byte of bytes) {
-      hash ^= byte;
-      hash = Math.imul(hash, 16777619);
-    }
-    return `${values.constructor.name}:${values.length}:${hash >>> 0}`;
-  }
+function memberStructuralEvidenceFields(member = {}) {
+  const state = member.state || {};
+  const identity = member.mesh?.userData?.identity || {};
+  const draw = identity.draw || {};
+  const geometry = identity.geometry_state || {};
+  const positionCount = member.mesh?.geometry?.attributes?.position?.count;
+  const surfaceIndexCount = member.mesh?.geometry?.index?.count
+    ?? member.mesh?.geometry?.index?.array?.length;
+  return [
+    state.skinningSourceKey ?? null,
+    state.influenceCount ?? null,
+    state.encoding ?? null,
+    draw.count ?? null,
+    draw.start ?? null,
+    draw.base ?? null,
+    geometry.ib_file ?? null,
+    geometry.index_size ?? null,
+    geometry.position_file ?? null,
+    geometry.position_stride ?? null,
+    geometry.texcoord_file ?? null,
+    geometry.texcoord_stride ?? null,
+    positionCount ?? null,
+    surfaceIndexCount ?? null,
+  ];
+}
 
+export function memberStructuralEvidenceKey(member = {}) {
+  return JSON.stringify(memberStructuralEvidenceFields(member));
+}
+
+function memberCompatibilityEvidenceKey(member = {}) {
+  // Some authored draw records share identical Rig evidence while their
+  // provenance-only draw start differs. Keep that broader key as a candidate
+  // only; memberEvidenceEqual remains the final identity decision.
+  const fields = memberStructuralEvidenceFields(member);
+  fields.splice(4, 1);
+  return JSON.stringify(fields);
+}
+
+function createSourceSession({states, knownMeshes, modelWeightState,
+    sourceSkinningRigs, ensureRigMeshPrepared, ensureInfluenceGraph,
+    rebuildRestFrames,
+    cloneForest} = {}) {
   function memberArraysEqual(left, right) {
     if (left === right) return true;
     if (!left || !right || left.length !== right.length) return false;
@@ -39,34 +66,53 @@ function createSourceSession({states, knownMeshes, modelWeightState,
   }
 
   function memberEvidenceEqual(left, right) {
-    return left.state.influenceCount === right.state.influenceCount
-      && memberArraysEqual(left.state.baselinePositions,
-        right.state.baselinePositions)
-      && memberArraysEqual(left.state.indices, right.state.indices)
-      && memberArraysEqual(left.state.weights, right.state.weights)
-      && memberArraysEqual(left.state.boneIds, right.state.boneIds)
-      && memberArraysEqual(left.surfaceIndices, right.surfaceIndices);
+    const leftState = left.state;
+    const rightState = right.state;
+    if (leftState.influenceCount !== rightState.influenceCount) return false;
+    const leftLengths = [
+      leftState.baselinePositions,
+      leftState.indices,
+      leftState.weights,
+      leftState.boneIds,
+      left.surfaceIndices,
+    ].map(values => values?.length ?? null);
+    const rightLengths = [
+      rightState.baselinePositions,
+      rightState.indices,
+      rightState.weights,
+      rightState.boneIds,
+      right.surfaceIndices,
+    ].map(values => values?.length ?? null);
+    if (leftLengths.some((length, index) => length !== rightLengths[index])) {
+      return false;
+    }
+    return memberArraysEqual(leftState.boneIds, rightState.boneIds)
+      && memberArraysEqual(left.surfaceIndices, right.surfaceIndices)
+      && memberArraysEqual(leftState.indices, rightState.indices)
+      && memberArraysEqual(leftState.weights, rightState.weights)
+      && memberArraysEqual(leftState.baselinePositions,
+        rightState.baselinePositions);
   }
 
   function normalizeMembers(members) {
-    const buckets = new Map();
+    const structuralBuckets = new Map();
+    const compatibilityBuckets = new Map();
     const uniqueMembers = [];
     for (const member of members) {
-      const state = member.state;
-      const fingerprint = [
-        state.influenceCount,
-        memberArrayFingerprint(state.baselinePositions),
-        memberArrayFingerprint(state.indices),
-        memberArrayFingerprint(state.weights),
-        memberArrayFingerprint(state.boneIds),
-        memberArrayFingerprint(member.surfaceIndices),
-      ].join('|');
-      const bucket = buckets.get(fingerprint) || [];
+      const structuralKey = memberStructuralEvidenceKey(member);
+      const bucket = structuralBuckets.get(structuralKey) || [];
       if (bucket.some(candidate => memberEvidenceEqual(candidate, member))) {
         continue;
       }
+      const compatibilityKey = memberCompatibilityEvidenceKey(member);
+      const compatibilityBucket = compatibilityBuckets.get(compatibilityKey)
+        || [];
+      if (compatibilityBucket.some(candidate =>
+          memberEvidenceEqual(candidate, member))) continue;
       bucket.push(member);
-      buckets.set(fingerprint, bucket);
+      structuralBuckets.set(structuralKey, bucket);
+      compatibilityBucket.push(member);
+      compatibilityBuckets.set(compatibilityKey, compatibilityBucket);
       uniqueMembers.push(member);
     }
     return uniqueMembers;
@@ -75,20 +121,26 @@ function createSourceSession({states, knownMeshes, modelWeightState,
   function aggregateInfluenceGraph(members) {
     const loadedMembers = members.map(mesh => {
       const state = states.get(mesh);
+      if (state?.loaded) ensureRigMeshPrepared?.(mesh, state);
       return state?.loaded ? {
         mesh,
         state,
         surfaceIndices: mesh.geometry?.index?.array || null,
-        surfaceEvidence: inspectSurfaceTopology(
-          state.baselinePositions, mesh.geometry?.index?.array || null),
       } : null;
     }).filter(Boolean);
     const uniqueMembers = normalizeMembers(loadedMembers);
-    const evidenceMode = loadedMembers.every(member =>
-      member.surfaceEvidence.surfaceEvidenceAvailable) ? 'surface' : 'vertex';
-    const graph = aggregateInfluenceGraphs(uniqueMembers.map(member =>
-      ensureInfluenceGraph(member.mesh, member.state, evidenceMode,
-        member.surfaceEvidence)));
+    const surfaceEligible = uniqueMembers.map(member =>
+      hasUsableSurfaceTopology(
+        member.state.baselinePositions, member.surfaceIndices));
+    const evidenceMode = surfaceEligible.every(Boolean) ? 'surface' : 'vertex';
+    const graph = aggregateInfluenceGraphs(uniqueMembers.map(member => {
+      const surfaceEvidence = evidenceMode === 'surface'
+        ? {surfaceEvidenceAvailable: true}
+        : inspectSurfaceTopology(
+          member.state.baselinePositions, member.surfaceIndices);
+      return ensureInfluenceGraph(
+        member.mesh, member.state, evidenceMode, surfaceEvidence);
+    }));
     return {
       ...graph,
       memberCount: loadedMembers.length,
@@ -216,7 +268,7 @@ export function initializeRigSourceSession(options) {
 }
 
 function createSession({state, modelWeightState, getGeneration,
-    loadModelWeights, buildAllSourceSkinningRigs, buildModelSkinningRig,
+    ensureModelWeightsLoaded, buildAllSourceSkinningRigs, buildModelSkinningRig,
     getSnapshot, notifyChanged, requestRender, cancelWeightPicking,
     pickFromSurface, getModelJointId, rotationSnapValues} = {}) {
   let loadToken = null;
@@ -276,7 +328,7 @@ function createSession({state, modelWeightState, getGeneration,
     state.error = null;
     state.pickStatus = '';
     notifyChanged();
-    const promise = loadModelWeights()
+    const promise = ensureModelWeightsLoaded()
       .then(() => {
         if (generation !== getGeneration() || loadToken !== token) {
           return getSnapshot();

--- a/src/web/js/mesh/rig-model-session.js
+++ b/src/web/js/mesh/rig-model-session.js
@@ -536,6 +536,7 @@ function createSession({state, modelWeightState, getGeneration,
     ensureModelWeightsLoaded, buildAllSourceSkinningRigs,
     buildAllSourceSkinningRigsCooperatively = buildAllSourceSkinningRigs,
     buildModelSkinningRig,
+    syncPhysicsToSelection,
     getSnapshot, notifyChanged, requestRender, cancelWeightPicking,
     pickFromSurface, getModelJointId, rotationSnapValues} = {}) {
   let loadToken = null;
@@ -615,6 +616,7 @@ function createSession({state, modelWeightState, getGeneration,
           return getSnapshot();
         }
         state.loaded = true;
+        syncPhysicsToSelection?.();
         return getSnapshot();
       })
       .catch(error => {

--- a/src/web/js/mesh/skinning-runtime.js
+++ b/src/web/js/mesh/skinning-runtime.js
@@ -10,9 +10,13 @@ import {
 import {buildSelectedWeightMask} from './weight-selection.js';
 import {
   buildInfluenceNodes as buildRigInfluenceNodes,
+  buildInfluenceNodesCooperative as buildRigInfluenceNodesCooperative,
   buildInfluenceRelationships as buildRigInfluenceRelationships,
+  buildInfluenceRelationshipsCooperative as buildRigInfluenceRelationshipsCooperative,
   buildSurfaceInfluenceGraph,
+  buildSurfaceInfluenceGraphCooperative,
   inspectSurfaceTopology,
+  inspectSurfaceTopologyCooperative,
 } from './weight-rig.js';
 import {EMPTY_ACTIVE_VERTICES} from './weight-runtime.js';
 import {createWorkBudget} from './cooperative-scheduler.js';
@@ -68,6 +72,7 @@ export function createSkinningRuntime({
   } = {}) {
   const modelRigState = getModelRigState();
   const rigPresetState = getRigPresetState();
+  const cooperativeGraphInFlight = new WeakMap();
 
   function markFinalBoundsDirty(mesh, state) {
     if (state.preDeformationFrustumCulled === null
@@ -359,6 +364,116 @@ export function createSkinningRuntime({
     if (modelWeightState.heatmapEnabled) updateModelWeightHeatmap();
     notifyModelWeightChanged();
     return true;
+  }
+
+  async function ensureRigMeshPreparedCooperative(mesh, state, {
+      budget = createWorkBudget(), isCurrent = () => true,
+  } = {}) {
+    if (!state?.loaded || !isCurrent()) return false;
+    const position = mesh.geometry?.attributes?.position;
+    if (!position) throw new Error('The selected mesh has no position data.');
+    const normal = mesh.geometry?.attributes?.normal;
+    if (!state.baselinePositions
+        || state.baselinePositions.length !== position.array.length) {
+      state.baselinePositions = new Float32Array(position.array);
+    }
+    if (normal && (!state.baselineNormals
+        || state.baselineNormals.length !== normal.array.length)) {
+      state.baselineNormals = new Float32Array(normal.array);
+    } else if (!normal) {
+      state.baselineNormals = null;
+    }
+    if (!state.originalMaterial) state.originalMaterial = mesh.material;
+    if (!state.influenceNodes) {
+      const nodes = await buildRigInfluenceNodesCooperative(
+        state.baselinePositions, state.indices, state.weights,
+        state.influenceCount, state.boneIds, {budget, isCurrent});
+      if (!nodes || !state.loaded || !isCurrent()) return false;
+      state.influenceNodes = nodes;
+    }
+    if (!state.centerByBoneId) {
+      state.centerByBoneId = new Map(state.influenceNodes.map(node => [
+        node.boneId, node.weightedCenter]));
+    }
+    return isCurrent() && state.loaded;
+  }
+
+  async function buildInfluenceGraphCooperative(mesh, state,
+      requestedEvidenceMode = 'vertex', surfaceEvidence = null, {
+        budget = createWorkBudget(), isCurrent = () => true,
+      } = {}) {
+    if (!(await ensureRigMeshPreparedCooperative(mesh, state,
+      {budget, isCurrent}))) return null;
+    if (!mesh.geometry.boundingSphere) mesh.geometry.computeBoundingSphere();
+    const radius = Number(mesh.geometry.boundingSphere?.radius);
+    let measure = surfaceEvidence;
+    if (!measure && requestedEvidenceMode === 'surface') {
+      measure = await inspectSurfaceTopologyCooperative(
+        state.baselinePositions, mesh.geometry?.index?.array || null,
+        {budget, isCurrent});
+      if (!measure) return null;
+    }
+    const evidenceMode = requestedEvidenceMode === 'surface'
+      && measure?.surfaceEvidenceAvailable ? 'surface' : 'vertex';
+    if (evidenceMode === 'surface') {
+      return buildSurfaceInfluenceGraphCooperative(
+        state.baselinePositions, mesh.geometry?.index?.array || null,
+        state.indices, state.weights, state.influenceCount, state.boneIds,
+        Number.isFinite(radius) && radius > 0 ? radius : null,
+        {budget, isCurrent});
+    }
+    const relationships = await buildRigInfluenceRelationshipsCooperative(
+      state.baselinePositions, state.indices, state.weights,
+      state.influenceCount, state.influenceNodes,
+      Number.isFinite(radius) && radius > 0 ? radius : null,
+      {budget, isCurrent});
+    if (!relationships || !isCurrent()) return null;
+    return {
+      nodes: state.influenceNodes, relationships,
+      boundingSphereRadius: Number.isFinite(radius) && radius > 0 ? radius : null,
+      evidenceMode,
+      triangleCount: measure?.triangleCount || 0,
+      validTriangleCount: measure?.validTriangleCount || 0,
+      degenerateTriangleCount: measure?.degenerateTriangleCount || 0,
+      invalidTriangleCount: measure?.invalidTriangleCount || 0,
+      totalSurfaceArea: measure?.totalSurfaceArea || 0,
+      measuredVertexCount: measure?.measuredVertexCount || 0,
+      zeroMeasureVertexCount: measure?.zeroMeasureVertexCount || 0,
+      fallbackReason: requestedEvidenceMode === 'surface'
+        && evidenceMode === 'vertex' ? 'surface_evidence_unavailable'
+        : requestedEvidenceMode === 'vertex' && measure
+          && !measure.surfaceEvidenceAvailable
+          ? 'surface_evidence_unavailable' : null,
+    };
+  }
+
+  async function ensureInfluenceGraphCooperative(mesh, state,
+      evidenceMode = 'vertex', surfaceEvidence = null, options = {}) {
+    if (!state?.loaded) return null;
+    if (state.influenceGraph?.evidenceMode === evidenceMode) {
+      return state.influenceGraph;
+    }
+    let pendingByMode = cooperativeGraphInFlight.get(mesh);
+    if (!pendingByMode) {
+      pendingByMode = new Map();
+      cooperativeGraphInFlight.set(mesh, pendingByMode);
+    }
+    const key = String(evidenceMode);
+    const pending = pendingByMode.get(key);
+    if (pending) return pending;
+    const promise = buildInfluenceGraphCooperative(
+      mesh, state, evidenceMode, surfaceEvidence, options)
+      .then(graph => {
+        if (graph && state.loaded && (!options.isCurrent
+            || options.isCurrent())) state.influenceGraph = graph;
+        return graph;
+      })
+      .finally(() => {
+        if (pendingByMode.get(key) === promise) pendingByMode.delete(key);
+        if (!pendingByMode.size) cooperativeGraphInFlight.delete(mesh);
+      });
+    pendingByMode.set(key, promise);
+    return promise;
   }
 
   function setModelWeightLoadError(error) {
@@ -701,7 +816,8 @@ export function createSkinningRuntime({
 
   return {
     applyDeformation, buildInfluenceGraph, ensureInfluenceGraph,
-    ensureRigMeshPrepared,
+    buildInfluenceGraphCooperative, ensureInfluenceGraphCooperative,
+    ensureRigMeshPrepared, ensureRigMeshPreparedCooperative,
     finalizeDeformationGeometry, forEachRigMesh,
     getSkinningState: mesh => states.get(mesh) || null,
     getSkinningBaseMaterial, withSkinningBaseMaterial,

--- a/src/web/js/mesh/skinning-runtime.js
+++ b/src/web/js/mesh/skinning-runtime.js
@@ -187,6 +187,7 @@ export function createSkinningRuntime({
 
   function buildInfluenceGraph(mesh, state, requestedEvidenceMode = 'vertex',
       surfaceEvidence = null) {
+    ensureRigMeshPrepared(mesh, state);
     if (!mesh.geometry.boundingSphere) mesh.geometry.computeBoundingSphere();
     const radius = Number(mesh.geometry.boundingSphere?.radius);
     const rawNodes = state.influenceNodes || buildRigInfluenceNodes(
@@ -229,6 +230,7 @@ export function createSkinningRuntime({
 
   function ensureInfluenceGraph(mesh, state, evidenceMode = 'vertex',
       surfaceEvidence = null) {
+    ensureRigMeshPrepared(mesh, state);
     if (!state.influenceGraph
         || state.influenceGraph.evidenceMode !== evidenceMode) {
       state.influenceGraph = buildInfluenceGraph(
@@ -237,13 +239,48 @@ export function createSkinningRuntime({
     return state.influenceGraph;
   }
 
-  function captureBaseline(mesh, state) {
+  function ensureRigMeshPrepared(mesh, state) {
+    if (!state?.loaded) return false;
     const position = mesh.geometry?.attributes?.position;
     if (!position) throw new Error('The selected mesh has no position data.');
     const normal = mesh.geometry?.attributes?.normal;
-    state.baselinePositions = new Float32Array(position.array);
-    state.baselineNormals = normal ? new Float32Array(normal.array) : null;
-    state.originalMaterial = mesh.material;
+    if (!state.baselinePositions
+        || state.baselinePositions.length !== position.array.length) {
+      state.baselinePositions = new Float32Array(position.array);
+    }
+    if (normal && (!state.baselineNormals
+        || state.baselineNormals.length !== normal.array.length)) {
+      state.baselineNormals = new Float32Array(normal.array);
+    } else if (!normal) {
+      state.baselineNormals = null;
+    }
+    if (!state.originalMaterial) state.originalMaterial = mesh.material;
+    if (!state.influenceNodes) {
+      state.influenceNodes = buildRigInfluenceNodes(
+        state.baselinePositions, state.indices, state.weights,
+        state.influenceCount, state.boneIds);
+    }
+    if (!state.centerByBoneId) {
+      state.centerByBoneId = new Map(state.influenceNodes.map(node => [
+        node.boneId, node.weightedCenter]));
+    }
+    return true;
+  }
+
+  function normalizeWeightBoneStats(stats) {
+    return Object.fromEntries(Object.entries(stats || {}).flatMap(
+      ([rawBoneId, rawEntry]) => {
+        const boneId = Number(rawBoneId);
+        const affectedVertexCount = Number(
+          rawEntry?.affectedVertexCount ?? rawEntry?.affected_vertex_count);
+        const totalWeight = Number(
+          rawEntry?.totalWeight ?? rawEntry?.total_weight);
+        if (!Number.isFinite(boneId) || !Number.isFinite(affectedVertexCount)
+            || affectedVertexCount < 0 || !Number.isFinite(totalWeight)) {
+          return [];
+        }
+        return [[String(boneId), {affectedVertexCount, totalWeight}]];
+      }));
   }
 
   function sourceDescriptorForEntry(entry) {
@@ -281,7 +318,12 @@ export function createSkinningRuntime({
         || weights.length !== position.count * influenceCount) {
       throw new Error('Skin data does not match rendered vertices.');
     }
-    captureBaseline(mesh, state);
+    state.originalMaterial = mesh.material;
+    state.baselinePositions = null;
+    state.baselineNormals = null;
+    state.influenceNodes = null;
+    state.influenceGraph = null;
+    state.centerByBoneId = null;
     state.indices = indices;
     state.weights = weights;
     state.influenceCount = influenceCount;
@@ -291,13 +333,9 @@ export function createSkinningRuntime({
       : buildBoneIds(indices, weights, influenceCount);
     state.encoding = entry.encoding || null;
     state.diagnostics = entry.diagnostics || null;
+    state.weightBoneStats = normalizeWeightBoneStats(entry.weight_stats);
     state.loaded = true;
     state.error = null;
-    state.influenceNodes = buildRigInfluenceNodes(
-      state.baselinePositions, state.indices, state.weights,
-      state.influenceCount, state.boneIds);
-    state.centerByBoneId = new Map(state.influenceNodes.map(node => [
-      node.boneId, node.weightedCenter]));
     refreshSelectedWeightMask(mesh, state);
     return state;
   }
@@ -312,14 +350,25 @@ export function createSkinningRuntime({
   function loadModelWeights() {
     if (modelWeightState.loaded) return Promise.resolve(modelWeightSnapshot());
     if (modelWeightState.promise) return modelWeightState.promise;
-    const meshes = [...knownMeshes].filter(eligibleSkinningMesh);
     const generation = getGeneration();
+    const deferPhysicsSync = () => {
+      const readyGeneration = generation;
+      const afterPaint = typeof requestAnimationFrame === 'function'
+        ? requestAnimationFrame : callback => setTimeout(callback, 0);
+      afterPaint(() => setTimeout(() => {
+        if (readyGeneration !== getGeneration() || !modelWeightState.loaded) {
+          return;
+        }
+        syncPhysicsToSelection();
+      }, 0));
+    };
+    const meshes = [...knownMeshes].filter(eligibleSkinningMesh);
     if (!meshes.length) {
       modelWeightState.loaded = true;
       modelWeightState.noWeights = true;
       modelWeightState.savedSelectionApplied = true;
       refreshModelWeightSummary({refreshStats: true});
-      syncPhysicsToSelection();
+      deferPhysicsSync();
       notifyModelWeightChanged();
       return Promise.resolve(modelWeightSnapshot());
     }
@@ -368,9 +417,10 @@ export function createSkinningRuntime({
       if (!modelWeightState.savedSelectionApplied) {
         modelWeightState.savedSelectionApplied = true;
         setSelectedBones(sourceSelectionEntries(
-          modelWeightState.savedBonesBySource));
+          modelWeightState.savedBonesBySource), {syncPhysics: false});
+        deferPhysicsSync();
       } else {
-        syncPhysicsToSelection();
+        deferPhysicsSync();
         notifyModelWeightChanged();
       }
       return modelWeightSnapshot();
@@ -394,7 +444,11 @@ export function createSkinningRuntime({
   }
 
   function updateHeatmap(mesh, state, selectedMask = state.selectedWeightMask) {
-    if (!state.heatmapMode || !selectedMask) return;
+    if (!state.heatmapMode) return;
+    if (!selectedMask) {
+      disableHeatmap(mesh, state);
+      return;
+    }
     const count = Math.floor(state.indices.length / state.influenceCount);
     const colors = new Float32Array(count * 3);
     for (let vertex = 0; vertex < count; vertex += 1) {
@@ -554,11 +608,9 @@ export function createSkinningRuntime({
     mesh.geometry.computeBoundingSphere();
     state.baselinePositions = new Float32Array(position.array);
     state.baselineNormals = normal ? new Float32Array(normal.array) : null;
-    state.influenceNodes = buildRigInfluenceNodes(
-      state.baselinePositions, state.indices, state.weights,
-      state.influenceCount, state.boneIds);
-    state.centerByBoneId = new Map(state.influenceNodes.map(node => [
-      node.boneId, node.weightedCenter]));
+    state.influenceNodes = null;
+    state.centerByBoneId = null;
+    ensureRigMeshPrepared(mesh, state);
     state.influenceGraph = null;
     if (wasPhysicsEnabled && modelPhysicsSession.getState().enabled
         && sourceKey) {
@@ -589,6 +641,7 @@ export function createSkinningRuntime({
 
   return {
     applyDeformation, buildInfluenceGraph, ensureInfluenceGraph,
+    ensureRigMeshPrepared,
     finalizeDeformationGeometry, forEachRigMesh,
     getSkinningState: mesh => states.get(mesh) || null,
     getSkinningBaseMaterial, withSkinningBaseMaterial,

--- a/src/web/js/mesh/skinning-runtime.js
+++ b/src/web/js/mesh/skinning-runtime.js
@@ -15,8 +15,14 @@ import {
   inspectSurfaceTopology,
 } from './weight-rig.js';
 import {EMPTY_ACTIVE_VERTICES} from './weight-runtime.js';
+import {createWorkBudget} from './cooperative-scheduler.js';
 
 let activeRuntime = null;
+
+function clockNow() {
+  return typeof globalThis.performance?.now === 'function'
+    ? globalThis.performance.now() : Date.now();
+}
 
 function typedView(buffer, descriptor, Type, typeName) {
   if (!descriptor || descriptor.type !== typeName) {
@@ -56,6 +62,7 @@ export function createSkinningRuntime({
     invalidateHumanoidDetection, invalidateModelRigLoad, clearPickedPoint,
     resetModelPose,
     syncPhysicsParticipants, buildAllSourceSkinningRigs,
+    buildAllSourceSkinningRigsCooperatively = null,
     buildModelSkinningRig, notifyModelWeightChanged, notifyModelRigChanged,
     resetModelState, requestRender, invalidateShadow,
   } = {}) {
@@ -299,7 +306,7 @@ export function createSkinningRuntime({
     return null;
   }
 
-  function installSkinningEntry(mesh, entry, buffer) {
+  function installSkinningEntry(mesh, entry, buffer, {refreshSelection = true} = {}) {
     const state = stateFor(mesh);
     const source = sourceDescriptorForEntry(entry);
     if (!source) throw new Error(
@@ -336,8 +343,22 @@ export function createSkinningRuntime({
     state.weightBoneStats = normalizeWeightBoneStats(entry.weight_stats);
     state.loaded = true;
     state.error = null;
-    refreshSelectedWeightMask(mesh, state);
+    if (refreshSelection) refreshSelectedWeightMask(mesh, state);
     return state;
+  }
+
+  async function restoreSelectedWeightMasks(generation) {
+    const budget = createWorkBudget();
+    for (const mesh of knownMeshes) {
+      if (generation !== getGeneration()) return false;
+      const state = states.get(mesh);
+      if (state?.loaded) refreshSelectedWeightMask(mesh, state);
+      await budget.checkpoint();
+    }
+    if (generation !== getGeneration()) return false;
+    if (modelWeightState.heatmapEnabled) updateModelWeightHeatmap();
+    notifyModelWeightChanged();
+    return true;
   }
 
   function setModelWeightLoadError(error) {
@@ -351,6 +372,9 @@ export function createSkinningRuntime({
     if (modelWeightState.loaded) return Promise.resolve(modelWeightSnapshot());
     if (modelWeightState.promise) return modelWeightState.promise;
     const generation = getGeneration();
+    const loadStartedAt = clockNow();
+    const performance = {};
+    modelWeightState.performance = performance;
     const deferPhysicsSync = () => {
       const readyGeneration = generation;
       const afterPaint = typeof requestAnimationFrame === 'function'
@@ -395,8 +419,11 @@ export function createSkinningRuntime({
       if (buffer && buffer.byteLength !== Number(preview.data.length)) {
         throw new Error('Skin data download was incomplete.');
       }
+      performance.fetchMs = clockNow() - loadStartedAt;
+      const installStartedAt = clockNow();
+      const installBudget = createWorkBudget();
       for (const mesh of meshes) {
-        if (generation !== getGeneration() || !knownMeshes.has(mesh)) break;
+        if (generation !== getGeneration() || !knownMeshes.has(mesh)) return modelWeightSnapshot();
         const state = stateFor(mesh);
         const entry = preview?.meshes?.[mesh.userData.semanticKey];
         if (!entry || entry.status !== 'ok') {
@@ -405,24 +432,39 @@ export function createSkinningRuntime({
           continue;
         }
         try {
-          installSkinningEntry(mesh, entry, buffer);
+          installSkinningEntry(mesh, entry, buffer, {refreshSelection: false});
         } catch (error) {
           state.error = error instanceof Error ? error.message : String(error);
           state.loaded = false;
         }
+        await installBudget.checkpoint();
       }
       if (generation !== getGeneration()) return modelWeightSnapshot();
       modelWeightState.loaded = true;
       refreshModelWeightSummary({refreshStats: true});
+      performance.basicInstallMs = clockNow() - installStartedAt;
+      performance.weightReadyMs = clockNow() - loadStartedAt;
+      Object.assign(performance, installBudget.getStats());
+      // Basic Weight data is usable before derived selection masks and
+      // physics restoration begin.  Keep the loading flag tied to this
+      // milestone so the UI can paint and accept input immediately.
+      modelWeightState.loading = false;
+      notifyModelWeightChanged();
       if (!modelWeightState.savedSelectionApplied) {
         modelWeightState.savedSelectionApplied = true;
         setSelectedBones(sourceSelectionEntries(
-          modelWeightState.savedBonesBySource), {syncPhysics: false});
+          modelWeightState.savedBonesBySource), {
+            syncPhysics: false, refreshMasks: false,
+          });
+        await restoreSelectedWeightMasks(generation);
         deferPhysicsSync();
       } else {
+        await restoreSelectedWeightMasks(generation);
         deferPhysicsSync();
         notifyModelWeightChanged();
       }
+      performance.selectedMaskRestoreMs = clockNow() - loadStartedAt
+        - performance.weightReadyMs;
       return modelWeightSnapshot();
     })();
     return modelWeightState.promise
@@ -436,6 +478,7 @@ export function createSkinningRuntime({
       })
       .finally(() => {
         if (generation === getGeneration()) {
+          performance.totalMs = clockNow() - loadStartedAt;
           modelWeightState.loading = false;
           modelWeightState.promise = null;
           notifyModelWeightChanged();
@@ -550,9 +593,26 @@ export function createSkinningRuntime({
       syncPhysicsParticipants(new Set([sourceKey]));
     }
     if (modelRigState.loaded) {
-      buildAllSourceSkinningRigs();
-      buildModelSkinningRig();
-      modelRigState.loaded = true;
+      const generation = getGeneration();
+      modelRigState.loading = true;
+      notifyModelRigChanged();
+      const buildSources = buildAllSourceSkinningRigsCooperatively
+        || (() => Promise.resolve(buildAllSourceSkinningRigs()));
+      void buildSources({
+        generation,
+        isCurrent: () => generation === getGeneration(),
+      }).then(sourceRigs => {
+        if (!sourceRigs || generation !== getGeneration()) return null;
+        return buildModelSkinningRig(sourceRigs, {
+          generation,
+          isCurrent: () => generation === getGeneration(),
+        });
+      }).catch(() => null).then(built => {
+        if (generation !== getGeneration()) return;
+        modelRigState.loading = false;
+        if (built) modelRigState.loaded = true;
+        notifyModelRigChanged();
+      });
     }
     notifyModelRigChanged();
     notifyModelWeightChanged();

--- a/src/web/js/mesh/weight-model-session.js
+++ b/src/web/js/mesh/weight-model-session.js
@@ -5,7 +5,7 @@ import * as THREE from 'three';
 import {createWeightPickController} from '../scene/weight-pick-controller.js';
 import {computeModelBounds} from '../scene/model-bounds.js';
 import {sampleSkinningAtIntersection} from './weight-selection.js';
-import {aggregateModelBoneStats} from './weight-runtime.js';
+import {aggregateModelWeightBoneStats} from './weight-runtime.js';
 
 let activeSession = null;
 let activePickingSession = null;
@@ -147,22 +147,22 @@ function createSession({modelWeightState, states, knownMeshes,
     refreshSelectedWeightMask,
     updateModelWeightHeatmap, syncPhysicsToSelection, sameBoneSelection,
     serializeBoneSelection, eligibleSkinningMesh, notifyChanged,
-    requestRender, getGeneration} = {}) {
+    requestRender, getGeneration, ensureModelWeightsLoaded} = {}) {
   let selectionSavePromise = null;
 
   function refreshModelBoneStats() {
-    const nodesBySource = new Map();
+    const statsBySource = new Map();
     for (const mesh of knownMeshes) {
       const state = states.get(mesh);
       if (!state?.loaded || !state.skinningSourceKey) continue;
-      const nodes = state.influenceNodes || [];
-      const sourceNodes = nodesBySource.get(state.skinningSourceKey) || [];
-      sourceNodes.push(nodes);
-      nodesBySource.set(state.skinningSourceKey, sourceNodes);
+      const sourceStats = statsBySource.get(state.skinningSourceKey) || [];
+      sourceStats.push(state.weightBoneStats || {});
+      statsBySource.set(state.skinningSourceKey, sourceStats);
     }
     modelWeightState.sources = modelWeightState.sources.map(source => ({
       ...source,
-      boneStats: aggregateModelBoneStats(nodesBySource.get(source.key) || []),
+      boneStats: aggregateModelWeightBoneStats(
+        statsBySource.get(source.key) || []),
     }));
   }
 
@@ -221,7 +221,7 @@ function createSession({modelWeightState, states, knownMeshes,
     if (refreshStats) refreshModelBoneStats();
   }
 
-  function setSelectedBones(selection) {
+  function setSelectedBones(selection, {syncPhysics = true} = {}) {
     refreshModelWeightSummary();
     const next = selectionMapFromEntries(selection);
     if (modelWeightState.loaded) {
@@ -243,7 +243,7 @@ function createSession({modelWeightState, states, knownMeshes,
       modelWeightState.selectedBonesBySource);
     const nextEntries = sourceSelectionEntries(next);
     if (sameBoneSelection(previousEntries, nextEntries)) {
-      syncPhysicsToSelection();
+      if (syncPhysics) syncPhysicsToSelection();
       return modelWeightSnapshot();
     }
     const changedSourceKeys = new Set([
@@ -267,7 +267,7 @@ function createSession({modelWeightState, states, knownMeshes,
     if (modelWeightState.heatmapEnabled) {
       updateModelWeightHeatmap(changedSourceKeys);
     }
-    syncPhysicsToSelection(changedSourceKeys);
+    if (syncPhysics) syncPhysicsToSelection(changedSourceKeys);
     notifyChanged();
     requestRender();
     return modelWeightSnapshot();
@@ -330,6 +330,8 @@ function createSession({modelWeightState, states, knownMeshes,
   return {
     getState: modelWeightSnapshot,
     refreshModelWeightSummary,
+    ensureLoaded: () => ensureModelWeightsLoaded?.() || Promise.resolve(
+      modelWeightSnapshot()),
     setSelectedBones,
     setBoneSelected,
     clearSelectedBones: () => setSelectedBones([]),
@@ -362,8 +364,9 @@ export function getModelWeightState() { return session().getState(); }
 export function refreshModelWeightSummary(options) {
   return session().refreshModelWeightSummary(options);
 }
-export function setSelectedBones(selection) {
-  return session().setSelectedBones(selection);
+export function ensureModelWeightsLoaded() { return session().ensureLoaded(); }
+export function setSelectedBones(selection, options) {
+  return session().setSelectedBones(selection, options);
 }
 export function setBoneSelected(sourceKey, boneId, selected) {
   return session().setBoneSelected(sourceKey, boneId, selected);

--- a/src/web/js/mesh/weight-model-session.js
+++ b/src/web/js/mesh/weight-model-session.js
@@ -221,7 +221,8 @@ function createSession({modelWeightState, states, knownMeshes,
     if (refreshStats) refreshModelBoneStats();
   }
 
-  function setSelectedBones(selection, {syncPhysics = true} = {}) {
+  function setSelectedBones(selection, {syncPhysics = true,
+      refreshMasks = true} = {}) {
     refreshModelWeightSummary();
     const next = selectionMapFromEntries(selection);
     if (modelWeightState.loaded) {
@@ -258,13 +259,13 @@ function createSession({modelWeightState, states, knownMeshes,
       ])),
     )));
     modelWeightState.selectedBonesBySource = next;
-    knownMeshes.forEach(mesh => {
+    if (refreshMasks) knownMeshes.forEach(mesh => {
       const state = states.get(mesh);
       if (changedSourceKeys.has(state?.skinningSourceKey)) {
         refreshSelectedWeightMask(mesh, state);
       }
     });
-    if (modelWeightState.heatmapEnabled) {
+    if (refreshMasks && modelWeightState.heatmapEnabled) {
       updateModelWeightHeatmap(changedSourceKeys);
     }
     if (syncPhysics) syncPhysicsToSelection(changedSourceKeys);

--- a/src/web/js/mesh/weight-physics-controller.js
+++ b/src/web/js/mesh/weight-physics-controller.js
@@ -8,15 +8,18 @@ export function createWeightPhysicsCoordinator({modelPhysicsSession,
     selectedBoneCount, eligibleSkinningMesh, createSourcePhysicsRig,
     createSourcePhysicsParticipant, getModelTransformState,
     invalidateCharacterShadowGeometry, notifyModelRigChanged, requestRender,
-    defaults} = {}) {
+    defaults, getGeneration = () => 0, setRigLoading = () => {}} = {}) {
+  let participantSyncToken = 0;
+
   function disable() {
     if (!modelPhysicsSession.getState().enabled) return false;
+    participantSyncToken += 1;
     modelPhysicsSession.disable();
     notifyModelRigChanged();
     return true;
   }
 
-  function syncParticipants(changedSourceKeys = null) {
+  async function syncParticipants(changedSourceKeys = null) {
     if (!modelPhysicsSession.getState().enabled) return;
     if (!selectedBoneCount(modelWeightState.selectedBonesBySource)) {
       disable();
@@ -46,6 +49,11 @@ export function createWeightPhysicsCoordinator({modelPhysicsSession,
       members.push(mesh);
       groups.set(state.skinningSourceKey, members);
     }
+    const syncToken = ++participantSyncToken;
+    const generation = getGeneration();
+    const isCurrent = () => syncToken === participantSyncToken
+      && generation === getGeneration()
+      && modelPhysicsSession.getState().enabled;
     const affected = changedSourceKeys
       ? new Set(changedSourceKeys)
       : new Set([...groups.keys(), ...sourcePhysicsRigs.keys()]);
@@ -66,6 +74,7 @@ export function createWeightPhysicsCoordinator({modelPhysicsSession,
 
     let attached = false;
     for (const [sourceKey, members] of groups) {
+      if (!isCurrent()) return false;
       const selected = modelWeightState.selectedBonesBySource.get(sourceKey);
       members.forEach(mesh => {
         const state = states.get(mesh);
@@ -75,8 +84,22 @@ export function createWeightPhysicsCoordinator({modelPhysicsSession,
         }
       });
       if (!selected?.size) continue;
-      const rig = sourcePhysicsRigs.get(sourceKey)
-        || createSourcePhysicsRig(sourceKey, members);
+      let rig = sourcePhysicsRigs.get(sourceKey);
+      if (!rig) {
+        setRigLoading(true);
+        try {
+          const requestedRig = createSourcePhysicsRig(sourceKey, members, {
+            generation,
+            isCurrent: () => generation === getGeneration()
+              && syncToken === participantSyncToken,
+          });
+          rig = typeof requestedRig?.then === 'function'
+            ? await requestedRig : requestedRig;
+        } finally {
+          setRigLoading(false);
+        }
+      }
+      if (!rig || !isCurrent()) return false;
       sourcePhysicsRigs.set(sourceKey, rig);
       if (!rig.physicsForest) continue;
       if (!modelPhysicsSession.getParticipant(sourceKey)) {
@@ -90,6 +113,7 @@ export function createWeightPhysicsCoordinator({modelPhysicsSession,
       requestRender();
     }
     notifyModelRigChanged();
+    return true;
   }
 
   function syncToSelection(changedSourceKeys = null) {
@@ -103,7 +127,7 @@ export function createWeightPhysicsCoordinator({modelPhysicsSession,
     if (!enabled) {
       modelPhysicsSession.enable(getModelTransformState());
     }
-    syncParticipants(changedSourceKeys);
+    void syncParticipants(changedSourceKeys).catch(() => false);
     return true;
   }
 

--- a/src/web/js/mesh/weight-rig-core.js
+++ b/src/web/js/mesh/weight-rig-core.js
@@ -343,6 +343,7 @@ rigModelSession = initializeRigModelSession({
   buildAllSourceSkinningRigs,
   buildAllSourceSkinningRigsCooperatively,
   buildModelSkinningRig,
+  syncPhysicsToSelection,
   getSnapshot: () => rigSnapshot(),
   notifyChanged: notifyModelRigChanged,
   requestRender,
@@ -632,12 +633,15 @@ function notifyModelWeightChanged() {
 function selectionRecordsFromMap(selectionMap) {
   return [...(selectionMap || [])].map(([sourceKey, boneIds]) => {
     const separator = String(sourceKey).lastIndexOf('|offset=');
-    const fallbackOffset = Number(String(sourceKey).slice(separator + 8));
+    const sourceKeyText = String(sourceKey);
+    const nextSegment = sourceKeyText.indexOf('|', separator + 8);
+    const fallbackOffset = Number(sourceKeyText.slice(
+      separator + 8, nextSegment < 0 ? undefined : nextSegment));
     const descriptor = modelWeightState.sourceDescriptors.get(sourceKey)
       || (separator > 0 && Number.isInteger(fallbackOffset)
         ? {
           sourceKey,
-          sourceFile: String(sourceKey).slice(0, separator),
+          sourceFile: sourceKeyText.slice(0, separator),
           boneIdOffset: fallbackOffset,
         } : null);
     return descriptor ? {

--- a/src/web/js/mesh/weight-rig-core.js
+++ b/src/web/js/mesh/weight-rig-core.js
@@ -70,6 +70,7 @@ import {
   createRigRuntimeState, createWeightRuntimeState, matrixIsIdentity,
   EMPTY_ACTIVE_VERTICES, RIG_LIMB_ROLES, RIG_ROTATION_SNAP_DEGREES,
 } from './weight-runtime.js';
+import {createWorkBudget} from './cooperative-scheduler.js';
 import {characterAxesFromOrientation} from './humanoid-orientation.js';
 import {
   buildHumanoidDriverBaseTransforms,
@@ -118,6 +119,11 @@ let humanoidControlRigSnapshotCache = null;
 const RIG_IDENTITY_MATRIX = new THREE.Matrix4();
 let humanoidRigEditSession = null;
 
+function clockNow() {
+  return typeof globalThis.performance?.now === 'function'
+    ? globalThis.performance.now() : Date.now();
+}
+
 function invalidateHumanoidDetection() {
   humanoidControlRigCacheKey = '';
   humanoidControlRigSnapshotCache = null;
@@ -160,6 +166,14 @@ physicsCoordinator = createWeightPhysicsCoordinator({
   notifyModelRigChanged,
   requestRender,
   defaults: DEFAULT_MODEL_PHYSICS_SETTINGS,
+  getGeneration: () => modelWeightGeneration,
+  setRigLoading: loading => {
+    if (modelRigState.loaded && !loading) return;
+    if (!loading && modelRigState.promise) return;
+    if (modelRigState.loading === !!loading) return;
+    modelRigState.loading = !!loading;
+    notifyModelRigChanged();
+  },
 });
 
 skinningRuntime = initializeSkinningRuntime({
@@ -189,6 +203,7 @@ skinningRuntime = initializeSkinningRuntime({
   resetModelPose,
   syncPhysicsParticipants,
   buildAllSourceSkinningRigs,
+  buildAllSourceSkinningRigsCooperatively,
   buildModelSkinningRig: (...args) => buildModelSkinningRig(...args),
   resetModelState: resetModelWeightState,
   notifyModelWeightChanged,
@@ -286,12 +301,30 @@ humanoidRigEditSession = initializeHumanoidRigEditSession({
   cancelRigPicking: cancelRigJointPicking,
   rebuildActiveRig: async () => {
     if (!modelSkinningRig) return;
-    const sourceRigs = buildAllSourceSkinningRigs();
-    buildModelSkinningRig(sourceRigs);
-    // Edit mode starts from rest and does not carry a virtual pose into the
-    // rebuilt control rig.
-    modelRigState.humanoidPose = {};
-    applyModelPose({request: false});
+    const generation = modelWeightGeneration;
+    modelRigState.loading = true;
+    notifyModelRigChanged();
+    try {
+      const sourceRigs = await buildAllSourceSkinningRigsCooperatively({
+        generation,
+        isCurrent: () => generation === modelWeightGeneration,
+      });
+      if (!sourceRigs || generation !== modelWeightGeneration) return;
+      const built = await buildModelSkinningRig(sourceRigs, {
+        generation,
+        isCurrent: () => generation === modelWeightGeneration,
+      });
+      if (!built) return;
+      // Edit mode starts from rest and does not carry a virtual pose into the
+      // rebuilt control rig.
+      modelRigState.humanoidPose = {};
+      applyModelPose({request: false});
+    } finally {
+      if (generation === modelWeightGeneration) {
+        modelRigState.loading = false;
+        notifyModelRigChanged();
+      }
+    }
   },
   notifyChanged: notifyModelRigChanged,
   requestRender,
@@ -303,6 +336,7 @@ rigModelSession = initializeRigModelSession({
   getGeneration: () => modelWeightGeneration,
   ensureModelWeightsLoaded: () => skinningRuntime.loadModelWeights(),
   buildAllSourceSkinningRigs,
+  buildAllSourceSkinningRigsCooperatively,
   buildModelSkinningRig,
   getSnapshot: () => rigSnapshot(),
   notifyChanged: notifyModelRigChanged,
@@ -668,6 +702,7 @@ function resetModelWeightState() {
   resetWeightPickingSession();
   sourcePhysicsRigs.clear();
   sourceSkinningRigs.clear();
+  rigSourceSession?.reset?.();
   modelSkinningRig = null;
   weightRuntime.resetModelWeightState();
   resetWeightModelSession();
@@ -683,6 +718,23 @@ function ensureSourceSkinningRig(sourceKey, members) {
 
 function buildAllSourceSkinningRigs() {
   return rigSourceSession?.buildAll() || [];
+}
+
+function ensureSourceSkinningRigCooperatively(sourceKey, members, options) {
+  return rigSourceSession?.ensureCooperative(sourceKey, members, options)
+    || Promise.resolve(null);
+}
+
+function buildAllSourceSkinningRigsCooperatively(options) {
+  const startedAt = clockNow();
+  return (rigSourceSession?.buildAllCooperative(options)
+    || Promise.resolve([])).then(result => {
+      if (!options?.isCurrent || options.isCurrent()) {
+        modelRigState.performance.sourceRigPreparationMs =
+          clockNow() - startedAt;
+      }
+      return result;
+    });
 }
 
 function resetSourceSkinningPose(rig) {
@@ -890,7 +942,19 @@ function restoreDefaultModelRigOrientation(rig) {
   return true;
 }
 
-function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
+async function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()], {
+    generation = null, isCurrent = () => true,
+  } = {}) {
+  const startedAt = clockNow();
+  const performance = modelRigState.performance || {};
+  modelRigState.performance = performance;
+  const budget = createWorkBudget();
+  const checkpoint = async () => {
+    if (generation !== null && !isCurrent()) return false;
+    await budget.checkpoint();
+    return generation === null || isCurrent();
+  };
+  if (!(await checkpoint())) return null;
   const previousSelectedJointId = modelRigState.selectedJointId;
   const previousRootSignatures = new Set(
     modelRigState.explicitRootSignatures);
@@ -898,6 +962,8 @@ function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
   const savedOverrides = humanoidRigEditSession?.getSavedOverrides?.();
   const savedMainRig = hasSavedHumanoidMainRig(savedOverrides);
   const savedGuide = buildSavedHumanoidJointGuide(savedOverrides);
+  performance.savedGuideMs = clockNow() - startedAt;
+  if (!(await checkpoint())) return null;
   let humanoidGuide = null;
   let guideFallbackReason = savedGuide?.fallbackReason || null;
   if (savedGuide?.controlRig) {
@@ -915,6 +981,9 @@ function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
       semanticBySourceBoneKey: humanoidGuide.sourceBoneClassifications,
       humanoidGuidanceDiagnostics: humanoidGuide.diagnostics,
     } : undefined);
+  performance.reconciliationMs = clockNow() - startedAt
+    - (performance.savedGuideMs || 0);
+  if (!(await checkpoint())) return null;
   const joints = reconciliation.joints || [];
   const rig = {
     key: 'model-rig',
@@ -980,6 +1049,7 @@ function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
         ? guideFallbackReason || 'guided_humanoid_rig_failed' : null,
     },
   };
+  if (!(await checkpoint())) return null;
   // Install provenance-derived edge pivots before capturing the default
   // orientation. Reset Pose must restore the same pivots used on first load.
   rebuildModelRestFrames(rig, rig.inferredForest);
@@ -1012,6 +1082,7 @@ function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
       rig.structureRevision = ++rigRuntime.structureRevision;
     }
   }
+  if (!(await checkpoint())) return null;
   modelRigState.explicitRootSignatures = restoredRootSignatures;
   rigPresetState.lastApplyResult = null;
   sourceRigs.forEach(sourceRig => {
@@ -1023,6 +1094,7 @@ function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
     sourceRig.poseTransformCache.clear();
     sourceRig.poseFrameCache.clear();
   });
+  if (!(await checkpoint())) return null;
   modelSkinningRig = rig;
   buildPrimaryHumanoidRig(rig);
   skinningRuntime.updateModelWeightHeatmap();
@@ -1030,6 +1102,8 @@ function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values()]) {
   modelRigState.selectedJointId = Number.isInteger(previousSelectedJointId)
     && joints[previousSelectedJointId] ? previousSelectedJointId : null;
   updateModelPoseFrameCache(rig, rig.poseTransforms);
+  performance.totalRigBuildMs = clockNow() - startedAt;
+  Object.assign(performance, budget.getStats());
   return rig;
 }
 
@@ -1144,9 +1218,13 @@ function updateModelSourceAliases(rig) {
   }
 }
 
-function createSourcePhysicsRig(sourceKey, members) {
+function sourceMembersMatch(rig, members) {
+  return rig?.meshes?.size === members.length
+    && members.every(mesh => rig.meshes.has(mesh));
+}
+
+function buildSourcePhysicsRig(sourceKey, members, skinRig) {
   const descriptor = modelWeightState.sourceDescriptors.get(sourceKey);
-  const skinRig = ensureSourceSkinningRig(sourceKey, members);
   const rig = {
     key: sourceKey,
     sourceKey,
@@ -1177,6 +1255,22 @@ function createSourcePhysicsRig(sourceKey, members) {
   skinRig.physicsRig = rig;
   refreshSourcePhysicsRig(rig, members);
   return rig;
+}
+
+function createSourcePhysicsRig(sourceKey, members, options = {}) {
+  const cached = sourceSkinningRigs.get(sourceKey);
+  if (cached && sourceMembersMatch(cached, members)) {
+    // A prepared source rig is safe to consume synchronously. This preserves
+    // immediate participant updates while first-time preparation remains
+    // cooperative below.
+    return buildSourcePhysicsRig(sourceKey, members, cached);
+  }
+  return (async () => {
+    const skinRig = await ensureSourceSkinningRigCooperatively(
+      sourceKey, members, options);
+    if (!skinRig) return null;
+    return buildSourcePhysicsRig(sourceKey, members, skinRig);
+  })();
 }
 
 function refreshSourcePhysicsRig(rig, members) {
@@ -1648,7 +1742,8 @@ function setRigComponentRootForSource(sourceKey, boneId) {
 }
 
 function syncPhysicsParticipants(...args) {
-  return physicsCoordinator?.syncParticipants(...args);
+  const result = physicsCoordinator?.syncParticipants(...args);
+  return result?.catch?.(() => false) || result;
 }
 
 function syncPhysicsToSelection(...args) {

--- a/src/web/js/mesh/weight-rig-core.js
+++ b/src/web/js/mesh/weight-rig-core.js
@@ -15,7 +15,8 @@ import {
   buildInferredRigRestFrames, rebuildModelRestFrames,
 } from './weight-rig-frames.js';
 import {
-  buildModelRigReconciliation, orientModelRigForest, sourceBoneKey,
+  buildModelRigReconciliationCooperative,
+  orientModelRigForest, sourceBoneKey,
 } from './weight-rig-reconcile.js';
 import {GRAVITY_WORLD_DIRECTION} from './weight-physics.js';
 import {
@@ -219,8 +220,12 @@ rigSourceSession = initializeRigSourceSession({
   sourceSkinningRigs,
   ensureRigMeshPrepared: (...args) =>
     skinningRuntime.ensureRigMeshPrepared(...args),
+  ensureRigMeshPreparedCooperative: (...args) =>
+    skinningRuntime.ensureRigMeshPreparedCooperative(...args),
   ensureInfluenceGraph: (...args) =>
     skinningRuntime.ensureInfluenceGraph(...args),
+  ensureInfluenceGraphCooperative: (...args) =>
+    skinningRuntime.ensureInfluenceGraphCooperative(...args),
   rebuildRestFrames: rebuildSourceRigRestFrames,
   cloneForest: cloneSourceForest,
 });
@@ -732,6 +737,21 @@ function buildAllSourceSkinningRigsCooperatively(options) {
       if (!options?.isCurrent || options.isCurrent()) {
         modelRigState.performance.sourceRigPreparationMs =
           clockNow() - startedAt;
+        const stats = (result || []).map(rig => rig.__cooperativeStats || {});
+        const timings = (result || []).map((rig, index) => {
+          const timing = rig.__cooperativeTimings;
+          const stat = rig.__cooperativeStats || {};
+          return timing ? {
+            ...timing,
+            largestChunkMs: Number(stat?.largestChunkMs) || 0,
+            yieldCount: Number(stat?.yieldCount) || 0,
+          } : null;
+        }).filter(Boolean);
+        modelRigState.performance.sourceRigLargestChunkMs = Math.max(
+          0, ...stats.map(item => Number(item.largestChunkMs) || 0));
+        modelRigState.performance.sourceRigYieldCount = stats.reduce(
+          (sum, item) => sum + (Number(item.yieldCount) || 0), 0);
+        modelRigState.performance.sourceRigDetails = timings;
       }
       return result;
     });
@@ -976,11 +996,16 @@ async function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values(
     }
   }
   applyHumanoidJointGuide(sourceRigs, humanoidGuide);
-  const reconciliation = buildModelRigReconciliation(sourceRigs,
+  const reconciliation = await buildModelRigReconciliationCooperative(sourceRigs,
     humanoidGuide ? {
       semanticBySourceBoneKey: humanoidGuide.sourceBoneClassifications,
       humanoidGuidanceDiagnostics: humanoidGuide.diagnostics,
-    } : undefined);
+    } : {}, {
+      budget,
+      isCurrent: () => generation === null || isCurrent(),
+      timings: performance,
+    });
+  if (!reconciliation) return null;
   performance.reconciliationMs = clockNow() - startedAt
     - (performance.savedGuideMs || 0);
   if (!(await checkpoint())) return null;
@@ -1103,7 +1128,9 @@ async function buildModelSkinningRig(sourceRigs = [...sourceSkinningRigs.values(
     && joints[previousSelectedJointId] ? previousSelectedJointId : null;
   updateModelPoseFrameCache(rig, rig.poseTransforms);
   performance.totalRigBuildMs = clockNow() - startedAt;
-  Object.assign(performance, budget.getStats());
+  const modelStats = budget.getStats();
+  performance.modelRigLargestChunkMs = modelStats.largestChunkMs;
+  performance.modelRigYieldCount = modelStats.yieldCount;
   return rig;
 }
 

--- a/src/web/js/mesh/weight-rig-core.js
+++ b/src/web/js/mesh/weight-rig-core.js
@@ -68,7 +68,7 @@ import {initializeRigPoseRuntime} from './rig-pose-runtime.js';
 import {
   activePoseJointIds,
   createRigRuntimeState, createWeightRuntimeState, matrixIsIdentity,
-  RIG_LIMB_ROLES, RIG_ROTATION_SNAP_DEGREES,
+  EMPTY_ACTIVE_VERTICES, RIG_LIMB_ROLES, RIG_ROTATION_SNAP_DEGREES,
 } from './weight-runtime.js';
 import {characterAxesFromOrientation} from './humanoid-orientation.js';
 import {
@@ -173,7 +173,7 @@ skinningRuntime = initializeSkinningRuntime({
   modelWeightSnapshot,
   selectionMapFromEntries,
   sourceSelectionEntries,
-  setSelectedBones: entries => setWeightModelSelectedBones(entries),
+  setSelectedBones: (...args) => setWeightModelSelectedBones(...args),
   syncPhysicsToSelection,
   refreshModelWeightSummary,
   refreshSelectedWeightMask,
@@ -202,6 +202,8 @@ rigSourceSession = initializeRigSourceSession({
   knownMeshes,
   modelWeightState,
   sourceSkinningRigs,
+  ensureRigMeshPrepared: (...args) =>
+    skinningRuntime.ensureRigMeshPrepared(...args),
   ensureInfluenceGraph: (...args) =>
     skinningRuntime.ensureInfluenceGraph(...args),
   rebuildRestFrames: rebuildSourceRigRestFrames,
@@ -254,6 +256,7 @@ initializeWeightModelSession({
   notifyChanged: () => notifyModelWeightChanged(),
   requestRender,
   getGeneration: () => modelWeightGeneration,
+  ensureModelWeightsLoaded: () => skinningRuntime.loadModelWeights(),
 });
 
 initializeHumanoidPoseRuntime({
@@ -298,7 +301,7 @@ rigModelSession = initializeRigModelSession({
   state: modelRigState,
   modelWeightState,
   getGeneration: () => modelWeightGeneration,
-  loadModelWeights: () => skinningRuntime.loadModelWeights(),
+  ensureModelWeightsLoaded: () => skinningRuntime.loadModelWeights(),
   buildAllSourceSkinningRigs,
   buildModelSkinningRig,
   getSnapshot: () => rigSnapshot(),
@@ -638,6 +641,13 @@ function refreshSelectedWeightMask(mesh, state) {
   if (!state?.loaded) return null;
   const selected = modelWeightState.selectedBonesBySource.get(
     state.skinningSourceKey) || new Set();
+  if (!selected.size) {
+    state.selectedWeightMask = null;
+    state.physicsActiveVertices = EMPTY_ACTIVE_VERTICES;
+    state.combinedPhysicsVerticesRef = null;
+    state.combinedActiveVertices = null;
+    return null;
+  }
   state.selectedWeightMask = buildSelectedWeightMask(
     state.indices, state.weights, state.influenceCount,
     selected);

--- a/src/web/js/mesh/weight-rig-reconcile.js
+++ b/src/web/js/mesh/weight-rig-reconcile.js
@@ -3,6 +3,7 @@
 // viewer-owned model graph from neutral geometry and source topology.
 
 import {Quaternion, Vector3} from 'three';
+import {createWorkBudget} from './cooperative-scheduler.js';
 
 export const CROSS_SOURCE_CANDIDATE_DISTANCE = 0.1;
 export const CROSS_SOURCE_STRICT_DISTANCE = 0.04;
@@ -15,6 +16,11 @@ export const CROSS_SOURCE_GRAPH_ALIGNMENT_MARGIN = 0.1;
 export const CROSS_SOURCE_GRAPH_ALIGNMENT_MIN_SCORE = 0.6;
 
 const EPSILON = 1e-8;
+
+function clockNow() {
+  return typeof globalThis.performance?.now === 'function'
+    ? globalThis.performance.now() : Date.now();
+}
 
 function number(value, fallback = 0) {
   const result = Number(value);
@@ -311,6 +317,58 @@ function vertexSamplesForRig(rig) {
     left.sampleKey.localeCompare(right.sampleKey));
 }
 
+export async function vertexSamplesForRigCooperative(rig, {
+    budget = createWorkBudget(), isCurrent = () => true,
+    vertexBatch = 256,
+} = {}) {
+  const samples = [];
+  for (const [entryIndex, entry] of (rig?.vertexEvidence || []).entries()) {
+    const positions = entry.positions || entry.baselinePositions;
+    const indices = entry.indices;
+    const weights = entry.weights;
+    const influenceCount = Number(entry.influenceCount);
+    if (!positions || !indices || !weights || !Number.isInteger(influenceCount)
+        || influenceCount <= 0) continue;
+    const vertexCount = Math.floor(Math.min(
+      positions.length / 3, indices.length / influenceCount,
+      weights.length / influenceCount));
+    for (let vertexIndex = 0; vertexIndex < vertexCount; vertexIndex += 1) {
+      if (vertexIndex % vertexBatch === 0) {
+        if (!isCurrent()) return null;
+        await budget.checkpoint();
+        if (!isCurrent()) return null;
+      }
+      const offset = vertexIndex * 3;
+      const point = vectorFrom([
+        positions[offset], positions[offset + 1], positions[offset + 2],
+      ]);
+      if (!point) continue;
+      const influenceMap = new Map();
+      const start = vertexIndex * influenceCount;
+      for (let influenceIndex = 0; influenceIndex < influenceCount;
+           influenceIndex += 1) {
+        const boneId = Number(indices[start + influenceIndex]);
+        const weight = Number(weights[start + influenceIndex]);
+        if (!Number.isInteger(boneId) || boneId < 0
+            || !Number.isFinite(weight) || weight <= 0) continue;
+        influenceMap.set(boneId, (influenceMap.get(boneId) || 0) + weight);
+      }
+      if (!influenceMap.size) continue;
+      samples.push({
+        sampleKey: `${String(entry.meshKey || entryIndex)}#vertex=${vertexIndex}`,
+        point,
+        influences: [...influenceMap.entries()].map(([boneId, weight]) => ({
+          boneId, weight,
+        })),
+      });
+    }
+  }
+  if (!isCurrent()) return null;
+  samples.sort((left, right) => left.sampleKey.localeCompare(right.sampleKey));
+  await budget.checkpoint();
+  return samples;
+}
+
 function cellKey(point, cellSize) {
   return [point.x, point.y, point.z].map(value =>
     Math.floor(value / cellSize)).join(':');
@@ -349,6 +407,46 @@ function nearestSample(sample, cells, cellSize, matchDistance) {
   return best;
 }
 
+async function nearestSampleCooperative(sample, cells, cellSize, matchDistance,
+    {budget, isCurrent}) {
+  const [x, y, z] = cellKey(sample.point, cellSize).split(':').map(Number);
+  let best = null;
+  let candidateCount = 0;
+  for (let dx = -1; dx <= 1; dx += 1) {
+    for (let dy = -1; dy <= 1; dy += 1) {
+      for (let dz = -1; dz <= 1; dz += 1) {
+        const entries = cells.get(`${x + dx}:${y + dy}:${z + dz}`);
+        if (!entries) continue;
+        for (const candidate of entries) {
+          if ((candidateCount++ & 255) === 0) {
+            if (!isCurrent()) return {cancelled: true};
+            await budget.checkpoint();
+            if (!isCurrent()) return {cancelled: true};
+          }
+          const deltaX = sample.point.x - candidate.point.x;
+          const deltaY = sample.point.y - candidate.point.y;
+          const deltaZ = sample.point.z - candidate.point.z;
+          const distanceSquared = deltaX * deltaX + deltaY * deltaY
+            + deltaZ * deltaZ;
+          let distance = null;
+          if (distanceSquared > matchDistance * matchDistance
+              && (distance = Math.sqrt(distanceSquared)) > matchDistance) continue;
+          if (best && distanceSquared > best.distanceSquared) continue;
+          distance ??= Math.sqrt(distanceSquared);
+          if (distance > matchDistance) continue;
+          if (!best || distance < best.distance
+              || distance === best.distance
+                && candidate.sampleKey.localeCompare(
+                  best.sample.sampleKey) < 0) {
+            best = {sample: candidate, distance, distanceSquared};
+          }
+        }
+      }
+    }
+  }
+  return best;
+}
+
 function buildSpatialCells(samples, cellSize) {
   const cells = new Map();
   samples.forEach(sample => {
@@ -357,6 +455,28 @@ function buildSpatialCells(samples, cellSize) {
     entries.push(sample);
     cells.set(key, entries);
   });
+  return cells;
+}
+
+export async function buildSpatialCellsCooperative(samples, cellSize, {
+    budget = createWorkBudget(), isCurrent = () => true,
+    sampleBatch = 256,
+} = {}) {
+  const cells = new Map();
+  for (let index = 0; index < samples.length; index += 1) {
+    if (index % sampleBatch === 0) {
+      if (!isCurrent()) return null;
+      await budget.checkpoint();
+      if (!isCurrent()) return null;
+    }
+    const sample = samples[index];
+    const key = cellKey(sample.point, cellSize);
+    const entries = cells.get(key) || [];
+    entries.push(sample);
+    cells.set(key, entries);
+  }
+  if (!isCurrent()) return null;
+  await budget.checkpoint();
   return cells;
 }
 
@@ -445,6 +565,116 @@ export function crossSourceWeightEvidence(
         / CROSS_SOURCE_STRONG_WEIGHT_STRENGTH));
     delete record.matchedVertexKeys;
   });
+  return evidence;
+}
+
+export async function crossSourceWeightEvidenceCooperative(
+    leftRig, rightRig, referenceRadius, leftSamples = null,
+    rightSamples = null, leftCells = null, rightCells = null, {
+      budget = createWorkBudget(), isCurrent = () => true,
+      sampleBatch = 128,
+    } = {}) {
+  const leftSampleList = leftSamples || await vertexSamplesForRigCooperative(
+    leftRig, {budget, isCurrent});
+  const rightSampleList = rightSamples || await vertexSamplesForRigCooperative(
+    rightRig, {budget, isCurrent});
+  if (!leftSampleList || !rightSampleList) return null;
+  if (!leftSampleList.length || !rightSampleList.length) return new Map();
+  const matchDistance = Math.max(referenceRadius * 0.02, EPSILON);
+  const cellSize = matchDistance;
+  const leftCellMap = leftCells || await buildSpatialCellsCooperative(
+    leftSampleList, cellSize, {budget, isCurrent});
+  const rightCellMap = rightCells || await buildSpatialCellsCooperative(
+    rightSampleList, cellSize, {budget, isCurrent});
+  if (!leftCellMap || !rightCellMap) return null;
+  const nearestLeftByRight = new Map();
+  const nearestRightByLeft = new Map();
+  for (let index = 0; index < rightSampleList.length; index += 1) {
+    if (index % sampleBatch === 0) {
+      if (!isCurrent()) return null;
+      await budget.checkpoint();
+    }
+    const rightSample = rightSampleList[index];
+    const best = await nearestSampleCooperative(rightSample, leftCellMap,
+      cellSize, matchDistance, {budget, isCurrent});
+    if (best?.cancelled) return null;
+    if (best) nearestLeftByRight.set(rightSample, {
+      leftSample: best.sample, distance: best.distance,
+    });
+  }
+  for (let index = 0; index < leftSampleList.length; index += 1) {
+    if (index % sampleBatch === 0) {
+      if (!isCurrent()) return null;
+      await budget.checkpoint();
+    }
+    const leftSample = leftSampleList[index];
+    const best = await nearestSampleCooperative(leftSample, rightCellMap,
+      cellSize, matchDistance, {budget, isCurrent});
+    if (best?.cancelled) return null;
+    if (best) nearestRightByLeft.set(leftSample, {
+      rightSample: best.sample, distance: best.distance,
+    });
+  }
+
+  const evidence = new Map();
+  let pairIndex = 0;
+  for (const [rightSample, {leftSample, distance}] of
+      nearestLeftByRight.entries()) {
+    if (pairIndex++ % sampleBatch === 0) {
+      if (!isCurrent()) return null;
+      await budget.checkpoint();
+    }
+    const reverse = nearestRightByLeft.get(leftSample);
+    if (!reverse || reverse.rightSample !== rightSample) continue;
+    const confidence = clamp(1 - distance / matchDistance);
+    for (const leftInfluence of leftSample.influences) {
+      for (const rightInfluence of rightSample.influences) {
+        const leftKey = sourceBoneKey(leftRig.sourceKey,
+          leftInfluence.boneId);
+        const rightKey = sourceBoneKey(rightRig.sourceKey,
+          rightInfluence.boneId);
+        const key = crossPairKey(leftKey, rightKey);
+        const record = evidence.get(key) || {
+          leftSourceBoneKey: leftKey,
+          rightSourceBoneKey: rightKey,
+          matchedVertexCount: 0,
+          weightedMatchStrength: 0,
+          leftMass: 0,
+          rightMass: 0,
+          matchedVertexKeys: new Set(),
+        };
+        const leftMass = leftInfluence.weight * confidence;
+        const rightMass = rightInfluence.weight * confidence;
+        const vertexPairKey = `${leftSample.sampleKey}|${rightSample.sampleKey}`;
+        if (!record.matchedVertexKeys.has(vertexPairKey)) {
+          record.matchedVertexKeys.add(vertexPairKey);
+          record.matchedVertexCount += 1;
+        }
+        record.weightedMatchStrength += leftInfluence.weight
+          * rightInfluence.weight * confidence;
+        record.leftMass += leftMass;
+        record.rightMass += rightMass;
+        evidence.set(key, record);
+      }
+    }
+  }
+  for (const record of evidence.values()) {
+    if (!isCurrent()) return null;
+    const minimumMass = Math.max(EPSILON,
+      Math.min(record.leftMass, record.rightMass));
+    const unionMass = Math.max(EPSILON,
+      record.leftMass + record.rightMass - record.weightedMatchStrength);
+    record.crossContainment = clamp(
+      record.weightedMatchStrength / minimumMass);
+    record.crossJaccard = clamp(record.weightedMatchStrength / unionMass);
+    record.overlapScore = clamp(record.crossContainment * .55
+      + record.crossJaccard * .45);
+    record.supportReliability = Math.min(
+      clamp(record.matchedVertexCount / CROSS_SOURCE_STRONG_VERTEX_COUNT),
+      clamp(record.weightedMatchStrength
+        / CROSS_SOURCE_STRONG_WEIGHT_STRENGTH));
+    delete record.matchedVertexKeys;
+  }
   return evidence;
 }
 
@@ -808,10 +1038,66 @@ function buildCrossSourceWeightEvidence(sourceRigs, referenceRadius) {
   return evidence;
 }
 
+async function buildCrossSourceWeightEvidenceCooperative(sourceRigs,
+    referenceRadius, {budget = createWorkBudget(), isCurrent = () => true,
+      timings = null} = {}) {
+  const rigs = [...sourceRigs].sort((left, right) =>
+    String(left.sourceKey).localeCompare(String(right.sourceKey)));
+  const matchDistance = Math.max(referenceRadius * 0.02, EPSILON);
+  const samplesBySourceKey = new Map();
+  const cellsBySourceKey = new Map();
+  for (const rig of rigs) {
+    if (!isCurrent()) return null;
+    const sourceKey = String(rig.sourceKey);
+    const sampleStartedAt = clockNow();
+    const samples = await vertexSamplesForRigCooperative(rig, {
+      budget, isCurrent,
+    });
+    if (!samples) return null;
+    if (timings) timings.sampleBuildMs = (timings.sampleBuildMs || 0)
+      + clockNow() - sampleStartedAt;
+    const spatialStartedAt = clockNow();
+    const cells = await buildSpatialCellsCooperative(samples, matchDistance, {
+      budget, isCurrent,
+    });
+    if (!cells) return null;
+    if (timings) timings.spatialIndexMs = (timings.spatialIndexMs || 0)
+      + clockNow() - spatialStartedAt;
+    samplesBySourceKey.set(sourceKey, samples);
+    cellsBySourceKey.set(sourceKey, cells);
+    await budget.checkpoint();
+  }
+  const evidence = new Map();
+  let pairIndex = 0;
+  for (let leftIndex = 0; leftIndex < rigs.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < rigs.length; rightIndex += 1) {
+      if (pairIndex++ % 2 === 0) {
+        if (!isCurrent()) return null;
+        await budget.checkpoint();
+      }
+      const leftRig = rigs[leftIndex];
+      const rightRig = rigs[rightIndex];
+      const matchStartedAt = clockNow();
+      const pairEvidence = await crossSourceWeightEvidenceCooperative(
+        leftRig, rightRig, referenceRadius,
+        samplesBySourceKey.get(String(leftRig.sourceKey)),
+        samplesBySourceKey.get(String(rightRig.sourceKey)),
+        cellsBySourceKey.get(String(leftRig.sourceKey)),
+        cellsBySourceKey.get(String(rightRig.sourceKey)),
+        {budget, isCurrent});
+      if (!pairEvidence) return null;
+      if (timings) timings.crossSourceMatchMs =
+        (timings.crossSourceMatchMs || 0) + clockNow() - matchStartedAt;
+      pairEvidence.forEach((record, key) => evidence.set(key, record));
+    }
+  }
+  return evidence;
+}
+
 function buildCandidates(evidenceByKey, referenceRadius, sourceRigs = [],
     options = {}) {
-  const crossEvidenceByPair = buildCrossSourceWeightEvidence(
-    sourceRigs, referenceRadius);
+  const crossEvidenceByPair = options.crossEvidenceByPair
+    || buildCrossSourceWeightEvidence(sourceRigs, referenceRadius);
   const bySource = new Map();
   for (const evidence of evidenceByKey.values()) {
     const entries = bySource.get(evidence.sourceKey) || [];
@@ -2267,4 +2553,41 @@ export function buildModelRigReconciliation(sourceRigs = [], options = {}) {
     componentByJointId: finalForest.componentByJointId,
     reconciliation,
   };
+}
+
+/**
+ * Build Model Rig reconciliation while chunking the vertex-sample and
+ * cross-source matching work. The final graph assembly intentionally reuses
+ * the synchronous path after those large geometry passes are complete.
+ */
+export async function buildModelRigReconciliationCooperative(
+    sourceRigs = [], options = {}, {
+      budget = createWorkBudget(), isCurrent = () => true, timings = null,
+    } = {}) {
+  const rigs = [...sourceRigs].filter(rig => rig?.sourceKey !== undefined)
+    .sort((left, right) => String(left.sourceKey)
+      .localeCompare(String(right.sourceKey)));
+  const evidenceByKey = new Map();
+  for (const rig of rigs) {
+    if (!isCurrent()) return null;
+    collectSourceBoneEvidence(rig).forEach((evidence, key) =>
+      evidenceByKey.set(key, evidence));
+    await budget.checkpoint();
+  }
+  prepareSourceBoneEvidence(evidenceByKey);
+  const referenceRadius = Math.max(EPSILON, number(options.modelReferenceRadius,
+    modelReferenceRadius(evidenceByKey)));
+  const crossEvidenceByPair = await buildCrossSourceWeightEvidenceCooperative(
+    rigs, referenceRadius, {budget, isCurrent, timings});
+  if (!crossEvidenceByPair || !isCurrent()) return null;
+  await budget.checkpoint();
+  if (!isCurrent()) return null;
+  const graphStartedAt = clockNow();
+  const result = buildModelRigReconciliation(rigs, {
+    ...options,
+    modelReferenceRadius: referenceRadius,
+    crossEvidenceByPair,
+  });
+  if (timings) timings.graphBuildMs = clockNow() - graphStartedAt;
+  return result;
 }

--- a/src/web/js/mesh/weight-rig-reconcile.js
+++ b/src/web/js/mesh/weight-rig-reconcile.js
@@ -177,9 +177,48 @@ function collectSourceBoneEvidence(rig) {
   return result;
 }
 
+function prepareSourceBoneEvidence(evidenceByKey) {
+  evidenceByKey.forEach(evidence => {
+    const weightedCenter = vectorFrom(evidence.weightedCenter);
+    const restAnchor = vectorFrom(evidence.restAnchor);
+    const restDirection = vectorFrom(evidence.restDirection);
+    const jointPivot = vectorFrom(evidence.jointPivot);
+    Object.defineProperties(evidence, {
+      _weightedCenterVector: {
+        value: weightedCenter ? Object.freeze(weightedCenter) : null,
+        enumerable: false,
+      },
+      _restAnchorVector: {
+        value: restAnchor ? Object.freeze(restAnchor) : null,
+        enumerable: false,
+      },
+      _restDirectionVector: {
+        value: restDirection ? Object.freeze(restDirection) : null,
+        enumerable: false,
+      },
+      _jointPivotVector: {
+        value: jointPivot ? Object.freeze(jointPivot) : null,
+        enumerable: false,
+      },
+      _neighborBoneKeys: {
+        value: Object.freeze((evidence.neighborBoneIds || []).map(boneId =>
+          sourceBoneKey(evidence.sourceKey, boneId))),
+        enumerable: false,
+      },
+    });
+  });
+  return evidenceByKey;
+}
+
+function evidenceVector(evidence, property, fallback) {
+  return evidence?.[property]?.clone()
+    || vectorFrom(evidence?.[fallback]);
+}
+
 function modelReferenceRadius(evidence) {
   const points = [...evidence.values()].map(item =>
-    vectorFrom(item.weightedCenter)).filter(Boolean);
+    evidenceVector(item, '_weightedCenterVector', 'weightedCenter'))
+    .filter(Boolean);
   if (!points.length) return 1;
   const center = points.reduce((sum, point) => sum.add(point), new Vector3())
     .multiplyScalar(1 / points.length);
@@ -195,14 +234,15 @@ function neighborDirection(evidence, allEvidence, incoming) {
   if (incoming) {
     const parent = allEvidence.get(sourceBoneKey(
       evidence.sourceKey, evidence.parentBoneId));
-    const vector = parent && vectorFrom(evidence.restAnchor)
-      && vectorFrom(parent.restAnchor)
-      ? vectorFrom(evidence.restAnchor).sub(vectorFrom(parent.restAnchor))
+    const vector = parent && evidenceVector(evidence, '_restAnchorVector',
+      'restAnchor') && evidenceVector(parent, '_restAnchorVector', 'restAnchor')
+      ? evidenceVector(evidence, '_restAnchorVector', 'restAnchor')
+        .sub(evidenceVector(parent, '_restAnchorVector', 'restAnchor'))
       : null;
     if (vector?.length() > EPSILON) return vector.normalize();
   }
   return directionAvailable(evidence)
-    ? vectorFrom(evidence.restDirection) : null;
+    ? evidenceVector(evidence, '_restDirectionVector', 'restDirection') : null;
 }
 
 function topologyFeature(left, right) {
@@ -282,26 +322,47 @@ function nearestSample(sample, cells, cellSize, matchDistance) {
   for (let dx = -1; dx <= 1; dx += 1) {
     for (let dy = -1; dy <= 1; dy += 1) {
       for (let dz = -1; dz <= 1; dz += 1) {
-        const entries = cells.get(`${x + dx}:${y + dy}:${z + dz}`) || [];
-        entries.forEach(candidate => {
-          const distance = sample.point.distanceTo(candidate.point);
-          if (distance > matchDistance) return;
+        const entries = cells.get(`${x + dx}:${y + dy}:${z + dz}`);
+        if (!entries) continue;
+        for (const candidate of entries) {
+          const deltaX = sample.point.x - candidate.point.x;
+          const deltaY = sample.point.y - candidate.point.y;
+          const deltaZ = sample.point.z - candidate.point.z;
+          const distanceSquared = deltaX * deltaX + deltaY * deltaY
+            + deltaZ * deltaZ;
+          let distance = null;
+          if (distanceSquared > matchDistance * matchDistance
+              && (distance = Math.sqrt(distanceSquared)) > matchDistance) continue;
+          if (best && distanceSquared > best.distanceSquared) continue;
+          distance ??= Math.sqrt(distanceSquared);
+          if (distance > matchDistance) continue;
           if (!best || distance < best.distance
               || distance === best.distance
                 && candidate.sampleKey.localeCompare(
                   best.sample.sampleKey) < 0) {
-            best = {sample: candidate, distance};
+            best = {sample: candidate, distance, distanceSquared};
           }
-        });
+        }
       }
     }
   }
   return best;
 }
 
+function buildSpatialCells(samples, cellSize) {
+  const cells = new Map();
+  samples.forEach(sample => {
+    const key = cellKey(sample.point, cellSize);
+    const entries = cells.get(key) || [];
+    entries.push(sample);
+    cells.set(key, entries);
+  });
+  return cells;
+}
+
 export function crossSourceWeightEvidence(
     leftRig, rightRig, referenceRadius, leftSamples = null,
-    rightSamples = null) {
+    rightSamples = null, leftCells = null, rightCells = null) {
   const leftSampleList = leftSamples || vertexSamplesForRig(leftRig);
   const rightSampleList = rightSamples || vertexSamplesForRig(rightRig);
   if (!leftSampleList.length || !rightSampleList.length) return new Map();
@@ -309,24 +370,14 @@ export function crossSourceWeightEvidence(
   // The search examines one neighboring cell in each axis, so each cell must
   // cover the full match radius to avoid missing a valid pair at a boundary.
   const cellSize = matchDistance;
-  const leftCells = new Map();
-  leftSampleList.forEach(sample => {
-    const key = cellKey(sample.point, cellSize);
-    const entries = leftCells.get(key) || [];
-    entries.push(sample);
-    leftCells.set(key, entries);
-  });
-  const rightCells = new Map();
-  rightSampleList.forEach(sample => {
-    const key = cellKey(sample.point, cellSize);
-    const entries = rightCells.get(key) || [];
-    entries.push(sample);
-    rightCells.set(key, entries);
-  });
+  const leftCellMap = leftCells
+    || buildSpatialCells(leftSampleList, cellSize);
+  const rightCellMap = rightCells
+    || buildSpatialCells(rightSampleList, cellSize);
   const nearestLeftByRight = new Map();
   const nearestRightByLeft = new Map();
   rightSampleList.forEach(rightSample => {
-    const best = nearestSample(rightSample, leftCells, cellSize,
+    const best = nearestSample(rightSample, leftCellMap, cellSize,
       matchDistance);
     if (!best) return;
     nearestLeftByRight.set(rightSample, {
@@ -334,7 +385,7 @@ export function crossSourceWeightEvidence(
     });
   });
   leftSampleList.forEach(leftSample => {
-    const best = nearestSample(leftSample, rightCells, cellSize,
+    const best = nearestSample(leftSample, rightCellMap, cellSize,
       matchDistance);
     if (!best) return;
     nearestRightByLeft.set(leftSample, {
@@ -416,16 +467,19 @@ function semanticRelationshipFor(left, right, semanticBySourceBoneKey) {
 function candidateFor(left, right, allEvidence, crossEvidenceByPair, gate) {
   // Equivalence compares like-for-like neutral regions. The parent joint pivot
   // is a structural anchor, not a replacement for a source bone's region.
-  const leftCenter = vectorFrom(left.weightedCenter);
-  const rightCenter = vectorFrom(right.weightedCenter);
+  const leftCenter = evidenceVector(left, '_weightedCenterVector',
+    'weightedCenter');
+  const rightCenter = evidenceVector(right, '_weightedCenterVector',
+    'weightedCenter');
   const distance = leftCenter?.distanceTo(rightCenter);
   if (!Number.isFinite(distance)) return null;
   const normalizedDistance = distance / gate.referenceRadius;
   if (normalizedDistance > CROSS_SOURCE_CANDIDATE_DISTANCE) return null;
   const directionAlignment = directionAvailable(left)
     && directionAvailable(right)
-    ? Math.abs(vectorFrom(left.restDirection)
-      .dot(vectorFrom(right.restDirection))) : null;
+    ? Math.abs(evidenceVector(left, '_restDirectionVector', 'restDirection')
+      .dot(evidenceVector(right, '_restDirectionVector', 'restDirection')))
+    : null;
   const radiusRatio = left.weightedRadius > EPSILON
     && right.weightedRadius > EPSILON
     ? Math.min(left.weightedRadius, right.weightedRadius)
@@ -594,13 +648,19 @@ function neighborMatches(candidate, evidenceByKey, unionFind) {
   }
   const leftNeighbors = left.neighborBoneIds || [];
   const rightNeighbors = right.neighborBoneIds || [];
+  const leftNeighborKeys = left._neighborBoneKeys || leftNeighbors.map(
+    boneId => sourceBoneKey(left.sourceKey, boneId));
+  const rightNeighborKeys = right._neighborBoneKeys || rightNeighbors.map(
+    boneId => sourceBoneKey(right.sourceKey, boneId));
   const usedRightNeighbors = new Set();
   const matchedNeighborPairs = [];
   leftNeighbors.forEach(leftNeighborId => {
-    const rightNeighborId = rightNeighbors.find(candidateId =>
-      !usedRightNeighbors.has(candidateId)
-      && unionFind.same(sourceBoneKey(left.sourceKey, leftNeighborId),
-        sourceBoneKey(right.sourceKey, candidateId)));
+    const leftNeighborIndex = leftNeighbors.indexOf(leftNeighborId);
+    const rightNeighborIndex = rightNeighborKeys.findIndex((candidateKey,
+      index) => !usedRightNeighbors.has(rightNeighbors[index])
+      && unionFind.same(leftNeighborKeys[leftNeighborIndex], candidateKey));
+    const rightNeighborId = rightNeighborIndex < 0
+      ? undefined : rightNeighbors[rightNeighborIndex];
     if (rightNeighborId === undefined) return;
     usedRightNeighbors.add(rightNeighborId);
     matchedNeighborPairs.push({leftBoneId: leftNeighborId, rightBoneId: rightNeighborId});
@@ -628,10 +688,12 @@ function graphAlignmentFeatures(candidate, evidenceByKey, unionFind) {
       left.sourceKey, pair.leftBoneId));
     const rightNeighbor = evidenceByKey.get(sourceBoneKey(
       right.sourceKey, pair.rightBoneId));
-    const leftVector = vectorFrom(leftNeighbor?.weightedCenter)
-      ?.sub(vectorFrom(left.weightedCenter));
-    const rightVector = vectorFrom(rightNeighbor?.weightedCenter)
-      ?.sub(vectorFrom(right.weightedCenter));
+    const leftVector = evidenceVector(leftNeighbor, '_weightedCenterVector',
+      'weightedCenter')?.sub(evidenceVector(left, '_weightedCenterVector',
+      'weightedCenter'));
+    const rightVector = evidenceVector(rightNeighbor, '_weightedCenterVector',
+      'weightedCenter')?.sub(evidenceVector(right, '_weightedCenterVector',
+      'weightedCenter'));
     if (!leftVector || !rightVector
         || leftVector.length() <= EPSILON || rightVector.length() <= EPSILON) {
       return;
@@ -707,20 +769,39 @@ function diagnosticCandidate(candidate, decision, rejectionReason = null) {
   };
 }
 
-function buildCrossSourceWeightEvidence(sourceRigs, referenceRadius) {
-  const evidence = new Map();
+function prepareCrossSourceEvidence(sourceRigs, referenceRadius) {
   const rigs = [...sourceRigs].sort((left, right) =>
     String(left.sourceKey).localeCompare(String(right.sourceKey)));
-  const samplesBySourceKey = new Map(rigs.map(rig => [
-    String(rig.sourceKey), vertexSamplesForRig(rig),
-  ]));
+  const matchDistance = Math.max(referenceRadius * 0.02, EPSILON);
+  const samplesBySourceKey = new Map();
+  const cellsBySourceKey = new Map();
+  rigs.forEach(rig => {
+    const sourceKey = String(rig.sourceKey);
+    const samples = vertexSamplesForRig(rig);
+    samplesBySourceKey.set(sourceKey, samples);
+    cellsBySourceKey.set(sourceKey,
+      buildSpatialCells(samples, matchDistance));
+  });
+  return {
+    rigs,
+    samplesBySourceKey,
+    cellsBySourceKey,
+  };
+}
+
+function buildCrossSourceWeightEvidence(sourceRigs, referenceRadius) {
+  const evidence = new Map();
+  const preparation = prepareCrossSourceEvidence(sourceRigs, referenceRadius);
+  const {rigs, samplesBySourceKey, cellsBySourceKey} = preparation;
   for (let leftIndex = 0; leftIndex < rigs.length; leftIndex += 1) {
     for (let rightIndex = leftIndex + 1; rightIndex < rigs.length; rightIndex += 1) {
       const leftRig = rigs[leftIndex];
       const rightRig = rigs[rightIndex];
       crossSourceWeightEvidence(leftRig, rightRig, referenceRadius,
         samplesBySourceKey.get(String(leftRig.sourceKey)),
-        samplesBySourceKey.get(String(rightRig.sourceKey)))
+        samplesBySourceKey.get(String(rightRig.sourceKey)),
+        cellsBySourceKey.get(String(leftRig.sourceKey)),
+        cellsBySourceKey.get(String(rightRig.sourceKey)))
         .forEach((record, key) => evidence.set(key, record));
     }
   }
@@ -760,28 +841,20 @@ function buildCandidates(evidenceByKey, referenceRadius, sourceRigs = [],
 
 function markSpatialRelationships(candidates) {
   const endpointMap = new Map();
-  const competitionKey = (endpoint, otherSource) => JSON.stringify([
-    endpoint, String(otherSource),
-  ]);
-  const endpointDescriptor = (candidate, endpoint) =>
-    candidate.left.sourceBoneKey === endpoint
-      ? {otherSource: candidate.right.sourceKey,
-        otherKey: candidate.right.sourceBoneKey}
-      : {otherSource: candidate.left.sourceKey,
-        otherKey: candidate.left.sourceBoneKey};
   candidates.forEach(candidate => {
     for (const endpoint of [candidate.left.sourceBoneKey,
       candidate.right.sourceBoneKey]) {
       const descriptor = endpointDescriptor(candidate, endpoint);
-      const key = competitionKey(endpoint, descriptor.otherSource);
+      const key = endpointCompetitionKey(endpoint, descriptor.otherSource);
       const incident = endpointMap.get(key) || [];
       incident.push(candidate);
       endpointMap.set(key, incident);
     }
   });
-  const rankFor = (endpoint, candidatesForEndpoint) => {
-    const ranked = [...candidatesForEndpoint];
-    ranked.sort((left, right) => {
+  const rankedByEndpoint = new Map();
+  endpointMap.forEach((candidatesForEndpoint, key) => {
+    const [endpoint] = JSON.parse(key);
+    rankedByEndpoint.set(key, [...candidatesForEndpoint].sort((left, right) => {
       const leftDescriptor = endpointDescriptor(left, endpoint);
       const rightDescriptor = endpointDescriptor(right, endpoint);
       return (right.confidenceClass || 0) - (left.confidenceClass || 0)
@@ -791,20 +864,17 @@ function markSpatialRelationships(candidates) {
         || right.geometryConfidence - left.geometryConfidence
         || left.normalizedDistance - right.normalizedDistance
         || leftDescriptor.otherKey.localeCompare(rightDescriptor.otherKey);
-    });
-    return ranked;
-  };
+    }));
+  });
   candidates.forEach(candidate => {
     const leftDescriptor = endpointDescriptor(
       candidate, candidate.left.sourceBoneKey);
     const rightDescriptor = endpointDescriptor(
       candidate, candidate.right.sourceBoneKey);
-    const leftCandidates = rankFor(candidate.left.sourceBoneKey,
-      endpointMap.get(competitionKey(candidate.left.sourceBoneKey,
-        leftDescriptor.otherSource)) || []);
-    const rightCandidates = rankFor(candidate.right.sourceBoneKey,
-      endpointMap.get(competitionKey(candidate.right.sourceBoneKey,
-        rightDescriptor.otherSource)) || []);
+    const leftCandidates = rankedByEndpoint.get(endpointCompetitionKey(
+      candidate.left.sourceBoneKey, leftDescriptor.otherSource)) || [];
+    const rightCandidates = rankedByEndpoint.get(endpointCompetitionKey(
+      candidate.right.sourceBoneKey, rightDescriptor.otherSource)) || [];
     candidate.mutualBest = leftCandidates[0] === candidate
       && rightCandidates[0] === candidate;
     candidate.leftAmbiguous = candidateAmbiguous(
@@ -855,25 +925,6 @@ function compareGraphAlignmentCandidate(left, right) {
     || left.right.sourceBoneKey.localeCompare(right.right.sourceBoneKey);
 }
 
-function graphAlignmentCandidatesFor(candidates, endpoint, otherSource,
-    unionFind) {
-  return candidates.filter(candidate => {
-    // Rank only candidates incident to this endpoint. An unrelated branch
-    // must not compete with the endpoint's real correspondence.
-    if (candidate.left.sourceBoneKey !== endpoint
-        && candidate.right.sourceBoneKey !== endpoint) return false;
-    if (unionFind.same(candidate.left.sourceBoneKey,
-      candidate.right.sourceBoneKey)) return false;
-    const descriptor = endpointDescriptor(candidate, endpoint);
-    return descriptor.otherSource === otherSource
-      && descriptor.otherKey !== endpoint
-      && candidate.matchedNeighborCount > 0
-      && candidate.graphAlignmentScore
-        >= CROSS_SOURCE_GRAPH_ALIGNMENT_MIN_SCORE
-      && candidate.topology.degree >= .5;
-  }).sort(compareGraphAlignmentCandidate);
-}
-
 function uniqueGraphWinner(candidate, ranked, tier) {
   if (ranked[0] !== candidate) return false;
   const second = ranked[1];
@@ -904,16 +955,30 @@ function runGraphAlignment(candidates, evidenceByKey, unionFind,
       && candidate.topology.degree >= .5
       && !unionFind.same(candidate.left.sourceBoneKey,
         candidate.right.sourceBoneKey));
+    const rankedByEndpoint = new Map();
+    available.forEach(candidate => {
+      for (const endpoint of [candidate.left.sourceBoneKey,
+        candidate.right.sourceBoneKey]) {
+        const descriptor = endpointDescriptor(candidate, endpoint);
+        const key = endpointCompetitionKey(endpoint, descriptor.otherSource);
+        const bucket = rankedByEndpoint.get(key) || [];
+        bucket.push(candidate);
+        rankedByEndpoint.set(key, bucket);
+      }
+    });
+    rankedByEndpoint.forEach(bucket => {
+      bucket.sort(compareGraphAlignmentCandidate);
+    });
     const rankFor = candidate => {
       const leftDescriptor = endpointDescriptor(
         candidate, candidate.left.sourceBoneKey);
       const rightDescriptor = endpointDescriptor(
         candidate, candidate.right.sourceBoneKey);
       return {
-        left: graphAlignmentCandidatesFor(available,
-          candidate.left.sourceBoneKey, leftDescriptor.otherSource, unionFind),
-        right: graphAlignmentCandidatesFor(available,
-          candidate.right.sourceBoneKey, rightDescriptor.otherSource, unionFind),
+        left: rankedByEndpoint.get(endpointCompetitionKey(
+          candidate.left.sourceBoneKey, leftDescriptor.otherSource)) || [],
+        right: rankedByEndpoint.get(endpointCompetitionKey(
+          candidate.right.sourceBoneKey, rightDescriptor.otherSource)) || [],
       };
     };
     const selected = available.filter(candidate => {
@@ -994,6 +1059,14 @@ function runPathAlignment(candidates, evidenceByKey, unionFind,
     candidate,
   ]));
   let changed = true;
+  const pathCache = new Map();
+  const pathFor = (startKey, endKey) => {
+    const key = `${startKey}\u0000${endKey}`;
+    if (pathCache.has(key)) return pathCache.get(key);
+    const path = pathBetweenSourceBones(startKey, endKey, evidenceByKey);
+    pathCache.set(key, path);
+    return path;
+  };
   while (changed) {
     changed = false;
     const alignments = new Map();
@@ -1003,10 +1076,8 @@ function runPathAlignment(candidates, evidenceByKey, unionFind,
              rightIndex < anchors.length; rightIndex += 1) {
           const first = anchors[leftIndex];
           const second = anchors[rightIndex];
-          const leftPath = pathBetweenSourceBones(
-            first.left, second.left, evidenceByKey);
-          const rightPath = pathBetweenSourceBones(
-            first.right, second.right, evidenceByKey);
+          const leftPath = pathFor(first.left, second.left);
+          const rightPath = pathFor(first.right, second.right);
           if (!leftPath || !rightPath || leftPath.length !== rightPath.length
               || leftPath.length < 3) continue;
           const internal = [];
@@ -1114,45 +1185,37 @@ function runEquivalencePasses(candidates, evidenceByKey, unionFind) {
       return candidate.matchedNeighborCount > 0;
     });
     const endpointMap = new Map();
-    const competitionKey = (endpoint, otherSource) => JSON.stringify([
-      endpoint, String(otherSource),
-    ]);
-    const endpointDescriptor = (candidate, endpoint) =>
-      candidate.left.sourceBoneKey === endpoint
-        ? {otherSource: candidate.right.sourceKey,
-          otherKey: candidate.right.sourceBoneKey}
-        : {otherSource: candidate.left.sourceKey,
-          otherKey: candidate.left.sourceBoneKey};
     propagation.forEach(candidate => {
       for (const endpoint of [candidate.left.sourceBoneKey,
         candidate.right.sourceBoneKey]) {
         const descriptor = endpointDescriptor(candidate, endpoint);
-        const key = competitionKey(endpoint, descriptor.otherSource);
+        const key = endpointCompetitionKey(endpoint, descriptor.otherSource);
         const incident = endpointMap.get(key) || [];
         incident.push(candidate);
         endpointMap.set(key, incident);
       }
     });
-    const rankedFor = (endpoint, candidatesForEndpoint) =>
-      [...candidatesForEndpoint].sort((left, right) =>
+    const rankedByEndpoint = new Map();
+    endpointMap.forEach((candidatesForEndpoint, key) => {
+      const [endpoint] = JSON.parse(key);
+      rankedByEndpoint.set(key, [...candidatesForEndpoint].sort((left, right) =>
         right.propagationScore - left.propagationScore
         || (right.confidenceClass || 0) - (left.confidenceClass || 0)
         || right.combinedConfidence - left.combinedConfidence
         || right.supportReliability - left.supportReliability
         || left.normalizedDistance - right.normalizedDistance
         || endpointDescriptor(left, endpoint).otherKey.localeCompare(
-          endpointDescriptor(right, endpoint).otherKey));
+          endpointDescriptor(right, endpoint).otherKey)));
+    });
     const selected = propagation.filter(candidate => {
       const leftDescriptor = endpointDescriptor(
         candidate, candidate.left.sourceBoneKey);
       const rightDescriptor = endpointDescriptor(
         candidate, candidate.right.sourceBoneKey);
-      const leftBest = rankedFor(candidate.left.sourceBoneKey,
-        endpointMap.get(competitionKey(candidate.left.sourceBoneKey,
-          leftDescriptor.otherSource)) || []);
-      const rightBest = rankedFor(candidate.right.sourceBoneKey,
-        endpointMap.get(competitionKey(candidate.right.sourceBoneKey,
-          rightDescriptor.otherSource)) || []);
+      const leftBest = rankedByEndpoint.get(endpointCompetitionKey(
+        candidate.left.sourceBoneKey, leftDescriptor.otherSource)) || [];
+      const rightBest = rankedByEndpoint.get(endpointCompetitionKey(
+        candidate.right.sourceBoneKey, rightDescriptor.otherSource)) || [];
       const leftAmbiguous = candidateAmbiguous(
         leftBest[0] && {...leftBest[0], score: leftBest[0].propagationScore},
         leftBest[1] && {...leftBest[1], score: leftBest[1].propagationScore});
@@ -1234,11 +1297,14 @@ function buildModelJoints(unionFind, evidenceByKey, strengthByKey,
     const members = memberKeys.map(key => evidenceByKey.get(key)).filter(Boolean);
     const signature = JSON.stringify(memberKeys);
     const center = weightedAverage(members.map(evidence => ({
-      point: vectorFrom(evidence.weightedCenter)?.toArray(),
+      point: evidenceVector(evidence, '_weightedCenterVector',
+        'weightedCenter')?.toArray(),
       weight: Math.max(evidence.totalWeight, evidence.affectedVertexCount, 1),
     }))) || [0, 0, 0];
-    const pivots = members.map(evidence => vectorFrom(
-      evidence.jointPivot || (evidence.isRoot ? null : evidence.restAnchor)))
+    const pivots = members.map(evidence =>
+      evidenceVector(evidence, '_jointPivotVector', 'jointPivot')
+        || (evidence.isRoot ? null : evidenceVector(evidence,
+          '_restAnchorVector', 'restAnchor')))
       .filter(Boolean);
     const pivotMedoid = medoid(pivots);
     const pivotTolerance = referenceRadius * CROSS_SOURCE_STRICT_DISTANCE;
@@ -1765,12 +1831,15 @@ function aggregateJointCrossEvidence(left, right, crossEvidenceByPair) {
 }
 
 function aggregateComponentCrossEvidence(component, target, joints,
-    crossEvidenceByPair, referenceRadius) {
+    crossEvidenceByPair, referenceRadius, jointEvidenceByPair = null) {
   const jointEvidence = [];
   component.nodeIds.forEach(accessoryId => {
     target.nodeIds.forEach(targetId => {
-      const evidence = aggregateJointCrossEvidence(joints[accessoryId],
-        joints[targetId], crossEvidenceByPair);
+      const key = jointPairKey(accessoryId, targetId);
+      const evidence = jointEvidenceByPair?.get(key)
+        || aggregateJointCrossEvidence(joints[accessoryId],
+          joints[targetId], crossEvidenceByPair);
+      jointEvidenceByPair?.set(key, evidence);
       const accessoryCenter = vectorFrom(joints[accessoryId]?.restCenter);
       const targetCenter = vectorFrom(joints[targetId]?.restCenter);
       const distance = accessoryCenter && targetCenter
@@ -1804,14 +1873,21 @@ function aggregateComponentCrossEvidence(component, target, joints,
   };
 }
 
-function sourceWitnessesForJoints(targetJoint, accessoryJoint) {
+function sourceKeysForJoint(joint) {
+  return [...new Set((joint?.members || []).map(member =>
+    String(member.sourceKey ?? '')).filter(Boolean))].sort();
+}
+
+function sourceWitnessesForJoints(targetJoint, accessoryJoint,
+    sourceKeysByJointId = null) {
   const witnesses = new Set();
-  for (const targetMember of targetJoint?.members || []) {
-    const targetSourceKey = String(targetMember.sourceKey ?? '');
-    if (!targetSourceKey) continue;
-    for (const accessoryMember of accessoryJoint?.members || []) {
-      const accessorySourceKey = String(accessoryMember.sourceKey ?? '');
-      if (!accessorySourceKey || targetSourceKey === accessorySourceKey) {
+  const targetSourceKeys = sourceKeysByJointId?.get(targetJoint?.jointId)
+    || sourceKeysForJoint(targetJoint);
+  const accessorySourceKeys = sourceKeysByJointId?.get(
+    accessoryJoint?.jointId) || sourceKeysForJoint(accessoryJoint);
+  for (const targetSourceKey of targetSourceKeys) {
+    for (const accessorySourceKey of accessorySourceKeys) {
+      if (targetSourceKey === accessorySourceKey) {
         continue;
       }
       witnesses.add(`${targetSourceKey}\u0000${accessorySourceKey}`);
@@ -1831,16 +1907,29 @@ function attachmentCandidates(joints, forest, referenceRadius,
   const candidates = [];
   const components = forest.components;
   const componentEvidenceByPair = new Map();
+  const jointEvidenceByPair = new Map();
+  const sourceKeysByJointId = new Map(joints.map(joint => [
+    joint.jointId, sourceKeysForJoint(joint),
+  ]));
+  const sourceWitnessesByJointPair = new Map();
+  const supportByComponentId = new Map(components.map(component => [
+    component.componentId, componentSupport(component, joints),
+  ]));
+  const jointDescriptorById = new Map(joints.map(joint => [joint.jointId, {
+    anchor: vectorFrom(joint.restCenter),
+    direction: vectorFrom(joint.restDirection),
+  }]));
   const componentEvidenceFor = (accessory, target) => {
     const key = `${accessory.componentId}:${target.componentId}`;
     if (!componentEvidenceByPair.has(key)) {
       componentEvidenceByPair.set(key, aggregateComponentCrossEvidence(
-        accessory, target, joints, crossEvidenceByPair, referenceRadius));
+        accessory, target, joints, crossEvidenceByPair, referenceRadius,
+        jointEvidenceByPair));
     }
     return componentEvidenceByPair.get(key);
   };
-  const directions = new Map(joints.map(joint => [joint.jointId,
-    vectorFrom(joint.restDirection)]));
+  const directions = new Map([...jointDescriptorById.entries()].map(([
+    jointId, descriptor]) => [jointId, descriptor.direction]));
   // The model joint direction is represented by the selected source member's
   // rest frame +Y. Keeping this derivation here avoids inventing labels or
   // changing the source-local rest-frame contract.
@@ -1851,10 +1940,11 @@ function attachmentCandidates(joints, forest, referenceRadius,
       .applyQuaternion(frame).normalize());
   });
   for (const accessory of components) {
-    const accessorySupport = componentSupport(accessory, joints);
+    const accessorySupport = supportByComponentId.get(accessory.componentId)
+      || 0;
     for (const target of components) {
       if (target.componentId === accessory.componentId) continue;
-      const targetSupport = componentSupport(target, joints);
+      const targetSupport = supportByComponentId.get(target.componentId) || 0;
       // Attach smaller inferred components to a larger body. This also makes
       // the direction of an attachment deterministic when two disconnected
       // components have identical synthetic support in a test fixture.
@@ -1867,14 +1957,19 @@ function attachmentCandidates(joints, forest, referenceRadius,
       const componentEvidence = componentEvidenceFor(accessory, target);
       for (const targetId of target.nodeIds) {
         const targetJoint = joints[targetId];
-        const targetAnchor = vectorFrom(targetJoint?.restCenter);
+        const targetAnchor = jointDescriptorById.get(targetId)?.anchor;
         if (!targetAnchor) continue;
         for (const accessoryId of accessory.nodeIds) {
           const accessoryJoint = joints[accessoryId];
-          const accessoryAnchor = vectorFrom(accessoryJoint?.restCenter);
+          const accessoryAnchor = jointDescriptorById.get(accessoryId)?.anchor;
           if (!accessoryAnchor) continue;
-          const sourceWitnesses = sourceWitnessesForJoints(
-            targetJoint, accessoryJoint);
+          const witnessKey = jointPairKey(targetId, accessoryId);
+          let sourceWitnesses = sourceWitnessesByJointPair.get(witnessKey);
+          if (!sourceWitnesses) {
+            sourceWitnesses = sourceWitnessesForJoints(targetJoint,
+              accessoryJoint, sourceKeysByJointId);
+            sourceWitnessesByJointPair.set(witnessKey, sourceWitnesses);
+          }
           if (!sourceWitnesses.length) continue;
           const towardAccessory = accessoryAnchor.clone().sub(targetAnchor);
           const distance = towardAccessory.length();
@@ -1885,8 +1980,10 @@ function attachmentCandidates(joints, forest, referenceRadius,
           const directionAlignment = accessoryDirection
             ? Math.abs(accessoryDirection.dot(towardAccessory.normalize()))
             : null;
-          const pairEvidence = aggregateJointCrossEvidence(targetJoint,
-            accessoryJoint, crossEvidenceByPair);
+          const pairEvidence = jointEvidenceByPair.get(witnessKey)
+            || aggregateJointCrossEvidence(targetJoint, accessoryJoint,
+              crossEvidenceByPair);
+          jointEvidenceByPair.set(witnessKey, pairEvidence);
           const nearbyTargetAgreement = Math.max(0,
             (componentEvidence.supportedTargetCountByAccessory.get(accessoryId)
               || 0) - (pairEvidence.matchedVertexCount > 0 ? 1 : 0));
@@ -2072,16 +2169,17 @@ export function buildModelRigReconciliation(sourceRigs = [], options = {}) {
     .sort((left, right) => String(left.sourceKey)
       .localeCompare(String(right.sourceKey)));
   const evidenceByKey = new Map();
-  rigs.forEach(rig => collectSourceBoneEvidence(rig).forEach((evidence, key) =>
-    evidenceByKey.set(key, evidence)));
+  rigs.forEach(rig =>
+    collectSourceBoneEvidence(rig).forEach((evidence, key) =>
+      evidenceByKey.set(key, evidence)));
+  prepareSourceBoneEvidence(evidenceByKey);
   const referenceRadius = Math.max(EPSILON, number(options.modelReferenceRadius,
     modelReferenceRadius(evidenceByKey)));
   const candidateBuild = buildCandidates(
     evidenceByKey, referenceRadius, rigs, options);
   const candidates = candidateBuild.candidates;
   const unionFind = new GuardedUnionFind([...evidenceByKey.keys()]);
-  const equivalence = runEquivalencePasses(
-    candidates, evidenceByKey, unionFind);
+  const equivalence = runEquivalencePasses(candidates, evidenceByKey, unionFind);
   const model = buildModelJoints(unionFind, evidenceByKey,
     equivalence.correspondenceStrength, referenceRadius);
   const sourceEdges = sourceModelEdges(rigs, model.keyToJoint);

--- a/src/web/js/mesh/weight-rig-runtime.js
+++ b/src/web/js/mesh/weight-rig-runtime.js
@@ -8,6 +8,7 @@ export {
   clearSelectedBones,
   beginWeightModelPicking,
   cancelWeightModelPicking,
+  ensureModelWeightsLoaded,
   getModelWeightState,
   loadSavedBoneSelection,
   saveModelWeightSelection,

--- a/src/web/js/mesh/weight-rig.js
+++ b/src/web/js/mesh/weight-rig.js
@@ -17,6 +17,33 @@ function triangleArea(points) {
     ab[0] * ac[1] - ab[1] * ac[0]);
 }
 
+function readSurfaceTriangle(
+    positionArray, indexArray, indexed, positionCount, triangle) {
+  const indices = [0, 1, 2].map(offset => {
+    const index = triangle * 3 + offset;
+    return indexed ? Number(indexArray[index]) : index;
+  });
+  if (indices.some(index => !Number.isInteger(index)
+      || index < 0 || index >= positionCount)) {
+    return {kind: 'invalid'};
+  }
+  const points = indices.map(vertex => {
+    const offset = vertex * 3;
+    return [
+      Number(positionArray[offset]),
+      Number(positionArray[offset + 1]),
+      Number(positionArray[offset + 2]),
+    ];
+  });
+  if (points.some(point => point.some(value => !Number.isFinite(value)))) {
+    return {kind: 'invalid'};
+  }
+  const area = triangleArea(points);
+  if (!Number.isFinite(area)) return {kind: 'invalid'};
+  if (area <= 0) return {kind: 'degenerate', indices, points, area};
+  return {kind: 'valid', indices, points, area};
+}
+
 function collectSurfaceTriangles(
     positions, triangleIndices = null, includeTriangles = true) {
   const positionArray = positions || [];
@@ -34,40 +61,22 @@ function collectSurfaceTriangles(
   let validTriangleCount = 0;
   let totalSurfaceArea = 0;
   for (let triangle = 0; triangle < triangleCount; triangle += 1) {
-    const indices = [0, 1, 2].map(offset => {
-      const index = triangle * 3 + offset;
-      return indexed ? Number(indexArray[index]) : index;
-    });
-    if (indices.some(index => !Number.isInteger(index)
-        || index < 0 || index >= positionCount)) {
+    const sample = readSurfaceTriangle(
+      positionArray, indexArray, indexed, positionCount, triangle);
+    if (sample.kind === 'invalid') {
       invalidTriangleCount += 1;
       continue;
     }
-    const points = indices.map(vertex => {
-      const offset = vertex * 3;
-      return [
-        Number(positionArray[offset]),
-        Number(positionArray[offset + 1]),
-        Number(positionArray[offset + 2]),
-      ];
-    });
-    if (points.some(point => point.some(value => !Number.isFinite(value)))) {
-      invalidTriangleCount += 1;
-      continue;
-    }
-    const area = triangleArea(points);
-    if (!Number.isFinite(area)) {
-      invalidTriangleCount += 1;
-      continue;
-    }
-    if (area === 0) {
+    if (sample.kind === 'degenerate') {
       degenerateTriangleCount += 1;
       continue;
     }
     validTriangleCount += 1;
-    totalSurfaceArea += area;
-    indices.forEach(index => measuredVertices.add(index));
-    if (triangles) triangles.push({indices, points, area});
+    totalSurfaceArea += sample.area;
+    sample.indices.forEach(index => measuredVertices.add(index));
+    if (triangles) triangles.push({
+      indices: sample.indices, points: sample.points, area: sample.area,
+    });
   }
   return {
     positionCount,
@@ -128,14 +137,11 @@ function barycentricSecondMoment(left, right, area) {
   return left === right ? area / 6 : area / 12;
 }
 
-function barycentricThirdMoment(first, second, third, area) {
-  const counts = [first, second, third].reduce((map, index) => {
-    map.set(index, (map.get(index) || 0) + 1);
-    return map;
-  }, new Map());
-  const multiplicities = [...counts.values()];
-  if (multiplicities.length === 1) return area / 10;
-  if (multiplicities.length === 2) return area / 30;
+export function barycentricThirdMoment(first, second, third, area) {
+  if (first === second && second === third) return area / 10;
+  if (first === second || first === third || second === third) {
+    return area / 30;
+  }
   return area / 60;
 }
 
@@ -162,7 +168,7 @@ function integrateLinearPosition(points, weights, area) {
   return result;
 }
 
-function integrateLinearSecondMoment(points, weights, area) {
+export function integrateLinearSecondMoment(points, weights, area) {
   let result = 0;
   for (let left = 0; left < 3; left += 1) {
     for (let right = 0; right < 3; right += 1) {
@@ -187,7 +193,7 @@ function integrateLinearProduct(leftWeights, rightWeights, area) {
   return result;
 }
 
-function integratePositionProduct(points, leftWeights, rightWeights, area) {
+export function integratePositionProduct(points, leftWeights, rightWeights, area) {
   const result = [0, 0, 0];
   for (let point = 0; point < 3; point += 1) {
     for (let left = 0; left < 3; left += 1) {
@@ -275,6 +281,24 @@ function integrateMinimumLinearWeight(
   const rightRegion = clipLinearWeightPolygon(vertices, false);
   return integratePolygonLinearWeight(leftRegion, 'leftWeight')
     + integratePolygonLinearWeight(rightRegion, 'rightWeight');
+}
+
+/** Return whether topology contains at least one usable positive-area triangle. */
+export function hasUsableSurfaceTopology(positions, triangleIndices = null) {
+  const positionArray = positions || [];
+  const positionCount = Math.floor(positionArray.length / 3);
+  const indexed = triangleIndices !== null && triangleIndices !== undefined;
+  const indexArray = indexed ? triangleIndices : null;
+  const indexCount = indexed
+    ? Number(indexArray?.length) || 0
+    : Number(positionArray.length) / 3;
+  const triangleCount = Math.ceil(indexCount / 3);
+  for (let triangle = 0; triangle < triangleCount; triangle += 1) {
+    const sample = readSurfaceTriangle(
+      positionArray, indexArray, indexed, positionCount, triangle);
+    if (sample.kind === 'valid' && sample.area > 0) return true;
+  }
+  return false;
 }
 
 function surfaceInfluenceWeights(

--- a/src/web/js/mesh/weight-rig.js
+++ b/src/web/js/mesh/weight-rig.js
@@ -4,6 +4,8 @@
 // the Rig/Pose mode consume the same inferred topology, while
 // retaining their own runtime selection and deformation state.
 
+import {createWorkBudget} from './cooperative-scheduler.js';
+
 export const CANDIDATE_CONTAINMENT_THRESHOLD = 0.02;
 export const CANDIDATE_JACCARD_THRESHOLD = 0.01;
 
@@ -481,6 +483,274 @@ export function buildSurfaceInfluenceGraph(
   };
 }
 
+function surfaceTriangleCount(positions, triangleIndices = null) {
+  const positionArray = positions || [];
+  const indexed = triangleIndices !== null && triangleIndices !== undefined;
+  const indexCount = indexed
+    ? Number(triangleIndices?.length) || 0
+    : Number(positionArray.length) / 3;
+  return {
+    positionArray,
+    positionCount: Math.floor(positionArray.length / 3),
+    indexed,
+    indexArray: indexed ? triangleIndices : null,
+    triangleCount: Math.ceil(indexCount / 3),
+  };
+}
+
+function createSurfaceGraphAccumulator(
+    baselinePositions, triangleIndices, indices, weights, influenceCount,
+    boneIds = null, boundingSphereRadius = null) {
+  const shape = surfaceTriangleCount(baselinePositions, triangleIndices);
+  const requested = boneIds === null || boneIds === undefined
+    ? null : new Set([...boneIds].map(Number));
+  const nodeEntries = new Map();
+  const relationshipEntries = new Map();
+  const topology = {
+    triangleCount: shape.triangleCount,
+    validTriangleCount: 0,
+    degenerateTriangleCount: 0,
+    invalidTriangleCount: 0,
+    totalSurfaceArea: 0,
+    measuredVertices: new Set(),
+  };
+
+  function process(sample) {
+    if (sample.kind === 'invalid') {
+      topology.invalidTriangleCount += 1;
+      return;
+    }
+    if (sample.kind === 'degenerate') {
+      topology.degenerateTriangleCount += 1;
+      return;
+    }
+    topology.validTriangleCount += 1;
+    topology.totalSurfaceArea += sample.area;
+    sample.indices.forEach(index => topology.measuredVertices.add(index));
+    const cornerWeights = sample.indices.map(vertex => surfaceInfluenceWeights(
+      indices, weights, influenceCount, vertex, requested));
+    const ids = [...new Set(cornerWeights.flatMap(values => [...values.keys()]))]
+      .sort((left, right) => left - right);
+    for (const boneId of ids) {
+      const boneWeights = cornerWeights.map(values => values.get(boneId) || 0);
+      const support = integrateLinear(boneWeights, sample.area);
+      if (support <= 0) continue;
+      const firstMoment = integrateLinearPosition(
+        sample.points, boneWeights, sample.area);
+      const secondMoment = integrateLinearSecondMoment(
+        sample.points, boneWeights, sample.area);
+      const entry = nodeEntries.get(boneId) || {
+        boneId,
+        totalWeight: 0,
+        affectedVertexCount: 0,
+        affectedVertices: new Set(),
+        affectedMeasure: 0,
+        maxVertexWeight: 0,
+        weightedX: 0,
+        weightedY: 0,
+        weightedZ: 0,
+        secondMoment: 0,
+      };
+      entry.totalWeight += support;
+      sample.indices.forEach((vertex, index) => {
+        if (cornerWeights[index].has(boneId)) entry.affectedVertices.add(vertex);
+      });
+      entry.affectedMeasure += sample.area;
+      entry.maxVertexWeight = Math.max(entry.maxVertexWeight, ...boneWeights);
+      entry.weightedX += firstMoment[0];
+      entry.weightedY += firstMoment[1];
+      entry.weightedZ += firstMoment[2];
+      entry.secondMoment += secondMoment;
+      nodeEntries.set(boneId, entry);
+    }
+    for (let left = 0; left < ids.length; left += 1) {
+      for (let right = left + 1; right < ids.length; right += 1) {
+        const boneA = ids[left];
+        const boneB = ids[right];
+        const weightsA = cornerWeights.map(values => values.get(boneA) || 0);
+        const weightsB = cornerWeights.map(values => values.get(boneB) || 0);
+        const productOverlap = integrateLinearProduct(
+          weightsA, weightsB, sample.area);
+        if (productOverlap <= 0) continue;
+        const key = pairKey(boneA, boneB);
+        const jointMoment = integratePositionProduct(
+          sample.points, weightsA, weightsB, sample.area);
+        const relationship = relationshipEntries.get(key) || {
+          boneA,
+          boneB,
+          sharedVertexCount: 0,
+          sharedMeasure: 0,
+          minOverlap: 0,
+          productOverlap: 0,
+          jointWeightTotal: 0,
+          jointX: 0,
+          jointY: 0,
+          jointZ: 0,
+        };
+        relationship.sharedVertexCount += sample.indices.filter((vertex, index) =>
+          cornerWeights[index].has(boneA)
+          && cornerWeights[index].has(boneB)).length;
+        relationship.sharedMeasure += sample.area;
+        relationship.minOverlap += integrateMinimumLinearWeight(
+          sample.points, weightsA, weightsB, sample.area);
+        relationship.productOverlap += productOverlap;
+        relationship.jointWeightTotal += productOverlap;
+        relationship.jointX += jointMoment[0];
+        relationship.jointY += jointMoment[1];
+        relationship.jointZ += jointMoment[2];
+        relationshipEntries.set(key, relationship);
+      }
+    }
+  }
+
+  function finish() {
+    const nodes = [...nodeEntries.values()].map(entry => {
+      const center = entry.totalWeight > 0 ? [
+        entry.weightedX / entry.totalWeight,
+        entry.weightedY / entry.totalWeight,
+        entry.weightedZ / entry.totalWeight,
+      ] : [0, 0, 0];
+      return {
+        boneId: entry.boneId,
+        totalWeight: entry.totalWeight,
+        affectedVertexCount: entry.affectedVertices.size,
+        affectedMeasure: entry.affectedMeasure,
+        maxVertexWeight: entry.maxVertexWeight,
+        weightedCenter: center,
+        weightedRadius: Math.sqrt(Math.max(0,
+          entry.secondMoment / entry.totalWeight - dot3(center, center))),
+      };
+    }).sort((left, right) => left.boneId - right.boneId);
+    const nodeById = new Map(nodes.map(node => [node.boneId, node]));
+    const radius = Number(boundingSphereRadius);
+    const totalNodeWeight = nodes.reduce(
+      (sum, node) => sum + node.totalWeight, 0);
+    const sourceCenter = nodes.length ? nodes.reduce((sum, node) => [
+      sum[0] + node.weightedCenter[0] * node.totalWeight,
+      sum[1] + node.weightedCenter[1] * node.totalWeight,
+      sum[2] + node.weightedCenter[2] * node.totalWeight,
+    ], [0, 0, 0]).map(value =>
+      totalNodeWeight > 0 ? value / totalNodeWeight : 0) : [0, 0, 0];
+    const sourceRadius = nodes.length ? Math.max(...nodes.map(node =>
+      (centerDistance(node.weightedCenter, sourceCenter) || 0)
+        + (Number(node.weightedRadius) || 0))) : null;
+    const relationships = [...relationshipEntries.values()].map(relationship => {
+      const nodeA = nodeById.get(relationship.boneA);
+      const nodeB = nodeById.get(relationship.boneB);
+      const supportA = Number(nodeA?.totalWeight) || 0;
+      const supportB = Number(nodeB?.totalWeight) || 0;
+      const denominator = Math.min(supportA, supportB);
+      const jaccardDenominator = supportA + supportB - relationship.minOverlap;
+      const distance = centerDistance(nodeA?.weightedCenter, nodeB?.weightedCenter);
+      const normalizedDistance = distance !== null
+        && Number.isFinite(radius) && radius > 0
+        ? distance / radius : null;
+      const distancePenalty = Number.isFinite(normalizedDistance)
+        ? 1 / (1 + Math.max(0, normalizedDistance)) : 1;
+      return {
+        ...relationship,
+        jointCenter: relationship.jointWeightTotal > 0
+          ? [relationship.jointX / relationship.jointWeightTotal,
+            relationship.jointY / relationship.jointWeightTotal,
+            relationship.jointZ / relationship.jointWeightTotal]
+          : null,
+        containment: denominator > 0 ? relationship.minOverlap / denominator : 0,
+        jaccard: jaccardDenominator > 0
+          ? relationship.minOverlap / jaccardDenominator : 0,
+        centerDistance: distance,
+        normalizedDistance,
+        treeEdgeScore: (denominator > 0
+          ? relationship.minOverlap / denominator : 0) * distancePenalty,
+      };
+    });
+    return {
+      nodes,
+      relationships,
+      boundingSphereRadius: Number.isFinite(radius) && radius > 0
+        ? radius : sourceRadius,
+      evidenceMode: 'surface',
+      triangleCount: topology.triangleCount,
+      validTriangleCount: topology.validTriangleCount,
+      degenerateTriangleCount: topology.degenerateTriangleCount,
+      invalidTriangleCount: topology.invalidTriangleCount,
+      totalSurfaceArea: topology.totalSurfaceArea,
+      measuredVertexCount: topology.measuredVertices.size,
+      zeroMeasureVertexCount: shape.positionCount
+        - topology.measuredVertices.size,
+      fallbackReason: null,
+    };
+  }
+
+  return {shape, process, finish};
+}
+
+export async function inspectSurfaceTopologyCooperative(
+    positions, triangleIndices = null,
+    {budget = createWorkBudget(), isCurrent = () => true,
+      triangleBatch = 32} = {}) {
+  const shape = surfaceTriangleCount(positions, triangleIndices);
+  let validTriangleCount = 0;
+  let degenerateTriangleCount = 0;
+  let invalidTriangleCount = 0;
+  let totalSurfaceArea = 0;
+  const measuredVertices = new Set();
+  for (let triangle = 0; triangle < shape.triangleCount; triangle += 1) {
+    if (triangle % triangleBatch === 0) {
+      if (!isCurrent()) return null;
+      await budget.checkpoint();
+      if (!isCurrent()) return null;
+    }
+    const sample = readSurfaceTriangle(
+      shape.positionArray, shape.indexArray, shape.indexed,
+      shape.positionCount, triangle);
+    if (sample.kind === 'invalid') {
+      invalidTriangleCount += 1;
+    } else if (sample.kind === 'degenerate') {
+      degenerateTriangleCount += 1;
+    } else {
+      validTriangleCount += 1;
+      totalSurfaceArea += sample.area;
+      sample.indices.forEach(index => measuredVertices.add(index));
+    }
+  }
+  if (!isCurrent()) return null;
+  await budget.checkpoint();
+  return {
+    triangleCount: shape.triangleCount,
+    validTriangleCount,
+    degenerateTriangleCount,
+    invalidTriangleCount,
+    totalSurfaceArea,
+    measuredVertexCount: measuredVertices.size,
+    zeroMeasureVertexCount: shape.positionCount - measuredVertices.size,
+    surfaceEvidenceAvailable: validTriangleCount > 0 && totalSurfaceArea > 0,
+  };
+}
+
+export async function buildSurfaceInfluenceGraphCooperative(
+    baselinePositions, triangleIndices, indices, weights, influenceCount,
+    boneIds = null, boundingSphereRadius = null,
+    {budget = createWorkBudget(), isCurrent = () => true,
+      triangleBatch = 32} = {}) {
+  const accumulator = createSurfaceGraphAccumulator(
+    baselinePositions, triangleIndices, indices, weights, influenceCount,
+    boneIds, boundingSphereRadius);
+  const {shape} = accumulator;
+  for (let triangle = 0; triangle < shape.triangleCount; triangle += 1) {
+    if (triangle % triangleBatch === 0) {
+      if (!isCurrent()) return null;
+      await budget.checkpoint();
+      if (!isCurrent()) return null;
+    }
+    accumulator.process(readSurfaceTriangle(
+      shape.positionArray, shape.indexArray, shape.indexed,
+      shape.positionCount, triangle));
+  }
+  if (!isCurrent()) return null;
+  await budget.checkpoint();
+  return accumulator.finish();
+}
+
 export function buildInfluenceNodes(
     baselinePositions, indices, weights, influenceCount, boneIds = null) {
   const vertexCount = compactVertexCount(indices, weights, influenceCount);
@@ -526,6 +796,85 @@ export function buildInfluenceNodes(
     });
   }
 
+  const orderedIds = requested ? [...requested] : [...entries.keys()];
+  return orderedIds.filter(boneId => entries.has(boneId)).map(boneId => {
+    const entry = entries.get(boneId);
+    const nodeCenter = entry.positionWeight > 0
+      ? [entry.weightedX / entry.positionWeight,
+        entry.weightedY / entry.positionWeight,
+        entry.weightedZ / entry.positionWeight]
+      : [0, 0, 0];
+    const weightedRadius = entry.positionWeight > 0
+      ? Math.sqrt(Math.max(0,
+        entry.squaredPositionWeight / entry.positionWeight
+        - (nodeCenter[0] ** 2 + nodeCenter[1] ** 2
+          + nodeCenter[2] ** 2)))
+      : null;
+    return {
+      boneId: entry.boneId,
+      totalWeight: entry.totalWeight,
+      affectedVertexCount: entry.affectedVertexCount,
+      affectedMeasure: entry.affectedMeasure,
+      maxVertexWeight: entry.maxVertexWeight,
+      weightedCenter: nodeCenter,
+      weightedRadius,
+    };
+  });
+}
+
+export async function buildInfluenceNodesCooperative(
+    baselinePositions, indices, weights, influenceCount, boneIds = null,
+    {budget = createWorkBudget(), isCurrent = () => true,
+      vertexBatch = 256} = {}) {
+  const vertexCount = compactVertexCount(indices, weights, influenceCount);
+  const requested = boneIds === null || boneIds === undefined
+    ? null : new Set([...boneIds].map(Number));
+  const entries = new Map();
+  for (let vertex = 0; vertex < vertexCount; vertex += 1) {
+    if (vertex % vertexBatch === 0) {
+      if (!isCurrent()) return null;
+      await budget.checkpoint();
+      if (!isCurrent()) return null;
+    }
+    const influences = positiveInfluencesForVertex(
+      indices, weights, influenceCount, vertex);
+    influences.forEach((weight, boneId) => {
+      if (requested && !requested.has(boneId)) return;
+      const entry = entries.get(boneId) || {
+        boneId,
+        totalWeight: 0,
+        affectedVertexCount: 0,
+        affectedMeasure: null,
+        maxVertexWeight: 0,
+        weightedX: 0,
+        weightedY: 0,
+        weightedZ: 0,
+        squaredPositionWeight: 0,
+        positionWeight: 0,
+      };
+      entry.totalWeight += weight;
+      entry.affectedVertexCount += 1;
+      entry.maxVertexWeight = Math.max(entry.maxVertexWeight, weight);
+      if (baselinePositions
+          && baselinePositions.length >= vertex * 3 + 3) {
+        const offset = vertex * 3;
+        const x = Number(baselinePositions[offset]);
+        const y = Number(baselinePositions[offset + 1]);
+        const z = Number(baselinePositions[offset + 2]);
+        if ([x, y, z].every(Number.isFinite)) {
+          entry.weightedX += x * weight;
+          entry.weightedY += y * weight;
+          entry.weightedZ += z * weight;
+          entry.squaredPositionWeight += (
+            x * x + y * y + z * z) * weight;
+          entry.positionWeight += weight;
+        }
+      }
+      entries.set(boneId, entry);
+    });
+  }
+  if (!isCurrent()) return null;
+  await budget.checkpoint();
   const orderedIds = requested ? [...requested] : [...entries.keys()];
   return orderedIds.filter(boneId => entries.has(boneId)).map(boneId => {
     const entry = entries.get(boneId);
@@ -637,6 +986,110 @@ export function buildInfluenceRelationships(
     }
   }
 
+  const radius = Number(boundingSphereRadius);
+  return [...relationships.values()].map(relationship => {
+    const nodeA = nodeById.get(relationship.boneA);
+    const nodeB = nodeById.get(relationship.boneB);
+    const supportA = Number(nodeA?.totalWeight) || 0;
+    const supportB = Number(nodeB?.totalWeight) || 0;
+    const containmentDenominator = Math.min(supportA, supportB);
+    const jaccardDenominator = supportA + supportB
+      - relationship.minOverlap;
+    const distance = centerDistance(
+      nodeA?.weightedCenter, nodeB?.weightedCenter);
+    const jointCenter = relationship.jointWeightTotal > 0
+      ? [relationship.jointX / relationship.jointWeightTotal,
+        relationship.jointY / relationship.jointWeightTotal,
+        relationship.jointZ / relationship.jointWeightTotal]
+      : null;
+    return {
+      ...relationship,
+      jointCenter,
+      containment: containmentDenominator > 0
+        ? relationship.minOverlap / containmentDenominator : 0,
+      jaccard: jaccardDenominator > 0
+        ? relationship.minOverlap / jaccardDenominator : 0,
+      centerDistance: distance,
+      normalizedDistance: distance !== null && radius > 0
+        ? distance / radius : null,
+    };
+  });
+}
+
+export async function buildInfluenceRelationshipsCooperative(
+    baselinePositions, indices, weights, influenceCount, nodes,
+    boundingSphereRadius = null,
+    {budget = createWorkBudget(), isCurrent = () => true,
+      vertexBatch = 128} = {}) {
+  const nodeById = new Map((nodes || []).map(node => [
+    Number(node.boneId), node]));
+  const vertexCount = compactVertexCount(indices, weights, influenceCount);
+  const relationships = new Map();
+  const ids = [];
+  const mergedWeights = [];
+  for (let vertex = 0; vertex < vertexCount; vertex += 1) {
+    if (vertex % vertexBatch === 0) {
+      if (!isCurrent()) return null;
+      await budget.checkpoint();
+      if (!isCurrent()) return null;
+    }
+    ids.length = 0;
+    mergedWeights.length = 0;
+    const start = vertex * influenceCount;
+    for (let influence = 0; influence < influenceCount; influence += 1) {
+      const boneId = Number(indices[start + influence]);
+      const weight = Number(weights[start + influence]);
+      if (!nodeById.has(boneId) || !Number.isFinite(weight) || weight <= 0) {
+        continue;
+      }
+      const existing = ids.indexOf(boneId);
+      if (existing >= 0) mergedWeights[existing] += weight;
+      else {
+        ids.push(boneId);
+        mergedWeights.push(weight);
+      }
+    }
+    for (let left = 0; left < ids.length; left += 1) {
+      for (let right = left + 1; right < ids.length; right += 1) {
+        const [boneA, boneB] = pairIds(ids[left], ids[right]);
+        const key = pairKey(boneA, boneB);
+        const weightA = mergedWeights[left];
+        const weightB = mergedWeights[right];
+        const jointWeight = weightA * weightB;
+        const relationship = relationships.get(key) || {
+          boneA,
+          boneB,
+          sharedVertexCount: 0,
+          sharedMeasure: null,
+          minOverlap: 0,
+          productOverlap: 0,
+          jointWeightTotal: 0,
+          jointX: 0,
+          jointY: 0,
+          jointZ: 0,
+        };
+        relationship.sharedVertexCount += 1;
+        relationship.minOverlap += Math.min(weightA, weightB);
+        relationship.productOverlap += jointWeight;
+        if (baselinePositions && baselinePositions.length >= vertex * 3 + 3
+            && Number.isFinite(jointWeight) && jointWeight > 0) {
+          const offset = vertex * 3;
+          const x = Number(baselinePositions[offset]);
+          const y = Number(baselinePositions[offset + 1]);
+          const z = Number(baselinePositions[offset + 2]);
+          if ([x, y, z].every(Number.isFinite)) {
+            relationship.jointWeightTotal += jointWeight;
+            relationship.jointX += x * jointWeight;
+            relationship.jointY += y * jointWeight;
+            relationship.jointZ += z * jointWeight;
+          }
+        }
+        relationships.set(key, relationship);
+      }
+    }
+  }
+  if (!isCurrent()) return null;
+  await budget.checkpoint();
   const radius = Number(boundingSphereRadius);
   return [...relationships.values()].map(relationship => {
     const nodeA = nodeById.get(relationship.boneA);

--- a/src/web/js/mesh/weight-runtime.js
+++ b/src/web/js/mesh/weight-runtime.js
@@ -117,6 +117,37 @@ export function aggregateModelBoneStats(nodeLists) {
     }]));
 }
 
+export function aggregateModelWeightBoneStats(statMaps) {
+  const totals = new Map();
+  for (const stats of statMaps || []) {
+    for (const [rawBoneId, rawEntry] of Object.entries(stats || {})) {
+      const boneId = Number(rawBoneId);
+      const affectedVertexCount = Number(
+        rawEntry?.affectedVertexCount ?? rawEntry?.affected_vertex_count);
+      const totalWeight = Number(
+        rawEntry?.totalWeight ?? rawEntry?.total_weight);
+      if (!Number.isFinite(boneId) || !Number.isFinite(affectedVertexCount)
+          || affectedVertexCount < 0 || !Number.isFinite(totalWeight)) {
+        continue;
+      }
+      const entry = totals.get(boneId) || {
+        affectedVertexCount: 0,
+        totalWeight: 0,
+      };
+      entry.affectedVertexCount += affectedVertexCount;
+      entry.totalWeight += totalWeight;
+      totals.set(boneId, entry);
+    }
+  }
+  return Object.fromEntries([...totals.entries()]
+    .sort(([left], [right]) => Number(left) - Number(right))
+    .map(([boneId, entry]) => [boneId, {
+      affectedVertexCount: entry.affectedVertexCount,
+      averageInfluence: entry.affectedVertexCount > 0
+        ? entry.totalWeight / entry.affectedVertexCount : 0,
+    }]));
+}
+
 export function createWeightRuntimeState() {
   const states = new WeakMap();
   const knownMeshes = new Set();
@@ -170,6 +201,7 @@ export function createWeightRuntimeState() {
       debugMaterial: null,
       heatmapMode: null,
       diagnostics: null,
+      weightBoneStats: {},
       encoding: null,
       centerByBoneId: null,
       poseTransforms: null,

--- a/src/web/js/mesh/weight-runtime.js
+++ b/src/web/js/mesh/weight-runtime.js
@@ -58,6 +58,7 @@ function createModelRigDefaults() {
     activeLimbRole: 'left_arm',
     selectedHumanoidControlKey: null,
     explicitRootSignatures: new Set(),
+    performance: {},
   };
 }
 
@@ -171,6 +172,7 @@ export function createWeightRuntimeState() {
     pickerViewMode: 'all',
     pickStatus: '',
     picking: false,
+    performance: {},
   });
   const modelWeightState = createModelWeightDefaults();
 

--- a/src/web/js/mesh/weight-selection.js
+++ b/src/web/js/mesh/weight-selection.js
@@ -266,7 +266,9 @@ function sourceDescriptor(value, fallbackKey = '') {
     const separator = fallbackKey.lastIndexOf('|offset=');
     if (separator > 0) {
       file = normalizedSourceFile(fallbackKey.slice(0, separator));
-      offset = Number(fallbackKey.slice(separator + 8));
+      const nextSegment = fallbackKey.indexOf('|', separator + 8);
+      offset = Number(fallbackKey.slice(
+        separator + 8, nextSegment < 0 ? undefined : nextSegment));
     }
   }
   if (!file || !Number.isInteger(offset) || offset < 0) return null;
@@ -296,7 +298,7 @@ export function normalizeBoneSelection(entries) {
       ? (() => {
         const sourceFile = normalizedSourceFile(raw.source);
         const offset = Number(raw.bone_id_offset ?? raw.boneIdOffset ?? 0);
-        const sourceKey = String(raw.sourceKey
+        const sourceKey = String(raw.sourceKey ?? raw.source_key
           ?? `${sourceFile.toLowerCase()}|offset=${offset}`);
         return sourceFile && Number.isInteger(offset) && offset >= 0
           && sourceKey ? {
@@ -330,6 +332,7 @@ export function selectionForSource(selection, sourceKey) {
 export function serializeBoneSelection(selection) {
   return normalizeBoneSelection(selection).map(entry => ({
     source: entry.sourceFile,
+    source_key: entry.sourceKey,
     bone_id_offset: entry.boneIdOffset,
     bone_ids: [...entry.boneIds],
   }));

--- a/src/web/js/panels/weight-rig-panel.js
+++ b/src/web/js/panels/weight-rig-panel.js
@@ -3,7 +3,8 @@
 
 import {
   beginWeightModelPicking, cancelWeightModelPicking, clearSelectedBones,
-  ensureModelRigLoaded, getModelPhysicsState, getModelRigState,
+  ensureModelRigLoaded, ensureModelWeightsLoaded, getModelPhysicsState,
+  getModelRigState,
   getModelWeightState, loadSavedBoneSelection,
   clearRigJointSelection, resetModelPhysics, resetRigJoint, resetRigPose,
   saveModelWeightSelection,
@@ -901,7 +902,8 @@ function syncStatus() {
   const weight = latestWeightState || getModelWeightState();
   const rig = latestRigState || getModelRigState();
   let status = '';
-  if (weight.loading || rig.loading) status = 'Loading weights and rig…';
+  if (weight.loading) status = 'Loading weights…';
+  else if (rig.loading) status = 'Loading Rig…';
   else if (weight.error) status = weight.error;
   else if (rig.error) status = rig.error;
   else if (rig.humanoidRigEdit?.error) status = rig.humanoidRigEdit.error;
@@ -920,9 +922,27 @@ function closePopover() {
   ui.boneButton.setAttribute('aria-expanded', 'false');
 }
 
+function scheduleRigLoadAfterPaint(generation) {
+  const afterPaint = typeof requestAnimationFrame === 'function'
+    ? requestAnimationFrame : callback => setTimeout(callback, 0);
+  afterPaint(() => setTimeout(() => {
+    const weight = getModelWeightState();
+    if (weight.generation !== generation || !weight.loaded
+        || weight.error || weight.noWeights) return;
+    void ensureModelRigLoaded();
+  }, 0));
+}
+
 function loadOnDemand() {
   if (loadingPromise) return loadingPromise;
-  loadingPromise = ensureModelRigLoaded().finally(() => { loadingPromise = null; });
+  loadingPromise = ensureModelWeightsLoaded()
+    .then(weight => {
+      if (weight?.loaded && !weight.error && !weight.noWeights) {
+        scheduleRigLoadAfterPaint(weight.generation);
+      }
+      return weight;
+    })
+    .finally(() => { loadingPromise = null; });
   return loadingPromise;
 }
 

--- a/src/web/js/panels/weight-rig-panel.js
+++ b/src/web/js/panels/weight-rig-panel.js
@@ -902,15 +902,15 @@ function syncStatus() {
   const weight = latestWeightState || getModelWeightState();
   const rig = latestRigState || getModelRigState();
   let status = '';
-  if (weight.loading) status = 'Loading weights…';
-  else if (rig.loading) status = 'Loading Rig…';
-  else if (weight.error) status = weight.error;
+  if (weight.error) status = weight.error;
   else if (rig.error) status = rig.error;
   else if (rig.humanoidRigEdit?.error) status = rig.humanoidRigEdit.error;
+  else if (weight.selectionSaveError) {
+    status = `Could not save bone selection: ${weight.selectionSaveError}`;
+  } else if (weight.loading) status = 'Loading weights…';
+  else if (rig.loading) status = 'Loading Rig…';
   else if (weight.loaded && (!weight.sources?.length || weight.noWeights)) {
     status = 'No skin weights available for this model.';
-  } else if (weight.selectionSaveError) {
-    status = `Could not save bone selection: ${weight.selectionSaveError}`;
   } else if (!weight.loaded && !rig.loaded) status = '';
   if (weight.pickStatus || rig.pickStatus) status = weight.pickStatus || rig.pickStatus;
   ui.status.textContent = status;


### PR DESCRIPTION
PR A — reuse model-load vertex mapping for Weight preview

## Root cause
Weight previously re-resolved draws and reran geometry preparation after the model had already been built, duplicating the computation that determines which source vertices form each compact rendered mesh.

## New flow
Model construction retains the compact source-vertex mapping produced by geometry packing in a private backend skinning manifest. Weight reuses that manifest to decode Blend and WWMI VertexVG streams directly, preserving the existing rendered mesh key and shared request-local buffer cache.

## Changes
- Added private SkinningManifestEntry records with packed uint32 source indices and the complete resolved SkinningSource.
- Exposed the already-prepared source mapping from geometry packing without a second preparation pass.
- Retained the manifest in the current ModPreview model session.
- Added centralized clear_loaded_model() cleanup and call it when load_asset() transitions away from a Mod.
- Kept the public application payload unchanged.
- Kept a narrow legacy fallback for callers without a loaded-model manifest.
- Added exact used_vertices assertions for BaseVertexLocation, invalid-triangle filtering, reverse winding, and shared vertices.

## Real representative-mod benchmark
Single before/after backend runs on the same large mod:

| Metric | main | PR #99 |
| --- | ---: | ---: |
| Model/backend load | 7.936 s | 7.823 s |
| Weight backend total | 2.159 s | 1.624 s |
| Resolve draws | 20.304 ms | 0 |
| Prepare vertices | 549.642 ms | 0 |
| Decode skinning | 1.474 s | 1.583 s |
| Blob publish | 0.033 ms | 0.038 ms |

Both runs produced 43 meshes, 283,314 compact vertices, 7 skinning sources, and an 18,132,096-byte Weight blob. The retained uint32 mapping is approximately 1.08 MiB for this model (4 bytes per compact vertex).

## Validation
The repository test suite passes: 1,381 passed, 1 skipped.

## Scope
Rig inference, Weight/Rig readiness, frontend influence-node behavior, baseline capture, reconciliation, humanoid binding, saved Main Rig state, and Physics are intentionally outside this checkpoint.