### PR TITLE
Use structural identity for Rig evidence preparation

### DIFF
--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1626,6 +1626,248 @@ def test_surface_topology_diagnostics_reject_bad_triangles_without_nan(
     }
 
 
+def test_surface_eligibility_probe_matches_topology_diagnostics(module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const rig = await import('./js/mesh/weight-rig.js');
+      const cases = [
+        {
+          name: 'indexed',
+          positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+          indices: [0, 1, 2],
+        },
+        {
+          name: 'nonIndexed',
+          positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+        },
+        {
+          name: 'laterValidTriangle',
+          positions: [0, 0, 0, 1, 0, 0, 0, 1, 0, NaN, 0, 0],
+          indices: [0, 1, 3, 0, 1, 2],
+        },
+        {
+          name: 'degenerate',
+          positions: [0, 0, 0, 1, 0, 0, 2, 0, 0],
+          indices: [0, 1, 2],
+        },
+        {
+          name: 'invalidIndex',
+          positions: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+          indices: [0, 1, 9],
+        },
+        {
+          name: 'empty',
+          positions: [],
+        },
+      ];
+      return cases.map(item => {
+        const positions = new Float32Array(item.positions);
+        const indices = item.indices === undefined
+          ? null : new Uint32Array(item.indices);
+        const diagnostics = rig.inspectSurfaceTopology(positions, indices);
+        return {
+          name: item.name,
+          usable: rig.hasUsableSurfaceTopology(positions, indices),
+          diagnosed: diagnostics.surfaceEvidenceAvailable,
+          validTriangleCount: diagnostics.validTriangleCount,
+        };
+      });
+    }""")
+    assert result == [
+        {"name": "indexed", "usable": True, "diagnosed": True,
+         "validTriangleCount": 1},
+        {"name": "nonIndexed", "usable": True, "diagnosed": True,
+         "validTriangleCount": 1},
+        {"name": "laterValidTriangle", "usable": True, "diagnosed": True,
+         "validTriangleCount": 1},
+        {"name": "degenerate", "usable": False, "diagnosed": False,
+         "validTriangleCount": 0},
+        {"name": "invalidIndex", "usable": False, "diagnosed": False,
+         "validTriangleCount": 0},
+        {"name": "empty", "usable": False, "diagnosed": False,
+         "validTriangleCount": 0},
+    ]
+
+
+def test_rig_member_structural_identity_ignores_ui_and_provenance(module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const {memberStructuralEvidenceKey} = await import(
+        './js/mesh/rig-model-session.js');
+      const makeMember = (changes = {}) => ({
+        state: {
+          skinningSourceKey: 'source', influenceCount: 4,
+          encoding: 'compact', ...changes.state,
+        },
+        mesh: {
+          userData: {
+            semanticKey: 'semantic-a', component: 'Body', occurrence: 1,
+            material: 'material-a', texture: 'texture-a', visible: true,
+            identity: {
+              draw: {count: 6, start: 0, base: 0},
+              geometry_state: {
+                ib_file: 'indices.buf', index_size: 2,
+                position_file: 'positions.buf', position_stride: 12,
+                texcoord_file: 'uv.buf', texcoord_stride: 8,
+              },
+              ...changes.identity,
+            },
+          },
+          geometry: {
+            attributes: {position: {count: 3}},
+            index: {count: 3},
+            ...changes.geometry,
+          },
+        },
+      });
+      const base = makeMember();
+      const uiOnly = makeMember({
+        state: {semanticKey: 'ignored-state-field'},
+        identity: {component: 'Legs', material: 'material-b',
+          texture: 'texture-b'},
+      });
+      const different = field => memberStructuralEvidenceKey(
+        makeMember(field));
+      const baseKey = memberStructuralEvidenceKey(base);
+      return {
+        uiOnlyMatches: baseKey === memberStructuralEvidenceKey(uiOnly),
+        changedKeys: [
+          different({state: {skinningSourceKey: 'other'}}),
+          different({state: {influenceCount: 8}}),
+          different({state: {encoding: 'expanded'}}),
+          different({identity: {draw: {count: 7, start: 0, base: 0}}}),
+          different({identity: {draw: {count: 6, start: 1, base: 0}}}),
+          different({identity: {draw: {count: 6, start: 0, base: 1}}}),
+          different({identity: {geometry_state: {ib_file: 'other'}}}),
+          different({identity: {geometry_state: {index_size: 4}}}),
+          different({identity: {geometry_state: {position_file: 'other'}}}),
+          different({identity: {geometry_state: {position_stride: 16}}}),
+          different({identity: {geometry_state: {texcoord_file: 'other'}}}),
+          different({identity: {geometry_state: {texcoord_stride: 16}}}),
+          different({geometry: {attributes: {position: {count: 4}}}}),
+          different({geometry: {index: {count: 6}}}),
+        ].map(key => key !== baseKey),
+      };
+    }""")
+    assert result == {
+        "uiOnlyMatches": True,
+        "changedKeys": [True] * 14,
+    }
+
+
+def test_rig_source_session_deduplicates_exact_evidence_and_falls_back_source_wide(
+        module_page):
+    page = module_page
+    result = page.evaluate("""async () => {
+      const {initializeRigSourceSession} = await import(
+        './js/mesh/rig-model-session.js');
+      const states = new Map();
+      const knownMeshes = new Set();
+      const sourceSkinningRigs = new Map();
+      const graphCalls = [];
+      const makeMesh = (name, valid, drawStart = 0) => {
+        const mesh = {
+          userData: {semanticKey: name, identity: {
+            draw: {count: 3, start: drawStart, base: 0},
+            geometry_state: {ib_file: 'indices.buf', index_size: 2,
+              position_file: 'positions.buf', position_stride: 12,
+              texcoord_file: 'uv.buf', texcoord_stride: 8},
+          }},
+          geometry: {
+            attributes: {position: {count: 3}},
+            index: {array: new Uint32Array([0, 1, 2]), count: 3},
+          },
+        };
+        states.set(mesh, {
+          loaded: true, skinningSourceKey: 'source', influenceCount: 1,
+          encoding: 'compact',
+          baselinePositions: new Float32Array(valid
+            ? [0, 0, 0, 1, 0, 0, 0, 1, 0]
+            : [0, 0, 0, 1, 0, 0, 2, 0, 0]),
+          indices: new Uint32Array([0, 1, 2]),
+          weights: new Float32Array([1, 1, 1]),
+          boneIds: new Uint16Array([1, 1, 1]),
+        });
+        knownMeshes.add(mesh);
+        return mesh;
+      };
+      const first = makeMesh('first', true);
+      const duplicate = makeMesh('duplicate', true, 2);
+      const invalid = makeMesh('invalid', false, 1);
+      const graphFor = (mesh, state, evidenceMode, surfaceEvidence) => {
+        graphCalls.push({mesh: mesh.userData.semanticKey, evidenceMode,
+          surfaceAvailable: surfaceEvidence?.surfaceEvidenceAvailable ?? null});
+        return {
+          nodes: [{boneId: 1, totalWeight: 1, affectedVertexCount: 3,
+            affectedMeasure: evidenceMode === 'surface' ? 1 : null,
+            maxVertexWeight: 1, weightedCenter: [0, 0, 0],
+            weightedRadius: 0}], relationships: [], evidenceMode,
+          triangleCount: evidenceMode === 'surface' ? 1 : 0,
+          validTriangleCount: evidenceMode === 'surface' ? 1 : 0,
+        };
+      };
+      const session = initializeRigSourceSession({
+        states, knownMeshes, modelWeightState: {
+          sourceDescriptors: new Map([['source', {
+            sourceFile: 'weights.buf', boneIdOffset: 0,
+          }]]),
+        }, sourceSkinningRigs,
+        ensureRigMeshPrepared: () => true,
+        ensureInfluenceGraph: graphFor,
+        rebuildRestFrames: () => {},
+        cloneForest: forest => forest,
+      });
+      const fallbackRig = session.ensure('source',
+        [first, duplicate, invalid]);
+      const fallback = {
+        memberCount: fallbackRig.influenceGraph.memberCount,
+        uniqueMemberCount: fallbackRig.influenceGraph.uniqueMemberCount,
+        evidenceMode: fallbackRig.influenceGraph.evidenceMode,
+        graphCalls: [...graphCalls],
+      };
+      graphCalls.length = 0;
+      const surfaceRig = session.ensure('source', [first, duplicate]);
+      return {
+        fallback,
+        surface: {
+          memberCount: surfaceRig.influenceGraph.memberCount,
+          uniqueMemberCount: surfaceRig.influenceGraph.uniqueMemberCount,
+          evidenceMode: surfaceRig.influenceGraph.evidenceMode,
+          graphCalls,
+        },
+        exactOutput: {
+          nodes: surfaceRig.influenceGraph.nodes,
+          relationships: surfaceRig.influenceGraph.relationships,
+        },
+      };
+    }""")
+    assert result["fallback"] == {
+        "memberCount": 3,
+        "uniqueMemberCount": 2,
+        "evidenceMode": "vertex",
+        "graphCalls": [
+            {"mesh": "first", "evidenceMode": "vertex",
+             "surfaceAvailable": True},
+            {"mesh": "invalid", "evidenceMode": "vertex",
+             "surfaceAvailable": False},
+        ],
+    }
+    assert result["surface"] == {
+        "memberCount": 2,
+        "uniqueMemberCount": 1,
+        "evidenceMode": "surface",
+        "graphCalls": [{"mesh": "first", "evidenceMode": "surface",
+                         "surfaceAvailable": True}],
+    }
+    assert result["exactOutput"] == {
+        "nodes": [{"boneId": 1, "totalWeight": 1,
+                    "affectedVertexCount": 3, "affectedMeasure": 1,
+                    "maxVertexWeight": 1,
+                    "weightedCenter": [0, 0, 0], "weightedRadius": 0}],
+        "relationships": [],
+    }
+
+
 def test_inferred_rig_rest_frames_are_deterministic_and_transport_axes(module_page):
     page = module_page
     result = page.evaluate("""async () => {

--- a/src/tests/web/test_modules.py
+++ b/src/tests/web/test_modules.py
@@ -1244,6 +1244,130 @@ def test_inferred_rig_pivots_aggregate_and_keep_disconnected_components(module_p
     assert result["nonZeroRootPivotKeys"] == [0, 2]
 
 
+def test_barycentric_third_moment_matches_reference_for_all_index_triples(
+        module_page):
+    result = module_page.evaluate("""async () => {
+      const {barycentricThirdMoment} = await import(
+        './js/mesh/weight-rig.js');
+      const reference = (first, second, third, area) => {
+        const counts = [first, second, third].reduce((map, index) => {
+          map.set(index, (map.get(index) || 0) + 1);
+          return map;
+        }, new Map());
+        const multiplicities = [...counts.values()];
+        if (multiplicities.length === 1) return area / 10;
+        if (multiplicities.length === 2) return area / 30;
+        return area / 60;
+      };
+      const areas = [0, 1, .5, .123456789, 1234.56789, 1e-12];
+      const mismatches = [];
+      let caseCount = 0;
+      for (let first = 0; first < 3; first += 1) {
+        for (let second = 0; second < 3; second += 1) {
+          for (let third = 0; third < 3; third += 1) {
+            for (const area of areas) {
+              caseCount += 1;
+              const actual = barycentricThirdMoment(
+                first, second, third, area);
+              const expected = reference(first, second, third, area);
+              if (!Object.is(actual, expected)) {
+                mismatches.push({first, second, third, area, actual, expected});
+              }
+            }
+          }
+        }
+      }
+      return {caseCount, mismatches};
+    }""")
+    assert result == {"caseCount": 162, "mismatches": []}
+
+
+def test_surface_integrators_match_reference_third_moment_order(module_page):
+    result = module_page.evaluate("""async () => {
+      const {integrateLinearSecondMoment, integratePositionProduct} =
+        await import('./js/mesh/weight-rig.js');
+      const referenceThirdMoment = (first, second, third, area) => {
+        const counts = [first, second, third].reduce((map, index) => {
+          map.set(index, (map.get(index) || 0) + 1);
+          return map;
+        }, new Map());
+        const multiplicities = [...counts.values()];
+        if (multiplicities.length === 1) return area / 10;
+        if (multiplicities.length === 2) return area / 30;
+        return area / 60;
+      };
+      const dot3 = (left, right) => left[0] * right[0]
+        + left[1] * right[1] + left[2] * right[2];
+      const referenceSecondMoment = (points, weights, area) => {
+        let result = 0;
+        for (let left = 0; left < 3; left += 1) {
+          for (let right = 0; right < 3; right += 1) {
+            for (let weight = 0; weight < 3; weight += 1) {
+              result += dot3(points[left], points[right])
+                * weights[weight]
+                * referenceThirdMoment(left, right, weight, area);
+            }
+          }
+        }
+        return result;
+      };
+      const referencePositionProduct = (
+          points, leftWeights, rightWeights, area) => {
+        const result = [0, 0, 0];
+        for (let point = 0; point < 3; point += 1) {
+          for (let left = 0; left < 3; left += 1) {
+            for (let right = 0; right < 3; right += 1) {
+              const contribution = leftWeights[left] * rightWeights[right]
+                * referenceThirdMoment(point, left, right, area);
+              result[0] += points[point][0] * contribution;
+              result[1] += points[point][1] * contribution;
+              result[2] += points[point][2] * contribution;
+            }
+          }
+        }
+        return result;
+      };
+      const cases = [
+        {
+          points: [[0, 0, 0], [2, 0, 0], [0, 2, 0]],
+          weights: [.25, .5, .75],
+          left: [.2, .3, .5], right: [.8, .1, .4], area: 2,
+        },
+        {
+          points: [[1, -2, .5], [-.25, 3, 1.75], [2.5, .25, -1]],
+          weights: [1, 0, 0],
+          left: [1, 0, 0], right: [0, 0, 1], area: .123456789,
+        },
+        {
+          points: [[-.7, .2, 1.1], [1.3, -1.4, .6], [2.2, .9, -2.5]],
+          weights: [1 / 3, 2 / 3, 1 / 7],
+          left: [.25, .5, .25], right: [.6, .2, .2], area: 1e-12,
+        },
+      ];
+      return cases.map(item => {
+        const actualSecond = integrateLinearSecondMoment(
+          item.points, item.weights, item.area);
+        const expectedSecond = referenceSecondMoment(
+          item.points, item.weights, item.area);
+        const actualPosition = integratePositionProduct(
+          item.points, item.left, item.right, item.area);
+        const expectedPosition = referencePositionProduct(
+          item.points, item.left, item.right, item.area);
+        return {
+          secondEqual: Object.is(actualSecond, expectedSecond),
+          positionEqual: actualPosition.every((value, index) =>
+            Object.is(value, expectedPosition[index])),
+          actualSecond, expectedSecond, actualPosition, expectedPosition,
+        };
+      });
+    }""")
+    assert all(item["secondEqual"] and item["positionEqual"]
+               for item in result)
+    for item in result:
+        assert item["actualSecond"] == item["expectedSecond"]
+        assert item["actualPosition"] == item["expectedPosition"]
+
+
 def test_surface_evidence_weights_rig_nodes_relationships_and_aggregation(
         module_page):
     page = module_page

--- a/src/web/js/mesh/rig-model-session.js
+++ b/src/web/js/mesh/rig-model-session.js
@@ -6,30 +6,56 @@ import {sourceBoneKey} from './weight-rig-reconcile.js';
 import {
   aggregateInfluenceGraphs,
   buildInferredRigForest,
+  hasUsableSurfaceTopology,
   inspectSurfaceTopology,
   jointPivotMap,
 } from './weight-rig.js';
 
 let activeSession = null;
 
+function memberStructuralEvidenceFields(member = {}) {
+  const state = member.state || {};
+  const identity = member.mesh?.userData?.identity || {};
+  const draw = identity.draw || {};
+  const geometry = identity.geometry_state || {};
+  const positionCount = member.mesh?.geometry?.attributes?.position?.count;
+  const surfaceIndexCount = member.mesh?.geometry?.index?.count
+    ?? member.mesh?.geometry?.index?.array?.length;
+  return [
+    state.skinningSourceKey ?? null,
+    state.influenceCount ?? null,
+    state.encoding ?? null,
+    draw.count ?? null,
+    draw.start ?? null,
+    draw.base ?? null,
+    geometry.ib_file ?? null,
+    geometry.index_size ?? null,
+    geometry.position_file ?? null,
+    geometry.position_stride ?? null,
+    geometry.texcoord_file ?? null,
+    geometry.texcoord_stride ?? null,
+    positionCount ?? null,
+    surfaceIndexCount ?? null,
+  ];
+}
+
+export function memberStructuralEvidenceKey(member = {}) {
+  return JSON.stringify(memberStructuralEvidenceFields(member));
+}
+
+function memberCompatibilityEvidenceKey(member = {}) {
+  // Some authored draw records share identical Rig evidence while their
+  // provenance-only draw start differs. Keep that broader key as a candidate
+  // only; memberEvidenceEqual remains the final identity decision.
+  const fields = memberStructuralEvidenceFields(member);
+  fields.splice(4, 1);
+  return JSON.stringify(fields);
+}
+
 function createSourceSession({states, knownMeshes, modelWeightState,
     sourceSkinningRigs, ensureRigMeshPrepared, ensureInfluenceGraph,
     rebuildRestFrames,
     cloneForest} = {}) {
-  function memberArrayFingerprint(values) {
-    if (!values) return 'none';
-    const bytes = ArrayBuffer.isView(values)
-      ? new Uint8Array(values.buffer, values.byteOffset, values.byteLength)
-      : null;
-    if (!bytes) return `array:${values.length}:${[...values].join(',')}`;
-    let hash = 2166136261;
-    for (const byte of bytes) {
-      hash ^= byte;
-      hash = Math.imul(hash, 16777619);
-    }
-    return `${values.constructor.name}:${values.length}:${hash >>> 0}`;
-  }
-
   function memberArraysEqual(left, right) {
     if (left === right) return true;
     if (!left || !right || left.length !== right.length) return false;
@@ -40,34 +66,53 @@ function createSourceSession({states, knownMeshes, modelWeightState,
   }
 
   function memberEvidenceEqual(left, right) {
-    return left.state.influenceCount === right.state.influenceCount
-      && memberArraysEqual(left.state.baselinePositions,
-        right.state.baselinePositions)
-      && memberArraysEqual(left.state.indices, right.state.indices)
-      && memberArraysEqual(left.state.weights, right.state.weights)
-      && memberArraysEqual(left.state.boneIds, right.state.boneIds)
-      && memberArraysEqual(left.surfaceIndices, right.surfaceIndices);
+    const leftState = left.state;
+    const rightState = right.state;
+    if (leftState.influenceCount !== rightState.influenceCount) return false;
+    const leftLengths = [
+      leftState.baselinePositions,
+      leftState.indices,
+      leftState.weights,
+      leftState.boneIds,
+      left.surfaceIndices,
+    ].map(values => values?.length ?? null);
+    const rightLengths = [
+      rightState.baselinePositions,
+      rightState.indices,
+      rightState.weights,
+      rightState.boneIds,
+      right.surfaceIndices,
+    ].map(values => values?.length ?? null);
+    if (leftLengths.some((length, index) => length !== rightLengths[index])) {
+      return false;
+    }
+    return memberArraysEqual(leftState.boneIds, rightState.boneIds)
+      && memberArraysEqual(left.surfaceIndices, right.surfaceIndices)
+      && memberArraysEqual(leftState.indices, rightState.indices)
+      && memberArraysEqual(leftState.weights, rightState.weights)
+      && memberArraysEqual(leftState.baselinePositions,
+        rightState.baselinePositions);
   }
 
   function normalizeMembers(members) {
-    const buckets = new Map();
+    const structuralBuckets = new Map();
+    const compatibilityBuckets = new Map();
     const uniqueMembers = [];
     for (const member of members) {
-      const state = member.state;
-      const fingerprint = [
-        state.influenceCount,
-        memberArrayFingerprint(state.baselinePositions),
-        memberArrayFingerprint(state.indices),
-        memberArrayFingerprint(state.weights),
-        memberArrayFingerprint(state.boneIds),
-        memberArrayFingerprint(member.surfaceIndices),
-      ].join('|');
-      const bucket = buckets.get(fingerprint) || [];
+      const structuralKey = memberStructuralEvidenceKey(member);
+      const bucket = structuralBuckets.get(structuralKey) || [];
       if (bucket.some(candidate => memberEvidenceEqual(candidate, member))) {
         continue;
       }
+      const compatibilityKey = memberCompatibilityEvidenceKey(member);
+      const compatibilityBucket = compatibilityBuckets.get(compatibilityKey)
+        || [];
+      if (compatibilityBucket.some(candidate =>
+          memberEvidenceEqual(candidate, member))) continue;
       bucket.push(member);
-      buckets.set(fingerprint, bucket);
+      structuralBuckets.set(structuralKey, bucket);
+      compatibilityBucket.push(member);
+      compatibilityBuckets.set(compatibilityKey, compatibilityBucket);
       uniqueMembers.push(member);
     }
     return uniqueMembers;
@@ -81,16 +126,21 @@ function createSourceSession({states, knownMeshes, modelWeightState,
         mesh,
         state,
         surfaceIndices: mesh.geometry?.index?.array || null,
-        surfaceEvidence: inspectSurfaceTopology(
-          state.baselinePositions, mesh.geometry?.index?.array || null),
       } : null;
     }).filter(Boolean);
     const uniqueMembers = normalizeMembers(loadedMembers);
-    const evidenceMode = loadedMembers.every(member =>
-      member.surfaceEvidence.surfaceEvidenceAvailable) ? 'surface' : 'vertex';
-    const graph = aggregateInfluenceGraphs(uniqueMembers.map(member =>
-      ensureInfluenceGraph(member.mesh, member.state, evidenceMode,
-        member.surfaceEvidence)));
+    const surfaceEligible = uniqueMembers.map(member =>
+      hasUsableSurfaceTopology(
+        member.state.baselinePositions, member.surfaceIndices));
+    const evidenceMode = surfaceEligible.every(Boolean) ? 'surface' : 'vertex';
+    const graph = aggregateInfluenceGraphs(uniqueMembers.map(member => {
+      const surfaceEvidence = evidenceMode === 'surface'
+        ? {surfaceEvidenceAvailable: true}
+        : inspectSurfaceTopology(
+          member.state.baselinePositions, member.surfaceIndices);
+      return ensureInfluenceGraph(
+        member.mesh, member.state, evidenceMode, surfaceEvidence);
+    }));
     return {
       ...graph,
       memberCount: loadedMembers.length,

--- a/src/web/js/mesh/weight-rig-reconcile.js
+++ b/src/web/js/mesh/weight-rig-reconcile.js
@@ -177,9 +177,48 @@ function collectSourceBoneEvidence(rig) {
   return result;
 }
 
+function prepareSourceBoneEvidence(evidenceByKey) {
+  evidenceByKey.forEach(evidence => {
+    const weightedCenter = vectorFrom(evidence.weightedCenter);
+    const restAnchor = vectorFrom(evidence.restAnchor);
+    const restDirection = vectorFrom(evidence.restDirection);
+    const jointPivot = vectorFrom(evidence.jointPivot);
+    Object.defineProperties(evidence, {
+      _weightedCenterVector: {
+        value: weightedCenter ? Object.freeze(weightedCenter) : null,
+        enumerable: false,
+      },
+      _restAnchorVector: {
+        value: restAnchor ? Object.freeze(restAnchor) : null,
+        enumerable: false,
+      },
+      _restDirectionVector: {
+        value: restDirection ? Object.freeze(restDirection) : null,
+        enumerable: false,
+      },
+      _jointPivotVector: {
+        value: jointPivot ? Object.freeze(jointPivot) : null,
+        enumerable: false,
+      },
+      _neighborBoneKeys: {
+        value: Object.freeze((evidence.neighborBoneIds || []).map(boneId =>
+          sourceBoneKey(evidence.sourceKey, boneId))),
+        enumerable: false,
+      },
+    });
+  });
+  return evidenceByKey;
+}
+
+function evidenceVector(evidence, property, fallback) {
+  return evidence?.[property]?.clone()
+    || vectorFrom(evidence?.[fallback]);
+}
+
 function modelReferenceRadius(evidence) {
   const points = [...evidence.values()].map(item =>
-    vectorFrom(item.weightedCenter)).filter(Boolean);
+    evidenceVector(item, '_weightedCenterVector', 'weightedCenter'))
+    .filter(Boolean);
   if (!points.length) return 1;
   const center = points.reduce((sum, point) => sum.add(point), new Vector3())
     .multiplyScalar(1 / points.length);
@@ -195,14 +234,15 @@ function neighborDirection(evidence, allEvidence, incoming) {
   if (incoming) {
     const parent = allEvidence.get(sourceBoneKey(
       evidence.sourceKey, evidence.parentBoneId));
-    const vector = parent && vectorFrom(evidence.restAnchor)
-      && vectorFrom(parent.restAnchor)
-      ? vectorFrom(evidence.restAnchor).sub(vectorFrom(parent.restAnchor))
+    const vector = parent && evidenceVector(evidence, '_restAnchorVector',
+      'restAnchor') && evidenceVector(parent, '_restAnchorVector', 'restAnchor')
+      ? evidenceVector(evidence, '_restAnchorVector', 'restAnchor')
+        .sub(evidenceVector(parent, '_restAnchorVector', 'restAnchor'))
       : null;
     if (vector?.length() > EPSILON) return vector.normalize();
   }
   return directionAvailable(evidence)
-    ? vectorFrom(evidence.restDirection) : null;
+    ? evidenceVector(evidence, '_restDirectionVector', 'restDirection') : null;
 }
 
 function topologyFeature(left, right) {
@@ -282,26 +322,47 @@ function nearestSample(sample, cells, cellSize, matchDistance) {
   for (let dx = -1; dx <= 1; dx += 1) {
     for (let dy = -1; dy <= 1; dy += 1) {
       for (let dz = -1; dz <= 1; dz += 1) {
-        const entries = cells.get(`${x + dx}:${y + dy}:${z + dz}`) || [];
-        entries.forEach(candidate => {
-          const distance = sample.point.distanceTo(candidate.point);
-          if (distance > matchDistance) return;
+        const entries = cells.get(`${x + dx}:${y + dy}:${z + dz}`);
+        if (!entries) continue;
+        for (const candidate of entries) {
+          const deltaX = sample.point.x - candidate.point.x;
+          const deltaY = sample.point.y - candidate.point.y;
+          const deltaZ = sample.point.z - candidate.point.z;
+          const distanceSquared = deltaX * deltaX + deltaY * deltaY
+            + deltaZ * deltaZ;
+          let distance = null;
+          if (distanceSquared > matchDistance * matchDistance
+              && (distance = Math.sqrt(distanceSquared)) > matchDistance) continue;
+          if (best && distanceSquared > best.distanceSquared) continue;
+          distance ??= Math.sqrt(distanceSquared);
+          if (distance > matchDistance) continue;
           if (!best || distance < best.distance
               || distance === best.distance
                 && candidate.sampleKey.localeCompare(
                   best.sample.sampleKey) < 0) {
-            best = {sample: candidate, distance};
+            best = {sample: candidate, distance, distanceSquared};
           }
-        });
+        }
       }
     }
   }
   return best;
 }
 
+function buildSpatialCells(samples, cellSize) {
+  const cells = new Map();
+  samples.forEach(sample => {
+    const key = cellKey(sample.point, cellSize);
+    const entries = cells.get(key) || [];
+    entries.push(sample);
+    cells.set(key, entries);
+  });
+  return cells;
+}
+
 export function crossSourceWeightEvidence(
     leftRig, rightRig, referenceRadius, leftSamples = null,
-    rightSamples = null) {
+    rightSamples = null, leftCells = null, rightCells = null) {
   const leftSampleList = leftSamples || vertexSamplesForRig(leftRig);
   const rightSampleList = rightSamples || vertexSamplesForRig(rightRig);
   if (!leftSampleList.length || !rightSampleList.length) return new Map();
@@ -309,24 +370,14 @@ export function crossSourceWeightEvidence(
   // The search examines one neighboring cell in each axis, so each cell must
   // cover the full match radius to avoid missing a valid pair at a boundary.
   const cellSize = matchDistance;
-  const leftCells = new Map();
-  leftSampleList.forEach(sample => {
-    const key = cellKey(sample.point, cellSize);
-    const entries = leftCells.get(key) || [];
-    entries.push(sample);
-    leftCells.set(key, entries);
-  });
-  const rightCells = new Map();
-  rightSampleList.forEach(sample => {
-    const key = cellKey(sample.point, cellSize);
-    const entries = rightCells.get(key) || [];
-    entries.push(sample);
-    rightCells.set(key, entries);
-  });
+  const leftCellMap = leftCells
+    || buildSpatialCells(leftSampleList, cellSize);
+  const rightCellMap = rightCells
+    || buildSpatialCells(rightSampleList, cellSize);
   const nearestLeftByRight = new Map();
   const nearestRightByLeft = new Map();
   rightSampleList.forEach(rightSample => {
-    const best = nearestSample(rightSample, leftCells, cellSize,
+    const best = nearestSample(rightSample, leftCellMap, cellSize,
       matchDistance);
     if (!best) return;
     nearestLeftByRight.set(rightSample, {
@@ -334,7 +385,7 @@ export function crossSourceWeightEvidence(
     });
   });
   leftSampleList.forEach(leftSample => {
-    const best = nearestSample(leftSample, rightCells, cellSize,
+    const best = nearestSample(leftSample, rightCellMap, cellSize,
       matchDistance);
     if (!best) return;
     nearestRightByLeft.set(leftSample, {
@@ -416,16 +467,19 @@ function semanticRelationshipFor(left, right, semanticBySourceBoneKey) {
 function candidateFor(left, right, allEvidence, crossEvidenceByPair, gate) {
   // Equivalence compares like-for-like neutral regions. The parent joint pivot
   // is a structural anchor, not a replacement for a source bone's region.
-  const leftCenter = vectorFrom(left.weightedCenter);
-  const rightCenter = vectorFrom(right.weightedCenter);
+  const leftCenter = evidenceVector(left, '_weightedCenterVector',
+    'weightedCenter');
+  const rightCenter = evidenceVector(right, '_weightedCenterVector',
+    'weightedCenter');
   const distance = leftCenter?.distanceTo(rightCenter);
   if (!Number.isFinite(distance)) return null;
   const normalizedDistance = distance / gate.referenceRadius;
   if (normalizedDistance > CROSS_SOURCE_CANDIDATE_DISTANCE) return null;
   const directionAlignment = directionAvailable(left)
     && directionAvailable(right)
-    ? Math.abs(vectorFrom(left.restDirection)
-      .dot(vectorFrom(right.restDirection))) : null;
+    ? Math.abs(evidenceVector(left, '_restDirectionVector', 'restDirection')
+      .dot(evidenceVector(right, '_restDirectionVector', 'restDirection')))
+    : null;
   const radiusRatio = left.weightedRadius > EPSILON
     && right.weightedRadius > EPSILON
     ? Math.min(left.weightedRadius, right.weightedRadius)
@@ -594,13 +648,19 @@ function neighborMatches(candidate, evidenceByKey, unionFind) {
   }
   const leftNeighbors = left.neighborBoneIds || [];
   const rightNeighbors = right.neighborBoneIds || [];
+  const leftNeighborKeys = left._neighborBoneKeys || leftNeighbors.map(
+    boneId => sourceBoneKey(left.sourceKey, boneId));
+  const rightNeighborKeys = right._neighborBoneKeys || rightNeighbors.map(
+    boneId => sourceBoneKey(right.sourceKey, boneId));
   const usedRightNeighbors = new Set();
   const matchedNeighborPairs = [];
   leftNeighbors.forEach(leftNeighborId => {
-    const rightNeighborId = rightNeighbors.find(candidateId =>
-      !usedRightNeighbors.has(candidateId)
-      && unionFind.same(sourceBoneKey(left.sourceKey, leftNeighborId),
-        sourceBoneKey(right.sourceKey, candidateId)));
+    const leftNeighborIndex = leftNeighbors.indexOf(leftNeighborId);
+    const rightNeighborIndex = rightNeighborKeys.findIndex((candidateKey,
+      index) => !usedRightNeighbors.has(rightNeighbors[index])
+      && unionFind.same(leftNeighborKeys[leftNeighborIndex], candidateKey));
+    const rightNeighborId = rightNeighborIndex < 0
+      ? undefined : rightNeighbors[rightNeighborIndex];
     if (rightNeighborId === undefined) return;
     usedRightNeighbors.add(rightNeighborId);
     matchedNeighborPairs.push({leftBoneId: leftNeighborId, rightBoneId: rightNeighborId});
@@ -628,10 +688,12 @@ function graphAlignmentFeatures(candidate, evidenceByKey, unionFind) {
       left.sourceKey, pair.leftBoneId));
     const rightNeighbor = evidenceByKey.get(sourceBoneKey(
       right.sourceKey, pair.rightBoneId));
-    const leftVector = vectorFrom(leftNeighbor?.weightedCenter)
-      ?.sub(vectorFrom(left.weightedCenter));
-    const rightVector = vectorFrom(rightNeighbor?.weightedCenter)
-      ?.sub(vectorFrom(right.weightedCenter));
+    const leftVector = evidenceVector(leftNeighbor, '_weightedCenterVector',
+      'weightedCenter')?.sub(evidenceVector(left, '_weightedCenterVector',
+      'weightedCenter'));
+    const rightVector = evidenceVector(rightNeighbor, '_weightedCenterVector',
+      'weightedCenter')?.sub(evidenceVector(right, '_weightedCenterVector',
+      'weightedCenter'));
     if (!leftVector || !rightVector
         || leftVector.length() <= EPSILON || rightVector.length() <= EPSILON) {
       return;
@@ -707,20 +769,39 @@ function diagnosticCandidate(candidate, decision, rejectionReason = null) {
   };
 }
 
-function buildCrossSourceWeightEvidence(sourceRigs, referenceRadius) {
-  const evidence = new Map();
+function prepareCrossSourceEvidence(sourceRigs, referenceRadius) {
   const rigs = [...sourceRigs].sort((left, right) =>
     String(left.sourceKey).localeCompare(String(right.sourceKey)));
-  const samplesBySourceKey = new Map(rigs.map(rig => [
-    String(rig.sourceKey), vertexSamplesForRig(rig),
-  ]));
+  const matchDistance = Math.max(referenceRadius * 0.02, EPSILON);
+  const samplesBySourceKey = new Map();
+  const cellsBySourceKey = new Map();
+  rigs.forEach(rig => {
+    const sourceKey = String(rig.sourceKey);
+    const samples = vertexSamplesForRig(rig);
+    samplesBySourceKey.set(sourceKey, samples);
+    cellsBySourceKey.set(sourceKey,
+      buildSpatialCells(samples, matchDistance));
+  });
+  return {
+    rigs,
+    samplesBySourceKey,
+    cellsBySourceKey,
+  };
+}
+
+function buildCrossSourceWeightEvidence(sourceRigs, referenceRadius) {
+  const evidence = new Map();
+  const preparation = prepareCrossSourceEvidence(sourceRigs, referenceRadius);
+  const {rigs, samplesBySourceKey, cellsBySourceKey} = preparation;
   for (let leftIndex = 0; leftIndex < rigs.length; leftIndex += 1) {
     for (let rightIndex = leftIndex + 1; rightIndex < rigs.length; rightIndex += 1) {
       const leftRig = rigs[leftIndex];
       const rightRig = rigs[rightIndex];
       crossSourceWeightEvidence(leftRig, rightRig, referenceRadius,
         samplesBySourceKey.get(String(leftRig.sourceKey)),
-        samplesBySourceKey.get(String(rightRig.sourceKey)))
+        samplesBySourceKey.get(String(rightRig.sourceKey)),
+        cellsBySourceKey.get(String(leftRig.sourceKey)),
+        cellsBySourceKey.get(String(rightRig.sourceKey)))
         .forEach((record, key) => evidence.set(key, record));
     }
   }
@@ -760,28 +841,20 @@ function buildCandidates(evidenceByKey, referenceRadius, sourceRigs = [],
 
 function markSpatialRelationships(candidates) {
   const endpointMap = new Map();
-  const competitionKey = (endpoint, otherSource) => JSON.stringify([
-    endpoint, String(otherSource),
-  ]);
-  const endpointDescriptor = (candidate, endpoint) =>
-    candidate.left.sourceBoneKey === endpoint
-      ? {otherSource: candidate.right.sourceKey,
-        otherKey: candidate.right.sourceBoneKey}
-      : {otherSource: candidate.left.sourceKey,
-        otherKey: candidate.left.sourceBoneKey};
   candidates.forEach(candidate => {
     for (const endpoint of [candidate.left.sourceBoneKey,
       candidate.right.sourceBoneKey]) {
       const descriptor = endpointDescriptor(candidate, endpoint);
-      const key = competitionKey(endpoint, descriptor.otherSource);
+      const key = endpointCompetitionKey(endpoint, descriptor.otherSource);
       const incident = endpointMap.get(key) || [];
       incident.push(candidate);
       endpointMap.set(key, incident);
     }
   });
-  const rankFor = (endpoint, candidatesForEndpoint) => {
-    const ranked = [...candidatesForEndpoint];
-    ranked.sort((left, right) => {
+  const rankedByEndpoint = new Map();
+  endpointMap.forEach((candidatesForEndpoint, key) => {
+    const [endpoint] = JSON.parse(key);
+    rankedByEndpoint.set(key, [...candidatesForEndpoint].sort((left, right) => {
       const leftDescriptor = endpointDescriptor(left, endpoint);
       const rightDescriptor = endpointDescriptor(right, endpoint);
       return (right.confidenceClass || 0) - (left.confidenceClass || 0)
@@ -791,20 +864,17 @@ function markSpatialRelationships(candidates) {
         || right.geometryConfidence - left.geometryConfidence
         || left.normalizedDistance - right.normalizedDistance
         || leftDescriptor.otherKey.localeCompare(rightDescriptor.otherKey);
-    });
-    return ranked;
-  };
+    }));
+  });
   candidates.forEach(candidate => {
     const leftDescriptor = endpointDescriptor(
       candidate, candidate.left.sourceBoneKey);
     const rightDescriptor = endpointDescriptor(
       candidate, candidate.right.sourceBoneKey);
-    const leftCandidates = rankFor(candidate.left.sourceBoneKey,
-      endpointMap.get(competitionKey(candidate.left.sourceBoneKey,
-        leftDescriptor.otherSource)) || []);
-    const rightCandidates = rankFor(candidate.right.sourceBoneKey,
-      endpointMap.get(competitionKey(candidate.right.sourceBoneKey,
-        rightDescriptor.otherSource)) || []);
+    const leftCandidates = rankedByEndpoint.get(endpointCompetitionKey(
+      candidate.left.sourceBoneKey, leftDescriptor.otherSource)) || [];
+    const rightCandidates = rankedByEndpoint.get(endpointCompetitionKey(
+      candidate.right.sourceBoneKey, rightDescriptor.otherSource)) || [];
     candidate.mutualBest = leftCandidates[0] === candidate
       && rightCandidates[0] === candidate;
     candidate.leftAmbiguous = candidateAmbiguous(
@@ -855,25 +925,6 @@ function compareGraphAlignmentCandidate(left, right) {
     || left.right.sourceBoneKey.localeCompare(right.right.sourceBoneKey);
 }
 
-function graphAlignmentCandidatesFor(candidates, endpoint, otherSource,
-    unionFind) {
-  return candidates.filter(candidate => {
-    // Rank only candidates incident to this endpoint. An unrelated branch
-    // must not compete with the endpoint's real correspondence.
-    if (candidate.left.sourceBoneKey !== endpoint
-        && candidate.right.sourceBoneKey !== endpoint) return false;
-    if (unionFind.same(candidate.left.sourceBoneKey,
-      candidate.right.sourceBoneKey)) return false;
-    const descriptor = endpointDescriptor(candidate, endpoint);
-    return descriptor.otherSource === otherSource
-      && descriptor.otherKey !== endpoint
-      && candidate.matchedNeighborCount > 0
-      && candidate.graphAlignmentScore
-        >= CROSS_SOURCE_GRAPH_ALIGNMENT_MIN_SCORE
-      && candidate.topology.degree >= .5;
-  }).sort(compareGraphAlignmentCandidate);
-}
-
 function uniqueGraphWinner(candidate, ranked, tier) {
   if (ranked[0] !== candidate) return false;
   const second = ranked[1];
@@ -904,16 +955,30 @@ function runGraphAlignment(candidates, evidenceByKey, unionFind,
       && candidate.topology.degree >= .5
       && !unionFind.same(candidate.left.sourceBoneKey,
         candidate.right.sourceBoneKey));
+    const rankedByEndpoint = new Map();
+    available.forEach(candidate => {
+      for (const endpoint of [candidate.left.sourceBoneKey,
+        candidate.right.sourceBoneKey]) {
+        const descriptor = endpointDescriptor(candidate, endpoint);
+        const key = endpointCompetitionKey(endpoint, descriptor.otherSource);
+        const bucket = rankedByEndpoint.get(key) || [];
+        bucket.push(candidate);
+        rankedByEndpoint.set(key, bucket);
+      }
+    });
+    rankedByEndpoint.forEach(bucket => {
+      bucket.sort(compareGraphAlignmentCandidate);
+    });
     const rankFor = candidate => {
       const leftDescriptor = endpointDescriptor(
         candidate, candidate.left.sourceBoneKey);
       const rightDescriptor = endpointDescriptor(
         candidate, candidate.right.sourceBoneKey);
       return {
-        left: graphAlignmentCandidatesFor(available,
-          candidate.left.sourceBoneKey, leftDescriptor.otherSource, unionFind),
-        right: graphAlignmentCandidatesFor(available,
-          candidate.right.sourceBoneKey, rightDescriptor.otherSource, unionFind),
+        left: rankedByEndpoint.get(endpointCompetitionKey(
+          candidate.left.sourceBoneKey, leftDescriptor.otherSource)) || [],
+        right: rankedByEndpoint.get(endpointCompetitionKey(
+          candidate.right.sourceBoneKey, rightDescriptor.otherSource)) || [],
       };
     };
     const selected = available.filter(candidate => {
@@ -994,6 +1059,14 @@ function runPathAlignment(candidates, evidenceByKey, unionFind,
     candidate,
   ]));
   let changed = true;
+  const pathCache = new Map();
+  const pathFor = (startKey, endKey) => {
+    const key = `${startKey}\u0000${endKey}`;
+    if (pathCache.has(key)) return pathCache.get(key);
+    const path = pathBetweenSourceBones(startKey, endKey, evidenceByKey);
+    pathCache.set(key, path);
+    return path;
+  };
   while (changed) {
     changed = false;
     const alignments = new Map();
@@ -1003,10 +1076,8 @@ function runPathAlignment(candidates, evidenceByKey, unionFind,
              rightIndex < anchors.length; rightIndex += 1) {
           const first = anchors[leftIndex];
           const second = anchors[rightIndex];
-          const leftPath = pathBetweenSourceBones(
-            first.left, second.left, evidenceByKey);
-          const rightPath = pathBetweenSourceBones(
-            first.right, second.right, evidenceByKey);
+          const leftPath = pathFor(first.left, second.left);
+          const rightPath = pathFor(first.right, second.right);
           if (!leftPath || !rightPath || leftPath.length !== rightPath.length
               || leftPath.length < 3) continue;
           const internal = [];
@@ -1114,45 +1185,37 @@ function runEquivalencePasses(candidates, evidenceByKey, unionFind) {
       return candidate.matchedNeighborCount > 0;
     });
     const endpointMap = new Map();
-    const competitionKey = (endpoint, otherSource) => JSON.stringify([
-      endpoint, String(otherSource),
-    ]);
-    const endpointDescriptor = (candidate, endpoint) =>
-      candidate.left.sourceBoneKey === endpoint
-        ? {otherSource: candidate.right.sourceKey,
-          otherKey: candidate.right.sourceBoneKey}
-        : {otherSource: candidate.left.sourceKey,
-          otherKey: candidate.left.sourceBoneKey};
     propagation.forEach(candidate => {
       for (const endpoint of [candidate.left.sourceBoneKey,
         candidate.right.sourceBoneKey]) {
         const descriptor = endpointDescriptor(candidate, endpoint);
-        const key = competitionKey(endpoint, descriptor.otherSource);
+        const key = endpointCompetitionKey(endpoint, descriptor.otherSource);
         const incident = endpointMap.get(key) || [];
         incident.push(candidate);
         endpointMap.set(key, incident);
       }
     });
-    const rankedFor = (endpoint, candidatesForEndpoint) =>
-      [...candidatesForEndpoint].sort((left, right) =>
+    const rankedByEndpoint = new Map();
+    endpointMap.forEach((candidatesForEndpoint, key) => {
+      const [endpoint] = JSON.parse(key);
+      rankedByEndpoint.set(key, [...candidatesForEndpoint].sort((left, right) =>
         right.propagationScore - left.propagationScore
         || (right.confidenceClass || 0) - (left.confidenceClass || 0)
         || right.combinedConfidence - left.combinedConfidence
         || right.supportReliability - left.supportReliability
         || left.normalizedDistance - right.normalizedDistance
         || endpointDescriptor(left, endpoint).otherKey.localeCompare(
-          endpointDescriptor(right, endpoint).otherKey));
+          endpointDescriptor(right, endpoint).otherKey)));
+    });
     const selected = propagation.filter(candidate => {
       const leftDescriptor = endpointDescriptor(
         candidate, candidate.left.sourceBoneKey);
       const rightDescriptor = endpointDescriptor(
         candidate, candidate.right.sourceBoneKey);
-      const leftBest = rankedFor(candidate.left.sourceBoneKey,
-        endpointMap.get(competitionKey(candidate.left.sourceBoneKey,
-          leftDescriptor.otherSource)) || []);
-      const rightBest = rankedFor(candidate.right.sourceBoneKey,
-        endpointMap.get(competitionKey(candidate.right.sourceBoneKey,
-          rightDescriptor.otherSource)) || []);
+      const leftBest = rankedByEndpoint.get(endpointCompetitionKey(
+        candidate.left.sourceBoneKey, leftDescriptor.otherSource)) || [];
+      const rightBest = rankedByEndpoint.get(endpointCompetitionKey(
+        candidate.right.sourceBoneKey, rightDescriptor.otherSource)) || [];
       const leftAmbiguous = candidateAmbiguous(
         leftBest[0] && {...leftBest[0], score: leftBest[0].propagationScore},
         leftBest[1] && {...leftBest[1], score: leftBest[1].propagationScore});
@@ -1234,11 +1297,14 @@ function buildModelJoints(unionFind, evidenceByKey, strengthByKey,
     const members = memberKeys.map(key => evidenceByKey.get(key)).filter(Boolean);
     const signature = JSON.stringify(memberKeys);
     const center = weightedAverage(members.map(evidence => ({
-      point: vectorFrom(evidence.weightedCenter)?.toArray(),
+      point: evidenceVector(evidence, '_weightedCenterVector',
+        'weightedCenter')?.toArray(),
       weight: Math.max(evidence.totalWeight, evidence.affectedVertexCount, 1),
     }))) || [0, 0, 0];
-    const pivots = members.map(evidence => vectorFrom(
-      evidence.jointPivot || (evidence.isRoot ? null : evidence.restAnchor)))
+    const pivots = members.map(evidence =>
+      evidenceVector(evidence, '_jointPivotVector', 'jointPivot')
+        || (evidence.isRoot ? null : evidenceVector(evidence,
+          '_restAnchorVector', 'restAnchor')))
       .filter(Boolean);
     const pivotMedoid = medoid(pivots);
     const pivotTolerance = referenceRadius * CROSS_SOURCE_STRICT_DISTANCE;
@@ -1765,12 +1831,15 @@ function aggregateJointCrossEvidence(left, right, crossEvidenceByPair) {
 }
 
 function aggregateComponentCrossEvidence(component, target, joints,
-    crossEvidenceByPair, referenceRadius) {
+    crossEvidenceByPair, referenceRadius, jointEvidenceByPair = null) {
   const jointEvidence = [];
   component.nodeIds.forEach(accessoryId => {
     target.nodeIds.forEach(targetId => {
-      const evidence = aggregateJointCrossEvidence(joints[accessoryId],
-        joints[targetId], crossEvidenceByPair);
+      const key = jointPairKey(accessoryId, targetId);
+      const evidence = jointEvidenceByPair?.get(key)
+        || aggregateJointCrossEvidence(joints[accessoryId],
+          joints[targetId], crossEvidenceByPair);
+      jointEvidenceByPair?.set(key, evidence);
       const accessoryCenter = vectorFrom(joints[accessoryId]?.restCenter);
       const targetCenter = vectorFrom(joints[targetId]?.restCenter);
       const distance = accessoryCenter && targetCenter
@@ -1804,14 +1873,21 @@ function aggregateComponentCrossEvidence(component, target, joints,
   };
 }
 
-function sourceWitnessesForJoints(targetJoint, accessoryJoint) {
+function sourceKeysForJoint(joint) {
+  return [...new Set((joint?.members || []).map(member =>
+    String(member.sourceKey ?? '')).filter(Boolean))].sort();
+}
+
+function sourceWitnessesForJoints(targetJoint, accessoryJoint,
+    sourceKeysByJointId = null) {
   const witnesses = new Set();
-  for (const targetMember of targetJoint?.members || []) {
-    const targetSourceKey = String(targetMember.sourceKey ?? '');
-    if (!targetSourceKey) continue;
-    for (const accessoryMember of accessoryJoint?.members || []) {
-      const accessorySourceKey = String(accessoryMember.sourceKey ?? '');
-      if (!accessorySourceKey || targetSourceKey === accessorySourceKey) {
+  const targetSourceKeys = sourceKeysByJointId?.get(targetJoint?.jointId)
+    || sourceKeysForJoint(targetJoint);
+  const accessorySourceKeys = sourceKeysByJointId?.get(
+    accessoryJoint?.jointId) || sourceKeysForJoint(accessoryJoint);
+  for (const targetSourceKey of targetSourceKeys) {
+    for (const accessorySourceKey of accessorySourceKeys) {
+      if (targetSourceKey === accessorySourceKey) {
         continue;
       }
       witnesses.add(`${targetSourceKey}\u0000${accessorySourceKey}`);
@@ -1831,16 +1907,29 @@ function attachmentCandidates(joints, forest, referenceRadius,
   const candidates = [];
   const components = forest.components;
   const componentEvidenceByPair = new Map();
+  const jointEvidenceByPair = new Map();
+  const sourceKeysByJointId = new Map(joints.map(joint => [
+    joint.jointId, sourceKeysForJoint(joint),
+  ]));
+  const sourceWitnessesByJointPair = new Map();
+  const supportByComponentId = new Map(components.map(component => [
+    component.componentId, componentSupport(component, joints),
+  ]));
+  const jointDescriptorById = new Map(joints.map(joint => [joint.jointId, {
+    anchor: vectorFrom(joint.restCenter),
+    direction: vectorFrom(joint.restDirection),
+  }]));
   const componentEvidenceFor = (accessory, target) => {
     const key = `${accessory.componentId}:${target.componentId}`;
     if (!componentEvidenceByPair.has(key)) {
       componentEvidenceByPair.set(key, aggregateComponentCrossEvidence(
-        accessory, target, joints, crossEvidenceByPair, referenceRadius));
+        accessory, target, joints, crossEvidenceByPair, referenceRadius,
+        jointEvidenceByPair));
     }
     return componentEvidenceByPair.get(key);
   };
-  const directions = new Map(joints.map(joint => [joint.jointId,
-    vectorFrom(joint.restDirection)]));
+  const directions = new Map([...jointDescriptorById.entries()].map(([
+    jointId, descriptor]) => [jointId, descriptor.direction]));
   // The model joint direction is represented by the selected source member's
   // rest frame +Y. Keeping this derivation here avoids inventing labels or
   // changing the source-local rest-frame contract.
@@ -1851,10 +1940,11 @@ function attachmentCandidates(joints, forest, referenceRadius,
       .applyQuaternion(frame).normalize());
   });
   for (const accessory of components) {
-    const accessorySupport = componentSupport(accessory, joints);
+    const accessorySupport = supportByComponentId.get(accessory.componentId)
+      || 0;
     for (const target of components) {
       if (target.componentId === accessory.componentId) continue;
-      const targetSupport = componentSupport(target, joints);
+      const targetSupport = supportByComponentId.get(target.componentId) || 0;
       // Attach smaller inferred components to a larger body. This also makes
       // the direction of an attachment deterministic when two disconnected
       // components have identical synthetic support in a test fixture.
@@ -1867,14 +1957,19 @@ function attachmentCandidates(joints, forest, referenceRadius,
       const componentEvidence = componentEvidenceFor(accessory, target);
       for (const targetId of target.nodeIds) {
         const targetJoint = joints[targetId];
-        const targetAnchor = vectorFrom(targetJoint?.restCenter);
+        const targetAnchor = jointDescriptorById.get(targetId)?.anchor;
         if (!targetAnchor) continue;
         for (const accessoryId of accessory.nodeIds) {
           const accessoryJoint = joints[accessoryId];
-          const accessoryAnchor = vectorFrom(accessoryJoint?.restCenter);
+          const accessoryAnchor = jointDescriptorById.get(accessoryId)?.anchor;
           if (!accessoryAnchor) continue;
-          const sourceWitnesses = sourceWitnessesForJoints(
-            targetJoint, accessoryJoint);
+          const witnessKey = jointPairKey(targetId, accessoryId);
+          let sourceWitnesses = sourceWitnessesByJointPair.get(witnessKey);
+          if (!sourceWitnesses) {
+            sourceWitnesses = sourceWitnessesForJoints(targetJoint,
+              accessoryJoint, sourceKeysByJointId);
+            sourceWitnessesByJointPair.set(witnessKey, sourceWitnesses);
+          }
           if (!sourceWitnesses.length) continue;
           const towardAccessory = accessoryAnchor.clone().sub(targetAnchor);
           const distance = towardAccessory.length();
@@ -1885,8 +1980,10 @@ function attachmentCandidates(joints, forest, referenceRadius,
           const directionAlignment = accessoryDirection
             ? Math.abs(accessoryDirection.dot(towardAccessory.normalize()))
             : null;
-          const pairEvidence = aggregateJointCrossEvidence(targetJoint,
-            accessoryJoint, crossEvidenceByPair);
+          const pairEvidence = jointEvidenceByPair.get(witnessKey)
+            || aggregateJointCrossEvidence(targetJoint, accessoryJoint,
+              crossEvidenceByPair);
+          jointEvidenceByPair.set(witnessKey, pairEvidence);
           const nearbyTargetAgreement = Math.max(0,
             (componentEvidence.supportedTargetCountByAccessory.get(accessoryId)
               || 0) - (pairEvidence.matchedVertexCount > 0 ? 1 : 0));
@@ -2072,16 +2169,17 @@ export function buildModelRigReconciliation(sourceRigs = [], options = {}) {
     .sort((left, right) => String(left.sourceKey)
       .localeCompare(String(right.sourceKey)));
   const evidenceByKey = new Map();
-  rigs.forEach(rig => collectSourceBoneEvidence(rig).forEach((evidence, key) =>
-    evidenceByKey.set(key, evidence)));
+  rigs.forEach(rig =>
+    collectSourceBoneEvidence(rig).forEach((evidence, key) =>
+      evidenceByKey.set(key, evidence)));
+  prepareSourceBoneEvidence(evidenceByKey);
   const referenceRadius = Math.max(EPSILON, number(options.modelReferenceRadius,
     modelReferenceRadius(evidenceByKey)));
   const candidateBuild = buildCandidates(
     evidenceByKey, referenceRadius, rigs, options);
   const candidates = candidateBuild.candidates;
   const unionFind = new GuardedUnionFind([...evidenceByKey.keys()]);
-  const equivalence = runEquivalencePasses(
-    candidates, evidenceByKey, unionFind);
+  const equivalence = runEquivalencePasses(candidates, evidenceByKey, unionFind);
   const model = buildModelJoints(unionFind, evidenceByKey,
     equivalence.correspondenceStrength, referenceRadius);
   const sourceEdges = sourceModelEdges(rigs, model.keyToJoint);

--- a/src/web/js/mesh/weight-rig.js
+++ b/src/web/js/mesh/weight-rig.js
@@ -137,14 +137,11 @@ function barycentricSecondMoment(left, right, area) {
   return left === right ? area / 6 : area / 12;
 }
 
-function barycentricThirdMoment(first, second, third, area) {
-  const counts = [first, second, third].reduce((map, index) => {
-    map.set(index, (map.get(index) || 0) + 1);
-    return map;
-  }, new Map());
-  const multiplicities = [...counts.values()];
-  if (multiplicities.length === 1) return area / 10;
-  if (multiplicities.length === 2) return area / 30;
+export function barycentricThirdMoment(first, second, third, area) {
+  if (first === second && second === third) return area / 10;
+  if (first === second || first === third || second === third) {
+    return area / 30;
+  }
   return area / 60;
 }
 
@@ -171,7 +168,7 @@ function integrateLinearPosition(points, weights, area) {
   return result;
 }
 
-function integrateLinearSecondMoment(points, weights, area) {
+export function integrateLinearSecondMoment(points, weights, area) {
   let result = 0;
   for (let left = 0; left < 3; left += 1) {
     for (let right = 0; right < 3; right += 1) {
@@ -196,7 +193,7 @@ function integrateLinearProduct(leftWeights, rightWeights, area) {
   return result;
 }
 
-function integratePositionProduct(points, leftWeights, rightWeights, area) {
+export function integratePositionProduct(points, leftWeights, rightWeights, area) {
   const result = [0, 0, 0];
   for (let point = 0; point < 3; point += 1) {
     for (let left = 0; left < 3; left += 1) {

--- a/src/web/js/mesh/weight-rig.js
+++ b/src/web/js/mesh/weight-rig.js
@@ -17,6 +17,33 @@ function triangleArea(points) {
     ab[0] * ac[1] - ab[1] * ac[0]);
 }
 
+function readSurfaceTriangle(
+    positionArray, indexArray, indexed, positionCount, triangle) {
+  const indices = [0, 1, 2].map(offset => {
+    const index = triangle * 3 + offset;
+    return indexed ? Number(indexArray[index]) : index;
+  });
+  if (indices.some(index => !Number.isInteger(index)
+      || index < 0 || index >= positionCount)) {
+    return {kind: 'invalid'};
+  }
+  const points = indices.map(vertex => {
+    const offset = vertex * 3;
+    return [
+      Number(positionArray[offset]),
+      Number(positionArray[offset + 1]),
+      Number(positionArray[offset + 2]),
+    ];
+  });
+  if (points.some(point => point.some(value => !Number.isFinite(value)))) {
+    return {kind: 'invalid'};
+  }
+  const area = triangleArea(points);
+  if (!Number.isFinite(area)) return {kind: 'invalid'};
+  if (area <= 0) return {kind: 'degenerate', indices, points, area};
+  return {kind: 'valid', indices, points, area};
+}
+
 function collectSurfaceTriangles(
     positions, triangleIndices = null, includeTriangles = true) {
   const positionArray = positions || [];
@@ -34,40 +61,22 @@ function collectSurfaceTriangles(
   let validTriangleCount = 0;
   let totalSurfaceArea = 0;
   for (let triangle = 0; triangle < triangleCount; triangle += 1) {
-    const indices = [0, 1, 2].map(offset => {
-      const index = triangle * 3 + offset;
-      return indexed ? Number(indexArray[index]) : index;
-    });
-    if (indices.some(index => !Number.isInteger(index)
-        || index < 0 || index >= positionCount)) {
+    const sample = readSurfaceTriangle(
+      positionArray, indexArray, indexed, positionCount, triangle);
+    if (sample.kind === 'invalid') {
       invalidTriangleCount += 1;
       continue;
     }
-    const points = indices.map(vertex => {
-      const offset = vertex * 3;
-      return [
-        Number(positionArray[offset]),
-        Number(positionArray[offset + 1]),
-        Number(positionArray[offset + 2]),
-      ];
-    });
-    if (points.some(point => point.some(value => !Number.isFinite(value)))) {
-      invalidTriangleCount += 1;
-      continue;
-    }
-    const area = triangleArea(points);
-    if (!Number.isFinite(area)) {
-      invalidTriangleCount += 1;
-      continue;
-    }
-    if (area === 0) {
+    if (sample.kind === 'degenerate') {
       degenerateTriangleCount += 1;
       continue;
     }
     validTriangleCount += 1;
-    totalSurfaceArea += area;
-    indices.forEach(index => measuredVertices.add(index));
-    if (triangles) triangles.push({indices, points, area});
+    totalSurfaceArea += sample.area;
+    sample.indices.forEach(index => measuredVertices.add(index));
+    if (triangles) triangles.push({
+      indices: sample.indices, points: sample.points, area: sample.area,
+    });
   }
   return {
     positionCount,
@@ -275,6 +284,24 @@ function integrateMinimumLinearWeight(
   const rightRegion = clipLinearWeightPolygon(vertices, false);
   return integratePolygonLinearWeight(leftRegion, 'leftWeight')
     + integratePolygonLinearWeight(rightRegion, 'rightWeight');
+}
+
+/** Return whether topology contains at least one usable positive-area triangle. */
+export function hasUsableSurfaceTopology(positions, triangleIndices = null) {
+  const positionArray = positions || [];
+  const positionCount = Math.floor(positionArray.length / 3);
+  const indexed = triangleIndices !== null && triangleIndices !== undefined;
+  const indexArray = indexed ? triangleIndices : null;
+  const indexCount = indexed
+    ? Number(indexArray?.length) || 0
+    : Number(positionArray.length) / 3;
+  const triangleCount = Math.ceil(indexCount / 3);
+  for (let triangle = 0; triangle < triangleCount; triangle += 1) {
+    const sample = readSurfaceTriangle(
+      positionArray, indexArray, indexed, positionCount, triangle);
+    if (sample.kind === 'valid' && sample.area > 0) return true;
+  }
+  return false;
 }
 
 function surfaceInfluenceWeights(


### PR DESCRIPTION
## Summary\n\n- Replace full-array FNV member fingerprints with structural evidence candidates and an exact equality guard, including a narrow compatibility candidate for duplicate evidence with differing draw starts.\n- Defer full surface-topology diagnostics until the source-wide vertex fallback requires them; normal surface mode uses an early eligibility probe and preserves the existing graph math.\n- Add browser coverage for structural identity, topology eligibility, source-wide fallback, duplicate handling, and graph-output equivalence.\n\n## Validation\n\n- GitHub Actions CI.